### PR TITLE
Add SOKOL_API definition for public functions

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -9,7 +9,10 @@
 
     Optionally provide the following defines with your own implementations:
 
+    SOKOL_API           - public api function specifier (default: extern)
     SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
+    SOKOL_CALLOC(n, s)  - your own allocate and zero initialize array function (default: calloc(n,s))
+    SOKOL_FREE(p)       - your own free function (default: free(p))
     SOKOL_LOG(msg)      - your own logging function (default: puts(msg))
     SOKOL_UNREACHABLE() - a guard macro for unreachable code (default: assert(false))
     SOKOL_ABORT()       - called after an unrecoverable error (default: abort())
@@ -327,8 +330,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifdef __cplusplus
-extern "C" {
+#ifndef SOKOL_API
+    #ifdef __cplusplus
+        #define SOKOL_API extern "C"
+    #else
+        #define SOKOL_API
+    #endif
 #endif
 
 enum {
@@ -551,37 +558,33 @@ typedef struct {
 } sapp_desc;
 
 /* user-provided functions */
-extern sapp_desc sokol_main(int argc, char* argv[]);
+SOKOL_API sapp_desc sokol_main(int argc, char* argv[]);
 
 /* sokol_app API functions */
-extern bool sapp_isvalid(void);
-extern int sapp_width(void);
-extern int sapp_height(void);
-extern bool sapp_high_dpi(void);
-extern float sapp_dpi_scale(void);
-extern void sapp_show_keyboard(bool visible);
-extern bool sapp_keyboard_shown(void);
+SOKOL_API bool sapp_isvalid(void);
+SOKOL_API int sapp_width(void);
+SOKOL_API int sapp_height(void);
+SOKOL_API bool sapp_high_dpi(void);
+SOKOL_API float sapp_dpi_scale(void);
+SOKOL_API void sapp_show_keyboard(bool visible);
+SOKOL_API bool sapp_keyboard_shown(void);
 
 /* GL/GLES specific functions */
-extern bool sapp_gles2(void);
+SOKOL_API bool sapp_gles2(void);
 
 /* OSX/Metal specific functions */
-extern const void* sapp_metal_get_device(void);
-extern const void* sapp_metal_get_renderpass_descriptor(void);
-extern const void* sapp_metal_get_drawable(void); 
-extern const void* sapp_macos_get_window(void);
-extern const void* sapp_ios_get_window(void);
+SOKOL_API const void* sapp_metal_get_device(void);
+SOKOL_API const void* sapp_metal_get_renderpass_descriptor(void);
+SOKOL_API const void* sapp_metal_get_drawable(void); 
+SOKOL_API const void* sapp_macos_get_window(void);
+SOKOL_API const void* sapp_ios_get_window(void);
 
 /* Win32/D3D11 specific functions */
-extern const void* sapp_d3d11_get_device(void);
-extern const void* sapp_d3d11_get_device_context(void);
-extern const void* sapp_d3d11_get_render_target_view(void);
-extern const void* sapp_d3d11_get_depth_stencil_view(void);
-extern const void* sapp_win32_get_hwnd(void);
-
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+SOKOL_API const void* sapp_d3d11_get_device(void);
+SOKOL_API const void* sapp_d3d11_get_device_context(void);
+SOKOL_API const void* sapp_d3d11_get_render_target_view(void);
+SOKOL_API const void* sapp_d3d11_get_depth_stencil_view(void);
+SOKOL_API const void* sapp_win32_get_hwnd(void);
 
 /*-- IMPLEMENTATION ----------------------------------------------------------*/
 #ifdef SOKOL_IMPL
@@ -5660,31 +5663,31 @@ int main(int argc, char* argv[]) {
 #endif /* LINUX */
 
 /*== PUBLIC API FUNCTIONS ====================================================*/
-bool sapp_isvalid(void) {
+SOKOL_API bool sapp_isvalid(void) {
     return _sapp.valid;
 }
 
-int sapp_width(void) {
+SOKOL_API int sapp_width(void) {
     return (_sapp.framebuffer_width > 0) ? _sapp.framebuffer_width : 1;
 }
 
-int sapp_height(void) {
+SOKOL_API int sapp_height(void) {
     return (_sapp.framebuffer_height > 0) ? _sapp.framebuffer_height : 1;
 }
 
-bool sapp_high_dpi(void) {
+SOKOL_API bool sapp_high_dpi(void) {
     return _sapp.desc.high_dpi && (_sapp.dpi_scale > 1.5f);
 }
 
-float sapp_dpi_scale(void) {
+SOKOL_API float sapp_dpi_scale(void) {
     return _sapp.dpi_scale;
 }
 
-bool sapp_gles2(void) {
+SOKOL_API bool sapp_gles2(void) {
     return _sapp.gles2_fallback;
 }
 
-void sapp_show_keyboard(bool shown) {
+SOKOL_API void sapp_show_keyboard(bool shown) {
     #if TARGET_OS_IPHONE
     _sapp_ios_show_keyboard(shown);
     #elif __EMSCRIPTEN__
@@ -5694,11 +5697,11 @@ void sapp_show_keyboard(bool shown) {
     #endif
 }
 
-bool sapp_keyboard_shown(void) {
+SOKOL_API bool sapp_keyboard_shown(void) {
     return _sapp.onscreen_keyboard_shown;
 }
 
-const void* sapp_metal_get_device(void) {
+SOKOL_API const void* sapp_metal_get_device(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(SOKOL_METAL)
         const void* obj = (__bridge const void*) _sapp_mtl_device_obj;
@@ -5709,7 +5712,7 @@ const void* sapp_metal_get_device(void) {
     #endif
 }
 
-const void* sapp_metal_get_renderpass_descriptor(void) {
+SOKOL_API const void* sapp_metal_get_renderpass_descriptor(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(SOKOL_METAL)
         const void* obj =  (__bridge const void*) [_sapp_view_obj currentRenderPassDescriptor];
@@ -5720,7 +5723,7 @@ const void* sapp_metal_get_renderpass_descriptor(void) {
     #endif
 }
 
-const void* sapp_metal_get_drawable(void) {
+SOKOL_API const void* sapp_metal_get_drawable(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(SOKOL_METAL)
         const void* obj = (__bridge const void*) [_sapp_view_obj currentDrawable];
@@ -5731,7 +5734,7 @@ const void* sapp_metal_get_drawable(void) {
     #endif
 }
 
-const void* sapp_macos_get_window(void) {
+SOKOL_API const void* sapp_macos_get_window(void) {
     #if defined(__APPLE__) && !TARGET_OS_IPHONE
         const void* obj = (__bridge const void*) _sapp_macos_window_obj;
         SOKOL_ASSERT(obj);
@@ -5741,7 +5744,7 @@ const void* sapp_macos_get_window(void) {
     #endif
 }
 
-const void* sapp_ios_get_window(void) {
+SOKOL_API const void* sapp_ios_get_window(void) {
     #if defined(__APPLE__) && TARGET_OS_IPHONE
         const void* obj = (__bridge const void*) _sapp_ios_window_obj;
         SOKOL_ASSERT(obj);
@@ -5752,7 +5755,7 @@ const void* sapp_ios_get_window(void) {
 
 }
 
-const void* sapp_d3d11_get_device(void) {
+SOKOL_API const void* sapp_d3d11_get_device(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(SOKOL_D3D11)
         return _sapp_d3d11_device;
@@ -5761,7 +5764,7 @@ const void* sapp_d3d11_get_device(void) {
     #endif
 }
 
-const void* sapp_d3d11_get_device_context(void) {
+SOKOL_API const void* sapp_d3d11_get_device_context(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(SOKOL_D3D11)
         return _sapp_d3d11_device_context;
@@ -5770,7 +5773,7 @@ const void* sapp_d3d11_get_device_context(void) {
     #endif
 }
 
-const void* sapp_d3d11_get_render_target_view(void) {
+SOKOL_API const void* sapp_d3d11_get_render_target_view(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(SOKOL_D3D11)
         return _sapp_d3d11_rtv;
@@ -5779,7 +5782,7 @@ const void* sapp_d3d11_get_render_target_view(void) {
     #endif
 }
 
-const void* sapp_d3d11_get_depth_stencil_view(void) {
+SOKOL_API const void* sapp_d3d11_get_depth_stencil_view(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(SOKOL_D3D11)
         return _sapp_d3d11_dsv;
@@ -5788,7 +5791,7 @@ const void* sapp_d3d11_get_depth_stencil_view(void) {
     #endif
 }
 
-const void* sapp_win32_get_hwnd(void) {
+SOKOL_API const void* sapp_win32_get_hwnd(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(_WIN32)
         return _sapp_win32_hwnd;

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -10,6 +10,7 @@
     Optionally provide the following defines with your own implementations:
 
     SOKOL_AUDIO_NO_BACKEND  - use a dummy backend
+    SOKOL_API           - public api function specifier (default: extern)
     SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
     SOKOL_LOG(msg)      - your own logging function (default: puts(msg))
     SOKOL_MALLOC(s)     - your own malloc() implementation (default: malloc(s))
@@ -335,8 +336,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifdef __cplusplus
-extern "C" {
+#ifndef SOKOL_API
+    #ifdef __cplusplus
+        #define SOKOL_API extern "C"
+    #else
+        #define SOKOL_API
+    #endif
 #endif
 
 typedef struct {
@@ -349,25 +354,21 @@ typedef struct {
 } saudio_desc;
 
 /* setup sokol-audio */
-extern void saudio_setup(const saudio_desc* desc);
+SOKOL_API void saudio_setup(const saudio_desc* desc);
 /* shutdown sokol-audio */
-extern void saudio_shutdown(void);
+SOKOL_API void saudio_shutdown(void);
 /* true after setup if audio backend was successfully initialized */
-extern bool saudio_isvalid(void);
+SOKOL_API bool saudio_isvalid(void);
 /* actual sample rate */
-extern int saudio_sample_rate(void);
+SOKOL_API int saudio_sample_rate(void);
 /* actual backend buffer size */
-extern int saudio_buffer_size(void);
+SOKOL_API int saudio_buffer_size(void);
 /* actual number of channels */
-extern int saudio_channels(void);
+SOKOL_API int saudio_channels(void);
 /* get current number of frames to fill packet queue */
-extern int saudio_expect(void);
+SOKOL_API int saudio_expect(void);
 /* push sample frames from main thread, returns number of frames actually pushed */
-extern int saudio_push(const float* frames, int num_frames);
-
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+SOKOL_API int saudio_push(const float* frames, int num_frames);
 
 /*--- IMPLEMENTATION ---------------------------------------------------------*/
 #ifdef SOKOL_IMPL
@@ -1228,7 +1229,7 @@ _SOKOL_PRIVATE void _saudio_backend_shutdown(void) { };
 #endif
 
 /*=== PUBLIC API FUNCTIONS ===================================================*/
-void saudio_setup(const saudio_desc* desc) {
+SOKOL_API void saudio_setup(const saudio_desc* desc) {
     SOKOL_ASSERT(!_saudio.valid);
     SOKOL_ASSERT(desc);
     memset(&_saudio, 0, sizeof(_saudio));
@@ -1248,7 +1249,7 @@ void saudio_setup(const saudio_desc* desc) {
     }
 }
 
-void saudio_shutdown(void) {
+SOKOL_API void saudio_shutdown(void) {
     if (_saudio.valid) {
         _saudio_backend_shutdown();
         _saudio_fifo_shutdown(&_saudio.fifo);
@@ -1257,23 +1258,23 @@ void saudio_shutdown(void) {
     _saudio_mutex_destroy();
 }
 
-bool saudio_isvalid(void) {
+SOKOL_API bool saudio_isvalid(void) {
     return _saudio.valid;
 }
 
-int saudio_sample_rate(void) {
+SOKOL_API int saudio_sample_rate(void) {
     return _saudio.sample_rate;
 }
 
-int saudio_buffer_frames(void) {
+SOKOL_API int saudio_buffer_frames(void) {
     return _saudio.buffer_frames;
 }
 
-int saudio_channels(void) {
+SOKOL_API int saudio_channels(void) {
     return _saudio.num_channels;
 }
 
-int saudio_expect(void) {
+SOKOL_API int saudio_expect(void) {
     if (_saudio.valid) {
         const int num_frames = _saudio_fifo_writable_bytes(&_saudio.fifo) / _saudio.bytes_per_frame;
         return num_frames;
@@ -1283,7 +1284,7 @@ int saudio_expect(void) {
     }
 }
 
-int saudio_push(const float* frames, int num_frames) {
+SOKOL_API int saudio_push(const float* frames, int num_frames) {
     SOKOL_ASSERT(frames && (num_frames > 0));
     if (_saudio.valid) {
         const int num_bytes = num_frames * _saudio.bytes_per_frame;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -31,6 +31,7 @@
 
     Optionally provide the following defines with your own implementations:
 
+    SOKOL_API           - public api function specifier (default: extern)
     SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
     SOKOL_MALLOC(s)     - your own malloc function (default: malloc(s))
     SOKOL_FREE(p)       - your own free function (default: free(p))
@@ -312,8 +313,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifdef __cplusplus
-extern "C" {
+#ifndef SOKOL_API
+    #ifdef __cplusplus
+        #define SOKOL_API extern "C"
+    #else
+        #define SOKOL_API
+    #endif
 #endif
 
 #ifdef _MSC_VER
@@ -1477,71 +1482,68 @@ typedef struct {
 } sg_pass_desc;
 
 /* setup and misc functions */
-extern void sg_setup(const sg_desc* desc);
-extern void sg_shutdown(void);
-extern bool sg_isvalid(void);
-extern bool sg_query_feature(sg_feature feature);
-extern void sg_reset_state_cache(void);
+SOKOL_API void sg_setup(const sg_desc* desc);
+SOKOL_API void sg_shutdown(void);
+SOKOL_API bool sg_isvalid(void);
+SOKOL_API bool sg_query_feature(sg_feature feature);
+SOKOL_API void sg_reset_state_cache(void);
 
 /* resource creation, destruction and updating */
-extern sg_buffer sg_make_buffer(const sg_buffer_desc* desc);
-extern sg_image sg_make_image(const sg_image_desc* desc);
-extern sg_shader sg_make_shader(const sg_shader_desc* desc);
-extern sg_pipeline sg_make_pipeline(const sg_pipeline_desc* desc);
-extern sg_pass sg_make_pass(const sg_pass_desc* desc);
-extern void sg_destroy_buffer(sg_buffer buf);
-extern void sg_destroy_image(sg_image img);
-extern void sg_destroy_shader(sg_shader shd);
-extern void sg_destroy_pipeline(sg_pipeline pip);
-extern void sg_destroy_pass(sg_pass pass);
-extern void sg_update_buffer(sg_buffer buf, const void* data_ptr, int data_size);
-extern void sg_update_image(sg_image img, const sg_image_content* data);
+SOKOL_API sg_buffer sg_make_buffer(const sg_buffer_desc* desc);
+SOKOL_API sg_image sg_make_image(const sg_image_desc* desc);
+SOKOL_API sg_shader sg_make_shader(const sg_shader_desc* desc);
+SOKOL_API sg_pipeline sg_make_pipeline(const sg_pipeline_desc* desc);
+SOKOL_API sg_pass sg_make_pass(const sg_pass_desc* desc);
+SOKOL_API void sg_destroy_buffer(sg_buffer buf);
+SOKOL_API void sg_destroy_image(sg_image img);
+SOKOL_API void sg_destroy_shader(sg_shader shd);
+SOKOL_API void sg_destroy_pipeline(sg_pipeline pip);
+SOKOL_API void sg_destroy_pass(sg_pass pass);
+SOKOL_API void sg_update_buffer(sg_buffer buf, const void* data_ptr, int data_size);
+SOKOL_API void sg_update_image(sg_image img, const sg_image_content* data);
 
 /* get resource state (initial, alloc, valid, failed) */
-extern sg_resource_state sg_query_buffer_state(sg_buffer buf);
-extern sg_resource_state sg_query_image_state(sg_image img);
-extern sg_resource_state sg_query_shader_state(sg_shader shd);
-extern sg_resource_state sg_query_pipeline_state(sg_pipeline pip);
-extern sg_resource_state sg_query_pass_state(sg_pass pass);
+SOKOL_API sg_resource_state sg_query_buffer_state(sg_buffer buf);
+SOKOL_API sg_resource_state sg_query_image_state(sg_image img);
+SOKOL_API sg_resource_state sg_query_shader_state(sg_shader shd);
+SOKOL_API sg_resource_state sg_query_pipeline_state(sg_pipeline pip);
+SOKOL_API sg_resource_state sg_query_pass_state(sg_pass pass);
 
 /* rendering functions */
-extern void sg_begin_default_pass(const sg_pass_action* pass_action, int width, int height);
-extern void sg_begin_pass(sg_pass pass, const sg_pass_action* pass_action);
-extern void sg_apply_viewport(int x, int y, int width, int height, bool origin_top_left);
-extern void sg_apply_scissor_rect(int x, int y, int width, int height, bool origin_top_left);
-extern void sg_apply_draw_state(const sg_draw_state* ds);
-extern void sg_apply_uniform_block(sg_shader_stage stage, int ub_index, const void* data, int num_bytes);
-extern void sg_draw(int base_element, int num_elements, int num_instances);
-extern void sg_end_pass(void);
-extern void sg_commit(void);
+SOKOL_API void sg_begin_default_pass(const sg_pass_action* pass_action, int width, int height);
+SOKOL_API void sg_begin_pass(sg_pass pass, const sg_pass_action* pass_action);
+SOKOL_API void sg_apply_viewport(int x, int y, int width, int height, bool origin_top_left);
+SOKOL_API void sg_apply_scissor_rect(int x, int y, int width, int height, bool origin_top_left);
+SOKOL_API void sg_apply_draw_state(const sg_draw_state* ds);
+SOKOL_API void sg_apply_uniform_block(sg_shader_stage stage, int ub_index, const void* data, int num_bytes);
+SOKOL_API void sg_draw(int base_element, int num_elements, int num_instances);
+SOKOL_API void sg_end_pass(void);
+SOKOL_API void sg_commit(void);
 
 /* separate resource allocation and initialization (for async setup) */
-extern sg_buffer sg_alloc_buffer(void);
-extern sg_image sg_alloc_image(void);
-extern sg_shader sg_alloc_shader(void);
-extern sg_pipeline sg_alloc_pipeline(void);
-extern sg_pass sg_alloc_pass(void);
-extern void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc);
-extern void sg_init_image(sg_image img_id, const sg_image_desc* desc);
-extern void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc);
-extern void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc);
-extern void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc);
-extern void sg_fail_buffer(sg_buffer buf_id);
-extern void sg_fail_image(sg_image img_id);
-extern void sg_fail_shader(sg_shader shd_id);
-extern void sg_fail_pipeline(sg_pipeline pip_id);
-extern void sg_fail_pass(sg_pass pass_id);
+SOKOL_API sg_buffer sg_alloc_buffer(void);
+SOKOL_API sg_image sg_alloc_image(void);
+SOKOL_API sg_shader sg_alloc_shader(void);
+SOKOL_API sg_pipeline sg_alloc_pipeline(void);
+SOKOL_API sg_pass sg_alloc_pass(void);
+SOKOL_API void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc);
+SOKOL_API void sg_init_image(sg_image img_id, const sg_image_desc* desc);
+SOKOL_API void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc);
+SOKOL_API void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc);
+SOKOL_API void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc);
+SOKOL_API void sg_fail_buffer(sg_buffer buf_id);
+SOKOL_API void sg_fail_image(sg_image img_id);
+SOKOL_API void sg_fail_shader(sg_shader shd_id);
+SOKOL_API void sg_fail_pipeline(sg_pipeline pip_id);
+SOKOL_API void sg_fail_pass(sg_pass pass_id);
 
 /* rendering contexts (optional) */
-extern sg_context sg_setup_context(void);
-extern void sg_activate_context(sg_context ctx_id);
-extern void sg_discard_context(sg_context ctx_id);
+SOKOL_API sg_context sg_setup_context(void);
+SOKOL_API void sg_activate_context(sg_context ctx_id);
+SOKOL_API void sg_discard_context(sg_context ctx_id);
 
 #ifdef _MSC_VER
 #pragma warning(pop)
-#endif
-#ifdef __cplusplus
-} /* extern "C" */
 #endif
 
 /*--- IMPLEMENTATION ---------------------------------------------------------*/
@@ -8387,7 +8389,7 @@ _SOKOL_PRIVATE bool _sg_validate_update_image(const _sg_image* img, const sg_ima
 }
 
 /*== PUBLIC API FUNCTIONS ====================================================*/
-void sg_setup(const sg_desc* desc) {
+SOKOL_API void sg_setup(const sg_desc* desc) {
     SOKOL_ASSERT(desc);
     SOKOL_ASSERT((desc->_start_canary == 0) && (desc->_end_canary == 0));
     memset(&_sg, 0, sizeof(_sg));
@@ -8399,7 +8401,7 @@ void sg_setup(const sg_desc* desc) {
     _sg.valid = true;
 }
 
-void sg_shutdown(void) {
+SOKOL_API void sg_shutdown(void) {
     /* can only delete resources for the currently set context here, if multiple
     contexts are used, the app code must take care of properly releasing them
     (since only the app code can switch between 3D-API contexts)
@@ -8416,15 +8418,15 @@ void sg_shutdown(void) {
     _sg.valid = false;
 }
 
-bool sg_isvalid(void) {
+SOKOL_API bool sg_isvalid(void) {
     return _sg.valid;
 }
 
-bool sg_query_feature(sg_feature f) {
+SOKOL_API bool sg_query_feature(sg_feature f) {
     return _sg_query_feature(f);
 }
 
-sg_context sg_setup_context(void) {
+SOKOL_API sg_context sg_setup_context(void) {
     sg_context res;
     res.id = _sg_pool_alloc_id(&_sg.pools.context_pool);
     if (res.id != SG_INVALID_ID) {
@@ -8440,7 +8442,7 @@ sg_context sg_setup_context(void) {
     return res;
 }
 
-void sg_discard_context(sg_context ctx_id) {
+SOKOL_API void sg_discard_context(sg_context ctx_id) {
     _sg_destroy_all_resources(&_sg.pools, ctx_id.id);
     _sg_context* ctx = _sg_lookup_context(&_sg.pools, ctx_id.id);
     if (ctx) {
@@ -8451,7 +8453,7 @@ void sg_discard_context(sg_context ctx_id) {
     _sg_activate_context(0);
 }
 
-void sg_activate_context(sg_context ctx_id) {
+SOKOL_API void sg_activate_context(sg_context ctx_id) {
     _sg.active_context = ctx_id;
     _sg_context* ctx = _sg_lookup_context(&_sg.pools, ctx_id.id);
     /* NOTE: ctx can be 0 here if the context is no longer valid */
@@ -8459,7 +8461,7 @@ void sg_activate_context(sg_context ctx_id) {
 }
 
 /*-- allocate resource id ----------------------------------------------------*/
-sg_buffer sg_alloc_buffer(void) {
+SOKOL_API sg_buffer sg_alloc_buffer(void) {
     sg_buffer res;
     res.id = _sg_pool_alloc_id(&_sg.pools.buffer_pool);
     if (res.id != SG_INVALID_ID) {
@@ -8471,7 +8473,7 @@ sg_buffer sg_alloc_buffer(void) {
     return res;
 }
 
-sg_image sg_alloc_image(void) {
+SOKOL_API sg_image sg_alloc_image(void) {
     sg_image res;
     res.id = _sg_pool_alloc_id(&_sg.pools.image_pool);
     if (res.id != SG_INVALID_ID) {
@@ -8483,7 +8485,7 @@ sg_image sg_alloc_image(void) {
     return res;
 }
 
-sg_shader sg_alloc_shader(void) {
+SOKOL_API sg_shader sg_alloc_shader(void) {
     sg_shader res;
     res.id = _sg_pool_alloc_id(&_sg.pools.shader_pool);
     if (res.id != SG_INVALID_ID) {
@@ -8495,7 +8497,7 @@ sg_shader sg_alloc_shader(void) {
     return res;
 }
 
-sg_pipeline sg_alloc_pipeline(void) {
+SOKOL_API sg_pipeline sg_alloc_pipeline(void) {
     sg_pipeline res;
     res.id = _sg_pool_alloc_id(&_sg.pools.pipeline_pool);
     if (res.id != SG_INVALID_ID) {
@@ -8507,7 +8509,7 @@ sg_pipeline sg_alloc_pipeline(void) {
     return res;
 }
 
-sg_pass sg_alloc_pass(void) {
+SOKOL_API sg_pass sg_alloc_pass(void) {
     sg_pass res;
     res.id = _sg_pool_alloc_id(&_sg.pools.pass_pool);
     if (res.id != SG_INVALID_ID) {
@@ -8520,7 +8522,7 @@ sg_pass sg_alloc_pass(void) {
 }
 
 /*-- initialize an allocated resource ----------------------------------------*/
-void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc) {
+SOKOL_API void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc) {
     SOKOL_ASSERT(buf_id.id != SG_INVALID_ID && desc);
     _sg_buffer* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
     SOKOL_ASSERT(buf && buf->slot.state == SG_RESOURCESTATE_ALLOC);
@@ -8534,7 +8536,7 @@ void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc) {
     SOKOL_ASSERT((buf->slot.state == SG_RESOURCESTATE_VALID)||(buf->slot.state == SG_RESOURCESTATE_FAILED));
 }
 
-void sg_init_image(sg_image img_id, const sg_image_desc* desc) {
+SOKOL_API void sg_init_image(sg_image img_id, const sg_image_desc* desc) {
     SOKOL_ASSERT(img_id.id != SG_INVALID_ID && desc);
     _sg_image* img = _sg_lookup_image(&_sg.pools, img_id.id);
     SOKOL_ASSERT(img && img->slot.state == SG_RESOURCESTATE_ALLOC);
@@ -8548,7 +8550,7 @@ void sg_init_image(sg_image img_id, const sg_image_desc* desc) {
     SOKOL_ASSERT((img->slot.state == SG_RESOURCESTATE_VALID)||(img->slot.state == SG_RESOURCESTATE_FAILED));
 }
 
-void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc) {
+SOKOL_API void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc) {
     SOKOL_ASSERT(shd_id.id != SG_INVALID_ID && desc);
     _sg_shader* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
     SOKOL_ASSERT(shd && shd->slot.state == SG_RESOURCESTATE_ALLOC);
@@ -8562,7 +8564,7 @@ void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc) {
     SOKOL_ASSERT((shd->slot.state == SG_RESOURCESTATE_VALID)||(shd->slot.state == SG_RESOURCESTATE_FAILED));
 }
 
-void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc) {
+SOKOL_API void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc) {
     SOKOL_ASSERT(pip_id.id != SG_INVALID_ID && desc);
     _sg_pipeline* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
     SOKOL_ASSERT(pip && pip->slot.state == SG_RESOURCESTATE_ALLOC);
@@ -8578,7 +8580,7 @@ void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc) {
     SOKOL_ASSERT((pip->slot.state == SG_RESOURCESTATE_VALID)||(pip->slot.state == SG_RESOURCESTATE_FAILED));
 }
 
-void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc) {
+SOKOL_API void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc) {
     SOKOL_ASSERT(pass_id.id != SG_INVALID_ID && desc);
     _sg_pass* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
     SOKOL_ASSERT(pass && pass->slot.state == SG_RESOURCESTATE_ALLOC);
@@ -8612,35 +8614,35 @@ void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc) {
 }
 
 /*-- set allocated resource to failed state ----------------------------------*/
-void sg_fail_buffer(sg_buffer buf_id) {
+SOKOL_API void sg_fail_buffer(sg_buffer buf_id) {
     SOKOL_ASSERT(buf_id.id != SG_INVALID_ID);
     _sg_buffer* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
     SOKOL_ASSERT(buf && buf->slot.state == SG_RESOURCESTATE_ALLOC);
     buf->slot.state = SG_RESOURCESTATE_FAILED;
 }
 
-void sg_fail_image(sg_image img_id) {
+SOKOL_API void sg_fail_image(sg_image img_id) {
     SOKOL_ASSERT(img_id.id != SG_INVALID_ID);
     _sg_image* img = _sg_lookup_image(&_sg.pools, img_id.id);
     SOKOL_ASSERT(img && img->slot.state == SG_RESOURCESTATE_ALLOC);
     img->slot.state = SG_RESOURCESTATE_FAILED;
 }
 
-void sg_fail_shader(sg_shader shd_id) {
+SOKOL_API void sg_fail_shader(sg_shader shd_id) {
     SOKOL_ASSERT(shd_id.id != SG_INVALID_ID);
     _sg_shader* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
     SOKOL_ASSERT(shd && shd->slot.state == SG_RESOURCESTATE_ALLOC);
     shd->slot.state = SG_RESOURCESTATE_FAILED;
 }
 
-void sg_fail_pipeline(sg_pipeline pip_id) {
+SOKOL_API void sg_fail_pipeline(sg_pipeline pip_id) {
     SOKOL_ASSERT(pip_id.id != SG_INVALID_ID);
     _sg_pipeline* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
     SOKOL_ASSERT(pip && pip->slot.state == SG_RESOURCESTATE_ALLOC);
     pip->slot.state = SG_RESOURCESTATE_FAILED;
 }
 
-void sg_fail_pass(sg_pass pass_id) {
+SOKOL_API void sg_fail_pass(sg_pass pass_id) {
     SOKOL_ASSERT(pass_id.id != SG_INVALID_ID);
     _sg_pass* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
     SOKOL_ASSERT(pass && pass->slot.state == SG_RESOURCESTATE_ALLOC);
@@ -8648,7 +8650,7 @@ void sg_fail_pass(sg_pass pass_id) {
 }
 
 /*-- get resource state */
-sg_resource_state sg_query_buffer_state(sg_buffer buf_id) {
+SOKOL_API sg_resource_state sg_query_buffer_state(sg_buffer buf_id) {
     if (buf_id.id != SG_INVALID_ID) {
         _sg_buffer* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
         if (buf) {
@@ -8658,7 +8660,7 @@ sg_resource_state sg_query_buffer_state(sg_buffer buf_id) {
     return SG_RESOURCESTATE_INVALID;
 }
 
-sg_resource_state sg_query_image_state(sg_image img_id) {
+SOKOL_API sg_resource_state sg_query_image_state(sg_image img_id) {
     if (img_id.id != SG_INVALID_ID) {
         _sg_image* img = _sg_lookup_image(&_sg.pools, img_id.id);
         if (img) {
@@ -8668,7 +8670,7 @@ sg_resource_state sg_query_image_state(sg_image img_id) {
     return SG_RESOURCESTATE_INVALID;
 }
 
-sg_resource_state sg_query_shader_state(sg_shader shd_id) {
+SOKOL_API sg_resource_state sg_query_shader_state(sg_shader shd_id) {
     if (shd_id.id != SG_INVALID_ID) {
         _sg_shader* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
         if (shd) {
@@ -8678,7 +8680,7 @@ sg_resource_state sg_query_shader_state(sg_shader shd_id) {
     return SG_RESOURCESTATE_INVALID;
 }
 
-sg_resource_state sg_query_pipeline_state(sg_pipeline pip_id) {
+SOKOL_API sg_resource_state sg_query_pipeline_state(sg_pipeline pip_id) {
     if (pip_id.id != SG_INVALID_ID) {
         _sg_pipeline* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
         if (pip) {
@@ -8688,7 +8690,7 @@ sg_resource_state sg_query_pipeline_state(sg_pipeline pip_id) {
     return SG_RESOURCESTATE_INVALID;
 }
 
-sg_resource_state sg_query_pass_state(sg_pass pass_id) {
+SOKOL_API sg_resource_state sg_query_pass_state(sg_pass pass_id) {
     if (pass_id.id != SG_INVALID_ID) {
         _sg_pass* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
         if (pass) {
@@ -8699,7 +8701,7 @@ sg_resource_state sg_query_pass_state(sg_pass pass_id) {
 }
 
 /*-- allocate and initialize resource ----------------------------------------*/
-sg_buffer sg_make_buffer(const sg_buffer_desc* desc) {
+SOKOL_API sg_buffer sg_make_buffer(const sg_buffer_desc* desc) {
     SOKOL_ASSERT(desc);
     sg_buffer buf_id = sg_alloc_buffer();
     if (buf_id.id != SG_INVALID_ID) {
@@ -8711,7 +8713,7 @@ sg_buffer sg_make_buffer(const sg_buffer_desc* desc) {
     return buf_id;
 }
 
-sg_image sg_make_image(const sg_image_desc* desc) {
+SOKOL_API sg_image sg_make_image(const sg_image_desc* desc) {
     SOKOL_ASSERT(desc);
     sg_image img_id = sg_alloc_image();
     if (img_id.id != SG_INVALID_ID) {
@@ -8723,7 +8725,7 @@ sg_image sg_make_image(const sg_image_desc* desc) {
     return img_id;
 }
 
-sg_shader sg_make_shader(const sg_shader_desc* desc) {
+SOKOL_API sg_shader sg_make_shader(const sg_shader_desc* desc) {
     SOKOL_ASSERT(desc);
     sg_shader shd_id = sg_alloc_shader();
     if (shd_id.id != SG_INVALID_ID) {
@@ -8735,7 +8737,7 @@ sg_shader sg_make_shader(const sg_shader_desc* desc) {
     return shd_id;
 }
 
-sg_pipeline sg_make_pipeline(const sg_pipeline_desc* desc) {
+SOKOL_API sg_pipeline sg_make_pipeline(const sg_pipeline_desc* desc) {
     SOKOL_ASSERT(desc);
     sg_pipeline pip_id = sg_alloc_pipeline();
     if (pip_id.id != SG_INVALID_ID) {
@@ -8747,7 +8749,7 @@ sg_pipeline sg_make_pipeline(const sg_pipeline_desc* desc) {
     return pip_id;
 }
 
-sg_pass sg_make_pass(const sg_pass_desc* desc) {
+SOKOL_API sg_pass sg_make_pass(const sg_pass_desc* desc) {
     SOKOL_ASSERT(desc);
     sg_pass pass_id = sg_alloc_pass();
     if (pass_id.id != SG_INVALID_ID) {
@@ -8760,7 +8762,7 @@ sg_pass sg_make_pass(const sg_pass_desc* desc) {
 }
 
 /*-- destroy resource --------------------------------------------------------*/
-void sg_destroy_buffer(sg_buffer buf_id) {
+SOKOL_API void sg_destroy_buffer(sg_buffer buf_id) {
     _sg_buffer* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
     if (buf) {
         if (buf->slot.ctx_id == _sg.active_context.id) {
@@ -8773,7 +8775,7 @@ void sg_destroy_buffer(sg_buffer buf_id) {
     }
 }
 
-void sg_destroy_image(sg_image img_id) {
+SOKOL_API void sg_destroy_image(sg_image img_id) {
     _sg_image* img = _sg_lookup_image(&_sg.pools, img_id.id);
     if (img) {
         if (img->slot.ctx_id == _sg.active_context.id) {
@@ -8786,7 +8788,7 @@ void sg_destroy_image(sg_image img_id) {
     }
 }
 
-void sg_destroy_shader(sg_shader shd_id) {
+SOKOL_API void sg_destroy_shader(sg_shader shd_id) {
     _sg_shader* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
     if (shd) {
         if (shd->slot.ctx_id == _sg.active_context.id) {
@@ -8799,7 +8801,7 @@ void sg_destroy_shader(sg_shader shd_id) {
     }
 }
 
-void sg_destroy_pipeline(sg_pipeline pip_id) {
+SOKOL_API void sg_destroy_pipeline(sg_pipeline pip_id) {
     _sg_pipeline* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
     if (pip) {
         if (pip->slot.ctx_id == _sg.active_context.id) {
@@ -8812,7 +8814,7 @@ void sg_destroy_pipeline(sg_pipeline pip_id) {
     }
 }
 
-void sg_destroy_pass(sg_pass pass_id) {
+SOKOL_API void sg_destroy_pass(sg_pass pass_id) {
     _sg_pass* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
     if (pass) {
         if (pass->slot.ctx_id == _sg.active_context.id) {
@@ -8825,7 +8827,7 @@ void sg_destroy_pass(sg_pass pass_id) {
     }
 }
 
-void sg_begin_default_pass(const sg_pass_action* pass_action, int width, int height) {
+SOKOL_API void sg_begin_default_pass(const sg_pass_action* pass_action, int width, int height) {
     SOKOL_ASSERT(pass_action);
     SOKOL_ASSERT((pass_action->_start_canary == 0) && (pass_action->_end_canary == 0));
     sg_pass_action pa;
@@ -8835,7 +8837,7 @@ void sg_begin_default_pass(const sg_pass_action* pass_action, int width, int hei
     _sg_begin_pass(0, &pa, width, height);
 }
 
-void sg_begin_pass(sg_pass pass_id, const sg_pass_action* pass_action) {
+SOKOL_API void sg_begin_pass(sg_pass pass_id, const sg_pass_action* pass_action) {
     SOKOL_ASSERT(pass_action);
     SOKOL_ASSERT((pass_action->_start_canary == 0) && (pass_action->_end_canary == 0));
     _sg.cur_pass = pass_id;
@@ -8853,21 +8855,21 @@ void sg_begin_pass(sg_pass pass_id, const sg_pass_action* pass_action) {
     }
 }
 
-void sg_apply_viewport(int x, int y, int width, int height, bool origin_top_left) {
+SOKOL_API void sg_apply_viewport(int x, int y, int width, int height, bool origin_top_left) {
     if (!_sg.pass_valid) {
         return;
     }
     _sg_apply_viewport(x, y, width, height, origin_top_left);
 }
 
-void sg_apply_scissor_rect(int x, int y, int width, int height, bool origin_top_left) {
+SOKOL_API void sg_apply_scissor_rect(int x, int y, int width, int height, bool origin_top_left) {
     if (!_sg.pass_valid) {
         return;
     }
     _sg_apply_scissor_rect(x, y, width, height, origin_top_left);
 }
 
-void sg_apply_draw_state(const sg_draw_state* ds) {
+SOKOL_API void sg_apply_draw_state(const sg_draw_state* ds) {
     SOKOL_ASSERT(ds);
     SOKOL_ASSERT((ds->_start_canary==0) && (ds->_end_canary==0));
     if (!_sg_validate_draw_state(ds)) {
@@ -8941,7 +8943,7 @@ void sg_apply_draw_state(const sg_draw_state* ds) {
     }
 }
 
-void sg_apply_uniform_block(sg_shader_stage stage, int ub_index, const void* data, int num_bytes) {
+SOKOL_API void sg_apply_uniform_block(sg_shader_stage stage, int ub_index, const void* data, int num_bytes) {
     SOKOL_ASSERT((stage == SG_SHADERSTAGE_VS) || (stage == SG_SHADERSTAGE_FS));
     SOKOL_ASSERT((ub_index >= 0) && (ub_index < SG_MAX_SHADERSTAGE_UBS));
     SOKOL_ASSERT(data && (num_bytes > 0));
@@ -8955,14 +8957,14 @@ void sg_apply_uniform_block(sg_shader_stage stage, int ub_index, const void* dat
     _sg_apply_uniform_block(stage, ub_index, data, num_bytes);
 }
 
-void sg_draw(int base_element, int num_elements, int num_instances) {
+SOKOL_API void sg_draw(int base_element, int num_elements, int num_instances) {
     if (!(_sg.pass_valid && _sg.next_draw_valid)) {
         return;
     }
     _sg_draw(base_element, num_elements, num_instances);
 }
 
-void sg_end_pass(void) {
+SOKOL_API void sg_end_pass(void) {
     if (!_sg.pass_valid) {
         return;
     }
@@ -8972,16 +8974,16 @@ void sg_end_pass(void) {
     _sg.pass_valid = false;
 }
 
-void sg_commit() {
+SOKOL_API void sg_commit() {
     _sg_commit();
     _sg.frame_index++;
 }
 
-void sg_reset_state_cache(void) {
+SOKOL_API void sg_reset_state_cache(void) {
     _sg_reset_state_cache();
 }
 
-void sg_update_buffer(sg_buffer buf_id, const void* data, int num_bytes) {
+SOKOL_API void sg_update_buffer(sg_buffer buf_id, const void* data, int num_bytes) {
     if (num_bytes == 0) {
         return;
     }
@@ -8996,7 +8998,7 @@ void sg_update_buffer(sg_buffer buf_id, const void* data, int num_bytes) {
     }
 }
 
-void sg_update_image(sg_image img_id, const sg_image_content* data) {
+SOKOL_API void sg_update_image(sg_image img_id, const sg_image_content* data) {
     _sg_image* img = _sg_lookup_image(&_sg.pools, img_id.id);
     if (!(img && img->slot.state == SG_RESOURCESTATE_VALID)) {
         return;

--- a/sokol_time.h
+++ b/sokol_time.h
@@ -8,6 +8,7 @@
     implementation.
 
     Optionally provide the following defines with your own implementations:
+    SOKOL_API           - public api function specifier (default: extern)
     SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
 
     void stm_setup();
@@ -79,23 +80,23 @@
 */
 #include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
+#ifndef SOKOL_API
+    #ifdef __cplusplus
+        #define SOKOL_API extern "C"
+    #else
+        #define SOKOL_API
+    #endif
 #endif
 
-extern void stm_setup(void);
-extern uint64_t stm_now(void);
-extern uint64_t stm_diff(uint64_t new_ticks, uint64_t old_ticks);
-extern uint64_t stm_since(uint64_t start_ticks);
-extern uint64_t stm_laptime(uint64_t* last_time);
-extern double stm_sec(uint64_t ticks);
-extern double stm_ms(uint64_t ticks);
-extern double stm_us(uint64_t ticks);
-extern double stm_ns(uint64_t ticks);
-
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+SOKOL_API void stm_setup(void);
+SOKOL_API uint64_t stm_now(void);
+SOKOL_API uint64_t stm_diff(uint64_t new_ticks, uint64_t old_ticks);
+SOKOL_API uint64_t stm_since(uint64_t start_ticks);
+SOKOL_API uint64_t stm_laptime(uint64_t* last_time);
+SOKOL_API double stm_sec(uint64_t ticks);
+SOKOL_API double stm_ms(uint64_t ticks);
+SOKOL_API double stm_us(uint64_t ticks);
+SOKOL_API double stm_ns(uint64_t ticks);
 
 /*-- IMPLEMENTATION ----------------------------------------------------------*/
 #ifdef SOKOL_IMPL
@@ -133,7 +134,7 @@ static int64_t int64_muldiv(int64_t value, int64_t numer, int64_t denom) {
 #endif
 
 
-void stm_setup(void) {
+SOKOL_API void stm_setup(void) {
     SOKOL_ASSERT(0 == _stm_initialized);
     _stm_initialized = 1;
     #if defined(_WIN32)
@@ -149,7 +150,7 @@ void stm_setup(void) {
     #endif
 }
 
-uint64_t stm_now(void) {
+SOKOL_API uint64_t stm_now(void) {
     SOKOL_ASSERT(_stm_initialized);
     uint64_t now;
     #if defined(_WIN32)
@@ -167,7 +168,7 @@ uint64_t stm_now(void) {
     return now;
 }
 
-uint64_t stm_diff(uint64_t new_ticks, uint64_t old_ticks) {
+SOKOL_API uint64_t stm_diff(uint64_t new_ticks, uint64_t old_ticks) {
     if (new_ticks > old_ticks) {
         return new_ticks - old_ticks;
     }
@@ -177,11 +178,11 @@ uint64_t stm_diff(uint64_t new_ticks, uint64_t old_ticks) {
     }
 }
 
-uint64_t stm_since(uint64_t start_ticks) {
+SOKOL_API uint64_t stm_since(uint64_t start_ticks) {
     return stm_diff(stm_now(), start_ticks);
 }
 
-uint64_t stm_laptime(uint64_t* last_time) {
+SOKOL_API uint64_t stm_laptime(uint64_t* last_time) {
     SOKOL_ASSERT(last_time);
     uint64_t dt = 0;
     uint64_t now = stm_now();
@@ -192,19 +193,19 @@ uint64_t stm_laptime(uint64_t* last_time) {
     return dt;
 }
 
-double stm_sec(uint64_t ticks) {
+SOKOL_API double stm_sec(uint64_t ticks) {
     return (double)ticks / 1000000000.0;
 }
 
-double stm_ms(uint64_t ticks) {
+SOKOL_API double stm_ms(uint64_t ticks) {
     return (double)ticks / 1000000.0;
 }
 
-double stm_us(uint64_t ticks) {
+SOKOL_API double stm_us(uint64_t ticks) {
     return (double)ticks / 1000.0;
 }
 
-double stm_ns(uint64_t ticks) {
+SOKOL_API double stm_ns(uint64_t ticks) {
     return (double)ticks;
 }
 #endif /* SOKOL_IMPL */


### PR DESCRIPTION
decided to do a pull request to improve sokol APIs
Added SOKOL_API to all public functions that is overriable, instead of "extern", so the user can override public function specifiers. For example, one can ```#define SOKOL_API static``` to make functions private for wrappers/internal systems, or ```#define SOKOL_API __declspec(dllexport)``` to export them from dll ...

Also, a while back we were discussing a bug on sokol_app and d3d11 + cpp compiler, and you removed extern block from implementation .. I guess this brings linker _symbol not found_ when sokol headers are implemented inside cpp unit. So I put the new SOKOL_API before every function implementation too.
