### PR TITLE
Added names to public structs so they can be forward delcared

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sokol
 
-**Sokol (Сокол)**: Russian for Falcon, a smaller and more nimble 
+**Sokol (Сокол)**: Russian for Falcon, a smaller and more nimble
 bird of prey than the Eagle (Орёл, Oryol)
 
 Minimalistic header-only cross-platform libs in C:
@@ -11,7 +11,7 @@ Minimalistic header-only cross-platform libs in C:
 - **sokol\_audio.h**: minimal buffer-streaming audio playback
 - **sokol\_args.h**: unified cmdline/URL arg parser for web and native apps
 
-These are (mainly) the internal parts of the Oryol C++ framework 
+These are (mainly) the internal parts of the Oryol C++ framework
 rewritten in pure C as standalone header-only libs.
 
 WebAssembly is a 'first-class citizen', one important motivation for the
@@ -82,16 +82,16 @@ int main() {
         // positions            // colors
          0.0f,  0.5f, 0.5f,     1.0f, 0.0f, 0.0f, 1.0f,
          0.5f, -0.5f, 0.5f,     0.0f, 1.0f, 0.0f, 1.0f,
-        -0.5f, -0.5f, 0.5f,     0.0f, 0.0f, 1.0f, 1.0f 
+        -0.5f, -0.5f, 0.5f,     0.0f, 0.0f, 1.0f, 1.0f
     };
     sg_buffer vbuf = sg_make_buffer(&(sg_buffer_desc){
         .size = sizeof(vertices),
-        .content = vertices, 
+        .content = vertices,
     });
 
     /* a shader */
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
-        .vs.source = 
+        .vs.source =
             "#version 330\n"
             "in vec4 position;\n"
             "in vec4 color0;\n"
@@ -367,7 +367,7 @@ Emulators](https://floooh.github.io/tiny8bit/) for more interesting usage exampl
 
 # Updates
 
-- **29-Oct-2018**: 
+- **29-Oct-2018**:
     - sokol_gfx.h has a new function **sg_append_buffer()** which allows to
     append new data to a buffer multiple times per frame and interleave this
     with draw calls. This basically implements the
@@ -375,7 +375,7 @@ Emulators](https://floooh.github.io/tiny8bit/) for more interesting usage exampl
     example usage, see the updated Dear ImGui samples in the [sokol_samples
     repo](https://github.com/floooh/sokol-samples)
     - the GL state cache in sokol_gfx.h handles buffers bindings in a
-    more robust way, previously it might have happened that the 
+    more robust way, previously it might have happened that the
     buffer binding gets confused when creating buffers or updating
     buffer contents in the render loop
 
@@ -397,7 +397,7 @@ header documentation, and the new sample [multiwindow-glfw](https://github.com/f
 
 - **31-Jan-2018**: The vertex layout declaration in sg\_pipeline\_desc had
 some fairly subtle flaws and has been changed to work like Metal or Vulkan.
-The gist is that the vertex-buffer-layout properties (vertex stride, 
+The gist is that the vertex-buffer-layout properties (vertex stride,
 vertex-step-rate and -step-function for instancing) is now defined in a
 separate array from the vertex attributes. This removes some brittle backend
 code which tries to guess the right vertex attribute slot if no attribute
@@ -411,18 +411,18 @@ Oryol Gfx module over to sokol-gfx). Some code samples:
 sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
     .layout = {
         .buffers = {
-            [0] = { 
+            [0] = {
                 .stride = 20,
                 .step_func = SG_VERTEXSTEP_PER_VERTEX,
-                .step_rate = 1 
+                .step_rate = 1
             }
         },
         .attrs = {
-            [0] = { 
-                .name = "pos", 
-                .offset = 0, 
+            [0] = {
+                .name = "pos",
+                .offset = 0,
                 .format = SG_VERTEXFORMAT_FLOAT3,
-                .buffer_index = 0 
+                .buffer_index = 0
             },
             [1] = {
                 .name = "uv",
@@ -439,16 +439,16 @@ sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
 sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
     .layout = {
         .buffers = {
-            [0] = { 
+            [0] = {
                 .step_func = SG_VERTEXSTEP_PER_VERTEX,
                 .step_rate=1
             }
         },
         .attrs = {
-            [0] = { 
-                .name = "pos", 
+            [0] = {
+                .name = "pos",
                 .format = SG_VERTEXFORMAT_FLOAT3,
-                .buffer_index = 0 
+                .buffer_index = 0
             },
             [1] = {
                 .name = "uv",

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -343,7 +343,7 @@ enum {
     SAPP_MAX_KEYCODES = 512,
 };
 
-typedef enum {
+typedef enum sapp_event_type {
     SAPP_EVENTTYPE_INVALID,
     SAPP_EVENTTYPE_KEY_DOWN,
     SAPP_EVENTTYPE_KEY_UP,
@@ -369,7 +369,7 @@ typedef enum {
 } sapp_event_type;
 
 /* key codes are the same names and values as GLFW */
-typedef enum {
+typedef enum sapp_keycode {
     SAPP_KEYCODE_INVALID          = 0,
     SAPP_KEYCODE_SPACE            = 32,
     SAPP_KEYCODE_APOSTROPHE       = 39,  /* ' */
@@ -493,14 +493,14 @@ typedef enum {
     SAPP_KEYCODE_MENU             = 348,
 } sapp_keycode;
 
-typedef struct {
+typedef struct sapp_touchpoint {
     uintptr_t identifier;
     float pos_x;
     float pos_y;
     bool changed;
 } sapp_touchpoint;
 
-typedef enum {
+typedef enum sapp_mousebutton {
     SAPP_MOUSEBUTTON_INVALID = -1,
     SAPP_MOUSEBUTTON_LEFT = 0,
     SAPP_MOUSEBUTTON_RIGHT = 1,
@@ -514,7 +514,7 @@ enum {
     SAPP_MODIFIER_SUPER = (1<<3)
 };
 
-typedef struct {
+typedef struct sapp_event {
     sapp_event_type type;
     uint32_t frame_count;
     sapp_keycode key_code;
@@ -533,7 +533,7 @@ typedef struct {
     int framebuffer_height;
 } sapp_event;
 
-typedef struct {
+typedef struct sapp_desc {
     void (*init_cb)(void);
     void (*frame_cb)(void);
     void (*cleanup_cb)(void);

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4,7 +4,7 @@
 
     Do this:
         #define SOKOL_IMPL
-    before you include this file in *one* C or C++ file to create the 
+    before you include this file in *one* C or C++ file to create the
     implementation.
 
     Optionally provide the following defines with your own implementations:
@@ -29,7 +29,7 @@
 
     If you use sokol_app.h together with sokol_gfx.h, include both headers
     in the implementation source file, and include sokol_app.h before
-    sokol_gfx.h since sokol_app.h will also include the required 3D-API 
+    sokol_gfx.h since sokol_app.h will also include the required 3D-API
     headers.
 
     On Windows, a minimal 'GL header' and function loader is integrated which
@@ -107,7 +107,7 @@
     ============
     --- Add a sokol_main() to your code which returns a sapp_desc structure
         with initialization parameters and callback function pointers. This
-        function is called very early, usually at the start of the 
+        function is called very early, usually at the start of the
         platform's entry function (e.g. main or WinMain). You should do as
         little as possible here, since the rest of your code might be called
         from another thread (this depends on the platform):
@@ -129,7 +129,7 @@
         below.
 
         DO NOT call any sokol-app function from inside sokol_main(), since
-        sokol-app will not be initialized at this point. 
+        sokol-app will not be initialized at this point.
 
         The .width and .height parameters are the preferred size of the 3D
         rendering canvas. The actual size may differ from this depending on
@@ -156,7 +156,7 @@
             future may also be used to communicate other types of events
             to the application. Keep the event_cb struct member zero-initialized
             if your application doesn't require event handling.
-                      
+
     --- Implement the initialization callback function, this is called once
         after the rendering surface, 3D API and swap chain have been
         initialized by sokol_app. All sokol-app functions can be called
@@ -168,7 +168,7 @@
             from one frame to the next.
         int sapp_height(void)
             Likewise, returns the current height of the default framebuffer.
-        
+
         bool sapp_gles2(void)
             Returns true if as GLES2 or WebGL2 context had been created (for
             instance because GLES3/WebGL2 isn't available on the device)
@@ -196,7 +196,7 @@
         const void* sapp_d3d11_get_render_target_view(void);
         const void* sapp_d3d11_get_depth_stencil_view(void);
             Similar to the sapp_metal_* functions, the sapp_d3d11_* functions
-            return pointers to D3D11 API objects required for rendering, 
+            return pointers to D3D11 API objects required for rendering,
             only if the D3D11 backend has been selected. Otherwise they
             return a null pointer. Note that the returned pointers to the
             render-target-view and depth-stencil-view may change from one
@@ -268,7 +268,7 @@
     FULLSCREEN
     ==========
     If the sapp_desc.fullscreen flag is true, sokol-app will try to create
-    a fullscreen window on platforms with a 'proper' window system 
+    a fullscreen window on platforms with a 'proper' window system
     (mobile devices will always use fullscreen). The implementation details
     depend on the target platform, in general sokol-app will use a
     'soft approach' which doesn't interfere too much with the platform's
@@ -553,7 +553,7 @@ typedef struct {
     bool html5_canvas_resize;
     bool ios_keyboard_resizes_canvas;
     /* use GLES2 even if GLES3 is available */
-    bool gl_force_gles2; 
+    bool gl_force_gles2;
     /* if true, user is expected to manage cursor image and visibility on SAPP_EVENTTYPE_UPDATE_CURSOR */
     bool user_cursor;
 } sapp_desc;
@@ -576,7 +576,7 @@ SOKOL_API_DECL bool sapp_gles2(void);
 /* OSX/Metal specific functions */
 SOKOL_API_DECL const void* sapp_metal_get_device(void);
 SOKOL_API_DECL const void* sapp_metal_get_renderpass_descriptor(void);
-SOKOL_API_DECL const void* sapp_metal_get_drawable(void); 
+SOKOL_API_DECL const void* sapp_metal_get_drawable(void);
 SOKOL_API_DECL const void* sapp_macos_get_window(void);
 SOKOL_API_DECL const void* sapp_ios_get_window(void);
 
@@ -662,7 +662,7 @@ SOKOL_API_DECL const void* sapp_win32_get_hwnd(void);
     #define SOKOL_FREE(p) free(p)
 #endif
 #ifndef SOKOL_LOG
-    #ifdef SOKOL_DEBUG 
+    #ifdef SOKOL_DEBUG
         #include <stdio.h>
         #define SOKOL_LOG(s) { SOKOL_ASSERT(s); puts(s); }
     #else
@@ -1215,8 +1215,8 @@ _SOKOL_PRIVATE void _sapp_macos_app_event(sapp_event_type type) {
     }
 }
 - (void)keyUp:(NSEvent*)event {
-    _sapp_macos_key_event(SAPP_EVENTTYPE_KEY_UP, 
-        _sapp_translate_key(event.keyCode), 
+    _sapp_macos_key_event(SAPP_EVENTTYPE_KEY_UP,
+        _sapp_translate_key(event.keyCode),
         _sapp_macos_mod(event.modifierFlags));
 }
 - (void)flagsChanged:(NSEvent*)event {
@@ -1619,7 +1619,7 @@ _SOKOL_PRIVATE void _sapp_ios_touch_event(sapp_event_type type, NSSet<UITouch *>
 #if defined(SOKOL_GLES3)
 #include <GLES3/gl3.h>
 #else
-#ifndef GL_EXT_PROTOTYPES 
+#ifndef GL_EXT_PROTOTYPES
 #define GL_GLEXT_PROTOTYPES
 #endif
 #include <GLES2/gl2.h>
@@ -1872,7 +1872,7 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_key_cb(int emsc_type, const EmscriptenKeyboard
                 break;
             default:
                 type = SAPP_EVENTTYPE_INVALID;
-                break; 
+                break;
         }
         if (type != SAPP_EVENTTYPE_INVALID) {
             _sapp_init_event(type);
@@ -3716,7 +3716,7 @@ _SOKOL_PRIVATE void _sapp_win32_create_window(void) {
         rect.bottom = GetSystemMetrics(SM_CYSCREEN);
     }
     else {
-        win_style = WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_SIZEBOX; 
+        win_style = WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_SIZEBOX;
         rect.right = (int) (_sapp.window_width * _sapp_win32_window_scale);
         rect.bottom = (int) (_sapp.window_height * _sapp_win32_window_scale);
     }
@@ -3824,7 +3824,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     _sapp_win32_utf8_to_wide(_sapp.window_title, _sapp.window_title_wide, sizeof(_sapp.window_title_wide));
     _sapp_win32_init_dpi();
     _sapp_win32_create_window();
-    #if defined(SOKOL_D3D11) 
+    #if defined(SOKOL_D3D11)
         _sapp_d3d11_create_device_and_swapchain();
         _sapp_d3d11_create_default_render_target();
     #endif
@@ -3870,7 +3870,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     _sapp_win32_destroy_window();
     return 0;
 }
- 
+
 #undef _SAPP_SAFE_RELEASE
 #endif /* WINDOWS */
 
@@ -4006,19 +4006,19 @@ static const struct _sapp_x11_codepair {
   uint16_t keysym;
   uint16_t ucs;
 } _sapp_x11_keysymtab[] = {
-  { 0x01a1, 0x0104 }, 
-  { 0x01a2, 0x02d8 }, 
-  { 0x01a3, 0x0141 }, 
-  { 0x01a5, 0x013d }, 
-  { 0x01a6, 0x015a }, 
+  { 0x01a1, 0x0104 },
+  { 0x01a2, 0x02d8 },
+  { 0x01a3, 0x0141 },
+  { 0x01a5, 0x013d },
+  { 0x01a6, 0x015a },
   { 0x01a9, 0x0160 },
-  { 0x01aa, 0x015e }, 
-  { 0x01ab, 0x0164 }, 
-  { 0x01ac, 0x0179 }, 
-  { 0x01ae, 0x017d }, 
-  { 0x01af, 0x017b }, 
+  { 0x01aa, 0x015e },
+  { 0x01ab, 0x0164 },
+  { 0x01ac, 0x0179 },
+  { 0x01ae, 0x017d },
+  { 0x01af, 0x017b },
   { 0x01b1, 0x0105 },
-  { 0x01b2, 0x02db }, 
+  { 0x01b2, 0x02db },
   { 0x01b3, 0x0142 },
   { 0x01b5, 0x013e },
   { 0x01b6, 0x015b },
@@ -5536,7 +5536,7 @@ _SOKOL_PRIVATE int32_t _sapp_x11_keysym_to_unicode(KeySym keysym) {
 
 _SOKOL_PRIVATE void _sapp_x11_process_event(XEvent* event) {
     switch (event->type) {
-        case KeyPress: 
+        case KeyPress:
             {
                 const sapp_keycode key = _sapp_x11_translate_key(event->xkey.keycode);
                 const uint32_t mods = _sapp_x11_mod(event->xkey.state);
@@ -5551,7 +5551,7 @@ _SOKOL_PRIVATE void _sapp_x11_process_event(XEvent* event) {
                 }
             }
             break;
-        case KeyRelease: 
+        case KeyRelease:
             {
                 const sapp_keycode key = _sapp_x11_translate_key(event->xkey.keycode);
                 if (key != SAPP_KEYCODE_INVALID) {
@@ -5587,7 +5587,7 @@ _SOKOL_PRIVATE void _sapp_x11_process_event(XEvent* event) {
             }
             break;
         case EnterNotify:
-            _sapp_x11_mouse_event(SAPP_EVENTTYPE_MOUSE_ENTER, SAPP_MOUSEBUTTON_INVALID, _sapp_x11_mod(event->xcrossing.state)); 
+            _sapp_x11_mouse_event(SAPP_EVENTTYPE_MOUSE_ENTER, SAPP_MOUSEBUTTON_INVALID, _sapp_x11_mod(event->xcrossing.state));
             break;
         case LeaveNotify:
             _sapp_x11_mouse_event(SAPP_EVENTTYPE_MOUSE_LEAVE, SAPP_MOUSEBUTTON_INVALID, _sapp_x11_mod(event->xcrossing.state));
@@ -5650,7 +5650,7 @@ int main(int argc, char* argv[]) {
     _sapp_x11_screen = DefaultScreen(_sapp_x11_display);
     _sapp_x11_root = DefaultRootWindow(_sapp_x11_display);
     _sapp_x11_query_system_dpi();
-    _sapp.dpi_scale = _sapp_x11_dpi / 96.0f; 
+    _sapp.dpi_scale = _sapp_x11_dpi / 96.0f;
     _sapp_x11_init_extensions();
     _sapp_glx_init();
     Visual* visual = 0;

--- a/sokol_args.h
+++ b/sokol_args.h
@@ -4,7 +4,7 @@
 
     Do this:
         #define SOKOL_IMPL
-    before you include this file in *one* C or C++ file to create the 
+    before you include this file in *one* C or C++ file to create the
     implementation.
 
     Optionally provide the following defines with your own implementations:
@@ -31,7 +31,7 @@
 
     ARGUMENT FORMATTING
     ===================
-    On the web platform, arguments must be formatted as a valid URL query string 
+    On the web platform, arguments must be formatted as a valid URL query string
     with 'percent encoding' used for special characters.
 
     Strings are expected to be UTF-8 encoded (although sokol_args.h doesn't
@@ -47,7 +47,7 @@
 
     Key/value pairs are separated by 'whitespace', valid whitespace
     characters are space and tab.
-    
+
     Whitespace characters in front and after the separating '=' character
     are ignored:
 
@@ -59,7 +59,7 @@
 
     The 'key' string must be a simple string without escape sequences or whitespace.
 
-    Currently 'single keys' without values are not allowed, but may be 
+    Currently 'single keys' without values are not allowed, but may be
     in the future.
 
     The 'value' string can be quoted, and quoted value strings can contain
@@ -82,7 +82,7 @@
         \r  - carriage return
         \t  - tab
         \\  - escaped backslash
-    
+
     (more escape codes may be added in the future).
 
     CODE EXAMPLE
@@ -155,7 +155,7 @@
             char** argv     - the main function's argv parameter
             int max_args    - max number of key/value pairs, default is 16
             int buf_size    - size of the internal string buffer, default is 16384
-        
+
         Note that on the web, argc and argv will be ignored and the arguments
         will be taken from the page URL instead.
 
@@ -309,7 +309,7 @@ SOKOL_API_DECL const char* sargs_value_at(int index);
     #define SOKOL_FREE(p) free(p)
 #endif
 #ifndef SOKOL_LOG
-    #ifdef SOKOL_DEBUG 
+    #ifdef SOKOL_DEBUG
         #include <stdio.h>
         #define SOKOL_LOG(s) { SOKOL_ASSERT(s); puts(s); }
     #else
@@ -355,7 +355,7 @@ typedef struct {
     int buf_pos;        /* current buffer position */
     char* buf;          /* character buffer, first char is reserved and zero for 'empty string' */
     bool valid;
-    
+
     /* arg parsing isn't needed on emscripten */
     #if !defined(__EMSCRIPTEN__)
     uint32_t parse_state;
@@ -550,7 +550,7 @@ _SOKOL_PRIVATE bool _sargs_parse_carg(const char* src) {
         }
         else if (_sargs_parsing_val()) {
             if (_sargs_in_quotes()) {
-                /* when in quotes, whitespace is a normal character 
+                /* when in quotes, whitespace is a normal character
                    and a matching quote ends the value string
                 */
                 if (_sargs_is_quote(c)) {

--- a/sokol_args.h
+++ b/sokol_args.h
@@ -243,7 +243,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct sargs_desc {
     int argc;
     char** argv;
     int max_args;

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -345,7 +345,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct saudio_desc {
     int sample_rate;        /* requested sample rate */
     int num_channels;       /* number of channels, default: 1 (mono) */
     int buffer_frames;      /* number of frames in streaming buffer */

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -4,7 +4,7 @@
 
     Do this:
         #define SOKOL_IMPL
-    before you include this file in *one* C or C++ file to create the 
+    before you include this file in *one* C or C++ file to create the
     implementation.
 
     Optionally provide the following defines with your own implementations:
@@ -43,8 +43,8 @@
 
     The callback model is preferred because it is the most direct way to
     feed sample data into the audio backends and also has less moving parts
-    (there is no ring buffer between your code and the audio backend). 
-    
+    (there is no ring buffer between your code and the audio backend).
+
     Sometimes it is not possible to generate the audio stream directly in a
     callback function running in a separate thread, for such cases Sokol Audio
     provides the push-model as a convenience.
@@ -72,7 +72,7 @@
         a separate thread, on WebAudio, this is called per-frame in the
         browser thread.
 
-    - channel: 
+    - channel:
         A discrete track of audio data, currently 1-channel (mono) and
         2-channel (stereo) is supported and tested.
 
@@ -204,7 +204,7 @@
     calling saudio_setup().
 
     To provide sample data with the push model, call the saudio_push()
-    function at regular intervals (for instance once per frame). You can 
+    function at regular intervals (for instance once per frame). You can
     call the saudio_expect() function to ask Sokol Audio how much room is
     in the ring buffer, but if you provide a continuous stream of data
     at the right sample rate, saudio_expect() isn't required (it's a simple
@@ -213,7 +213,7 @@
 
     With saudio_push() you may need to maintain your own intermediate sample
     buffer, since pushing individual sample values isn't very efficient.
-    The following example is from the MOD player sample in 
+    The following example is from the MOD player sample in
     sokol-samples (https://github.com/floooh/sokol-samples):
 
         const int num_frames = saudio_expect();
@@ -257,7 +257,7 @@
 
     The WebAudio backend is automatically selected when compiling for
     emscripten (__EMSCRIPTEN__ define exists).
-    
+
     https://developers.google.com/web/updates/2017/12/audio-worklet
     https://developers.google.com/web/updates/2018/06/audio-worklet-design-pattern
 
@@ -402,7 +402,7 @@ SOKOL_API_DECL int saudio_push(const float* frames, int num_frames);
     #define SOKOL_FREE(p) free(p)
 #endif
 #ifndef SOKOL_LOG
-    #ifdef SOKOL_DEBUG 
+    #ifdef SOKOL_DEBUG
         #include <stdio.h>
         #define SOKOL_LOG(s) { SOKOL_ASSERT(s); puts(s); }
     #else
@@ -745,7 +745,7 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
 
     /* init or modify actual playback parameters */
     _saudio.bytes_per_frame = fmt.mBytesPerFrame;
-    
+
     /* ...and start playback */
     res = AudioQueueStart(_saudio_ca_audio_queue, NULL);
     SOKOL_ASSERT(0 == res);
@@ -913,7 +913,7 @@ typedef struct {
 } _saudio_wasapi_state;
 static _saudio_wasapi_state _saudio_wasapi;
 
-/* fill intermediate buffer with new data and reset buffer_pos */ 
+/* fill intermediate buffer with new data and reset buffer_pos */
 _SOKOL_PRIVATE void _saudio_wasapi_fill_buffer(void) {
     if (_saudio.stream_cb) {
         _saudio.stream_cb(_saudio_wasapi.thread.src_buffer, _saudio_wasapi.thread.src_buffer_frames, _saudio.num_channels);
@@ -1011,25 +1011,25 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
         SOKOL_LOG("sokol_audio wasapi: failed to create buffer_end_event");
         goto error;
     }
-    if (FAILED(CoCreateInstance(&_saudio_CLSID_IMMDeviceEnumerator, 
-        0, CLSCTX_ALL, 
-        &_saudio_IID_IMMDeviceEnumerator, 
-        (void**)&_saudio_wasapi.device_enumerator))) 
+    if (FAILED(CoCreateInstance(&_saudio_CLSID_IMMDeviceEnumerator,
+        0, CLSCTX_ALL,
+        &_saudio_IID_IMMDeviceEnumerator,
+        (void**)&_saudio_wasapi.device_enumerator)))
     {
         SOKOL_LOG("sokol_audio wasapi: failed to create device enumerator");
         goto error;
     }
     if (FAILED(IMMDeviceEnumerator_GetDefaultAudioEndpoint(_saudio_wasapi.device_enumerator,
-        eRender, eConsole, 
-        &_saudio_wasapi.device))) 
+        eRender, eConsole,
+        &_saudio_wasapi.device)))
     {
         SOKOL_LOG("sokol_audio wasapi: GetDefaultAudioEndPoint failed");
         goto error;
-    } 
+    }
     if (FAILED(IMMDevice_Activate(_saudio_wasapi.device,
         &_saudio_IID_IAudioClient,
         CLSCTX_ALL, 0,
-        (void**)&_saudio_wasapi.audio_client))) 
+        (void**)&_saudio_wasapi.audio_client)))
     {
         SOKOL_LOG("sokol_audio wasapi: device activate failed");
         goto error;
@@ -1056,7 +1056,7 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
         SOKOL_LOG("sokol_audio wasapi: audio client get buffer size failed");
         goto error;
     }
-    if (FAILED(IAudioClient_GetService(_saudio_wasapi.audio_client, 
+    if (FAILED(IAudioClient_GetService(_saudio_wasapi.audio_client,
         &_saudio_IID_IAudioRenderClient,
         (void**)&_saudio_wasapi.render_client)))
     {
@@ -1067,7 +1067,7 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
         SOKOL_LOG("sokol_audio wasapi: audio client SetEventHandle failed");
         goto error;
     }
-    _saudio_wasapi.si16_bytes_per_frame = _saudio.num_channels * sizeof(int16_t); 
+    _saudio_wasapi.si16_bytes_per_frame = _saudio.num_channels * sizeof(int16_t);
     _saudio.bytes_per_frame = _saudio.num_channels * sizeof(float);
     _saudio_wasapi.thread.src_buffer_frames = _saudio.buffer_frames;
     _saudio_wasapi.thread.src_buffer_byte_size = _saudio_wasapi.thread.src_buffer_frames * _saudio.bytes_per_frame;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -399,12 +399,12 @@ extern "C" {
     The resource ids are wrapped into a struct so that the compiler
     can complain when the wrong resource type is used.
 */
-typedef struct { uint32_t id; } sg_buffer;
-typedef struct { uint32_t id; } sg_image;
-typedef struct { uint32_t id; } sg_shader;
-typedef struct { uint32_t id; } sg_pipeline;
-typedef struct { uint32_t id; } sg_pass;
-typedef struct { uint32_t id; } sg_context;
+typedef struct sg_buffer   { uint32_t id; } sg_buffer;
+typedef struct sg_image    { uint32_t id; } sg_image;
+typedef struct sg_shader   { uint32_t id; } sg_shader;
+typedef struct sg_pipeline { uint32_t id; } sg_pipeline;
+typedef struct sg_pass     { uint32_t id; } sg_pass;
+typedef struct sg_context  { uint32_t id; } sg_context;
 
 /*
     various compile-time constants
@@ -432,7 +432,7 @@ enum {
     These are optional features, use the function
     sg_query_feature() to check whether the feature is supported.
 */
-typedef enum {
+typedef enum sg_feature {
     SG_FEATURE_INSTANCING,
     SG_FEATURE_TEXTURE_COMPRESSION_DXT,
     SG_FEATURE_TEXTURE_COMPRESSION_PVRTC,
@@ -469,7 +469,7 @@ typedef enum {
     The special INVALID state is returned in sg_query_xxx_state() if no
     resource object exists for the provided resource id.
 */
-typedef enum {
+typedef enum sg_resource_state {
     SG_RESOURCESTATE_INITIAL,
     SG_RESOURCESTATE_ALLOC,
     SG_RESOURCESTATE_VALID,
@@ -510,7 +510,7 @@ typedef enum {
 
     The default usage is SG_USAGE_IMMUTABLE.
 */
-typedef enum {
+typedef enum sg_usage {
     _SG_USAGE_DEFAULT,      /* value 0 reserved for default-init */
     SG_USAGE_IMMUTABLE,
     SG_USAGE_DYNAMIC,
@@ -527,7 +527,7 @@ typedef enum {
 
     The default value is SG_BUFFERTYPE_VERTEXBUFFER.
 */
-typedef enum {
+typedef enum sg_buffer_type {
     _SG_BUFFERTYPE_DEFAULT,         /* value 0 reserved for default-init */
     SG_BUFFERTYPE_VERTEXBUFFER,
     SG_BUFFERTYPE_INDEXBUFFER,
@@ -545,7 +545,7 @@ typedef enum {
 
     The default index type is SG_INDEXTYPE_NONE.
 */
-typedef enum {
+typedef enum sg_index_type {
     _SG_INDEXTYPE_DEFAULT,   /* value 0 reserved for default-init */
     SG_INDEXTYPE_NONE,
     SG_INDEXTYPE_UINT16,
@@ -564,7 +564,7 @@ typedef enum {
 
     The default image type when creating an image is SG_IMAGETYPE_2D.
 */
-typedef enum {
+typedef enum sg_image_type {
     _SG_IMAGETYPE_DEFAULT,  /* value 0 reserved for default-init */
     SG_IMAGETYPE_2D,
     SG_IMAGETYPE_CUBE,
@@ -580,7 +580,7 @@ typedef enum {
     The cubemap faces. Use these as indices in the sg_image_desc.content
     array.
 */
-typedef enum {
+typedef enum sg_cube_face {
     SG_CUBEFACE_POS_X,
     SG_CUBEFACE_NEG_X,
     SG_CUBEFACE_POS_Y,
@@ -602,7 +602,7 @@ typedef enum {
     - SG_MAX_SHADERSTAGE_IMAGES slots for images used as textures by
       the shader function
 */
-typedef enum {
+typedef enum sg_shader_stage {
     SG_SHADERSTAGE_VS,
     SG_SHADERSTAGE_FS,
     _SG_SHADERSTAGE_FORCE_U32 = 0x7FFFFFFF
@@ -617,7 +617,7 @@ typedef enum {
 
     The default pixel format when creating an image is SG_PIXELFORMAT_RGBA8.
 */
-typedef enum {
+typedef enum sg_pixel_format {
     _SG_PIXELFORMAT_DEFAULT,    /* value 0 reserved for default-init */
     SG_PIXELFORMAT_NONE,
     SG_PIXELFORMAT_RGBA8,
@@ -655,7 +655,7 @@ typedef enum {
 
     The default primitive type is SG_PRIMITIVETYPE_TRIANGLES.
 */
-typedef enum {
+typedef enum sg_primitive_type {
     _SG_PRIMITIVETYPE_DEFAULT,  /* value 0 reserved for default-init */
     SG_PRIMITIVETYPE_POINTS,
     SG_PRIMITIVETYPE_LINES,
@@ -675,7 +675,7 @@ typedef enum {
 
     The default filter mode is SG_FILTER_NEAREST.
 */
-typedef enum {
+typedef enum sg_filter {
     _SG_FILTER_DEFAULT, /* value 0 reserved for default-init */
     SG_FILTER_NEAREST,
     SG_FILTER_LINEAR,
@@ -696,7 +696,7 @@ typedef enum {
 
     The default wrap mode is SG_WRAP_REPEAT.
 */
-typedef enum {
+typedef enum sg_wrap {
     _SG_WRAP_DEFAULT,   /* value 0 reserved for default-init */
     SG_WRAP_REPEAT,
     SG_WRAP_CLAMP_TO_EDGE,
@@ -711,7 +711,7 @@ typedef enum {
     The data type of a vertex component. This is used to describe
     the layout of vertex data when creating a pipeline object.
 */
-typedef enum {
+typedef enum sg_vertex_format {
     SG_VERTEXFORMAT_INVALID,
     SG_VERTEXFORMAT_FLOAT,
     SG_VERTEXFORMAT_FLOAT2,
@@ -741,7 +741,7 @@ typedef enum {
     The vertex-step is part of the vertex-layout definition
     when creating pipeline objects.
 */
-typedef enum {
+typedef enum sg_vertex_step {
     _SG_VERTEXSTEP_DEFAULT,     /* value 0 reserved for default-init */
     SG_VERTEXSTEP_PER_VERTEX,
     SG_VERTEXSTEP_PER_INSTANCE,
@@ -756,7 +756,7 @@ typedef enum {
     describe the internal layout of uniform blocks when creating
     a shader object.
 */
-typedef enum {
+typedef enum sg_uniform_type {
     SG_UNIFORMTYPE_INVALID,
     SG_UNIFORMTYPE_FLOAT,
     SG_UNIFORMTYPE_FLOAT2,
@@ -776,7 +776,7 @@ typedef enum {
 
     The default cull mode is SG_CULLMODE_NONE
 */
-typedef enum {
+typedef enum sg_cull_mode {
     _SG_CULLMODE_DEFAULT,   /* value 0 reserved for default-init */
     SG_CULLMODE_NONE,
     SG_CULLMODE_FRONT,
@@ -794,7 +794,7 @@ typedef enum {
 
     The default winding is SG_FACEWINDING_CW (clockwise)
 */
-typedef enum {
+typedef enum sg_face_winding {
     _SG_FACEWINDING_DEFAULT,    /* value 0 reserved for default-init */
     SG_FACEWINDING_CCW,
     SG_FACEWINDING_CW,
@@ -817,7 +817,7 @@ typedef enum {
     The default compare func for depth- and stencil-tests is
     SG_COMPAREFUNC_ALWAYS.
 */
-typedef enum {
+typedef enum sg_compare_func {
     _SG_COMPAREFUNC_DEFAULT,    /* value 0 reserved for default-init */
     SG_COMPAREFUNC_NEVER,
     SG_COMPAREFUNC_LESS,
@@ -851,7 +851,7 @@ typedef enum {
 
     The default value is SG_STENCILOP_KEEP.
 */
-typedef enum {
+typedef enum sg_stencil_op {
     _SG_STENCILOP_DEFAULT,      /* value 0 reserved for default-init */
     SG_STENCILOP_KEEP,
     SG_STENCILOP_ZERO,
@@ -881,7 +881,7 @@ typedef enum {
     The default value is SG_BLENDFACTOR_ONE for source
     factors, and SG_BLENDFACTOR_ZERO for destination factors.
 */
-typedef enum {
+typedef enum sg_blend_factor {
     _SG_BLENDFACTOR_DEFAULT,    /* value 0 reserved for default-init */
     SG_BLENDFACTOR_ZERO,
     SG_BLENDFACTOR_ONE,
@@ -916,7 +916,7 @@ typedef enum {
 
     The default value is SG_BLENDOP_ADD.
 */
-typedef enum {
+typedef enum sg_blend_op {
     _SG_BLENDOP_DEFAULT,    /* value 0 reserved for default-init */
     SG_BLENDOP_ADD,
     SG_BLENDOP_SUBTRACT,
@@ -934,7 +934,7 @@ typedef enum {
 
     The default colormask is SG_COLORMASK_RGBA (write all colors channels)
 */
-typedef enum {
+typedef enum sg_color_mask {
     _SG_COLORMASK_DEFAULT = 0,      /* value 0 reserved for default-init */
     SG_COLORMASK_NONE = (0x10),     /* special value for 'all channels disabled */
     SG_COLORMASK_R = (1<<0),
@@ -964,7 +964,7 @@ typedef enum {
     only set the clear color, but the 'action' field as well (as long as this
     is in its _SG_ACTION_DEFAULT, the value fields will be ignored).
 */
-typedef enum {
+typedef enum sg_action {
     _SG_ACTION_DEFAULT,
     SG_ACTION_CLEAR,
     SG_ACTION_LOAD,
@@ -992,22 +992,22 @@ typedef enum {
     - SG_DEFAULT_CLEAR_DEPTH:   1.0f
     - SG_DEFAULT_CLEAR_STENCIL: 0
 */
-typedef struct {
+typedef struct sg_color_attachment_action {
     sg_action action;
     float val[4];
 } sg_color_attachment_action;
 
-typedef struct {
+typedef struct sg_depth_attachment_action {
     sg_action action;
     float val;
 } sg_depth_attachment_action;
 
-typedef struct {
+typedef struct sg_stencil_attachment_action {
     sg_action action;
     uint8_t val;
 } sg_stencil_attachment_action;
 
-typedef struct {
+typedef struct sg_pass_action {
     uint32_t _start_canary;
     sg_color_attachment_action colors[SG_MAX_COLOR_ATTACHMENTS];
     sg_depth_attachment_action depth;
@@ -1039,7 +1039,7 @@ typedef struct {
     The optional buffer offsets can be used to group different chunks
     of vertex- and/or index-data into the same buffer objects.
 */
-typedef struct {
+typedef struct sg_draw_state {
     uint32_t _start_canary;
     sg_pipeline pipeline;
     sg_buffer vertex_buffers[SG_MAX_SHADERSTAGE_BUFFERS];
@@ -1116,7 +1116,7 @@ typedef struct {
         this function will be called in sg_begin_pass() when rendering
         to the default framebuffer
 */
-typedef struct {
+typedef struct sg_desc {
     uint32_t _start_canary;
     int buffer_pool_size;
     int image_pool_size;
@@ -1180,7 +1180,7 @@ typedef struct {
     Also you need to call sg_reset_state_cache() after calling native 3D-API
     functions, and before calling any sokol_gfx function.
 */
-typedef struct {
+typedef struct sg_buffer_desc {
     uint32_t _start_canary;
     int size;
     sg_buffer_type type;
@@ -1207,7 +1207,7 @@ typedef struct {
     3D-slices of the mipmap level. It is only possible to update
     an entire mipmap level, not parts of it.
 */
-typedef struct {
+typedef struct sg_subimage_content {
     const void* ptr;    /* pointer to subimage data */
     int size;           /* size in bytes of pointed-to subimage data */
 } sg_subimage_content;
@@ -1220,7 +1220,7 @@ typedef struct {
     is the cubemap face, and the second array dimension the
     mipmap level.
 */
-typedef struct {
+typedef struct sg_image_content {
     sg_subimage_content subimage[SG_CUBEFACE_NUM][SG_MAX_MIPMAPS];
 } sg_image_content;
 
@@ -1272,7 +1272,7 @@ typedef struct {
     The same rules apply as for injecting native buffers
     (see sg_buffer_desc documentation for more details).
 */
-typedef struct {
+typedef struct sg_image_desc {
     uint32_t _start_canary;
     sg_image_type type;
     bool render_target;
@@ -1312,23 +1312,23 @@ typedef struct {
 
     TODO: source code vs byte code, 3D backend API specifics.
 */
-typedef struct {
+typedef struct sg_shader_uniform_desc {
     const char* name;
     sg_uniform_type type;
     int array_count;
 } sg_shader_uniform_desc;
 
-typedef struct {
+typedef struct sg_shader_uniform_block_desc {
     int size;
     sg_shader_uniform_desc uniforms[SG_MAX_UB_MEMBERS];
 } sg_shader_uniform_block_desc;
 
-typedef struct {
+typedef struct sg_shader_image_desc {
     const char* name;
     sg_image_type type;
 } sg_shader_image_desc;
 
-typedef struct {
+typedef struct sg_shader_stage_desc {
     const char* source;
     const uint8_t* byte_code;
     int byte_code_size;
@@ -1337,7 +1337,7 @@ typedef struct {
     sg_shader_image_desc images[SG_MAX_SHADERSTAGE_IMAGES];
 } sg_shader_stage_desc;
 
-typedef struct {
+typedef struct sg_shader_desc {
     uint32_t _start_canary;
     sg_shader_stage_desc vs;
     sg_shader_stage_desc fs;
@@ -1417,13 +1417,13 @@ typedef struct {
         .depth_bias_slope_scale:        0.0f
         .depth_bias_clamp:              0.0f
 */
-typedef struct {
+typedef struct sg_buffer_layout_desc {
     int stride;
     sg_vertex_step step_func;
     int step_rate;
 } sg_buffer_layout_desc;
 
-typedef struct {
+typedef struct sg_vertex_attr_desc {
     const char* name;
     const char* sem_name;
     int sem_index;
@@ -1432,19 +1432,19 @@ typedef struct {
     sg_vertex_format format;
 } sg_vertex_attr_desc;
 
-typedef struct {
+typedef struct sg_layout_desc {
     sg_buffer_layout_desc buffers[SG_MAX_SHADERSTAGE_BUFFERS];
     sg_vertex_attr_desc attrs[SG_MAX_VERTEX_ATTRIBUTES];
 } sg_layout_desc;
 
-typedef struct {
+typedef struct sg_stencil_state {
     sg_stencil_op fail_op;
     sg_stencil_op depth_fail_op;
     sg_stencil_op pass_op;
     sg_compare_func compare_func;
 } sg_stencil_state;
 
-typedef struct {
+typedef struct sg_depth_stencil_state {
     sg_stencil_state stencil_front;
     sg_stencil_state stencil_back;
     sg_compare_func depth_compare_func;
@@ -1455,7 +1455,7 @@ typedef struct {
     uint8_t stencil_ref;
 } sg_depth_stencil_state;
 
-typedef struct {
+typedef struct sg_blend_state {
     bool enabled;
     sg_blend_factor src_factor_rgb;
     sg_blend_factor dst_factor_rgb;
@@ -1470,7 +1470,7 @@ typedef struct {
     float blend_color[4];
 } sg_blend_state;
 
-typedef struct {
+typedef struct sg_rasterizer_state {
     bool alpha_to_coverage_enabled;
     sg_cull_mode cull_mode;
     sg_face_winding face_winding;
@@ -1480,7 +1480,7 @@ typedef struct {
     float depth_bias_clamp;
 } sg_rasterizer_state;
 
-typedef struct {
+typedef struct sg_pipeline_desc {
     uint32_t _start_canary;
     sg_layout_desc layout;
     sg_shader shader;
@@ -1515,7 +1515,7 @@ typedef struct {
     In addition, all color-attachment images must have the same
     pixel format.
 */
-typedef struct {
+typedef struct sg_attachment_desc {
     sg_image image;
     int mip_level;
     union {
@@ -1525,7 +1525,7 @@ typedef struct {
     };
 } sg_attachment_desc;
 
-typedef struct {
+typedef struct sg_pass_desc {
     uint32_t _start_canary;
     sg_attachment_desc color_attachments[SG_MAX_COLOR_ATTACHMENTS];
     sg_attachment_desc depth_stencil_attachment;

--- a/sokol_time.h
+++ b/sokol_time.h
@@ -4,7 +4,7 @@
 
     Do this:
         #define SOKOL_IMPL
-    before you include this file in *one* C or C++ file to create the 
+    before you include this file in *one* C or C++ file to create the
     implementation.
 
     Optionally provide the following defines with your own implementations:
@@ -55,7 +55,7 @@
     MacOS/iOS:      mach_absolute_time()
     emscripten:     clock_gettime(CLOCK_MONOTONIC)
     Linux+others:   clock_gettime(CLOCK_MONITONIC)
-    
+
     zlib/libpng license
 
     Copyright (c) 2018 Andre Weissflog
@@ -162,7 +162,7 @@ SOKOL_API_IMPL void stm_setup(void) {
     #else
         struct timespec ts;
         clock_gettime(CLOCK_MONOTONIC, &ts);
-        _stm_posix_start = (uint64_t)ts.tv_sec*1000000000 + (uint64_t)ts.tv_nsec; 
+        _stm_posix_start = (uint64_t)ts.tv_sec*1000000000 + (uint64_t)ts.tv_nsec;
     #endif
 }
 


### PR DESCRIPTION
Currently there is no way of using these structs in headers without also including the relevant `sokol_` headers. By giving the public structs and enums names, this is now possible