### PR TITLE
add missing defaults to switch statements

### DIFF
--- a/_sokol_gfx.impl.h
+++ b/_sokol_gfx.impl.h
@@ -14,6 +14,9 @@
     #include <assert.h>
     #define SOKOL_ASSERT(c) assert(c)
 #endif
+#ifndef SOKOL_UNREACHABLE
+    #define SOKOL_UNREACHABLE SOKOL_ASSERT(false)
+#endif
 #ifndef SOKOL_MALLOC
     #include <stdlib.h>
     #define SOKOL_MALLOC(s) malloc(s)
@@ -338,6 +341,9 @@ static int _sg_vertexformat_bytesize(sg_vertex_format fmt) {
         case SG_VERTEXFORMAT_SHORT4N:   return 8;
         case SG_VERTEXFORMAT_UINT10_N2: return 4;
         case SG_VERTEXFORMAT_INVALID:   return 0;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
 }
 
@@ -350,6 +356,9 @@ static int _sg_uniform_size(sg_uniform_type type, int count) {
         case SG_UNIFORMTYPE_FLOAT3:     return 12 * count; /* FIXME: std140??? */
         case SG_UNIFORMTYPE_FLOAT4:     return 16 * count;
         case SG_UNIFORMTYPE_MAT4:       return 64 * count;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
 }
 

--- a/_sokol_gfx_gl.impl.h
+++ b/_sokol_gfx_gl.impl.h
@@ -47,6 +47,9 @@ static GLenum _sg_gl_buffer_target(sg_buffer_type t) {
     switch (t) {
         case SG_BUFFERTYPE_VERTEXBUFFER:    return GL_ARRAY_BUFFER;
         case SG_BUFFERTYPE_INDEXBUFFER:     return GL_ELEMENT_ARRAY_BUFFER;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
 }
 
@@ -67,6 +70,9 @@ static GLenum _sg_gl_usage(sg_usage u) {
         case SG_USAGE_IMMUTABLE:    return GL_STATIC_DRAW;
         case SG_USAGE_DYNAMIC:      return GL_DYNAMIC_DRAW;
         case SG_USAGE_STREAM:       return GL_STREAM_DRAW;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
 }
 
@@ -74,6 +80,9 @@ static GLenum _sg_gl_shader_stage(sg_shader_stage stage) {
     switch (stage) {
         case SG_SHADERSTAGE_VS:     return GL_VERTEX_SHADER;
         case SG_SHADERSTAGE_FS:     return GL_FRAGMENT_SHADER;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
 }
 
@@ -141,6 +150,9 @@ static GLenum _sg_gl_primitive_type(sg_primitive_type t) {
         case SG_PRIMITIVETYPE_LINE_STRIP:       return GL_LINE_STRIP;
         case SG_PRIMITIVETYPE_TRIANGLES:        return GL_TRIANGLES;
         case SG_PRIMITIVETYPE_TRIANLE_STRIP:    return GL_TRIANGLE_STRIP;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
 }
 
@@ -149,6 +161,9 @@ static GLenum _sg_gl_index_type(sg_index_type t) {
         case SG_INDEXTYPE_NONE:     return 0;
         case SG_INDEXTYPE_UINT16:   return GL_UNSIGNED_SHORT;
         case SG_INDEXTYPE_UINT32:   return GL_UNSIGNED_INT;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
 }
 
@@ -162,6 +177,9 @@ static GLenum _sg_gl_compare_func(sg_compare_func cmp) {
         case SG_COMPAREFUNC_NOT_EQUAL:      return GL_NOTEQUAL;
         case SG_COMPAREFUNC_GREATER_EQUAL:  return GL_GEQUAL;
         case SG_COMPAREFUNC_ALWAYS:         return GL_ALWAYS;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
 }
 
@@ -175,6 +193,9 @@ static GLenum _sg_gl_stencil_op(sg_stencil_op op) {
         case SG_STENCILOP_INVERT:       return GL_INVERT;
         case SG_STENCILOP_INCR_WRAP:    return GL_INCR_WRAP;
         case SG_STENCILOP_DECR_WRAP:    return GL_DECR_WRAP;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
 }
 
@@ -195,6 +216,9 @@ static GLenum _sg_gl_blend_factor(sg_blend_factor f) {
         case SG_BLENDFACTOR_ONE_MINUS_BLEND_COLOR:  return GL_ONE_MINUS_CONSTANT_COLOR;
         case SG_BLENDFACTOR_BLEND_ALPHA:            return GL_CONSTANT_ALPHA;
         case SG_BLENDFACTOR_ONE_MINUS_BLEND_ALPHA:  return GL_ONE_MINUS_CONSTANT_ALPHA;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
 }
 
@@ -203,6 +227,9 @@ static GLenum _sg_gl_blend_op(sg_blend_op op) {
         case SG_BLENDOP_ADD:                return GL_FUNC_ADD;
         case SG_BLENDOP_SUBTRACT:           return GL_FUNC_SUBTRACT;
         case SG_BLENDOP_REVERSE_SUBTRACT:   return GL_FUNC_REVERSE_SUBTRACT;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
 }
 
@@ -211,6 +238,9 @@ static GLenum _sg_gl_cull_face(sg_face f) {
         case SG_FACE_FRONT: return GL_FRONT;
         case SG_FACE_BACK:  return GL_BACK;
         case SG_FACE_BOTH:  return GL_FRONT_AND_BACK;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
 }
 
@@ -222,6 +252,9 @@ static GLenum _sg_gl_filter(sg_filter f) {
         case SG_FILTER_NEAREST_MIPMAP_LINEAR:   return GL_NEAREST_MIPMAP_LINEAR;
         case SG_FILTER_LINEAR_MIPMAP_NEAREST:   return GL_LINEAR_MIPMAP_NEAREST;
         case SG_FILTER_LINEAR_MIPMAP_LINEAR:    return GL_LINEAR_MIPMAP_LINEAR;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
 }
 
@@ -230,6 +263,9 @@ static GLenum _sg_gl_wrap(sg_wrap w) {
         case SG_WRAP_CLAMP_TO_EDGE:     return GL_CLAMP_TO_EDGE;
         case SG_WRAP_REPEAT:            return GL_REPEAT;
         case SG_WRAP_MIRRORED_REPEAT:   return GL_MIRRORED_REPEAT;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
 }
 
@@ -309,6 +345,9 @@ static GLenum _sg_gl_teximage_format(sg_pixel_format fmt) {
             return GL_COMPRESSED_RGB8_ETC2;
         case SG_PIXELFORMAT_ETC2_SRGB8:
             return GL_COMPRESSED_SRGB8_ETC2;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
 }
 
@@ -369,6 +408,9 @@ static GLenum _sg_gl_teximage_internal_format(sg_pixel_format fmt) {
             return GL_COMPRESSED_RGB8_ETC2;
         case SG_PIXELFORMAT_ETC2_SRGB8:
             return GL_COMPRESSED_SRGB8_ETC2;
+        default:
+            SOKOL_UNREACHABLE;
+            return -1;
     }
     #endif
 }


### PR DESCRIPTION
When compiling with fips and vs2015 or vs2017, warnings are errors and switch statements without a default case are warnings.

This change adds a `SOKOL_UNREACHABLE` macro which right now is just defined to `SOKOL_ASSERT(false)`.