### PR TITLE
Conditional including of libs

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4074,13 +4074,19 @@ _SOKOL_PRIVATE void _sg_update_image(_sg_image* img, const sg_image_content* dat
 #include <windows.h>
 #include <d3d11.h>
 
+#if (defined(WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
+#pragma comment (lib, "WindowsApp.lib")
+#else
 #pragma comment (lib, "user32.lib")
 #pragma comment (lib, "dxgi.lib")
 #pragma comment (lib, "d3d11.lib")
 #pragma comment (lib, "dxguid.lib")
+#endif
 #if defined(SOKOL_D3D11_SHADER_COMPILER)
 #include <d3dcompiler.h>
+#if !(defined(WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
 #pragma comment (lib, "d3dcompiler.lib")
+#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Since sokol already uses Direct3D11 as a back-end and it's not calling desktop only APIs, it's already UWP compliant; only one issue - UWP apps are meant to only link against `WindowsApp.lib` and nothing else.
Source [here](https://docs.microsoft.com/en-us/uwp/win32-and-com/win32-and-com-for-uwp-apps):

> ....Win32 APIs that are part of the UWP and that are implemented by all Windows 10 devices.
> .For convenience, an umbrella library named WindowsApp.lib is provided in the Microsoft Windows Software Development Kit (SDK), which provides the exports for this set of Win32 APIs.
> Link your app with WindowsApp.lib (and no other libraries) to access these APIs.

P.S. Love the idea behind your work and am trying to use it myself. Hence the small fix to make it fully compatible :)