### PR TITLE
sokol_gfx.h: merge backend structs

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2262,7 +2262,9 @@ enum {
     _SG_MTL_INVALID_SLOT_INDEX = 0
 };
 
-/* Metal object-id pool */
+/* Metal object-id pool, NOTE that there's also a NSMutableArray* in the 
+    _sg_objc_t struct which can't be part of the POD C structs
+*/
 typedef struct {
     uint32_t frame_index;   /* frame index at which it is safe to release this resource */
     uint32_t slot_index;
@@ -2444,6 +2446,7 @@ typedef struct {
     id<MTLRenderCommandEncoder> cmd_encoder;
     dispatch_semaphore_t sem;
 } _sg_objc_t;
+
 static _sg_objc_t _sg_objc;
 
 #endif /* SOKOL_METAL */

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2115,7 +2115,7 @@ typedef struct {
 #elif defined(SOKOL_D3D11)
 
 typedef struct {
-    _sg_slot slot;
+    _sg_slot_t slot;
     int size;
     int append_pos;
     bool append_overflow;
@@ -2127,7 +2127,7 @@ typedef struct {
 } _sg_buffer_t;
 
 typedef struct {
-    _sg_slot slot;
+    _sg_slot_t slot;
     sg_image_type type;
     bool render_target;
     int width;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -1835,7 +1835,7 @@ typedef struct {
     uint32_t id;
     uint32_t ctx_id;
     sg_resource_state state;
-} _sg_slot;
+} _sg_slot_t;
 
 /* constants */
 enum {
@@ -1861,7 +1861,7 @@ enum {
 /*=== DUMMY BACKEND DECLARATIONS =============================================*/
 #if defined(SOKOL_DUMMY_BACKEND)
 typedef struct {
-    _sg_slot slot;
+    _sg_slot_t slot;
     int size;
     int append_pos;
     bool append_overflow;
@@ -1871,10 +1871,10 @@ typedef struct {
     uint32_t append_frame_index;
     int num_slots;
     int active_slot;
-} _sg_buffer;
+} _sg_buffer_t;
 
 typedef struct {
-    _sg_slot slot;
+    _sg_slot_t slot;
     sg_image_type type;
     bool render_target;
     int width;
@@ -1893,31 +1893,31 @@ typedef struct {
     uint32_t upd_frame_index;
     int num_slots;
     int active_slot;
-} _sg_image;
+} _sg_image_t;
 
 typedef struct {
     int size;
-} _sg_uniform_block;
+} _sg_uniform_block_t;
 
 typedef struct {
     sg_image_type type;
-} _sg_shader_image;
+} _sg_shader_image_t;
 
 typedef struct {
     int num_uniform_blocks;
     int num_images;
-    _sg_uniform_block uniform_blocks[SG_MAX_SHADERSTAGE_UBS];
-    _sg_shader_image images[SG_MAX_SHADERSTAGE_IMAGES];
-} _sg_shader_stage;
+    _sg_uniform_block_t uniform_blocks[SG_MAX_SHADERSTAGE_UBS];
+    _sg_shader_image_t images[SG_MAX_SHADERSTAGE_IMAGES];
+} _sg_shader_stage_t;
 
 typedef struct {
-    _sg_slot slot;
-    _sg_shader_stage stage[SG_NUM_SHADER_STAGES];
-} _sg_shader;
+    _sg_slot_t slot;
+    _sg_shader_stage_t stage[SG_NUM_SHADER_STAGES];
+} _sg_shader_t;
 
 typedef struct {
-    _sg_slot slot;
-    _sg_shader* shader;
+    _sg_slot_t slot;
+    _sg_shader_t* shader;
     sg_shader shader_id;
     bool vertex_layout_valid[SG_MAX_SHADERSTAGE_BUFFERS];
     int color_attachment_count;
@@ -1929,30 +1929,30 @@ typedef struct {
     float depth_bias_clamp;
     sg_index_type index_type;
     float blend_color[4];
-} _sg_pipeline;
+} _sg_pipeline_t;
 
 typedef struct {
-    _sg_image* image;
+    _sg_image_t* image;
     sg_image image_id;
     int mip_level;
     int slice;
-} _sg_attachment;
+} _sg_attachment_t;
 
 typedef struct {
-    _sg_slot slot;
+    _sg_slot_t slot;
     int num_color_atts;
-    _sg_attachment color_atts[SG_MAX_COLOR_ATTACHMENTS];
-    _sg_attachment ds_att;
-} _sg_pass;
+    _sg_attachment_t color_atts[SG_MAX_COLOR_ATTACHMENTS];
+    _sg_attachment_t ds_att;
+} _sg_pass_t;
 
 typedef struct {
-    _sg_slot slot;
-} _sg_context;
+    _sg_slot_t slot;
+} _sg_context_t;
 
 /*== GL BACKEND DECLARATIONS =================================================*/
 #elif defined(SOKOL_GLCORE33) || defined(SOKOL_GLES2) || defined(SOKOL_GLES3)
 typedef struct {
-    _sg_slot slot;
+    _sg_slot_t slot;
     int size;
     int append_pos;
     bool append_overflow;
@@ -1964,10 +1964,10 @@ typedef struct {
     int active_slot;
     GLuint gl_buf[SG_NUM_INFLIGHT_FRAMES];
     bool ext_buffers;   /* if true, external buffers were injected with sg_buffer_desc.gl_buffers */
-} _sg_buffer;
+} _sg_buffer_t;
 
 typedef struct {
-    _sg_slot slot;
+    _sg_slot_t slot;
     sg_image_type type;
     bool render_target;
     int width;
@@ -1991,39 +1991,39 @@ typedef struct {
     int active_slot;
     GLuint gl_tex[SG_NUM_INFLIGHT_FRAMES];
     bool ext_textures;  /* if true, external textures were injected with sg_image_desc.gl_textures */
-} _sg_image;
+} _sg_image_t;
 
 typedef struct {
     GLint gl_loc;
     sg_uniform_type type;
     uint8_t count;
     uint16_t offset;
-} _sg_uniform;
+} _sg_uniform_t;
 
 typedef struct {
     int size;
     int num_uniforms;
-    _sg_uniform uniforms[SG_MAX_UB_MEMBERS];
-} _sg_uniform_block;
+    _sg_uniform_t uniforms[SG_MAX_UB_MEMBERS];
+} _sg_uniform_block_t;
 
 typedef struct {
     sg_image_type type;
     GLint gl_loc;
     int gl_tex_slot;
-} _sg_shader_image;
+} _sg_shader_image_t;
 
 typedef struct {
     int num_uniform_blocks;
     int num_images;
-    _sg_uniform_block uniform_blocks[SG_MAX_SHADERSTAGE_UBS];
-    _sg_shader_image images[SG_MAX_SHADERSTAGE_IMAGES];
-} _sg_shader_stage;
+    _sg_uniform_block_t uniform_blocks[SG_MAX_SHADERSTAGE_UBS];
+    _sg_shader_image_t images[SG_MAX_SHADERSTAGE_IMAGES];
+} _sg_shader_stage_t;
 
 typedef struct {
-    _sg_slot slot;
+    _sg_slot_t slot;
     GLuint gl_prog;
-    _sg_shader_stage stage[SG_NUM_SHADER_STAGES];
-} _sg_shader;
+    _sg_shader_stage_t stage[SG_NUM_SHADER_STAGES];
+} _sg_shader_t;
 
 typedef struct {
     int8_t vb_index;        /* -1 if attr is not enabled */
@@ -2036,8 +2036,8 @@ typedef struct {
 } _sg_gl_attr_t;
 
 typedef struct {
-    _sg_slot slot;
-    _sg_shader* shader;
+    _sg_slot_t slot;
+    _sg_shader_t* shader;
     sg_shader shader_id;
     sg_primitive_type primitive_type;
     sg_index_type index_type;
@@ -2050,31 +2050,31 @@ typedef struct {
     sg_depth_stencil_state depth_stencil;
     sg_blend_state blend;
     sg_rasterizer_state rast;
-} _sg_pipeline;
+} _sg_pipeline_t;
 
 typedef struct {
-    _sg_image* image;
+    _sg_image_t* image;
     sg_image image_id;
     int mip_level;
     int slice;
     GLuint gl_msaa_resolve_buffer;
-} _sg_attachment;
+} _sg_attachment_t;
 
 typedef struct {
-    _sg_slot slot;
+    _sg_slot_t slot;
     GLuint gl_fb;
     int num_color_atts;
-    _sg_attachment color_atts[SG_MAX_COLOR_ATTACHMENTS];
-    _sg_attachment ds_att;
-} _sg_pass;
+    _sg_attachment_t color_atts[SG_MAX_COLOR_ATTACHMENTS];
+    _sg_attachment_t ds_att;
+} _sg_pass_t;
 
 typedef struct {
-    _sg_slot slot;
+    _sg_slot_t slot;
     #if !defined(SOKOL_GLES2)
     GLuint vao;
     #endif
     GLuint default_framebuffer;
-} _sg_context;
+} _sg_context_t;
 
 typedef struct {
     _sg_gl_attr_t gl_attr;
@@ -2092,7 +2092,7 @@ typedef struct {
     int cur_ib_offset;
     GLenum cur_primitive_type;
     GLenum cur_index_type;
-    _sg_pipeline* cur_pipeline;
+    _sg_pipeline_t* cur_pipeline;
     sg_pipeline cur_pipeline_id;
 } _sg_state_cache_t;
 
@@ -2102,8 +2102,8 @@ typedef struct {
     bool in_pass;
     int cur_pass_width;
     int cur_pass_height;
-    _sg_context* cur_context;
-    _sg_pass* cur_pass;
+    _sg_context_t* cur_context;
+    _sg_pass_t* cur_pass;
     sg_pass cur_pass_id;
     _sg_state_cache_t cache;
     bool features[SG_NUM_FEATURES];
@@ -2124,7 +2124,7 @@ typedef struct {
     uint32_t update_frame_index;
     uint32_t append_frame_index;
     ID3D11Buffer* d3d11_buf;
-} _sg_buffer;
+} _sg_buffer_t;
 
 typedef struct {
     _sg_slot slot;
@@ -2151,36 +2151,36 @@ typedef struct {
     ID3D11Texture2D* d3d11_texmsaa;
     ID3D11ShaderResourceView* d3d11_srv;
     ID3D11SamplerState* d3d11_smp;
-} _sg_image;
+} _sg_image_t;
 
 typedef struct {
     int size;
-} _sg_uniform_block;
+} _sg_uniform_block_t;
 
 typedef struct {
     sg_image_type type;
-} _sg_shader_image;
+} _sg_shader_image_t;
 
 typedef struct {
     int num_uniform_blocks;
     int num_images;
-    _sg_uniform_block uniform_blocks[SG_MAX_SHADERSTAGE_UBS];
-    _sg_shader_image images[SG_MAX_SHADERSTAGE_IMAGES];
+    _sg_uniform_block_t uniform_blocks[SG_MAX_SHADERSTAGE_UBS];
+    _sg_shader_image_t images[SG_MAX_SHADERSTAGE_IMAGES];
     ID3D11Buffer* d3d11_cbs[SG_MAX_SHADERSTAGE_UBS];
-} _sg_shader_stage;
+} _sg_shader_stage_t;
 
 typedef struct {
-    _sg_slot slot;
-    _sg_shader_stage stage[SG_NUM_SHADER_STAGES];
+    _sg_slot_t slot;
+    _sg_shader_stage_t stage[SG_NUM_SHADER_STAGES];
     ID3D11VertexShader* d3d11_vs;
     ID3D11PixelShader* d3d11_fs;
     void* d3d11_vs_blob;
     int d3d11_vs_blob_length;
-} _sg_shader;
+} _sg_shader_t;
 
 typedef struct {
-    _sg_slot slot;
-    _sg_shader* shader;
+    _sg_slot_t slot;
+    _sg_shader_t* shader;
     sg_shader shader_id;
     sg_index_type index_type;
     bool vertex_layout_valid[SG_MAX_SHADERSTAGE_BUFFERS];
@@ -2197,27 +2197,27 @@ typedef struct {
     ID3D11RasterizerState* d3d11_rs;
     ID3D11DepthStencilState* d3d11_dss;
     ID3D11BlendState* d3d11_bs;
-} _sg_pipeline;
+} _sg_pipeline_t;
 
 typedef struct {
-    _sg_image* image;
+    _sg_image_t* image;
     sg_image image_id;
     int mip_level;
     int slice;
-} _sg_attachment;
+} _sg_attachment_t;
 
 typedef struct {
-    _sg_slot slot;
+    _sg_slot_t slot;
     int num_color_atts;
-    _sg_attachment color_atts[SG_MAX_COLOR_ATTACHMENTS];
-    _sg_attachment ds_att;
+    _sg_attachment_t color_atts[SG_MAX_COLOR_ATTACHMENTS];
+    _sg_attachment_t ds_att;
     ID3D11RenderTargetView* d3d11_rtvs[SG_MAX_COLOR_ATTACHMENTS];
     ID3D11DepthStencilView* d3d11_dsv;
-} _sg_pass;
+} _sg_pass_t;
 
 typedef struct {
-    _sg_slot slot;
-} _sg_context;
+    _sg_slot_t slot;
+} _sg_context_t;
 
 typedef struct {
     bool valid;
@@ -2230,9 +2230,9 @@ typedef struct {
     int cur_width;
     int cur_height;
     int num_rtvs;
-    _sg_pass* cur_pass;
+    _sg_pass_t* cur_pass;
     sg_pass cur_pass_id;
-    _sg_pipeline* cur_pipeline;
+    _sg_pipeline_t* cur_pipeline;
     sg_pipeline cur_pipeline_id;
     ID3D11RenderTargetView* cur_rtvs[SG_MAX_COLOR_ATTACHMENTS];
     ID3D11DepthStencilView* cur_dsv;
@@ -2299,7 +2299,7 @@ typedef struct {
 } _sg_mtl_sampler_cache_t;
 
 typedef struct {
-    _sg_slot slot;
+    _sg_slot_t slot;
     int size;
     int append_pos;
     bool append_overflow;
@@ -2310,10 +2310,10 @@ typedef struct {
     int num_slots;
     int active_slot;
     uint32_t mtl_buf[SG_NUM_INFLIGHT_FRAMES];  /* index intp _sg_mtl_pool */
-} _sg_buffer;
+} _sg_buffer_t;
 
 typedef struct {
-    _sg_slot slot;
+    _sg_slot_t slot;
     sg_image_type type;
     bool render_target;
     int width;
@@ -2336,33 +2336,33 @@ typedef struct {
     uint32_t mtl_depth_tex;
     uint32_t mtl_msaa_tex;
     uint32_t mtl_sampler_state;
-} _sg_image;
+} _sg_image_t;
 
 typedef struct {
     int size;
-} _sg_uniform_block;
+} _sg_uniform_block_t;
 
 typedef struct {
     sg_image_type type;
-} _sg_shader_image;
+} _sg_shader_image_t;
 
 typedef struct {
     int num_uniform_blocks;
     int num_images;
-    _sg_uniform_block uniform_blocks[SG_MAX_SHADERSTAGE_UBS];
-    _sg_shader_image images[SG_MAX_SHADERSTAGE_IMAGES];
+    _sg_uniform_block_t uniform_blocks[SG_MAX_SHADERSTAGE_UBS];
+    _sg_shader_image_t images[SG_MAX_SHADERSTAGE_IMAGES];
     uint32_t mtl_lib;
     uint32_t mtl_func;
-} _sg_shader_stage;
+} _sg_shader_stage_t;
 
 typedef struct {
-    _sg_slot slot;
-    _sg_shader_stage stage[SG_NUM_SHADER_STAGES];
-} _sg_shader;
+    _sg_slot_t slot;
+    _sg_shader_stage_t stage[SG_NUM_SHADER_STAGES];
+} _sg_shader_t;
 
 typedef struct {
-    _sg_slot slot;
-    _sg_shader* shader;
+    _sg_slot_t slot;
+    _sg_shader_t* shader;
     sg_shader shader_id;
     bool vertex_layout_valid[SG_MAX_SHADERSTAGE_BUFFERS];
     int color_attachment_count;
@@ -2382,39 +2382,39 @@ typedef struct {
     uint32_t mtl_stencil_ref;
     uint32_t mtl_rps;
     uint32_t mtl_dss;
-} _sg_pipeline;
+} _sg_pipeline_t;
 
 typedef struct {
-    _sg_image* image;
+    _sg_image_t* image;
     sg_image image_id;
     int mip_level;
     int slice;
-} _sg_attachment;
+} _sg_attachment_t;
 
 typedef struct {
-    _sg_slot slot;
+    _sg_slot_t slot;
     int num_color_atts;
-    _sg_attachment color_atts[SG_MAX_COLOR_ATTACHMENTS];
-    _sg_attachment ds_att;
-} _sg_pass;
+    _sg_attachment_t color_atts[SG_MAX_COLOR_ATTACHMENTS];
+    _sg_attachment_t ds_att;
+} _sg_pass_t;
 
 typedef struct {
-    _sg_slot slot;
-} _sg_context;
+    _sg_slot_t slot;
+} _sg_context_t;
 
 /* resouce binding state cache */
 typedef struct {
-    const _sg_pipeline* cur_pipeline;
+    const _sg_pipeline_t* cur_pipeline;
     sg_pipeline cur_pipeline_id;
-    const _sg_buffer* cur_indexbuffer;
+    const _sg_buffer_t* cur_indexbuffer;
     int cur_indexbuffer_offset;
     sg_buffer cur_indexbuffer_id;
-    const _sg_buffer* cur_vertexbuffers[SG_MAX_SHADERSTAGE_BUFFERS];
+    const _sg_buffer_t* cur_vertexbuffers[SG_MAX_SHADERSTAGE_BUFFERS];
     int cur_vertexbuffer_offsets[SG_MAX_SHADERSTAGE_BUFFERS];
     sg_buffer cur_vertexbuffer_ids[SG_MAX_SHADERSTAGE_BUFFERS];
-    const _sg_image* cur_vs_images[SG_MAX_SHADERSTAGE_IMAGES];
+    const _sg_image_t* cur_vs_images[SG_MAX_SHADERSTAGE_IMAGES];
     sg_image cur_vs_image_ids[SG_MAX_SHADERSTAGE_IMAGES];
-    const _sg_image* cur_fs_images[SG_MAX_SHADERSTAGE_IMAGES];
+    const _sg_image_t* cur_fs_images[SG_MAX_SHADERSTAGE_IMAGES];
     sg_image cur_fs_image_ids[SG_MAX_SHADERSTAGE_IMAGES];
 } _sg_mtl_state_cache_t;
 
@@ -2461,22 +2461,22 @@ typedef struct {
     int queue_top;
     uint32_t* gen_ctrs;
     int* free_queue;
-} _sg_pool;
+} _sg_pool_t;
 
 typedef struct {
-    _sg_pool buffer_pool;
-    _sg_pool image_pool;
-    _sg_pool shader_pool;
-    _sg_pool pipeline_pool;
-    _sg_pool pass_pool;
-    _sg_pool context_pool;
-    _sg_buffer* buffers;
-    _sg_image* images;
-    _sg_shader* shaders;
-    _sg_pipeline* pipelines;
-    _sg_pass* passes;
-    _sg_context* contexts;
-} _sg_pools;
+    _sg_pool_t buffer_pool;
+    _sg_pool_t image_pool;
+    _sg_pool_t shader_pool;
+    _sg_pool_t pipeline_pool;
+    _sg_pool_t pass_pool;
+    _sg_pool_t context_pool;
+    _sg_buffer_t* buffers;
+    _sg_image_t* images;
+    _sg_shader_t* shaders;
+    _sg_pipeline_t* pipelines;
+    _sg_pass_t* passes;
+    _sg_context_t* contexts;
+} _sg_pools_t;
 
 /*=== VALIDATION LAYER DECLARATIONS ==========================================*/
 typedef enum {
@@ -2593,7 +2593,7 @@ typedef enum {
     _SG_VALIDATE_UPDIMG_SIZE,
     _SG_VALIDATE_UPDIMG_COMPRESSED,
     _SG_VALIDATE_UPDIMG_ONCE
-} _sg_validate_error;
+} _sg_validate_error_t;
 
 /*=== GENERIC BACKEND STATE ==================================================*/
 
@@ -2608,9 +2608,9 @@ typedef struct {
     bool bindings_valid;
     bool next_draw_valid;
     #if defined(SOKOL_DEBUG)
-    _sg_validate_error validate_error;
+    _sg_validate_error_t validate_error;
     #endif
-    _sg_pools pools;
+    _sg_pools_t pools;
     #if defined(SOKOL_GLCORE33) || defined(SOKOL_GLES2) || defined(SOKOL_GLES3)
     _sg_gl_backend_t gl;
     #elif defined(SOKOL_METAL)
@@ -2618,8 +2618,8 @@ typedef struct {
     #elif defined(SOKOL_D3D11)
     _sg_d3d11_backend_t d3d11;
     #endif
-} _sg_state;
-static _sg_state _sg;
+} _sg_state_t;
+static _sg_state_t _sg;
 
 /*-- helper functions --------------------------------------------------------*/
 
@@ -2846,23 +2846,23 @@ _SOKOL_PRIVATE void _sg_reset_state_cache(void) {
     /* empty*/
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_context(_sg_context* ctx) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     _SOKOL_UNUSED(ctx);
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_context(_sg_context* ctx) {
+_SOKOL_PRIVATE void _sg_destroy_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     _SOKOL_UNUSED(ctx);
 }
 
-_SOKOL_PRIVATE void _sg_activate_context(_sg_context* ctx) {
+_SOKOL_PRIVATE void _sg_activate_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     _SOKOL_UNUSED(ctx);
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_buffer(_sg_buffer* buf, const sg_buffer_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_buffer(_sg_buffer_t* buf, const sg_buffer_desc* desc) {
     SOKOL_ASSERT(buf && desc);
     buf->size = desc->size;
     buf->append_pos = 0;
@@ -2876,12 +2876,12 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_buffer(_sg_buffer* buf, const sg_buf
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_buffer(_sg_buffer* buf) {
+_SOKOL_PRIVATE void _sg_destroy_buffer(_sg_buffer_t* buf) {
     SOKOL_ASSERT(buf);
     _SOKOL_UNUSED(buf);
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_image(_sg_image* img, const sg_image_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_image(_sg_image_t* img, const sg_image_desc* desc) {
     SOKOL_ASSERT(img && desc);
     img->type = _sg_def(desc->type, SG_IMAGETYPE_2D);
     img->render_target = desc->render_target;
@@ -2904,24 +2904,24 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_image(_sg_image* img, const sg_image
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_image(_sg_image* img) {
+_SOKOL_PRIVATE void _sg_destroy_image(_sg_image_t* img) {
     SOKOL_ASSERT(img);
     _SOKOL_UNUSED(img);
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader* shd, const sg_shader_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader_t* shd, const sg_shader_desc* desc) {
     SOKOL_ASSERT(shd && desc);
     /* uniform block sizes and image types */
     for (int stage_index = 0; stage_index < SG_NUM_SHADER_STAGES; stage_index++) {
         const sg_shader_stage_desc* stage_desc = (stage_index == SG_SHADERSTAGE_VS) ? &desc->vs : &desc->fs;
-        _sg_shader_stage* stage = &shd->stage[stage_index];
+        _sg_shader_stage_t* stage = &shd->stage[stage_index];
         SOKOL_ASSERT(stage->num_uniform_blocks == 0);
         for (int ub_index = 0; ub_index < SG_MAX_SHADERSTAGE_UBS; ub_index++) {
             const sg_shader_uniform_block_desc* ub_desc = &stage_desc->uniform_blocks[ub_index];
             if (0 == ub_desc->size) {
                 break;
             }
-            _sg_uniform_block* ub = &stage->uniform_blocks[ub_index];
+            _sg_uniform_block_t* ub = &stage->uniform_blocks[ub_index];
             ub->size = ub_desc->size;
             stage->num_uniform_blocks++;
         }
@@ -2938,12 +2938,12 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader* shd, const sg_sha
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_shader(_sg_shader* shd) {
+_SOKOL_PRIVATE void _sg_destroy_shader(_sg_shader_t* shd) {
     SOKOL_ASSERT(shd);
     _SOKOL_UNUSED(shd);
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_pipeline(_sg_pipeline* pip, _sg_shader* shd, const sg_pipeline_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_pipeline(_sg_pipeline_t* pip, _sg_shader_t* shd, const sg_pipeline_desc* desc) {
     SOKOL_ASSERT(pip && desc);
     pip->shader = shd;
     pip->shader_id = desc->shader;
@@ -2969,17 +2969,17 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_pipeline(_sg_pipeline* pip, _sg_shad
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_pipeline(_sg_pipeline* pip) {
+_SOKOL_PRIVATE void _sg_destroy_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
     _SOKOL_UNUSED(pip);
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_pass(_sg_pass* pass, _sg_image** att_images, const sg_pass_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_pass(_sg_pass_t* pass, _sg_image_t** att_images, const sg_pass_desc* desc) {
     SOKOL_ASSERT(pass && desc);
     SOKOL_ASSERT(att_images && att_images[0]);
     /* copy image pointers and desc attributes */
     const sg_attachment_desc* att_desc;
-    _sg_attachment* att;
+    _sg_attachment_t* att;
     for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
         SOKOL_ASSERT(0 == pass->color_atts[i].image);
         att_desc = &desc->color_attachments[i];
@@ -3011,12 +3011,12 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_pass(_sg_pass* pass, _sg_image** att
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_pass(_sg_pass* pass) {
+_SOKOL_PRIVATE void _sg_destroy_pass(_sg_pass_t* pass) {
     SOKOL_ASSERT(pass);
     _SOKOL_UNUSED(pass);
 }
 
-_SOKOL_PRIVATE void _sg_begin_pass(_sg_pass* pass, const sg_pass_action* action, int w, int h) {
+_SOKOL_PRIVATE void _sg_begin_pass(_sg_pass_t* pass, const sg_pass_action* action, int w, int h) {
     SOKOL_ASSERT(action);
     _SOKOL_UNUSED(pass);
     _SOKOL_UNUSED(action);
@@ -3048,17 +3048,17 @@ _SOKOL_PRIVATE void _sg_apply_scissor_rect(int x, int y, int w, int h, bool orig
     _SOKOL_UNUSED(origin_top_left);
 }
 
-_SOKOL_PRIVATE void _sg_apply_pipeline(_sg_pipeline* pip) {
+_SOKOL_PRIVATE void _sg_apply_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
     _SOKOL_UNUSED(pip);
 }
 
 _SOKOL_PRIVATE void _sg_apply_bindings(
-    _sg_pipeline* pip,
-    _sg_buffer** vbs, const int* vb_offsets, int num_vbs,
-    _sg_buffer* ib, int ib_offset,
-    _sg_image** vs_imgs, int num_vs_imgs,
-    _sg_image** fs_imgs, int num_fs_imgs)
+    _sg_pipeline_t* pip,
+    _sg_buffer_t** vbs, const int* vb_offsets, int num_vbs,
+    _sg_buffer_t* ib, int ib_offset,
+    _sg_image_t** vs_imgs, int num_vs_imgs,
+    _sg_image_t** fs_imgs, int num_fs_imgs)
 {
     SOKOL_ASSERT(pip);
     SOKOL_ASSERT(vbs && vb_offsets);
@@ -3087,7 +3087,7 @@ _SOKOL_PRIVATE void _sg_draw(int base_element, int num_elements, int num_instanc
     _SOKOL_UNUSED(num_instances);
 }
 
-_SOKOL_PRIVATE void _sg_update_buffer(_sg_buffer* buf, const void* data, int data_size) {
+_SOKOL_PRIVATE void _sg_update_buffer(_sg_buffer_t* buf, const void* data, int data_size) {
     SOKOL_ASSERT(buf && data && (data_size > 0));
     _SOKOL_UNUSED(data);
     _SOKOL_UNUSED(data_size);
@@ -3096,7 +3096,7 @@ _SOKOL_PRIVATE void _sg_update_buffer(_sg_buffer* buf, const void* data, int dat
     }
 }
 
-_SOKOL_PRIVATE void _sg_append_buffer(_sg_buffer* buf, const void* data, int data_size, bool new_frame) {
+_SOKOL_PRIVATE void _sg_append_buffer(_sg_buffer_t* buf, const void* data, int data_size, bool new_frame) {
     SOKOL_ASSERT(buf && data && (data_size > 0));
     _SOKOL_UNUSED(data);
     _SOKOL_UNUSED(data_size);
@@ -3107,7 +3107,7 @@ _SOKOL_PRIVATE void _sg_append_buffer(_sg_buffer* buf, const void* data, int dat
     }
 }
 
-_SOKOL_PRIVATE void _sg_update_image(_sg_image* img, const sg_image_content* data) {
+_SOKOL_PRIVATE void _sg_update_image(_sg_image_t* img, const sg_image_content* data) {
     SOKOL_ASSERT(img && data);
     _SOKOL_UNUSED(data);
     if (++img->active_slot >= img->num_slots) {
@@ -3705,7 +3705,7 @@ _SOKOL_PRIVATE bool _sg_query_feature(sg_feature f) {
     return _sg.gl.features[f];
 }
 
-_SOKOL_PRIVATE void _sg_activate_context(_sg_context* ctx) {
+_SOKOL_PRIVATE void _sg_activate_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(_sg.gl.valid);
     /* NOTE: ctx can be 0 to unset the current context */
     _sg.gl.cur_context = ctx;
@@ -3713,7 +3713,7 @@ _SOKOL_PRIVATE void _sg_activate_context(_sg_context* ctx) {
 }
 
 /*-- GL backend resource creation and destruction ----------------------------*/
-_SOKOL_PRIVATE sg_resource_state _sg_create_context(_sg_context* ctx) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     SOKOL_ASSERT(0 == ctx->default_framebuffer);
     _SG_GL_CHECK_ERROR();
@@ -3730,7 +3730,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_context(_sg_context* ctx) {
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_context(_sg_context* ctx) {
+_SOKOL_PRIVATE void _sg_destroy_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     #if !defined(SOKOL_GLES2)
     if (!_sg.gl.gles2) {
@@ -3742,7 +3742,7 @@ _SOKOL_PRIVATE void _sg_destroy_context(_sg_context* ctx) {
     #endif
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_buffer(_sg_buffer* buf, const sg_buffer_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_buffer(_sg_buffer_t* buf, const sg_buffer_desc* desc) {
     SOKOL_ASSERT(buf && desc);
     _SG_GL_CHECK_ERROR();
     buf->size = desc->size;
@@ -3778,7 +3778,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_buffer(_sg_buffer* buf, const sg_buf
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_buffer(_sg_buffer* buf) {
+_SOKOL_PRIVATE void _sg_destroy_buffer(_sg_buffer_t* buf) {
     SOKOL_ASSERT(buf);
     _SG_GL_CHECK_ERROR();
     if (!buf->ext_buffers) {
@@ -3810,7 +3810,7 @@ _SOKOL_PRIVATE bool _sg_gl_supported_texture_format(sg_pixel_format fmt) {
     }
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_image(_sg_image* img, const sg_image_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_image(_sg_image_t* img, const sg_image_desc* desc) {
     SOKOL_ASSERT(img && desc);
     _SG_GL_CHECK_ERROR();
     img->type = _sg_def(desc->type, SG_IMAGETYPE_2D);
@@ -3994,7 +3994,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_image(_sg_image* img, const sg_image
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_image(_sg_image* img) {
+_SOKOL_PRIVATE void _sg_destroy_image(_sg_image_t* img) {
     SOKOL_ASSERT(img);
     _SG_GL_CHECK_ERROR();
     if (!img->ext_textures) {
@@ -4038,7 +4038,7 @@ _SOKOL_PRIVATE GLuint _sg_gl_compile_shader(sg_shader_stage stage, const char* s
     return gl_shd;
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader* shd, const sg_shader_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader_t* shd, const sg_shader_desc* desc) {
     SOKOL_ASSERT(shd && desc);
     SOKOL_ASSERT(!shd->gl_prog);
     _SG_GL_CHECK_ERROR();
@@ -4075,14 +4075,14 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader* shd, const sg_sha
     _SG_GL_CHECK_ERROR();
     for (int stage_index = 0; stage_index < SG_NUM_SHADER_STAGES; stage_index++) {
         const sg_shader_stage_desc* stage_desc = (stage_index == SG_SHADERSTAGE_VS)? &desc->vs : &desc->fs;
-        _sg_shader_stage* stage = &shd->stage[stage_index];
+        _sg_shader_stage_t* stage = &shd->stage[stage_index];
         SOKOL_ASSERT(stage->num_uniform_blocks == 0);
         for (int ub_index = 0; ub_index < SG_MAX_SHADERSTAGE_UBS; ub_index++) {
             const sg_shader_uniform_block_desc* ub_desc = &stage_desc->uniform_blocks[ub_index];
             if (0 == ub_desc->size) {
                 break;
             }
-            _sg_uniform_block* ub = &stage->uniform_blocks[ub_index];
+            _sg_uniform_block_t* ub = &stage->uniform_blocks[ub_index];
             ub->size = ub_desc->size;
             SOKOL_ASSERT(ub->num_uniforms == 0);
             int cur_uniform_offset = 0;
@@ -4091,7 +4091,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader* shd, const sg_sha
                 if (u_desc->type == SG_UNIFORMTYPE_INVALID) {
                     break;
                 }
-                _sg_uniform* u = &ub->uniforms[u_index];
+                _sg_uniform_t* u = &ub->uniforms[u_index];
                 u->type = u_desc->type;
                 u->count = (uint8_t) _sg_def(u_desc->array_count, 1);
                 u->offset = (uint16_t) cur_uniform_offset;
@@ -4114,14 +4114,14 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader* shd, const sg_sha
     int gl_tex_slot = 0;
     for (int stage_index = 0; stage_index < SG_NUM_SHADER_STAGES; stage_index++) {
         const sg_shader_stage_desc* stage_desc = (stage_index == SG_SHADERSTAGE_VS)? &desc->vs : &desc->fs;
-        _sg_shader_stage* stage = &shd->stage[stage_index];
+        _sg_shader_stage_t* stage = &shd->stage[stage_index];
         SOKOL_ASSERT(stage->num_images == 0);
         for (int img_index = 0; img_index < SG_MAX_SHADERSTAGE_IMAGES; img_index++) {
             const sg_shader_image_desc* img_desc = &stage_desc->images[img_index];
             if (img_desc->type == _SG_IMAGETYPE_DEFAULT) {
                 break;
             }
-            _sg_shader_image* img = &stage->images[img_index];
+            _sg_shader_image_t* img = &stage->images[img_index];
             img->type = img_desc->type;
             img->gl_loc = img_index;
             if (img_desc->name) {
@@ -4140,7 +4140,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader* shd, const sg_sha
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_shader(_sg_shader* shd) {
+_SOKOL_PRIVATE void _sg_destroy_shader(_sg_shader_t* shd) {
     SOKOL_ASSERT(shd);
     _SG_GL_CHECK_ERROR();
     if (shd->gl_prog) {
@@ -4196,7 +4196,7 @@ _SOKOL_PRIVATE void _sg_gl_load_rasterizer(const sg_rasterizer_state* src, sg_ra
     dst->depth_bias_clamp = src->depth_bias_clamp;
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_pipeline(_sg_pipeline* pip, _sg_shader* shd, const sg_pipeline_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_pipeline(_sg_pipeline_t* pip, _sg_shader_t* shd, const sg_pipeline_desc* desc) {
     SOKOL_ASSERT(pip && shd && desc);
     SOKOL_ASSERT(!pip->shader && pip->shader_id.id == SG_INVALID_ID);
     SOKOL_ASSERT(desc->shader.id == shd->slot.id);
@@ -4273,7 +4273,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_pipeline(_sg_pipeline* pip, _sg_shad
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_pipeline(_sg_pipeline* pip) {
+_SOKOL_PRIVATE void _sg_destroy_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
     /* empty */
 }
@@ -4285,14 +4285,14 @@ _SOKOL_PRIVATE void _sg_destroy_pipeline(_sg_pipeline* pip) {
     first entries are the color attachment images (or nullptr), last entry
     is the depth-stencil image (or nullptr).
 */
-_SOKOL_PRIVATE sg_resource_state _sg_create_pass(_sg_pass* pass, _sg_image** att_images, const sg_pass_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_pass(_sg_pass_t* pass, _sg_image_t** att_images, const sg_pass_desc* desc) {
     SOKOL_ASSERT(pass && att_images && desc);
     SOKOL_ASSERT(att_images && att_images[0]);
     _SG_GL_CHECK_ERROR();
 
     /* copy image pointers and desc attributes */
     const sg_attachment_desc* att_desc;
-    _sg_attachment* att;
+    _sg_attachment_t* att;
     for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
         SOKOL_ASSERT(0 == pass->color_atts[i].image);
         att_desc = &desc->color_attachments[i];
@@ -4334,7 +4334,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_pass(_sg_pass* pass, _sg_image** att
     const bool is_msaa = (0 != att_images[0]->gl_msaa_render_buffer);
     if (is_msaa) {
         for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
-            const _sg_image* att_img = pass->color_atts[i].image;
+            const _sg_image_t* att_img = pass->color_atts[i].image;
             if (att_img) {
                 const GLuint gl_render_buffer = att_img->gl_msaa_render_buffer;
                 SOKOL_ASSERT(gl_render_buffer);
@@ -4344,7 +4344,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_pass(_sg_pass* pass, _sg_image** att
     }
     else {
         for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
-            const _sg_image* att_img = pass->color_atts[i].image;
+            const _sg_image_t* att_img = pass->color_atts[i].image;
             const int mip_level = pass->color_atts[i].mip_level;
             const int slice = pass->color_atts[i].slice;
             if (att_img) {
@@ -4429,7 +4429,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_pass(_sg_pass* pass, _sg_image** att
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_pass(_sg_pass* pass) {
+_SOKOL_PRIVATE void _sg_destroy_pass(_sg_pass_t* pass) {
     SOKOL_ASSERT(pass);
     _SG_GL_CHECK_ERROR();
     if (0 != pass->gl_fb) {
@@ -4447,7 +4447,7 @@ _SOKOL_PRIVATE void _sg_destroy_pass(_sg_pass* pass) {
 }
 
 /*-- GL backend rendering functions ------------------------------------------*/
-_SOKOL_PRIVATE void _sg_begin_pass(_sg_pass* pass, const sg_pass_action* action, int w, int h) {
+_SOKOL_PRIVATE void _sg_begin_pass(_sg_pass_t* pass, const sg_pass_action* action, int w, int h) {
     /* FIXME: what if a texture used as render target is still bound, should we
        unbind all currently bound textures in begin pass? */
     SOKOL_ASSERT(action);
@@ -4592,7 +4592,7 @@ _SOKOL_PRIVATE void _sg_end_pass(void) {
     #if !defined(SOKOL_GLES2)
     if (!_sg.gl.gles2 && _sg.gl.cur_pass) {
         /* check if the pass object is still valid */
-        const _sg_pass* pass = _sg.gl.cur_pass;
+        const _sg_pass_t* pass = _sg.gl.cur_pass;
         SOKOL_ASSERT(pass->slot.id == _sg.gl.cur_pass_id.id);
         bool is_msaa = (0 != _sg.gl.cur_pass->color_atts[0].gl_msaa_resolve_buffer);
         if (is_msaa) {
@@ -4602,7 +4602,7 @@ _SOKOL_PRIVATE void _sg_end_pass(void) {
             const int w = pass->color_atts[0].image->width;
             const int h = pass->color_atts[0].image->height;
             for (int att_index = 0; att_index < SG_MAX_COLOR_ATTACHMENTS; att_index++) {
-                const _sg_attachment* att = &pass->color_atts[att_index];
+                const _sg_attachment_t* att = &pass->color_atts[att_index];
                 if (att->image) {
                     SOKOL_ASSERT(att->gl_msaa_resolve_buffer);
                     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, att->gl_msaa_resolve_buffer);
@@ -4641,7 +4641,7 @@ _SOKOL_PRIVATE void _sg_apply_scissor_rect(int x, int y, int w, int h, bool orig
     glScissor(x, y, w, h);
 }
 
-_SOKOL_PRIVATE void _sg_apply_pipeline(_sg_pipeline* pip) {
+_SOKOL_PRIVATE void _sg_apply_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
     SOKOL_ASSERT(pip->shader);
     _SG_GL_CHECK_ERROR();
@@ -4808,11 +4808,11 @@ _SOKOL_PRIVATE void _sg_apply_pipeline(_sg_pipeline* pip) {
 }
 
 _SOKOL_PRIVATE void _sg_apply_bindings(
-    _sg_pipeline* pip,
-    _sg_buffer** vbs, const int* vb_offsets, int num_vbs,
-    _sg_buffer* ib, int ib_offset,
-    _sg_image** vs_imgs, int num_vs_imgs,
-    _sg_image** fs_imgs, int num_fs_imgs)
+    _sg_pipeline_t* pip,
+    _sg_buffer_t** vbs, const int* vb_offsets, int num_vbs,
+    _sg_buffer_t* ib, int ib_offset,
+    _sg_image_t** vs_imgs, int num_vs_imgs,
+    _sg_image_t** fs_imgs, int num_fs_imgs)
 {
     SOKOL_ASSERT(pip);
     _SOKOL_UNUSED(num_fs_imgs);
@@ -4823,13 +4823,13 @@ _SOKOL_PRIVATE void _sg_apply_bindings(
     /* bind textures */
     _SG_GL_CHECK_ERROR();
     for (int stage_index = 0; stage_index < SG_NUM_SHADER_STAGES; stage_index++) {
-        const _sg_shader_stage* stage = &pip->shader->stage[stage_index];
-        _sg_image** imgs = (stage_index == SG_SHADERSTAGE_VS)? vs_imgs : fs_imgs;
+        const _sg_shader_stage_t* stage = &pip->shader->stage[stage_index];
+        _sg_image_t** imgs = (stage_index == SG_SHADERSTAGE_VS)? vs_imgs : fs_imgs;
         SOKOL_ASSERT(((stage_index == SG_SHADERSTAGE_VS)? num_vs_imgs : num_fs_imgs) == stage->num_images);
         for (int img_index = 0; img_index < stage->num_images; img_index++) {
-            const _sg_shader_image* shd_img = &stage->images[img_index];
+            const _sg_shader_image_t* shd_img = &stage->images[img_index];
             if (shd_img->gl_loc != -1) {
-                _sg_image* img = imgs[img_index];
+                _sg_image_t* img = imgs[img_index];
                 const GLuint gl_tex = img->gl_tex[img->active_slot];
                 SOKOL_ASSERT(img && img->gl_target);
                 SOKOL_ASSERT((shd_img->gl_tex_slot != -1) && gl_tex);
@@ -4856,7 +4856,7 @@ _SOKOL_PRIVATE void _sg_apply_bindings(
         if (attr->vb_index >= 0) {
             /* attribute is enabled */
             SOKOL_ASSERT(attr->vb_index < num_vbs);
-            _sg_buffer* vb = vbs[attr->vb_index];
+            _sg_buffer_t* vb = vbs[attr->vb_index];
             gl_vb = vb->gl_buf[vb->active_slot];
             SOKOL_ASSERT(vb);
             vb_offset = vb_offsets[attr->vb_index] + attr->offset;
@@ -4907,12 +4907,12 @@ _SOKOL_PRIVATE void _sg_apply_uniforms(sg_shader_stage stage_index, int ub_index
     SOKOL_ASSERT(_sg.gl.cache.cur_pipeline);
     SOKOL_ASSERT(_sg.gl.cache.cur_pipeline->slot.id == _sg.gl.cache.cur_pipeline_id.id);
     SOKOL_ASSERT(_sg.gl.cache.cur_pipeline->shader->slot.id == _sg.gl.cache.cur_pipeline->shader_id.id);
-    _sg_shader_stage* stage = &_sg.gl.cache.cur_pipeline->shader->stage[stage_index];
+    _sg_shader_stage_t* stage = &_sg.gl.cache.cur_pipeline->shader->stage[stage_index];
     SOKOL_ASSERT(ub_index < stage->num_uniform_blocks);
-    _sg_uniform_block* ub = &stage->uniform_blocks[ub_index];
+    _sg_uniform_block_t* ub = &stage->uniform_blocks[ub_index];
     SOKOL_ASSERT(ub->size == num_bytes);
     for (int u_index = 0; u_index < ub->num_uniforms; u_index++) {
-        _sg_uniform* u = &ub->uniforms[u_index];
+        _sg_uniform_t* u = &ub->uniforms[u_index];
         SOKOL_ASSERT(u->type != SG_UNIFORMTYPE_INVALID);
         if (u->gl_loc == -1) {
             continue;
@@ -4977,7 +4977,7 @@ _SOKOL_PRIVATE void _sg_commit(void) {
     SOKOL_ASSERT(!_sg.gl.in_pass);
 }
 
-_SOKOL_PRIVATE void _sg_update_buffer(_sg_buffer* buf, const void* data_ptr, int data_size) {
+_SOKOL_PRIVATE void _sg_update_buffer(_sg_buffer_t* buf, const void* data_ptr, int data_size) {
     SOKOL_ASSERT(buf && data_ptr && (data_size > 0));
     /* only one update per buffer per frame allowed */
     if (++buf->active_slot >= buf->num_slots) {
@@ -4993,7 +4993,7 @@ _SOKOL_PRIVATE void _sg_update_buffer(_sg_buffer* buf, const void* data_ptr, int
     _SG_GL_CHECK_ERROR();
 }
 
-_SOKOL_PRIVATE void _sg_append_buffer(_sg_buffer* buf, const void* data_ptr, int data_size, bool new_frame) {
+_SOKOL_PRIVATE void _sg_append_buffer(_sg_buffer_t* buf, const void* data_ptr, int data_size, bool new_frame) {
     SOKOL_ASSERT(buf && data_ptr && (data_size > 0));
     if (new_frame) {
         if (++buf->active_slot >= buf->num_slots) {
@@ -5010,7 +5010,7 @@ _SOKOL_PRIVATE void _sg_append_buffer(_sg_buffer* buf, const void* data_ptr, int
     _SG_GL_CHECK_ERROR();
 }
 
-_SOKOL_PRIVATE void _sg_update_image(_sg_image* img, const sg_image_content* data) {
+_SOKOL_PRIVATE void _sg_update_image(_sg_image_t* img, const sg_image_content* data) {
     SOKOL_ASSERT(img && data);
     /* only one update per image per frame allowed */
     if (++img->active_slot >= img->num_slots) {
@@ -5378,22 +5378,22 @@ _SOKOL_PRIVATE void _sg_reset_state_cache(void) {
     _sg_d3d11_clear_state();
 }
 
-_SOKOL_PRIVATE void _sg_activate_context(_sg_context* ctx) {
+_SOKOL_PRIVATE void _sg_activate_context(_sg_context_t* ctx) {
     _SOKOL_UNUSED(ctx);
     _sg_reset_state_cache();
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_context(_sg_context* ctx) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_context(_sg_context* ctx) {
+_SOKOL_PRIVATE void _sg_destroy_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     /* empty */
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_buffer(_sg_buffer* buf, const sg_buffer_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_buffer(_sg_buffer_t* buf, const sg_buffer_desc* desc) {
     SOKOL_ASSERT(buf && desc);
     SOKOL_ASSERT(!buf->d3d11_buf);
     buf->size = desc->size;
@@ -5430,14 +5430,14 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_buffer(_sg_buffer* buf, const sg_buf
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_buffer(_sg_buffer* buf) {
+_SOKOL_PRIVATE void _sg_destroy_buffer(_sg_buffer_t* buf) {
     SOKOL_ASSERT(buf);
     if (buf->d3d11_buf) {
         ID3D11Buffer_Release(buf->d3d11_buf);
     }
 }
 
-_SOKOL_PRIVATE void _sg_d3d11_fill_subres_data(const _sg_image* img, const sg_image_content* content) {
+_SOKOL_PRIVATE void _sg_d3d11_fill_subres_data(const _sg_image_t* img, const sg_image_content* content) {
     const int num_faces = (img->type == SG_IMAGETYPE_CUBE) ? 6:1;
     const int num_slices = (img->type == SG_IMAGETYPE_ARRAY) ? img->depth:1;
     int subres_index = 0;
@@ -5466,7 +5466,7 @@ _SOKOL_PRIVATE void _sg_d3d11_fill_subres_data(const _sg_image* img, const sg_im
     }
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_image(_sg_image* img, const sg_image_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_image(_sg_image_t* img, const sg_image_desc* desc) {
     SOKOL_ASSERT(img && desc);
     SOKOL_ASSERT(!img->d3d11_tex2d && !img->d3d11_tex3d && !img->d3d11_texds && !img->d3d11_texmsaa);
     SOKOL_ASSERT(!img->d3d11_srv && !img->d3d11_smp);
@@ -5665,7 +5665,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_image(_sg_image* img, const sg_image
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_image(_sg_image* img) {
+_SOKOL_PRIVATE void _sg_destroy_image(_sg_image_t* img) {
     SOKOL_ASSERT(img);
     if (img->d3d11_tex2d) {
         ID3D11Texture2D_Release(img->d3d11_tex2d);
@@ -5713,7 +5713,7 @@ _SOKOL_PRIVATE ID3DBlob* _sg_d3d11_compile_shader(const sg_shader_stage_desc* st
 
 #define _sg_d3d11_roundup(val, round_to) (((val)+((round_to)-1))&~((round_to)-1))
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader* shd, const sg_shader_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader_t* shd, const sg_shader_desc* desc) {
     SOKOL_ASSERT(shd && desc);
     SOKOL_ASSERT(!shd->d3d11_vs && !shd->d3d11_fs && !shd->d3d11_vs_blob);
     HRESULT hr;
@@ -5722,14 +5722,14 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader* shd, const sg_sha
     /* shader stage uniform blocks and image slots */
     for (int stage_index = 0; stage_index < SG_NUM_SHADER_STAGES; stage_index++) {
         const sg_shader_stage_desc* stage_desc = (stage_index == SG_SHADERSTAGE_VS) ? &desc->vs : &desc->fs;
-        _sg_shader_stage* stage = &shd->stage[stage_index];
+        _sg_shader_stage_t* stage = &shd->stage[stage_index];
         SOKOL_ASSERT(stage->num_uniform_blocks == 0);
         for (int ub_index = 0; ub_index < SG_MAX_SHADERSTAGE_UBS; ub_index++) {
             const sg_shader_uniform_block_desc* ub_desc = &stage_desc->uniform_blocks[ub_index];
             if (0 == ub_desc->size) {
                 break;
             }
-            _sg_uniform_block* ub = &stage->uniform_blocks[ub_index];
+            _sg_uniform_block_t* ub = &stage->uniform_blocks[ub_index];
             ub->size = ub_desc->size;
 
             /* create a D3D constant buffer */
@@ -5806,7 +5806,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader* shd, const sg_sha
     return result;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_shader(_sg_shader* shd) {
+_SOKOL_PRIVATE void _sg_destroy_shader(_sg_shader_t* shd) {
     SOKOL_ASSERT(shd);
     if (shd->d3d11_vs) {
         ID3D11VertexShader_Release(shd->d3d11_vs);
@@ -5818,7 +5818,7 @@ _SOKOL_PRIVATE void _sg_destroy_shader(_sg_shader* shd) {
         SOKOL_FREE(shd->d3d11_vs_blob);
     }
     for (int stage_index = 0; stage_index < SG_NUM_SHADER_STAGES; stage_index++) {
-        _sg_shader_stage* stage = &shd->stage[stage_index];
+        _sg_shader_stage_t* stage = &shd->stage[stage_index];
         for (int ub_index = 0; ub_index < stage->num_uniform_blocks; ub_index++) {
             if (stage->d3d11_cbs[ub_index]) {
                 ID3D11Buffer_Release(stage->d3d11_cbs[ub_index]);
@@ -5827,7 +5827,7 @@ _SOKOL_PRIVATE void _sg_destroy_shader(_sg_shader* shd) {
     }
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_pipeline(_sg_pipeline* pip, _sg_shader* shd, const sg_pipeline_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_pipeline(_sg_pipeline_t* pip, _sg_shader_t* shd, const sg_pipeline_desc* desc) {
     SOKOL_ASSERT(pip && shd && desc);
     SOKOL_ASSERT(desc->shader.id == shd->slot.id);
     SOKOL_ASSERT(shd->slot.state == SG_RESOURCESTATE_VALID);
@@ -5962,7 +5962,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_pipeline(_sg_pipeline* pip, _sg_shad
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_pipeline(_sg_pipeline* pip) {
+_SOKOL_PRIVATE void _sg_destroy_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
     if (pip->d3d11_il) {
         ID3D11InputLayout_Release(pip->d3d11_il);
@@ -5978,13 +5978,13 @@ _SOKOL_PRIVATE void _sg_destroy_pipeline(_sg_pipeline* pip) {
     }
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_pass(_sg_pass* pass, _sg_image** att_images, const sg_pass_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_pass(_sg_pass_t* pass, _sg_image_t** att_images, const sg_pass_desc* desc) {
     SOKOL_ASSERT(pass && desc);
     SOKOL_ASSERT(att_images && att_images[0]);
     SOKOL_ASSERT(_sg.d3d11.dev);
 
     const sg_attachment_desc* att_desc;
-    _sg_attachment* att;
+    _sg_attachment_t* att;
     for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
         SOKOL_ASSERT(0 == pass->color_atts[i].image);
         SOKOL_ASSERT(pass->d3d11_rtvs[i] == 0);
@@ -6087,7 +6087,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_pass(_sg_pass* pass, _sg_image** att
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_pass(_sg_pass* pass) {
+_SOKOL_PRIVATE void _sg_destroy_pass(_sg_pass_t* pass) {
     SOKOL_ASSERT(pass);
     for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
         if (pass->d3d11_rtvs[i]) {
@@ -6099,7 +6099,7 @@ _SOKOL_PRIVATE void _sg_destroy_pass(_sg_pass* pass) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_begin_pass(_sg_pass* pass, const sg_pass_action* action, int w, int h) {
+_SOKOL_PRIVATE void _sg_begin_pass(_sg_pass_t* pass, const sg_pass_action* action, int w, int h) {
     SOKOL_ASSERT(action);
     SOKOL_ASSERT(!_sg.d3d11.in_pass);
     _sg.d3d11.in_pass = true;
@@ -6177,12 +6177,12 @@ _SOKOL_PRIVATE void _sg_end_pass(void) {
     if (_sg.d3d11.cur_pass) {
         SOKOL_ASSERT(_sg.d3d11.cur_pass->slot.id == _sg.d3d11.cur_pass_id.id);
         for (int i = 0; i < _sg.d3d11.num_rtvs; i++) {
-            _sg_attachment* att = &_sg.d3d11.cur_pass->color_atts[i];
+            _sg_attachment_t* att = &_sg.d3d11.cur_pass->color_atts[i];
             SOKOL_ASSERT(att->image && (att->image->slot.id == att->image_id.id));
             if (att->image->sample_count > 1) {
                 SOKOL_ASSERT(att->image->d3d11_tex2d && att->image->d3d11_texmsaa && !att->image->d3d11_tex3d);
                 SOKOL_ASSERT(DXGI_FORMAT_UNKNOWN != att->image->d3d11_format);
-                const _sg_image* img = att->image;
+                const _sg_image_t* img = att->image;
                 UINT subres = _sg_d3d11_calcsubresource(att->mip_level, att->slice, img->num_mipmaps);
                 ID3D11DeviceContext_ResolveSubresource(_sg.d3d11.ctx,
                     (ID3D11Resource*) img->d3d11_tex2d,     /* pDstResource */
@@ -6228,7 +6228,7 @@ _SOKOL_PRIVATE void _sg_apply_scissor_rect(int x, int y, int w, int h, bool orig
     ID3D11DeviceContext_RSSetScissorRects(_sg.d3d11.ctx, 1, &rect);
 }
 
-_SOKOL_PRIVATE void _sg_apply_pipeline(_sg_pipeline* pip) {
+_SOKOL_PRIVATE void _sg_apply_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
     SOKOL_ASSERT(pip->shader);
     SOKOL_ASSERT(_sg.d3d11.ctx);
@@ -6251,11 +6251,11 @@ _SOKOL_PRIVATE void _sg_apply_pipeline(_sg_pipeline* pip) {
 }
 
 _SOKOL_PRIVATE void _sg_apply_bindings(
-    _sg_pipeline* pip,
-    _sg_buffer** vbs, const int* vb_offsets, int num_vbs,
-    _sg_buffer* ib, int ib_offset,
-    _sg_image** vs_imgs, int num_vs_imgs,
-    _sg_image** fs_imgs, int num_fs_imgs)
+    _sg_pipeline_t* pip,
+    _sg_buffer_t** vbs, const int* vb_offsets, int num_vbs,
+    _sg_buffer_t* ib, int ib_offset,
+    _sg_image_t** vs_imgs, int num_vs_imgs,
+    _sg_image_t** fs_imgs, int num_fs_imgs)
 {
     SOKOL_ASSERT(pip);
     SOKOL_ASSERT(_sg.d3d11.ctx);
@@ -6347,7 +6347,7 @@ _SOKOL_PRIVATE void _sg_commit(void) {
     SOKOL_ASSERT(!_sg.d3d11.in_pass);
 }
 
-_SOKOL_PRIVATE void _sg_update_buffer(_sg_buffer* buf, const void* data_ptr, int data_size) {
+_SOKOL_PRIVATE void _sg_update_buffer(_sg_buffer_t* buf, const void* data_ptr, int data_size) {
     SOKOL_ASSERT(buf && data_ptr && (data_size > 0));
     SOKOL_ASSERT(_sg.d3d11.ctx);
     SOKOL_ASSERT(buf->d3d11_buf);
@@ -6359,7 +6359,7 @@ _SOKOL_PRIVATE void _sg_update_buffer(_sg_buffer* buf, const void* data_ptr, int
     ID3D11DeviceContext_Unmap(_sg.d3d11.ctx, (ID3D11Resource*)buf->d3d11_buf, 0);
 }
 
-_SOKOL_PRIVATE void _sg_append_buffer(_sg_buffer* buf, const void* data_ptr, int data_size, bool new_frame) {
+_SOKOL_PRIVATE void _sg_append_buffer(_sg_buffer_t* buf, const void* data_ptr, int data_size, bool new_frame) {
     SOKOL_ASSERT(buf && data_ptr && (data_size > 0));
     SOKOL_ASSERT(_sg.d3d11.ctx);
     SOKOL_ASSERT(buf->d3d11_buf);
@@ -6373,7 +6373,7 @@ _SOKOL_PRIVATE void _sg_append_buffer(_sg_buffer* buf, const void* data_ptr, int
     ID3D11DeviceContext_Unmap(_sg.d3d11.ctx, (ID3D11Resource*)buf->d3d11_buf, 0);
 }
 
-_SOKOL_PRIVATE void _sg_update_image(_sg_image* img, const sg_image_content* data) {
+_SOKOL_PRIVATE void _sg_update_image(_sg_image_t* img, const sg_image_content* data) {
     SOKOL_ASSERT(img && data);
     SOKOL_ASSERT(_sg.d3d11.ctx);
     SOKOL_ASSERT(img->d3d11_tex2d || img->d3d11_tex3d);
@@ -7004,23 +7004,23 @@ _SOKOL_PRIVATE void _sg_reset_state_cache(void) {
     _sg_mtl_clear_state_cache();
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_context(_sg_context* ctx) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     _SOKOL_UNUSED(ctx);
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_context(_sg_context* ctx) {
+_SOKOL_PRIVATE void _sg_destroy_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     _SOKOL_UNUSED(ctx);
     /* empty */
 }
 
-_SOKOL_PRIVATE void _sg_activate_context(_sg_context* ctx) {
+_SOKOL_PRIVATE void _sg_activate_context(_sg_context_t* ctx) {
     _sg_reset_state_cache();
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_buffer(_sg_buffer* buf, const sg_buffer_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_buffer(_sg_buffer_t* buf, const sg_buffer_desc* desc) {
     SOKOL_ASSERT(buf && desc);
     buf->size = desc->size;
     buf->append_pos = 0;
@@ -7053,7 +7053,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_buffer(_sg_buffer* buf, const sg_buf
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_buffer(_sg_buffer* buf) {
+_SOKOL_PRIVATE void _sg_destroy_buffer(_sg_buffer_t* buf) {
     SOKOL_ASSERT(buf);
     for (int slot = 0; slot < buf->num_slots; slot++) {
         /* it's valid to call release resource with '0' */
@@ -7061,7 +7061,7 @@ _SOKOL_PRIVATE void _sg_destroy_buffer(_sg_buffer* buf) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_mtl_copy_image_content(const _sg_image* img, __unsafe_unretained id<MTLTexture> mtl_tex, const sg_image_content* content) {
+_SOKOL_PRIVATE void _sg_mtl_copy_image_content(const _sg_image_t* img, __unsafe_unretained id<MTLTexture> mtl_tex, const sg_image_content* content) {
     const int num_faces = (img->type == SG_IMAGETYPE_CUBE) ? 6:1;
     const int num_slices = (img->type == SG_IMAGETYPE_ARRAY) ? img->depth : 1;
     for (int face_index = 0; face_index < num_faces; face_index++) {
@@ -7102,7 +7102,7 @@ _SOKOL_PRIVATE void _sg_mtl_copy_image_content(const _sg_image* img, __unsafe_un
     }
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_image(_sg_image* img, const sg_image_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_image(_sg_image_t* img, const sg_image_desc* desc) {
     SOKOL_ASSERT(img && desc);
     img->type = _sg_def(desc->type, SG_IMAGETYPE_2D);
     img->render_target = desc->render_target;
@@ -7221,7 +7221,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_image(_sg_image* img, const sg_image
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_image(_sg_image* img) {
+_SOKOL_PRIVATE void _sg_destroy_image(_sg_image_t* img) {
     SOKOL_ASSERT(img);
     /* it's valid to call release resource with a 'null resource' */
     for (int slot = 0; slot < img->num_slots; slot++) {
@@ -7255,20 +7255,20 @@ _SOKOL_PRIVATE id<MTLLibrary> _sg_mtl_library_from_bytecode(const uint8_t* ptr, 
     return lib;
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader* shd, const sg_shader_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader_t* shd, const sg_shader_desc* desc) {
     SOKOL_ASSERT(shd && desc);
 
     /* uniform block sizes and image types */
     for (int stage_index = 0; stage_index < SG_NUM_SHADER_STAGES; stage_index++) {
         const sg_shader_stage_desc* stage_desc = (stage_index == SG_SHADERSTAGE_VS) ? &desc->vs : &desc->fs;
-        _sg_shader_stage* stage = &shd->stage[stage_index];
+        _sg_shader_stage_t* stage = &shd->stage[stage_index];
         SOKOL_ASSERT(stage->num_uniform_blocks == 0);
         for (int ub_index = 0; ub_index < SG_MAX_SHADERSTAGE_UBS; ub_index++) {
             const sg_shader_uniform_block_desc* ub_desc = &stage_desc->uniform_blocks[ub_index];
             if (0 == ub_desc->size) {
                 break;
             }
-            _sg_uniform_block* ub = &stage->uniform_blocks[ub_index];
+            _sg_uniform_block_t* ub = &stage->uniform_blocks[ub_index];
             ub->size = ub_desc->size;
             stage->num_uniform_blocks++;
         }
@@ -7329,7 +7329,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_shader(_sg_shader* shd, const sg_sha
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_shader(_sg_shader* shd) {
+_SOKOL_PRIVATE void _sg_destroy_shader(_sg_shader_t* shd) {
     SOKOL_ASSERT(shd);
     /* it is valid to call _sg_mtl_release_resource with a 'null resource' */
     _sg_mtl_release_resource(_sg.mtl.frame_index, shd->stage[SG_SHADERSTAGE_VS].mtl_func);
@@ -7338,7 +7338,7 @@ _SOKOL_PRIVATE void _sg_destroy_shader(_sg_shader* shd) {
     _sg_mtl_release_resource(_sg.mtl.frame_index, shd->stage[SG_SHADERSTAGE_FS].mtl_lib);
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_pipeline(_sg_pipeline* pip, _sg_shader* shd, const sg_pipeline_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_pipeline(_sg_pipeline_t* pip, _sg_shader_t* shd, const sg_pipeline_desc* desc) {
     SOKOL_ASSERT(pip && shd && desc);
     SOKOL_ASSERT(desc->shader.id == shd->slot.id);
 
@@ -7473,20 +7473,20 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_pipeline(_sg_pipeline* pip, _sg_shad
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_pipeline(_sg_pipeline* pip) {
+_SOKOL_PRIVATE void _sg_destroy_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
     /* it's valid to call release resource with a 'null resource' */
     _sg_mtl_release_resource(_sg.mtl.frame_index, pip->mtl_rps);
     _sg_mtl_release_resource(_sg.mtl.frame_index, pip->mtl_dss);
 }
 
-_SOKOL_PRIVATE sg_resource_state _sg_create_pass(_sg_pass* pass, _sg_image** att_images, const sg_pass_desc* desc) {
+_SOKOL_PRIVATE sg_resource_state _sg_create_pass(_sg_pass_t* pass, _sg_image_t** att_images, const sg_pass_desc* desc) {
     SOKOL_ASSERT(pass && desc);
     SOKOL_ASSERT(att_images && att_images[0]);
 
     /* copy image pointers and desc attributes */
     const sg_attachment_desc* att_desc;
-    _sg_attachment* att;
+    _sg_attachment_t* att;
     for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
         SOKOL_ASSERT(0 == pass->color_atts[i].image);
         att_desc = &desc->color_attachments[i];
@@ -7518,12 +7518,12 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_pass(_sg_pass* pass, _sg_image** att
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_pass(_sg_pass* pass) {
+_SOKOL_PRIVATE void _sg_destroy_pass(_sg_pass_t* pass) {
     SOKOL_ASSERT(pass);
     _SOKOL_UNUSED(pass);
 }
 
-_SOKOL_PRIVATE void _sg_begin_pass(_sg_pass* pass, const sg_pass_action* action, int w, int h) {
+_SOKOL_PRIVATE void _sg_begin_pass(_sg_pass_t* pass, const sg_pass_action* action, int w, int h) {
     SOKOL_ASSERT(action);
     SOKOL_ASSERT(!_sg.mtl.in_pass);
     SOKOL_ASSERT(_sg_objc.cmd_queue);
@@ -7570,7 +7570,7 @@ _SOKOL_PRIVATE void _sg_begin_pass(_sg_pass* pass, const sg_pass_action* action,
         /* setup pass descriptor for offscreen rendering */
         SOKOL_ASSERT(pass->slot.state == SG_RESOURCESTATE_VALID);
         for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
-            const _sg_attachment* att = &pass->color_atts[i];
+            const _sg_attachment_t* att = &pass->color_atts[i];
             if (0 == att->image) {
                 break;
             }
@@ -7615,7 +7615,7 @@ _SOKOL_PRIVATE void _sg_begin_pass(_sg_pass* pass, const sg_pass_action* action,
             }
         }
         if (0 != pass->ds_att.image) {
-            const _sg_attachment* att = &pass->ds_att;
+            const _sg_attachment_t* att = &pass->ds_att;
             SOKOL_ASSERT(att->image->slot.state == SG_RESOURCESTATE_VALID);
             SOKOL_ASSERT(att->image->slot.id == att->image_id.id);
             SOKOL_ASSERT(att->image->mtl_depth_tex != _SG_MTL_INVALID_SLOT_INDEX);
@@ -7745,7 +7745,7 @@ _SOKOL_PRIVATE void _sg_apply_scissor_rect(int x, int y, int w, int h, bool orig
     [_sg_objc.cmd_encoder setScissorRect:r];
 }
 
-_SOKOL_PRIVATE void _sg_apply_pipeline(_sg_pipeline* pip) {
+_SOKOL_PRIVATE void _sg_apply_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
     SOKOL_ASSERT(pip->shader);
     SOKOL_ASSERT(_sg.mtl.in_pass);
@@ -7771,11 +7771,11 @@ _SOKOL_PRIVATE void _sg_apply_pipeline(_sg_pipeline* pip) {
 }
 
 _SOKOL_PRIVATE void _sg_apply_bindings(
-    _sg_pipeline* pip,
-    _sg_buffer** vbs, const int* vb_offsets, int num_vbs,
-    _sg_buffer* ib, int ib_offset,
-    _sg_image** vs_imgs, int num_vs_imgs,
-    _sg_image** fs_imgs, int num_fs_imgs)
+    _sg_pipeline_t* pip,
+    _sg_buffer_t** vbs, const int* vb_offsets, int num_vbs,
+    _sg_buffer_t* ib, int ib_offset,
+    _sg_image_t** vs_imgs, int num_vs_imgs,
+    _sg_image_t** fs_imgs, int num_fs_imgs)
 {
     SOKOL_ASSERT(_sg.mtl.in_pass);
     if (!_sg.mtl.pass_valid) {
@@ -7798,7 +7798,7 @@ _SOKOL_PRIVATE void _sg_apply_bindings(
     /* apply vertex buffers */
     int slot;
     for (slot = 0; slot < num_vbs; slot++) {
-        const _sg_buffer* vb = vbs[slot];
+        const _sg_buffer_t* vb = vbs[slot];
         if ((_sg.mtl.state_cache.cur_vertexbuffers[slot] != vb) ||
             (_sg.mtl.state_cache.cur_vertexbuffer_offsets[slot] != vb_offsets[slot]) ||
             (_sg.mtl.state_cache.cur_vertexbuffer_ids[slot].id != vb->slot.id))
@@ -7816,7 +7816,7 @@ _SOKOL_PRIVATE void _sg_apply_bindings(
 
     /* apply vertex shader images */
     for (slot = 0; slot < num_vs_imgs; slot++) {
-        const _sg_image* img = vs_imgs[slot];
+        const _sg_image_t* img = vs_imgs[slot];
         if ((_sg.mtl.state_cache.cur_vs_images[slot] != img) || (_sg.mtl.state_cache.cur_vs_image_ids[slot].id != img->slot.id)) {
             _sg.mtl.state_cache.cur_vs_images[slot] = img;
             _sg.mtl.state_cache.cur_vs_image_ids[slot].id = img->slot.id;
@@ -7829,7 +7829,7 @@ _SOKOL_PRIVATE void _sg_apply_bindings(
 
     /* apply fragment shader images */
     for (slot = 0; slot < num_fs_imgs; slot++) {
-        const _sg_image* img = fs_imgs[slot];
+        const _sg_image_t* img = fs_imgs[slot];
         if ((_sg.mtl.state_cache.cur_fs_images[slot] != img) || (_sg.mtl.state_cache.cur_fs_image_ids[slot].id != img->slot.id)) {
             _sg.mtl.state_cache.cur_fs_images[slot] = img;
             _sg.mtl.state_cache.cur_fs_image_ids[slot].id = img->slot.id;
@@ -7882,7 +7882,7 @@ _SOKOL_PRIVATE void _sg_draw(int base_element, int num_elements, int num_instanc
     if (SG_INDEXTYPE_NONE != _sg.mtl.state_cache.cur_pipeline->index_type) {
         /* indexed rendering */
         SOKOL_ASSERT(_sg.mtl.state_cache.cur_indexbuffer && (_sg.mtl.state_cache.cur_indexbuffer->slot.id == _sg.mtl.state_cache.cur_indexbuffer_id.id));
-        const _sg_buffer* ib = _sg.mtl.state_cache.cur_indexbuffer;
+        const _sg_buffer_t* ib = _sg.mtl.state_cache.cur_indexbuffer;
         SOKOL_ASSERT(ib->mtl_buf[ib->active_slot] != _SG_MTL_INVALID_SLOT_INDEX);
         const NSUInteger index_buffer_offset = _sg.mtl.state_cache.cur_indexbuffer_offset +
             base_element * _sg.mtl.state_cache.cur_pipeline->mtl_index_size;
@@ -7902,7 +7902,7 @@ _SOKOL_PRIVATE void _sg_draw(int base_element, int num_elements, int num_instanc
     }
 }
 
-_SOKOL_PRIVATE void _sg_update_buffer(_sg_buffer* buf, const void* data, int data_size) {
+_SOKOL_PRIVATE void _sg_update_buffer(_sg_buffer_t* buf, const void* data, int data_size) {
     SOKOL_ASSERT(buf && data && (data_size > 0));
     if (++buf->active_slot >= buf->num_slots) {
         buf->active_slot = 0;
@@ -7915,7 +7915,7 @@ _SOKOL_PRIVATE void _sg_update_buffer(_sg_buffer* buf, const void* data, int dat
     #endif
 }
 
-_SOKOL_PRIVATE void _sg_append_buffer(_sg_buffer* buf, const void* data, int data_size, bool new_frame) {
+_SOKOL_PRIVATE void _sg_append_buffer(_sg_buffer_t* buf, const void* data, int data_size, bool new_frame) {
     SOKOL_ASSERT(buf && data && (data_size > 0));
     if (new_frame) {
         if (++buf->active_slot >= buf->num_slots) {
@@ -7931,7 +7931,7 @@ _SOKOL_PRIVATE void _sg_append_buffer(_sg_buffer* buf, const void* data, int dat
     #endif
 }
 
-_SOKOL_PRIVATE void _sg_update_image(_sg_image* img, const sg_image_content* data) {
+_SOKOL_PRIVATE void _sg_update_image(_sg_image_t* img, const sg_image_content* data) {
     SOKOL_ASSERT(img && data);
     if (++img->active_slot >= img->num_slots) {
         img->active_slot = 0;
@@ -7944,7 +7944,7 @@ _SOKOL_PRIVATE void _sg_update_image(_sg_image* img, const sg_image_content* dat
 
 /*== RESOURCE POOLS ==========================================================*/
 
-_SOKOL_PRIVATE void _sg_init_pool(_sg_pool* pool, int num) {
+_SOKOL_PRIVATE void _sg_init_pool(_sg_pool_t* pool, int num) {
     SOKOL_ASSERT(pool && (num >= 1));
     /* slot 0 is reserved for the 'invalid id', so bump the pool size by 1 */
     pool->size = num + 1;
@@ -7963,7 +7963,7 @@ _SOKOL_PRIVATE void _sg_init_pool(_sg_pool* pool, int num) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_discard_pool(_sg_pool* pool) {
+_SOKOL_PRIVATE void _sg_discard_pool(_sg_pool_t* pool) {
     SOKOL_ASSERT(pool);
     SOKOL_ASSERT(pool->free_queue);
     SOKOL_FREE(pool->free_queue);
@@ -7975,7 +7975,7 @@ _SOKOL_PRIVATE void _sg_discard_pool(_sg_pool* pool) {
     pool->queue_top = 0;
 }
 
-_SOKOL_PRIVATE int _sg_pool_alloc_index(_sg_pool* pool) {
+_SOKOL_PRIVATE int _sg_pool_alloc_index(_sg_pool_t* pool) {
     SOKOL_ASSERT(pool);
     SOKOL_ASSERT(pool->free_queue);
     if (pool->queue_top > 0) {
@@ -7989,7 +7989,7 @@ _SOKOL_PRIVATE int _sg_pool_alloc_index(_sg_pool* pool) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_pool_free_index(_sg_pool* pool, int slot_index) {
+_SOKOL_PRIVATE void _sg_pool_free_index(_sg_pool_t* pool, int slot_index) {
     SOKOL_ASSERT((slot_index > _SG_INVALID_SLOT_INDEX) && (slot_index < pool->size));
     SOKOL_ASSERT(pool);
     SOKOL_ASSERT(pool->free_queue);
@@ -8004,84 +8004,84 @@ _SOKOL_PRIVATE void _sg_pool_free_index(_sg_pool* pool, int slot_index) {
     SOKOL_ASSERT(pool->queue_top <= (pool->size-1));
 }
 
-_SOKOL_PRIVATE void _sg_reset_buffer(_sg_buffer* buf) {
+_SOKOL_PRIVATE void _sg_reset_buffer(_sg_buffer_t* buf) {
     SOKOL_ASSERT(buf);
-    memset(buf, 0, sizeof(_sg_buffer));
+    memset(buf, 0, sizeof(_sg_buffer_t));
 }
 
-_SOKOL_PRIVATE void _sg_reset_image(_sg_image* img) {
+_SOKOL_PRIVATE void _sg_reset_image(_sg_image_t* img) {
     SOKOL_ASSERT(img);
-    memset(img, 0, sizeof(_sg_image));
+    memset(img, 0, sizeof(_sg_image_t));
 }
 
-_SOKOL_PRIVATE void _sg_reset_shader(_sg_shader* shd) {
+_SOKOL_PRIVATE void _sg_reset_shader(_sg_shader_t* shd) {
     SOKOL_ASSERT(shd);
-    memset(shd, 0, sizeof(_sg_shader));
+    memset(shd, 0, sizeof(_sg_shader_t));
 }
 
-_SOKOL_PRIVATE void _sg_reset_pipeline(_sg_pipeline* pip) {
+_SOKOL_PRIVATE void _sg_reset_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
-    memset(pip, 0, sizeof(_sg_pipeline));
+    memset(pip, 0, sizeof(_sg_pipeline_t));
 }
 
-_SOKOL_PRIVATE void _sg_reset_pass(_sg_pass* pass) {
+_SOKOL_PRIVATE void _sg_reset_pass(_sg_pass_t* pass) {
     SOKOL_ASSERT(pass);
-    memset(pass, 0, sizeof(_sg_pass));
+    memset(pass, 0, sizeof(_sg_pass_t));
 }
 
-_SOKOL_PRIVATE void _sg_reset_context(_sg_context* ctx) {
+_SOKOL_PRIVATE void _sg_reset_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
-    memset(ctx, 0, sizeof(_sg_context));
+    memset(ctx, 0, sizeof(_sg_context_t));
 }
 
-_SOKOL_PRIVATE void _sg_setup_pools(_sg_pools* p, const sg_desc* desc) {
+_SOKOL_PRIVATE void _sg_setup_pools(_sg_pools_t* p, const sg_desc* desc) {
     SOKOL_ASSERT(p);
     SOKOL_ASSERT(desc);
     /* note: the pools here will have an additional item, since slot 0 is reserved */
     SOKOL_ASSERT((desc->buffer_pool_size >= 0) && (desc->buffer_pool_size < _SG_MAX_POOL_SIZE));
     _sg_init_pool(&p->buffer_pool, _sg_def(desc->buffer_pool_size, _SG_DEFAULT_BUFFER_POOL_SIZE));
-    size_t buffer_pool_byte_size = sizeof(_sg_buffer) * p->buffer_pool.size;
-    p->buffers = (_sg_buffer*) SOKOL_MALLOC(buffer_pool_byte_size);
+    size_t buffer_pool_byte_size = sizeof(_sg_buffer_t) * p->buffer_pool.size;
+    p->buffers = (_sg_buffer_t*) SOKOL_MALLOC(buffer_pool_byte_size);
     SOKOL_ASSERT(p->buffers);
     memset(p->buffers, 0, buffer_pool_byte_size);
 
     SOKOL_ASSERT((desc->image_pool_size >= 0) && (desc->image_pool_size < _SG_MAX_POOL_SIZE));
     _sg_init_pool(&p->image_pool, _sg_def(desc->image_pool_size, _SG_DEFAULT_IMAGE_POOL_SIZE));
-    size_t image_pool_byte_size = sizeof(_sg_image) * p->image_pool.size;
-    p->images = (_sg_image*) SOKOL_MALLOC(image_pool_byte_size);
+    size_t image_pool_byte_size = sizeof(_sg_image_t) * p->image_pool.size;
+    p->images = (_sg_image_t*) SOKOL_MALLOC(image_pool_byte_size);
     SOKOL_ASSERT(p->images);
     memset(p->images, 0, image_pool_byte_size);
 
     SOKOL_ASSERT((desc->shader_pool_size >= 0) && (desc->shader_pool_size < _SG_MAX_POOL_SIZE));
     _sg_init_pool(&p->shader_pool, _sg_def(desc->shader_pool_size, _SG_DEFAULT_SHADER_POOL_SIZE));
-    size_t shader_pool_byte_size = sizeof(_sg_shader) * p->shader_pool.size;
-    p->shaders = (_sg_shader*) SOKOL_MALLOC(shader_pool_byte_size);
+    size_t shader_pool_byte_size = sizeof(_sg_shader_t) * p->shader_pool.size;
+    p->shaders = (_sg_shader_t*) SOKOL_MALLOC(shader_pool_byte_size);
     SOKOL_ASSERT(p->shaders);
     memset(p->shaders, 0, shader_pool_byte_size);
 
     SOKOL_ASSERT((desc->pipeline_pool_size >= 0) && (desc->pipeline_pool_size < _SG_MAX_POOL_SIZE));
     _sg_init_pool(&p->pipeline_pool, _sg_def(desc->pipeline_pool_size, _SG_DEFAULT_PIPELINE_POOL_SIZE));
-    size_t pipeline_pool_byte_size = sizeof(_sg_pipeline) * p->pipeline_pool.size;
-    p->pipelines = (_sg_pipeline*) SOKOL_MALLOC(pipeline_pool_byte_size);
+    size_t pipeline_pool_byte_size = sizeof(_sg_pipeline_t) * p->pipeline_pool.size;
+    p->pipelines = (_sg_pipeline_t*) SOKOL_MALLOC(pipeline_pool_byte_size);
     SOKOL_ASSERT(p->pipelines);
     memset(p->pipelines, 0, pipeline_pool_byte_size);
 
     SOKOL_ASSERT((desc->pass_pool_size >= 0) && (desc->pass_pool_size < _SG_MAX_POOL_SIZE));
     _sg_init_pool(&p->pass_pool, _sg_def(desc->pass_pool_size, _SG_DEFAULT_PASS_POOL_SIZE));
-    size_t pass_pool_byte_size = sizeof(_sg_pass) * p->pass_pool.size;
-    p->passes = (_sg_pass*) SOKOL_MALLOC(pass_pool_byte_size);
+    size_t pass_pool_byte_size = sizeof(_sg_pass_t) * p->pass_pool.size;
+    p->passes = (_sg_pass_t*) SOKOL_MALLOC(pass_pool_byte_size);
     SOKOL_ASSERT(p->passes);
     memset(p->passes, 0, pass_pool_byte_size);
 
     SOKOL_ASSERT((desc->context_pool_size >= 0) && (desc->context_pool_size < _SG_MAX_POOL_SIZE));
     _sg_init_pool(&p->context_pool, _sg_def(desc->context_pool_size, _SG_DEFAULT_CONTEXT_POOL_SIZE));
-    size_t context_pool_byte_size = sizeof(_sg_context) * p->context_pool.size;
-    p->contexts = (_sg_context*) SOKOL_MALLOC(context_pool_byte_size);
+    size_t context_pool_byte_size = sizeof(_sg_context_t) * p->context_pool.size;
+    p->contexts = (_sg_context_t*) SOKOL_MALLOC(context_pool_byte_size);
     SOKOL_ASSERT(p->contexts);
     memset(p->contexts, 0, context_pool_byte_size);
 }
 
-_SOKOL_PRIVATE void _sg_discard_pools(_sg_pools* p) {
+_SOKOL_PRIVATE void _sg_discard_pools(_sg_pools_t* p) {
     SOKOL_ASSERT(p);
     SOKOL_FREE(p->contexts);    p->contexts = 0;
     SOKOL_FREE(p->passes);      p->passes = 0;
@@ -8104,7 +8104,7 @@ _SOKOL_PRIVATE void _sg_discard_pools(_sg_pools* p) {
     - set the slot's state to ALLOC
     - return the resource id
 */
-_SOKOL_PRIVATE uint32_t _sg_slot_alloc(_sg_pool* pool, _sg_slot* slot, int slot_index) {
+_SOKOL_PRIVATE uint32_t _sg_slot_alloc(_sg_pool_t* pool, _sg_slot_t* slot, int slot_index) {
     /* FIXME: add handling for an overflowing generation counter,
        for now, just overflow (another option is to disable
        the slot)
@@ -8126,42 +8126,42 @@ _SOKOL_PRIVATE int _sg_slot_index(uint32_t id) {
 }
 
 /* returns pointer to resource by id without matching id check */
-_SOKOL_PRIVATE _sg_buffer* _sg_buffer_at(const _sg_pools* p, uint32_t buf_id) {
+_SOKOL_PRIVATE _sg_buffer_t* _sg_buffer_at(const _sg_pools_t* p, uint32_t buf_id) {
     SOKOL_ASSERT(p && (SG_INVALID_ID != buf_id));
     int slot_index = _sg_slot_index(buf_id);
     SOKOL_ASSERT((slot_index > _SG_INVALID_SLOT_INDEX) && (slot_index < p->buffer_pool.size));
     return &p->buffers[slot_index];
 }
 
-_SOKOL_PRIVATE _sg_image* _sg_image_at(const _sg_pools* p, uint32_t img_id) {
+_SOKOL_PRIVATE _sg_image_t* _sg_image_at(const _sg_pools_t* p, uint32_t img_id) {
     SOKOL_ASSERT(p && (SG_INVALID_ID != img_id));
     int slot_index = _sg_slot_index(img_id);
     SOKOL_ASSERT((slot_index > _SG_INVALID_SLOT_INDEX) && (slot_index < p->image_pool.size));
     return &p->images[slot_index];
 }
 
-_SOKOL_PRIVATE _sg_shader* _sg_shader_at(const _sg_pools* p, uint32_t shd_id) {
+_SOKOL_PRIVATE _sg_shader_t* _sg_shader_at(const _sg_pools_t* p, uint32_t shd_id) {
     SOKOL_ASSERT(p && (SG_INVALID_ID != shd_id));
     int slot_index = _sg_slot_index(shd_id);
     SOKOL_ASSERT((slot_index > _SG_INVALID_SLOT_INDEX) && (slot_index < p->shader_pool.size));
     return &p->shaders[slot_index];
 }
 
-_SOKOL_PRIVATE _sg_pipeline* _sg_pipeline_at(const _sg_pools* p, uint32_t pip_id) {
+_SOKOL_PRIVATE _sg_pipeline_t* _sg_pipeline_at(const _sg_pools_t* p, uint32_t pip_id) {
     SOKOL_ASSERT(p && (SG_INVALID_ID != pip_id));
     int slot_index = _sg_slot_index(pip_id);
     SOKOL_ASSERT((slot_index > _SG_INVALID_SLOT_INDEX) && (slot_index < p->pipeline_pool.size));
     return &p->pipelines[slot_index];
 }
 
-_SOKOL_PRIVATE _sg_pass* _sg_pass_at(const _sg_pools* p, uint32_t pass_id) {
+_SOKOL_PRIVATE _sg_pass_t* _sg_pass_at(const _sg_pools_t* p, uint32_t pass_id) {
     SOKOL_ASSERT(p && (SG_INVALID_ID != pass_id));
     int slot_index = _sg_slot_index(pass_id);
     SOKOL_ASSERT((slot_index > _SG_INVALID_SLOT_INDEX) && (slot_index < p->pass_pool.size));
     return &p->passes[slot_index];
 }
 
-_SOKOL_PRIVATE _sg_context* _sg_context_at(const _sg_pools* p, uint32_t context_id) {
+_SOKOL_PRIVATE _sg_context_t* _sg_context_at(const _sg_pools_t* p, uint32_t context_id) {
     SOKOL_ASSERT(p && (SG_INVALID_ID != context_id));
     int slot_index = _sg_slot_index(context_id);
     SOKOL_ASSERT((slot_index > _SG_INVALID_SLOT_INDEX) && (slot_index < p->context_pool.size));
@@ -8169,9 +8169,9 @@ _SOKOL_PRIVATE _sg_context* _sg_context_at(const _sg_pools* p, uint32_t context_
 }
 
 /* returns pointer to resource with matching id check, may return 0 */
-_SOKOL_PRIVATE _sg_buffer* _sg_lookup_buffer(const _sg_pools* p, uint32_t buf_id) {
+_SOKOL_PRIVATE _sg_buffer_t* _sg_lookup_buffer(const _sg_pools_t* p, uint32_t buf_id) {
     if (SG_INVALID_ID != buf_id) {
-        _sg_buffer* buf = _sg_buffer_at(p, buf_id);
+        _sg_buffer_t* buf = _sg_buffer_at(p, buf_id);
         if (buf->slot.id == buf_id) {
             return buf;
         }
@@ -8179,9 +8179,9 @@ _SOKOL_PRIVATE _sg_buffer* _sg_lookup_buffer(const _sg_pools* p, uint32_t buf_id
     return 0;
 }
 
-_SOKOL_PRIVATE _sg_image* _sg_lookup_image(const _sg_pools* p, uint32_t img_id) {
+_SOKOL_PRIVATE _sg_image_t* _sg_lookup_image(const _sg_pools_t* p, uint32_t img_id) {
     if (SG_INVALID_ID != img_id) {
-        _sg_image* img = _sg_image_at(p, img_id);
+        _sg_image_t* img = _sg_image_at(p, img_id);
         if (img->slot.id == img_id) {
             return img;
         }
@@ -8189,10 +8189,10 @@ _SOKOL_PRIVATE _sg_image* _sg_lookup_image(const _sg_pools* p, uint32_t img_id) 
     return 0;
 }
 
-_SOKOL_PRIVATE _sg_shader* _sg_lookup_shader(const _sg_pools* p, uint32_t shd_id) {
+_SOKOL_PRIVATE _sg_shader_t* _sg_lookup_shader(const _sg_pools_t* p, uint32_t shd_id) {
     SOKOL_ASSERT(p);
     if (SG_INVALID_ID != shd_id) {
-        _sg_shader* shd = _sg_shader_at(p, shd_id);
+        _sg_shader_t* shd = _sg_shader_at(p, shd_id);
         if (shd->slot.id == shd_id) {
             return shd;
         }
@@ -8200,10 +8200,10 @@ _SOKOL_PRIVATE _sg_shader* _sg_lookup_shader(const _sg_pools* p, uint32_t shd_id
     return 0;
 }
 
-_SOKOL_PRIVATE _sg_pipeline* _sg_lookup_pipeline(const _sg_pools* p, uint32_t pip_id) {
+_SOKOL_PRIVATE _sg_pipeline_t* _sg_lookup_pipeline(const _sg_pools_t* p, uint32_t pip_id) {
     SOKOL_ASSERT(p);
     if (SG_INVALID_ID != pip_id) {
-        _sg_pipeline* pip = _sg_pipeline_at(p, pip_id);
+        _sg_pipeline_t* pip = _sg_pipeline_at(p, pip_id);
         if (pip->slot.id == pip_id) {
             return pip;
         }
@@ -8211,10 +8211,10 @@ _SOKOL_PRIVATE _sg_pipeline* _sg_lookup_pipeline(const _sg_pools* p, uint32_t pi
     return 0;
 }
 
-_SOKOL_PRIVATE _sg_pass* _sg_lookup_pass(const _sg_pools* p, uint32_t pass_id) {
+_SOKOL_PRIVATE _sg_pass_t* _sg_lookup_pass(const _sg_pools_t* p, uint32_t pass_id) {
     SOKOL_ASSERT(p);
     if (SG_INVALID_ID != pass_id) {
-        _sg_pass* pass = _sg_pass_at(p, pass_id);
+        _sg_pass_t* pass = _sg_pass_at(p, pass_id);
         if (pass->slot.id == pass_id) {
             return pass;
         }
@@ -8222,10 +8222,10 @@ _SOKOL_PRIVATE _sg_pass* _sg_lookup_pass(const _sg_pools* p, uint32_t pass_id) {
     return 0;
 }
 
-_SOKOL_PRIVATE _sg_context* _sg_lookup_context(const _sg_pools* p, uint32_t ctx_id) {
+_SOKOL_PRIVATE _sg_context_t* _sg_lookup_context(const _sg_pools_t* p, uint32_t ctx_id) {
     SOKOL_ASSERT(p);
     if (SG_INVALID_ID != ctx_id) {
-        _sg_context* ctx = _sg_context_at(p, ctx_id);
+        _sg_context_t* ctx = _sg_context_at(p, ctx_id);
         if (ctx->slot.id == ctx_id) {
             return ctx;
         }
@@ -8233,7 +8233,7 @@ _SOKOL_PRIVATE _sg_context* _sg_lookup_context(const _sg_pools* p, uint32_t ctx_
     return 0;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_all_resources(_sg_pools* p, uint32_t ctx_id) {
+_SOKOL_PRIVATE void _sg_destroy_all_resources(_sg_pools_t* p, uint32_t ctx_id) {
     /*  this is a bit dumb since it loops over all pool slots to
         find the occupied slots, on the other hand it is only ever
         executed at shutdown
@@ -8286,7 +8286,7 @@ _SOKOL_PRIVATE void _sg_destroy_all_resources(_sg_pools* p, uint32_t ctx_id) {
 /*== VALIDATION LAYER ========================================================*/
 #if defined(SOKOL_DEBUG)
 /* return a human readable string for an _sg_validate_error */
-_SOKOL_PRIVATE const char* _sg_validate_string(_sg_validate_error err) {
+_SOKOL_PRIVATE const char* _sg_validate_string(_sg_validate_error_t err) {
     switch (err) {
         /* buffer creation validation errors */
         case _SG_VALIDATE_BUFFERDESC_CANARY:        return "sg_buffer_desc not initialized";
@@ -8410,7 +8410,7 @@ _SOKOL_PRIVATE void _sg_validate_begin(void) {
     _sg.validate_error = _SG_VALIDATE_SUCCESS;
 }
 
-_SOKOL_PRIVATE void _sg_validate(bool cond, _sg_validate_error err) {
+_SOKOL_PRIVATE void _sg_validate(bool cond, _sg_validate_error_t err) {
     if (!cond) {
         _sg.validate_error = err;
         SOKOL_LOG(_sg_validate_string(err));
@@ -8599,7 +8599,7 @@ _SOKOL_PRIVATE bool _sg_validate_pipeline_desc(const sg_pipeline_desc* desc) {
         SOKOL_VALIDATE(desc->_start_canary == 0, _SG_VALIDATE_PIPELINEDESC_CANARY);
         SOKOL_VALIDATE(desc->_end_canary == 0, _SG_VALIDATE_PIPELINEDESC_CANARY);
         SOKOL_VALIDATE(desc->shader.id != SG_INVALID_ID, _SG_VALIDATE_PIPELINEDESC_SHADER);
-        const _sg_shader* shd = _sg_lookup_shader(&_sg.pools, desc->shader.id);
+        const _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, desc->shader.id);
         SOKOL_VALIDATE(shd && shd->slot.state == SG_RESOURCESTATE_VALID, _SG_VALIDATE_PIPELINEDESC_SHADER);
         for (int buf_index = 0; buf_index < SG_MAX_SHADERSTAGE_BUFFERS; buf_index++) {
             const sg_buffer_layout_desc* l_desc = &desc->layout.buffers[buf_index];
@@ -8650,7 +8650,7 @@ _SOKOL_PRIVATE bool _sg_validate_pass_desc(const sg_pass_desc* desc) {
                 continue;
             }
             SOKOL_VALIDATE(atts_cont, _SG_VALIDATE_PASSDESC_NO_CONT_COLOR_ATTS);
-            const _sg_image* img = _sg_lookup_image(&_sg.pools, att->image.id);
+            const _sg_image_t* img = _sg_lookup_image(&_sg.pools, att->image.id);
             SOKOL_VALIDATE(img && img->slot.state == SG_RESOURCESTATE_VALID, _SG_VALIDATE_PASSDESC_IMAGE);
             SOKOL_VALIDATE(att->mip_level < img->num_mipmaps, _SG_VALIDATE_PASSDESC_MIPLEVEL);
             if (img->type == SG_IMAGETYPE_CUBE) {
@@ -8679,7 +8679,7 @@ _SOKOL_PRIVATE bool _sg_validate_pass_desc(const sg_pass_desc* desc) {
         }
         if (desc->depth_stencil_attachment.image.id != SG_INVALID_ID) {
             const sg_attachment_desc* att = &desc->depth_stencil_attachment;
-            const _sg_image* img = _sg_lookup_image(&_sg.pools, att->image.id);
+            const _sg_image_t* img = _sg_lookup_image(&_sg.pools, att->image.id);
             SOKOL_VALIDATE(img && img->slot.state == SG_RESOURCESTATE_VALID, _SG_VALIDATE_PASSDESC_IMAGE);
             SOKOL_VALIDATE(att->mip_level < img->num_mipmaps, _SG_VALIDATE_PASSDESC_MIPLEVEL);
             if (img->type == SG_IMAGETYPE_CUBE) {
@@ -8701,7 +8701,7 @@ _SOKOL_PRIVATE bool _sg_validate_pass_desc(const sg_pass_desc* desc) {
     #endif
 }
 
-_SOKOL_PRIVATE bool _sg_validate_begin_pass(_sg_pass* pass) {
+_SOKOL_PRIVATE bool _sg_validate_begin_pass(_sg_pass_t* pass) {
     #if !defined(SOKOL_DEBUG)
         _SOKOL_UNUSED(pass);
         return true;
@@ -8709,14 +8709,14 @@ _SOKOL_PRIVATE bool _sg_validate_begin_pass(_sg_pass* pass) {
         SOKOL_VALIDATE_BEGIN();
         SOKOL_VALIDATE(pass->slot.state == SG_RESOURCESTATE_VALID, _SG_VALIDATE_BEGINPASS_PASS);
         for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
-            const _sg_attachment* att = &pass->color_atts[i];
+            const _sg_attachment_t* att = &pass->color_atts[i];
             if (att->image) {
                 SOKOL_VALIDATE(att->image->slot.state == SG_RESOURCESTATE_VALID, _SG_VALIDATE_BEGINPASS_IMAGE);
                 SOKOL_VALIDATE(att->image->slot.id == att->image_id.id, _SG_VALIDATE_BEGINPASS_IMAGE);
             }
         }
         if (pass->ds_att.image) {
-            const _sg_attachment* att = &pass->ds_att;
+            const _sg_attachment_t* att = &pass->ds_att;
             SOKOL_VALIDATE(att->image->slot.state == SG_RESOURCESTATE_VALID, _SG_VALIDATE_BEGINPASS_IMAGE);
             SOKOL_VALIDATE(att->image->slot.id == att->image_id.id, _SG_VALIDATE_BEGINPASS_IMAGE);
         }
@@ -8732,7 +8732,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_pipeline(sg_pipeline pip_id) {
         SOKOL_VALIDATE_BEGIN();
         /* the pipeline object must be alive and valid */
         SOKOL_VALIDATE(pip_id.id != SG_INVALID_ID, _SG_VALIDATE_APIP_PIPELINE_VALID_ID);
-        const _sg_pipeline* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
+        const _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
         SOKOL_VALIDATE(pip != 0, _SG_VALIDATE_APIP_PIPELINE_EXISTS);
         if (!pip) {
             return SOKOL_VALIDATE_END();
@@ -8743,7 +8743,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_pipeline(sg_pipeline pip_id) {
         SOKOL_VALIDATE(pip->shader->slot.id == pip->shader_id.id, _SG_VALIDATE_APIP_SHADER_EXISTS);
         SOKOL_VALIDATE(pip->shader->slot.state == SG_RESOURCESTATE_VALID, _SG_VALIDATE_APIP_SHADER_VALID);
         /* check that pipeline attributes match current pass attributes */
-        const _sg_pass* pass = _sg_lookup_pass(&_sg.pools, _sg.cur_pass.id);
+        const _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, _sg.cur_pass.id);
         if (pass) {
             /* an offscreen pass */
             SOKOL_VALIDATE(pip->color_attachment_count == pass->num_color_atts, _SG_VALIDATE_APIP_ATT_COUNT);
@@ -8776,7 +8776,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bind) {
 
         /* a pipeline object must have been applied */
         SOKOL_VALIDATE(_sg.cur_pipeline.id != SG_INVALID_ID, _SG_VALIDATE_ABND_PIPELINE);
-        const _sg_pipeline* pip = _sg_lookup_pipeline(&_sg.pools, _sg.cur_pipeline.id);
+        const _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, _sg.cur_pipeline.id);
         SOKOL_VALIDATE(pip != 0, _SG_VALIDATE_ABND_PIPELINE_EXISTS);
         if (!pip) {
             return SOKOL_VALIDATE_END();
@@ -8789,7 +8789,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bind) {
             if (bind->vertex_buffers[i].id != SG_INVALID_ID) {
                 SOKOL_VALIDATE(pip->vertex_layout_valid[i], _SG_VALIDATE_ABND_VBS);
                 /* buffers in vertex-buffer-slots must be of type SG_BUFFERTYPE_VERTEXBUFFER */
-                const _sg_buffer* buf = _sg_lookup_buffer(&_sg.pools, bind->vertex_buffers[i].id);
+                const _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, bind->vertex_buffers[i].id);
                 SOKOL_ASSERT(buf);
                 if (buf->slot.state == SG_RESOURCESTATE_VALID) {
                     SOKOL_VALIDATE(SG_BUFFERTYPE_VERTEXBUFFER == buf->type, _SG_VALIDATE_ABND_VB_TYPE);
@@ -8813,7 +8813,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bind) {
         }
         if (bind->index_buffer.id != SG_INVALID_ID) {
             /* buffer in index-buffer-slot must be of type SG_BUFFERTYPE_INDEXBUFFER */
-            const _sg_buffer* buf = _sg_lookup_buffer(&_sg.pools, bind->index_buffer.id);
+            const _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, bind->index_buffer.id);
             SOKOL_ASSERT(buf);
             if (buf->slot.state == SG_RESOURCESTATE_VALID) {
                 SOKOL_VALIDATE(SG_BUFFERTYPE_INDEXBUFFER == buf->type, _SG_VALIDATE_ABND_IB_TYPE);
@@ -8823,10 +8823,10 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bind) {
 
         /* has expected vertex shader images */
         for (int i = 0; i < SG_MAX_SHADERSTAGE_IMAGES; i++) {
-            _sg_shader_stage* stage = &pip->shader->stage[SG_SHADERSTAGE_VS];
+            _sg_shader_stage_t* stage = &pip->shader->stage[SG_SHADERSTAGE_VS];
             if (bind->vs_images[i].id != SG_INVALID_ID) {
                 SOKOL_VALIDATE(i < stage->num_images, _SG_VALIDATE_ABND_VS_IMGS);
-                const _sg_image* img = _sg_lookup_image(&_sg.pools, bind->vs_images[i].id);
+                const _sg_image_t* img = _sg_lookup_image(&_sg.pools, bind->vs_images[i].id);
                 SOKOL_ASSERT(img);
                 if (img->slot.state == SG_RESOURCESTATE_VALID) {
                     SOKOL_VALIDATE(img->type == stage->images[i].type, _SG_VALIDATE_ABND_VS_IMG_TYPES);
@@ -8839,10 +8839,10 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bind) {
 
         /* has expected fragment shader images */
         for (int i = 0; i < SG_MAX_SHADERSTAGE_IMAGES; i++) {
-            _sg_shader_stage* stage = &pip->shader->stage[SG_SHADERSTAGE_FS];
+            _sg_shader_stage_t* stage = &pip->shader->stage[SG_SHADERSTAGE_FS];
             if (bind->fs_images[i].id != SG_INVALID_ID) {
                 SOKOL_VALIDATE(i < stage->num_images, _SG_VALIDATE_ABND_FS_IMGS);
-                const _sg_image* img = _sg_lookup_image(&_sg.pools, bind->fs_images[i].id);
+                const _sg_image_t* img = _sg_lookup_image(&_sg.pools, bind->fs_images[i].id);
                 SOKOL_ASSERT(img);
                 if (img->slot.state == SG_RESOURCESTATE_VALID) {
                     SOKOL_VALIDATE(img->type == stage->images[i].type, _SG_VALIDATE_ABND_FS_IMG_TYPES);
@@ -8868,12 +8868,12 @@ _SOKOL_PRIVATE bool _sg_validate_apply_uniforms(sg_shader_stage stage_index, int
         SOKOL_ASSERT((ub_index >= 0) && (ub_index < SG_MAX_SHADERSTAGE_UBS));
         SOKOL_VALIDATE_BEGIN();
         SOKOL_VALIDATE(_sg.cur_pipeline.id != SG_INVALID_ID, _SG_VALIDATE_AUB_NO_PIPELINE);
-        const _sg_pipeline* pip = _sg_lookup_pipeline(&_sg.pools, _sg.cur_pipeline.id);
+        const _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, _sg.cur_pipeline.id);
         SOKOL_ASSERT(pip && (pip->slot.id == _sg.cur_pipeline.id));
         SOKOL_ASSERT(pip->shader && (pip->shader->slot.id == pip->shader_id.id));
 
         /* check that there is a uniform block at 'stage' and 'ub_index' */
-        const _sg_shader_stage* stage = &pip->shader->stage[stage_index];
+        const _sg_shader_stage_t* stage = &pip->shader->stage[stage_index];
         SOKOL_VALIDATE(ub_index < stage->num_uniform_blocks, _SG_VALIDATE_AUB_NO_UB_AT_SLOT);
 
         /* check that the provided data size doesn't exceed the uniform block size */
@@ -8883,7 +8883,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_uniforms(sg_shader_stage stage_index, int
     #endif
 }
 
-_SOKOL_PRIVATE bool _sg_validate_update_buffer(const _sg_buffer* buf, const void* data, int size) {
+_SOKOL_PRIVATE bool _sg_validate_update_buffer(const _sg_buffer_t* buf, const void* data, int size) {
     #if !defined(SOKOL_DEBUG)
         _SOKOL_UNUSED(buf);
         _SOKOL_UNUSED(data);
@@ -8900,7 +8900,7 @@ _SOKOL_PRIVATE bool _sg_validate_update_buffer(const _sg_buffer* buf, const void
     #endif
 }
 
-_SOKOL_PRIVATE bool _sg_validate_append_buffer(const _sg_buffer* buf, const void* data, int size) {
+_SOKOL_PRIVATE bool _sg_validate_append_buffer(const _sg_buffer_t* buf, const void* data, int size) {
     #if !defined(SOKOL_DEBUG)
         _SOKOL_UNUSED(buf);
         _SOKOL_UNUSED(data);
@@ -8916,7 +8916,7 @@ _SOKOL_PRIVATE bool _sg_validate_append_buffer(const _sg_buffer* buf, const void
     #endif
 }
 
-_SOKOL_PRIVATE bool _sg_validate_update_image(const _sg_image* img, const sg_image_content* data) {
+_SOKOL_PRIVATE bool _sg_validate_update_image(const _sg_image_t* img, const sg_image_content* data) {
     #if !defined(SOKOL_DEBUG)
         _SOKOL_UNUSED(img);
         _SOKOL_UNUSED(data);
@@ -8961,7 +8961,7 @@ SOKOL_API_IMPL void sg_shutdown(void) {
     (since only the app code can switch between 3D-API contexts)
     */
     if (_sg.active_context.id != SG_INVALID_ID) {
-        _sg_context* ctx = _sg_lookup_context(&_sg.pools, _sg.active_context.id);
+        _sg_context_t* ctx = _sg_lookup_context(&_sg.pools, _sg.active_context.id);
         if (ctx) {
             _sg_destroy_all_resources(&_sg.pools, _sg.active_context.id);
             _sg_destroy_context(ctx);
@@ -8985,7 +8985,7 @@ SOKOL_API_IMPL sg_context sg_setup_context(void) {
     int slot_index = _sg_pool_alloc_index(&_sg.pools.context_pool);
     if (_SG_INVALID_SLOT_INDEX != slot_index) {
         res.id = _sg_slot_alloc(&_sg.pools.context_pool, &_sg.pools.contexts[slot_index].slot, slot_index);
-        _sg_context* ctx = _sg_context_at(&_sg.pools, res.id);
+        _sg_context_t* ctx = _sg_context_at(&_sg.pools, res.id);
         ctx->slot.state = _sg_create_context(ctx);
         SOKOL_ASSERT(ctx->slot.state == SG_RESOURCESTATE_VALID);
         _sg_activate_context(ctx);
@@ -9000,7 +9000,7 @@ SOKOL_API_IMPL sg_context sg_setup_context(void) {
 
 SOKOL_API_IMPL void sg_discard_context(sg_context ctx_id) {
     _sg_destroy_all_resources(&_sg.pools, ctx_id.id);
-    _sg_context* ctx = _sg_lookup_context(&_sg.pools, ctx_id.id);
+    _sg_context_t* ctx = _sg_lookup_context(&_sg.pools, ctx_id.id);
     if (ctx) {
         _sg_destroy_context(ctx);
         _sg_reset_context(ctx);
@@ -9012,7 +9012,7 @@ SOKOL_API_IMPL void sg_discard_context(sg_context ctx_id) {
 
 SOKOL_API_IMPL void sg_activate_context(sg_context ctx_id) {
     _sg.active_context = ctx_id;
-    _sg_context* ctx = _sg_lookup_context(&_sg.pools, ctx_id.id);
+    _sg_context_t* ctx = _sg_lookup_context(&_sg.pools, ctx_id.id);
     /* NOTE: ctx can be 0 here if the context is no longer valid */
     _sg_activate_context(ctx);
 }
@@ -9086,7 +9086,7 @@ SOKOL_API_IMPL sg_pass sg_alloc_pass(void) {
 /*-- initialize an allocated resource ----------------------------------------*/
 SOKOL_API_IMPL void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc) {
     SOKOL_ASSERT(buf_id.id != SG_INVALID_ID && desc);
-    _sg_buffer* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
     SOKOL_ASSERT(buf && buf->slot.state == SG_RESOURCESTATE_ALLOC);
     buf->slot.ctx_id = _sg.active_context.id;
     if (_sg_validate_buffer_desc(desc)) {
@@ -9100,7 +9100,7 @@ SOKOL_API_IMPL void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc)
 
 SOKOL_API_IMPL void sg_init_image(sg_image img_id, const sg_image_desc* desc) {
     SOKOL_ASSERT(img_id.id != SG_INVALID_ID && desc);
-    _sg_image* img = _sg_lookup_image(&_sg.pools, img_id.id);
+    _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
     SOKOL_ASSERT(img && img->slot.state == SG_RESOURCESTATE_ALLOC);
     img->slot.ctx_id = _sg.active_context.id;
     if (_sg_validate_image_desc(desc)) {
@@ -9114,7 +9114,7 @@ SOKOL_API_IMPL void sg_init_image(sg_image img_id, const sg_image_desc* desc) {
 
 SOKOL_API_IMPL void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc) {
     SOKOL_ASSERT(shd_id.id != SG_INVALID_ID && desc);
-    _sg_shader* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
+    _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
     SOKOL_ASSERT(shd && shd->slot.state == SG_RESOURCESTATE_ALLOC);
     shd->slot.ctx_id = _sg.active_context.id;
     if (_sg_validate_shader_desc(desc)) {
@@ -9128,11 +9128,11 @@ SOKOL_API_IMPL void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc)
 
 SOKOL_API_IMPL void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc) {
     SOKOL_ASSERT(pip_id.id != SG_INVALID_ID && desc);
-    _sg_pipeline* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
+    _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
     SOKOL_ASSERT(pip && pip->slot.state == SG_RESOURCESTATE_ALLOC);
     pip->slot.ctx_id = _sg.active_context.id;
     if (_sg_validate_pipeline_desc(desc)) {
-        _sg_shader* shd = _sg_lookup_shader(&_sg.pools, desc->shader.id);
+        _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, desc->shader.id);
         SOKOL_ASSERT(shd && shd->slot.state == SG_RESOURCESTATE_VALID);
         pip->slot.state = _sg_create_pipeline(pip, shd, desc);
     }
@@ -9144,12 +9144,12 @@ SOKOL_API_IMPL void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc*
 
 SOKOL_API_IMPL void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc) {
     SOKOL_ASSERT(pass_id.id != SG_INVALID_ID && desc);
-    _sg_pass* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
+    _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
     SOKOL_ASSERT(pass && pass->slot.state == SG_RESOURCESTATE_ALLOC);
     pass->slot.ctx_id = _sg.active_context.id;
     if (_sg_validate_pass_desc(desc)) {
         /* lookup pass attachment image pointers */
-        _sg_image* att_imgs[SG_MAX_COLOR_ATTACHMENTS + 1];
+        _sg_image_t* att_imgs[SG_MAX_COLOR_ATTACHMENTS + 1];
         for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
             if (desc->color_attachments[i].image.id) {
                 att_imgs[i] = _sg_lookup_image(&_sg.pools, desc->color_attachments[i].image.id);
@@ -9178,7 +9178,7 @@ SOKOL_API_IMPL void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc) {
 /*-- set allocated resource to failed state ----------------------------------*/
 SOKOL_API_IMPL void sg_fail_buffer(sg_buffer buf_id) {
     SOKOL_ASSERT(buf_id.id != SG_INVALID_ID);
-    _sg_buffer* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
     SOKOL_ASSERT(buf && buf->slot.state == SG_RESOURCESTATE_ALLOC);
     buf->slot.ctx_id = _sg.active_context.id;
     buf->slot.state = SG_RESOURCESTATE_FAILED;
@@ -9186,7 +9186,7 @@ SOKOL_API_IMPL void sg_fail_buffer(sg_buffer buf_id) {
 
 SOKOL_API_IMPL void sg_fail_image(sg_image img_id) {
     SOKOL_ASSERT(img_id.id != SG_INVALID_ID);
-    _sg_image* img = _sg_lookup_image(&_sg.pools, img_id.id);
+    _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
     SOKOL_ASSERT(img && img->slot.state == SG_RESOURCESTATE_ALLOC);
     img->slot.ctx_id = _sg.active_context.id;
     img->slot.state = SG_RESOURCESTATE_FAILED;
@@ -9194,7 +9194,7 @@ SOKOL_API_IMPL void sg_fail_image(sg_image img_id) {
 
 SOKOL_API_IMPL void sg_fail_shader(sg_shader shd_id) {
     SOKOL_ASSERT(shd_id.id != SG_INVALID_ID);
-    _sg_shader* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
+    _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
     SOKOL_ASSERT(shd && shd->slot.state == SG_RESOURCESTATE_ALLOC);
     shd->slot.ctx_id = _sg.active_context.id;
     shd->slot.state = SG_RESOURCESTATE_FAILED;
@@ -9202,7 +9202,7 @@ SOKOL_API_IMPL void sg_fail_shader(sg_shader shd_id) {
 
 SOKOL_API_IMPL void sg_fail_pipeline(sg_pipeline pip_id) {
     SOKOL_ASSERT(pip_id.id != SG_INVALID_ID);
-    _sg_pipeline* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
+    _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
     SOKOL_ASSERT(pip && pip->slot.state == SG_RESOURCESTATE_ALLOC);
     pip->slot.ctx_id = _sg.active_context.id;
     pip->slot.state = SG_RESOURCESTATE_FAILED;
@@ -9210,7 +9210,7 @@ SOKOL_API_IMPL void sg_fail_pipeline(sg_pipeline pip_id) {
 
 SOKOL_API_IMPL void sg_fail_pass(sg_pass pass_id) {
     SOKOL_ASSERT(pass_id.id != SG_INVALID_ID);
-    _sg_pass* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
+    _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
     SOKOL_ASSERT(pass && pass->slot.state == SG_RESOURCESTATE_ALLOC);
     pass->slot.ctx_id = _sg.active_context.id;
     pass->slot.state = SG_RESOURCESTATE_FAILED;
@@ -9218,27 +9218,27 @@ SOKOL_API_IMPL void sg_fail_pass(sg_pass pass_id) {
 
 /*-- get resource state */
 SOKOL_API_IMPL sg_resource_state sg_query_buffer_state(sg_buffer buf_id) {
-    _sg_buffer* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
     return buf ? buf->slot.state : SG_RESOURCESTATE_INVALID;
 }
 
 SOKOL_API_IMPL sg_resource_state sg_query_image_state(sg_image img_id) {
-    _sg_image* img = _sg_lookup_image(&_sg.pools, img_id.id);
+    _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
     return img ? img->slot.state : SG_RESOURCESTATE_INVALID;
 }
 
 SOKOL_API_IMPL sg_resource_state sg_query_shader_state(sg_shader shd_id) {
-    _sg_shader* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
+    _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
     return shd ? shd->slot.state : SG_RESOURCESTATE_INVALID;
 }
 
 SOKOL_API_IMPL sg_resource_state sg_query_pipeline_state(sg_pipeline pip_id) {
-    _sg_pipeline* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
+    _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
     return pip ? pip->slot.state : SG_RESOURCESTATE_INVALID;
 }
 
 SOKOL_API_IMPL sg_resource_state sg_query_pass_state(sg_pass pass_id) {
-    _sg_pass* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
+    _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
     return pass ? pass->slot.state : SG_RESOURCESTATE_INVALID;
 }
 
@@ -9305,7 +9305,7 @@ SOKOL_API_IMPL sg_pass sg_make_pass(const sg_pass_desc* desc) {
 
 /*-- destroy resource --------------------------------------------------------*/
 SOKOL_API_IMPL void sg_destroy_buffer(sg_buffer buf_id) {
-    _sg_buffer* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
     if (buf) {
         if (buf->slot.ctx_id == _sg.active_context.id) {
             _sg_destroy_buffer(buf);
@@ -9319,7 +9319,7 @@ SOKOL_API_IMPL void sg_destroy_buffer(sg_buffer buf_id) {
 }
 
 SOKOL_API_IMPL void sg_destroy_image(sg_image img_id) {
-    _sg_image* img = _sg_lookup_image(&_sg.pools, img_id.id);
+    _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
     if (img) {
         if (img->slot.ctx_id == _sg.active_context.id) {
             _sg_destroy_image(img);
@@ -9333,7 +9333,7 @@ SOKOL_API_IMPL void sg_destroy_image(sg_image img_id) {
 }
 
 SOKOL_API_IMPL void sg_destroy_shader(sg_shader shd_id) {
-    _sg_shader* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
+    _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
     if (shd) {
         if (shd->slot.ctx_id == _sg.active_context.id) {
             _sg_destroy_shader(shd);
@@ -9347,7 +9347,7 @@ SOKOL_API_IMPL void sg_destroy_shader(sg_shader shd_id) {
 }
 
 SOKOL_API_IMPL void sg_destroy_pipeline(sg_pipeline pip_id) {
-    _sg_pipeline* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
+    _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
     if (pip) {
         if (pip->slot.ctx_id == _sg.active_context.id) {
             _sg_destroy_pipeline(pip);
@@ -9361,7 +9361,7 @@ SOKOL_API_IMPL void sg_destroy_pipeline(sg_pipeline pip_id) {
 }
 
 SOKOL_API_IMPL void sg_destroy_pass(sg_pass pass_id) {
-    _sg_pass* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
+    _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
     if (pass) {
         if (pass->slot.ctx_id == _sg.active_context.id) {
             _sg_destroy_pass(pass);
@@ -9388,7 +9388,7 @@ SOKOL_API_IMPL void sg_begin_pass(sg_pass pass_id, const sg_pass_action* pass_ac
     SOKOL_ASSERT(pass_action);
     SOKOL_ASSERT((pass_action->_start_canary == 0) && (pass_action->_end_canary == 0));
     _sg.cur_pass = pass_id;
-    _sg_pass* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
+    _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
     if (pass && _sg_validate_begin_pass(pass)) {
         _sg.pass_valid = true;
         sg_pass_action pa;
@@ -9426,7 +9426,7 @@ SOKOL_API_IMPL void sg_apply_pipeline(sg_pipeline pip_id) {
         return;
     }
     _sg.cur_pipeline = pip_id;
-    _sg_pipeline* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
+    _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
     SOKOL_ASSERT(pip);
     _sg.next_draw_valid = (SG_RESOURCESTATE_VALID == pip->slot.state);
     SOKOL_ASSERT(pip->shader && (pip->shader->slot.id == pip->shader_id.id));
@@ -9442,10 +9442,10 @@ SOKOL_API_IMPL void sg_apply_bindings(const sg_bindings* bind) {
     }
     _sg.bindings_valid = true;
 
-    _sg_pipeline* pip = _sg_lookup_pipeline(&_sg.pools, _sg.cur_pipeline.id);
+    _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, _sg.cur_pipeline.id);
     SOKOL_ASSERT(pip);
 
-    _sg_buffer* vbs[SG_MAX_SHADERSTAGE_BUFFERS] = { 0 };
+    _sg_buffer_t* vbs[SG_MAX_SHADERSTAGE_BUFFERS] = { 0 };
     int num_vbs = 0;
     for (int i = 0; i < SG_MAX_SHADERSTAGE_BUFFERS; i++, num_vbs++) {
         if (bind->vertex_buffers[i].id) {
@@ -9459,7 +9459,7 @@ SOKOL_API_IMPL void sg_apply_bindings(const sg_bindings* bind) {
         }
     }
 
-    _sg_buffer* ib = 0;
+    _sg_buffer_t* ib = 0;
     if (bind->index_buffer.id) {
         ib = _sg_lookup_buffer(&_sg.pools, bind->index_buffer.id);
         SOKOL_ASSERT(ib);
@@ -9467,7 +9467,7 @@ SOKOL_API_IMPL void sg_apply_bindings(const sg_bindings* bind) {
         _sg.next_draw_valid &= !ib->append_overflow;
     }
 
-    _sg_image* vs_imgs[SG_MAX_SHADERSTAGE_IMAGES] = { 0 };
+    _sg_image_t* vs_imgs[SG_MAX_SHADERSTAGE_IMAGES] = { 0 };
     int num_vs_imgs = 0;
     for (int i = 0; i < SG_MAX_SHADERSTAGE_IMAGES; i++, num_vs_imgs++) {
         if (bind->vs_images[i].id) {
@@ -9480,7 +9480,7 @@ SOKOL_API_IMPL void sg_apply_bindings(const sg_bindings* bind) {
         }
     }
 
-    _sg_image* fs_imgs[SG_MAX_SHADERSTAGE_IMAGES] = { 0 };
+    _sg_image_t* fs_imgs[SG_MAX_SHADERSTAGE_IMAGES] = { 0 };
     int num_fs_imgs = 0;
     for (int i = 0; i < SG_MAX_SHADERSTAGE_IMAGES; i++, num_fs_imgs++) {
         if (bind->fs_images[i].id) {
@@ -9548,7 +9548,7 @@ SOKOL_API_IMPL void sg_update_buffer(sg_buffer buf_id, const void* data, int num
     if (num_bytes == 0) {
         return;
     }
-    _sg_buffer* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
     if (!(buf && buf->slot.state == SG_RESOURCESTATE_VALID)) {
         return;
     }
@@ -9564,7 +9564,7 @@ SOKOL_API_IMPL void sg_update_buffer(sg_buffer buf_id, const void* data, int num
 }
 
 SOKOL_API_IMPL int sg_append_buffer(sg_buffer buf_id, const void* data, int num_bytes) {
-    _sg_buffer* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
     if (buf) {
         /* rewind append cursor in a new frame */
         if (buf->append_frame_index != _sg.frame_index) {
@@ -9595,7 +9595,7 @@ SOKOL_API_IMPL int sg_append_buffer(sg_buffer buf_id, const void* data, int num_
 }
 
 SOKOL_API_IMPL bool sg_query_buffer_overflow(sg_buffer buf_id) {
-    _sg_buffer* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
     if (buf) {
         return buf->append_overflow;
     }
@@ -9605,7 +9605,7 @@ SOKOL_API_IMPL bool sg_query_buffer_overflow(sg_buffer buf_id) {
 }
 
 SOKOL_API_IMPL void sg_update_image(sg_image img_id, const sg_image_content* data) {
-    _sg_image* img = _sg_lookup_image(&_sg.pools, img_id.id);
+    _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
     if (!(img && img->slot.state == SG_RESOURCESTATE_VALID)) {
         return;
     }


### PR DESCRIPTION
This merges all the scattered static variables into the _sg_state_t struct (with the exception of non-POD Objective-C items, these live in a separate struct).