### PR TITLE
Geometry shaders

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4556,12 +4556,16 @@ _SOKOL_PRIVATE void _sg_d3d11_clear_state() {
     ID3D11DeviceContext_IASetInputLayout(_sg_d3d11.ctx, NULL);
     ID3D11DeviceContext_VSSetShader(_sg_d3d11.ctx, NULL, NULL, 0);
     ID3D11DeviceContext_PSSetShader(_sg_d3d11.ctx, NULL, NULL, 0);
+	ID3D11DeviceContext_GSSetShader(_sg_d3d11.ctx, NULL, NULL, 0);
     ID3D11DeviceContext_VSSetConstantBuffers(_sg_d3d11.ctx, 0, SG_MAX_SHADERSTAGE_UBS, _sg_d3d11.zero_cbs);
     ID3D11DeviceContext_PSSetConstantBuffers(_sg_d3d11.ctx, 0, SG_MAX_SHADERSTAGE_UBS, _sg_d3d11.zero_cbs);
+	ID3D11DeviceContext_GSSetConstantBuffers(_sg_d3d11.ctx, 0, SG_MAX_SHADERSTAGE_UBS, _sg_d3d11.zero_cbs);
     ID3D11DeviceContext_VSSetShaderResources(_sg_d3d11.ctx, 0, SG_MAX_SHADERSTAGE_IMAGES, _sg_d3d11.zero_srvs);
     ID3D11DeviceContext_PSSetShaderResources(_sg_d3d11.ctx, 0, SG_MAX_SHADERSTAGE_IMAGES, _sg_d3d11.zero_srvs);
+	ID3D11DeviceContext_GSSetShaderResources(_sg_d3d11.ctx, 0, SG_MAX_SHADERSTAGE_IMAGES, _sg_d3d11.zero_srvs);
     ID3D11DeviceContext_VSSetSamplers(_sg_d3d11.ctx, 0, SG_MAX_SHADERSTAGE_IMAGES, _sg_d3d11.zero_smps);
     ID3D11DeviceContext_PSSetSamplers(_sg_d3d11.ctx, 0, SG_MAX_SHADERSTAGE_IMAGES, _sg_d3d11.zero_smps);
+	ID3D11DeviceContext_GSSetSamplers(_sg_d3d11.ctx, 0, SG_MAX_SHADERSTAGE_IMAGES, _sg_d3d11.zero_smps);
 }
 
 _SOKOL_PRIVATE void _sg_reset_state_cache() {
@@ -5502,6 +5506,11 @@ _SOKOL_PRIVATE void _sg_apply_draw_state(
     ID3D11DeviceContext_PSSetConstantBuffers(_sg_d3d11.ctx, 0, SG_MAX_SHADERSTAGE_UBS, pip->shader->stage[SG_SHADERSTAGE_FS].d3d11_cbs);
     ID3D11DeviceContext_PSSetShaderResources(_sg_d3d11.ctx, 0, SG_MAX_SHADERSTAGE_IMAGES, d3d11_fs_srvs);
     ID3D11DeviceContext_PSSetSamplers(_sg_d3d11.ctx, 0, SG_MAX_SHADERSTAGE_IMAGES, d3d11_fs_smps);
+
+	ID3D11DeviceContext_GSSetShader(_sg_d3d11.ctx, NULL, NULL, 0);
+	ID3D11DeviceContext_GSSetConstantBuffers(_sg_d3d11.ctx, 0, SG_MAX_SHADERSTAGE_UBS, _sg_d3d11.zero_cbs);
+	ID3D11DeviceContext_GSSetShaderResources(_sg_d3d11.ctx, 0, SG_MAX_SHADERSTAGE_IMAGES, _sg_d3d11.zero_srvs);
+	ID3D11DeviceContext_GSSetSamplers(_sg_d3d11.ctx, 0, SG_MAX_SHADERSTAGE_IMAGES, _sg_d3d11.zero_smps);
 }
 
 _SOKOL_PRIVATE void _sg_apply_uniform_block(sg_shader_stage stage_index, int ub_index, const void* data, int num_bytes) {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4074,13 +4074,19 @@ _SOKOL_PRIVATE void _sg_update_image(_sg_image* img, const sg_image_content* dat
 #include <windows.h>
 #include <d3d11.h>
 
+#if (defined(WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
+#pragma comment (lib, "WindowsApp.lib")
+#else
 #pragma comment (lib, "user32.lib")
 #pragma comment (lib, "dxgi.lib")
 #pragma comment (lib, "d3d11.lib")
 #pragma comment (lib, "dxguid.lib")
+#endif
 #if defined(SOKOL_D3D11_SHADER_COMPILER)
 #include <d3dcompiler.h>
+#if !(defined(WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
 #pragma comment (lib, "d3dcompiler.lib")
+#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Creating a separate PR since this is a bigger change and there may be reasons not to do this I don't understand.

Since Sokol doesn't seem to use geometry shaders, and to cope with cases where the app may be using native APIs as well, modifying d3d state change and reset code to explicitly unset geometry shaders and related resources.

This prevents valid pipelines from failing because some other call left a geometry shader set in the device.