### PR TITLE
Debugging UI extension headers via Dear ImGui

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,20 @@ Mainly some "missing features" for desktop apps:
 
 # Updates
 
+- **05-Mar-2019**: sokol_gfx.h now has a 'trace hook' API, and I have started
+implementing optional debug-inspection-UI headers on top of Dear ImGui:
+    - sokol_gfx.h has a new function sg_install_trace_hook(), this allows
+      you to install a callback function for each public sokol_gfx.h function
+      (and a couple or error callbacks). For more details, search for "TRACE HOOKS"
+      in sokol_gfx.h
+    - I have started a new 'subproject' in the 'imgui' directory, this will
+      contain a slowly growing set of optional debug-inspection-UI headers
+      which allow to peek under the hood of the Sokol headers. The UIs are
+      implemented with [Dear ImGui](https://github.com/ocornut/imgui). Again,
+      see the README in the 'imgui' directory and the headers in there 
+      for details, and check out the live demos on the [Sokol Sample Webpage](https://floooh.github.io/sokol-html5/)
+      (click on the little UI buttons in the top right corner of each thumbnail)
+
 - **21-Feb-2019**: sokol_app.h and sokol_audio.h now have an alternative
 set of callbacks with user_data arguments. This is useful if you don't
 want or cannot store your own application state in global variables.

--- a/fips.yml
+++ b/fips.yml
@@ -1,2 +1,2 @@
 exports:
-  header-dirs: [ . ]
+  header-dirs: [ ".", "imgui" ]

--- a/imgui/README.md
+++ b/imgui/README.md
@@ -525,8 +525,8 @@ if (ImGui::BeginMainMenuBar()) {
 
 The debug inspection headers also offer more granular drawing functions
 for more flexible integration into your own UI, for example the following
-```sokol_gfx_imgui.h``` functions only draw the window content (inside
-an ```ImGui::BeginChild() / ImGui::EndChild()``` pair:
+```sokol_gfx_imgui.h``` functions only draw the window content, so you
+can integrate the UIs into your own windows:
 
 ```cpp
 void sg_imgui_draw_buffers_content(sg_imgui_t* ctx);

--- a/imgui/README.md
+++ b/imgui/README.md
@@ -1,0 +1,64 @@
+# Sokol Debug Inspection UIs
+
+This directory contains optional 'extension headers' which implement debug
+inspection UIs for various Sokol headers implemented with [Dear
+ImGui](https://github.com/ocornut/imgui).
+
+## Integration Howto
+
+These are the steps to add the debug inspection UIs to your own project.
+
+### 1. Compile the implementation as C++ (or Objective-C++)
+
+Dear ImGui is a C++ library, and offers a C++ API. This means the implementation
+of the debug inspection headers is also written in C++, not the usual C, and
+must be compiled in C++ or Objective-C++ mode.
+
+### 2. Compile the Sokol headers with trace-hooks enabled
+
+The debug inspection headers may need to *hook into* the Sokol APIs via
+callback functions. These API callbacks are called **trace hooks** and must
+be enabled by defining ```SOKOL_TRACE_HOOKS``` before including the
+implementation.
+
+### 3. Include "imgui.h" before the implementation
+
+The debug inspection headers don't include ```imgui.h``` themselves,
+instead the ImGui header must be included before the implementation.
+
+### 3. Include the debug UI implementations after the Sokol implementations
+
+The debug inspection headers need access to private data and functions of
+their associated Sokol header. This means the implementation of the
+debug inspection headers must be included **after** the implementation
+of the their associated Sokol headers. I'd recomment putting all the
+Sokol headers of a project into a single implementation file, together
+with all *extension headers*. 
+
+```cpp
+// sokol-ui.cc
+//
+// Sokol header implementations and their debug inspection headers,
+// compiled as C++ code and with trace-hooks enabled. On macOS/iOS 
+// this would need to be an Objective-C++ file instead (.mm extension).
+//
+#define SOKOL_IMPL
+#define SOKOL_TRACE_HOOKS
+#include "sokol_app.h"
+#include "sokol_gfx.h"
+#include "sokol_time.h"
+#include "imgui.h"
+#include "sokol_app_imgui.h"
+#include "sokol_gfx_imgui.h"
+```
+
+### 4. Provide your own ImGui renderer
+
+(TODO)
+
+### 5. Add UI init- and rendering-calls to your code
+
+(TODO)
+
+
+

--- a/imgui/README.md
+++ b/imgui/README.md
@@ -11,7 +11,7 @@ These are the steps to add the debug inspection UIs to your own project.
 ### 1. Compile the implementation as C++ (or Objective-C++)
 
 Dear ImGui is a C++ library, and offers a C++ API. This means the implementation
-of the debug inspection headers is also written in C++, not the usual C, and
+of the debug inspection headers is also written in C++, and
 must be compiled in C++ or Objective-C++ mode.
 
 ### 2. Compile the Sokol headers with trace-hooks enabled
@@ -54,11 +54,485 @@ with all *extension headers*.
 
 ### 4. Provide your own ImGui renderer
 
-(TODO)
+You need to provide your own ImGui initialization and rendering
+code. If you are using sokol_gfx.h together with sokol_app.h, you
+can just copy the code from the sokol-samples:
+
+```cpp
+#pragma once
+/*
+    Implements a Dear ImGui renderer on top of sokol_gfx.h for 
+    the debug-visualization UIs.
+*/
+#include "sokol_app.h"
+#include "sokol_gfx.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+void imgui_init(int sample_count);
+void imgui_newframe(void);
+void imgui_draw(void);
+void imgui_event(const sapp_event* event);
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+//------------------------------------------------------------------------------
+#if defined(UI_IMPL)
+#include "imgui.h"
+
+typedef struct {
+    ImVec2 disp_size;
+} vs_params_t;
+
+static bool btn_down[SAPP_MAX_MOUSEBUTTONS];
+static bool btn_up[SAPP_MAX_MOUSEBUTTONS];
+static const int MaxVertices = (1<<17);
+static const int MaxIndices = MaxVertices * 3;
+static sg_pipeline imgui_pip;
+static sg_bindings imgui_bind;
+
+extern const char* vs_src_imgui;
+extern const char* fs_src_imgui;
+
+void imgui_init(int sample_count) {
+    ImGui::CreateContext();
+    ImGui::StyleColorsDark();
+    auto& style = ImGui::GetStyle();
+    style.WindowRounding = 0.0f;
+    style.WindowBorderSize = 1.0f;
+    style.Alpha = 1.0f;
+    auto& io = ImGui::GetIO();
+    io.Fonts->AddFontDefault();
+    io.IniFilename = nullptr;
+    io.KeyMap[ImGuiKey_Tab] = SAPP_KEYCODE_TAB;
+    io.KeyMap[ImGuiKey_LeftArrow] = SAPP_KEYCODE_LEFT;
+    io.KeyMap[ImGuiKey_RightArrow] = SAPP_KEYCODE_RIGHT;
+    io.KeyMap[ImGuiKey_UpArrow] = SAPP_KEYCODE_UP;
+    io.KeyMap[ImGuiKey_DownArrow] = SAPP_KEYCODE_DOWN;
+    io.KeyMap[ImGuiKey_PageUp] = SAPP_KEYCODE_PAGE_UP;
+    io.KeyMap[ImGuiKey_PageDown] = SAPP_KEYCODE_PAGE_DOWN;
+    io.KeyMap[ImGuiKey_Home] = SAPP_KEYCODE_HOME;
+    io.KeyMap[ImGuiKey_End] = SAPP_KEYCODE_END;
+    io.KeyMap[ImGuiKey_Delete] = SAPP_KEYCODE_DELETE;
+    io.KeyMap[ImGuiKey_Backspace] = SAPP_KEYCODE_BACKSPACE;
+    io.KeyMap[ImGuiKey_Space] = SAPP_KEYCODE_SPACE;
+    io.KeyMap[ImGuiKey_Enter] = SAPP_KEYCODE_ENTER;
+    io.KeyMap[ImGuiKey_Escape] = SAPP_KEYCODE_ESCAPE;
+    io.KeyMap[ImGuiKey_A] = SAPP_KEYCODE_A;
+    io.KeyMap[ImGuiKey_C] = SAPP_KEYCODE_C;
+    io.KeyMap[ImGuiKey_V] = SAPP_KEYCODE_V;
+    io.KeyMap[ImGuiKey_X] = SAPP_KEYCODE_X;
+    io.KeyMap[ImGuiKey_Y] = SAPP_KEYCODE_Y;
+    io.KeyMap[ImGuiKey_Z] = SAPP_KEYCODE_Z;
+
+    sg_push_debug_group("imgui init");
+
+    // dynamic vertex- and index-buffers for imgui-generated geometry
+    sg_buffer_desc vbuf_desc = { };
+    vbuf_desc.usage = SG_USAGE_STREAM;
+    vbuf_desc.size = MaxVertices * sizeof(ImDrawVert);
+    vbuf_desc.label = "imgui-vertices";
+    imgui_bind.vertex_buffers[0] = sg_make_buffer(&vbuf_desc);
+
+    sg_buffer_desc ibuf_desc = { };
+    ibuf_desc.type = SG_BUFFERTYPE_INDEXBUFFER;
+    ibuf_desc.usage = SG_USAGE_STREAM;
+    ibuf_desc.size = MaxIndices * sizeof(ImDrawIdx);
+    ibuf_desc.label = "imgui-indices";
+    imgui_bind.index_buffer = sg_make_buffer(&ibuf_desc);
+
+    // font texture for imgui's default font
+    unsigned char* font_pixels;
+    int font_width, font_height;
+    io.Fonts->GetTexDataAsRGBA32(&font_pixels, &font_width, &font_height);
+    sg_image_desc img_desc = { };
+    img_desc.width = font_width;
+    img_desc.height = font_height;
+    img_desc.pixel_format = SG_PIXELFORMAT_RGBA8;
+    img_desc.wrap_u = SG_WRAP_CLAMP_TO_EDGE;
+    img_desc.wrap_v = SG_WRAP_CLAMP_TO_EDGE;
+    img_desc.min_filter = SG_FILTER_LINEAR;
+    img_desc.mag_filter = SG_FILTER_LINEAR;
+    img_desc.content.subimage[0][0].ptr = font_pixels;
+    img_desc.content.subimage[0][0].size = font_width * font_height * 4;
+    img_desc.label = "imgui-font";
+    io.Fonts->TexID = (ImTextureID)(uintptr_t) sg_make_image(&img_desc).id;
+
+    // shader object for imgui rendering
+    sg_shader_desc shd_desc = { };
+    auto& ub = shd_desc.vs.uniform_blocks[0];
+    ub.size = sizeof(vs_params_t);
+    ub.uniforms[0].name = "disp_size";
+    ub.uniforms[0].type = SG_UNIFORMTYPE_FLOAT2;
+    shd_desc.fs.images[0].name = "tex";
+    shd_desc.fs.images[0].type = SG_IMAGETYPE_2D;
+    shd_desc.vs.source = vs_src_imgui;
+    shd_desc.fs.source = fs_src_imgui;
+    shd_desc.label = "imgui-shader";
+    sg_shader shd = sg_make_shader(&shd_desc);
+
+    // pipeline object for imgui rendering
+    sg_pipeline_desc pip_desc = { };
+    pip_desc.layout.buffers[0].stride = sizeof(ImDrawVert);
+    auto& attrs = pip_desc.layout.attrs;
+    attrs[0].name="position"; attrs[0].sem_name="POSITION"; attrs[0].offset=offsetof(ImDrawVert, pos); attrs[0].format=SG_VERTEXFORMAT_FLOAT2;
+    attrs[1].name="texcoord0"; attrs[1].sem_name="TEXCOORD"; attrs[1].offset=offsetof(ImDrawVert, uv); attrs[1].format=SG_VERTEXFORMAT_FLOAT2;
+    attrs[2].name="color0"; attrs[2].sem_name="COLOR"; attrs[2].offset=offsetof(ImDrawVert, col); attrs[2].format=SG_VERTEXFORMAT_UBYTE4N;
+    pip_desc.shader = shd;
+    pip_desc.index_type = SG_INDEXTYPE_UINT16;
+    pip_desc.blend.enabled = true;
+    pip_desc.blend.src_factor_rgb = SG_BLENDFACTOR_SRC_ALPHA;
+    pip_desc.blend.dst_factor_rgb = SG_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
+    pip_desc.blend.color_write_mask = SG_COLORMASK_RGB;
+    pip_desc.rasterizer.sample_count = sample_count;
+    pip_desc.label = "imgui-pipeline";
+    imgui_pip = sg_make_pipeline(&pip_desc);
+
+    sg_pop_debug_group();
+}
+
+void imgui_newframe(void) {
+    const int cur_width = sapp_width();
+    const int cur_height = sapp_height();
+    ImGuiIO& io = ImGui::GetIO();
+    io.DisplaySize = ImVec2(float(cur_width), float(cur_height));
+    io.DeltaTime = 1.0f / 60.0f;
+    for (int i = 0; i < SAPP_MAX_MOUSEBUTTONS; i++) {
+        if (btn_down[i]) {
+            btn_down[i] = false;
+            io.MouseDown[i] = true;
+        }
+        else if (btn_up[i]) {
+            btn_up[i] = false;
+            io.MouseDown[i] = false;
+        }
+    }
+    ImGui::NewFrame();
+}
+
+void imgui_draw(void) {
+    ImGui::Render();
+    ImDrawData* draw_data = ImGui::GetDrawData();
+    if (nullptr == draw_data) {
+        return;
+    }
+    if (draw_data->CmdListsCount == 0) {
+        return;
+    }
+
+    // render the command list
+    sg_push_debug_group("imgui");
+    sg_apply_pipeline(imgui_pip);
+    vs_params_t vs_params;
+    vs_params.disp_size.x = ImGui::GetIO().DisplaySize.x;
+    vs_params.disp_size.y = ImGui::GetIO().DisplaySize.y;
+    sg_apply_uniforms(SG_SHADERSTAGE_VS, 0, &vs_params, sizeof(vs_params));
+    for (int cl_index = 0; cl_index < draw_data->CmdListsCount; cl_index++) {
+        const ImDrawList* cl = draw_data->CmdLists[cl_index];
+
+        // append vertices and indices to buffers, record start offsets in draw state
+        const int vtx_size = cl->VtxBuffer.size() * sizeof(ImDrawVert);
+        const int idx_size = cl->IdxBuffer.size() * sizeof(ImDrawIdx);
+        const int vb_offset = sg_append_buffer(imgui_bind.vertex_buffers[0], &cl->VtxBuffer.front(), vtx_size);
+        const int ib_offset = sg_append_buffer(imgui_bind.index_buffer, &cl->IdxBuffer.front(), idx_size);
+        /* don't render anything if the buffer is in overflow state (this is also
+            checked internally in sokol_gfx, draw calls that attempt from
+            overflowed buffers will be silently dropped)
+        */
+        if (sg_query_buffer_overflow(imgui_bind.vertex_buffers[0]) ||
+            sg_query_buffer_overflow(imgui_bind.index_buffer))
+        {
+            break;
+        }
+
+        ImTextureID tex_id = ImGui::GetIO().Fonts->TexID;
+        imgui_bind.vertex_buffer_offsets[0] = vb_offset;
+        imgui_bind.index_buffer_offset = ib_offset;
+        imgui_bind.fs_images[0].id = (uint32_t)(uintptr_t)tex_id;
+
+        sg_apply_bindings(&imgui_bind);
+        int base_element = 0;
+        for (const ImDrawCmd& pcmd : cl->CmdBuffer) {
+            if (pcmd.UserCallback) {
+                pcmd.UserCallback(cl, &pcmd);
+            }
+            else {
+                if (tex_id != pcmd.TextureId) {
+                    tex_id = pcmd.TextureId;
+                    imgui_bind.fs_images[0].id = (uint32_t)(uintptr_t)tex_id;
+                    sg_apply_bindings(&imgui_bind);
+                }
+                const int scissor_x = (int) (pcmd.ClipRect.x);
+                const int scissor_y = (int) (pcmd.ClipRect.y);
+                const int scissor_w = (int) (pcmd.ClipRect.z - pcmd.ClipRect.x);
+                const int scissor_h = (int) (pcmd.ClipRect.w - pcmd.ClipRect.y);
+                sg_apply_scissor_rect(scissor_x, scissor_y, scissor_w, scissor_h, true);
+                sg_draw(base_element, pcmd.ElemCount, 1);
+            }
+            base_element += pcmd.ElemCount;
+        }
+    }
+    sg_pop_debug_group();
+}
+
+void imgui_event(const sapp_event* event) {
+    auto& io = ImGui::GetIO();
+    io.KeyAlt = (event->modifiers & SAPP_MODIFIER_ALT) != 0;
+    io.KeyCtrl = (event->modifiers & SAPP_MODIFIER_CTRL) != 0;
+    io.KeyShift = (event->modifiers & SAPP_MODIFIER_SHIFT) != 0;
+    io.KeySuper = (event->modifiers & SAPP_MODIFIER_SUPER) != 0;
+    switch (event->type) {
+        case SAPP_EVENTTYPE_MOUSE_DOWN:
+            io.MousePos.x = event->mouse_x;
+            io.MousePos.y = event->mouse_y;
+            btn_down[event->mouse_button] = true;
+            break;
+        case SAPP_EVENTTYPE_MOUSE_UP:
+            io.MousePos.x = event->mouse_x;
+            io.MousePos.y = event->mouse_y;
+            btn_up[event->mouse_button] = true;
+            break;
+        case SAPP_EVENTTYPE_MOUSE_MOVE:
+            io.MousePos.x = event->mouse_x;
+            io.MousePos.y = event->mouse_y;
+            break;
+        case SAPP_EVENTTYPE_MOUSE_ENTER:
+        case SAPP_EVENTTYPE_MOUSE_LEAVE:
+            for (int i = 0; i < 3; i++) {
+                btn_down[i] = false;
+                btn_up[i] = false;
+                io.MouseDown[i] = false;
+            }
+            break;
+        case SAPP_EVENTTYPE_MOUSE_SCROLL:
+            io.MouseWheelH = event->scroll_x;
+            io.MouseWheel = event->scroll_y;
+            break;
+        case SAPP_EVENTTYPE_TOUCHES_BEGAN:
+            btn_down[0] = true;
+            io.MousePos.x = event->touches[0].pos_x;
+            io.MousePos.y = event->touches[0].pos_y;
+            break;
+        case SAPP_EVENTTYPE_TOUCHES_MOVED:
+            io.MousePos.x = event->touches[0].pos_x;
+            io.MousePos.y = event->touches[0].pos_y;
+            break;
+        case SAPP_EVENTTYPE_TOUCHES_ENDED:
+            btn_up[0] = true;
+            io.MousePos.x = event->touches[0].pos_x;
+            io.MousePos.y = event->touches[0].pos_y;
+            break;
+        case SAPP_EVENTTYPE_TOUCHES_CANCELLED:
+            btn_up[0] = btn_down[0] = false;
+            break;
+        case SAPP_EVENTTYPE_KEY_DOWN:
+            io.KeysDown[event->key_code] = true;
+            break;
+        case SAPP_EVENTTYPE_KEY_UP:
+            io.KeysDown[event->key_code] = false;
+            break;
+        case SAPP_EVENTTYPE_CHAR:
+            io.AddInputCharacter((ImWchar)event->char_code);
+            break;
+        default:
+            break;
+    }
+}
+
+#if defined(SOKOL_GLCORE33)
+const char* vs_src_imgui =
+    "#version 330\n"
+    "uniform vec2 disp_size;\n"
+    "in vec2 position;\n"
+    "in vec2 texcoord0;\n"
+    "in vec4 color0;\n"
+    "out vec2 uv;\n"
+    "out vec4 color;\n"
+    "void main() {\n"
+    "    gl_Position = vec4(((position/disp_size)-0.5)*vec2(2.0,-2.0), 0.5, 1.0);\n"
+    "    uv = texcoord0;\n"
+    "    color = color0;\n"
+    "}\n";
+const char* fs_src_imgui =
+    "#version 330\n"
+    "uniform sampler2D tex;\n"
+    "in vec2 uv;\n"
+    "in vec4 color;\n"
+    "out vec4 frag_color;\n"
+    "void main() {\n"
+    "    frag_color = texture(tex, uv) * color;\n"
+    "}\n";
+#elif defined(SOKOL_GLES2) || defined(SOKOL_GLES3)
+const char* vs_src_imgui =
+    "uniform vec2 disp_size;\n"
+    "attribute vec2 position;\n"
+    "attribute vec2 texcoord0;\n"
+    "attribute vec4 color0;\n"
+    "varying vec2 uv;\n"
+    "varying vec4 color;\n"
+    "void main() {\n"
+    "    gl_Position = vec4(((position/disp_size)-0.5)*vec2(2.0,-2.0), 0.5, 1.0);\n"
+    "    uv = texcoord0;\n"
+    "    color = color0;\n"
+    "}\n";
+const char* fs_src_imgui =
+    "precision mediump float;\n"
+    "uniform sampler2D tex;\n"
+    "varying vec2 uv;\n"
+    "varying vec4 color;\n"
+    "void main() {\n"
+    "    gl_FragColor = texture2D(tex, uv) * color;\n"
+    "}\n";
+#elif defined(SOKOL_METAL)
+const char* vs_src_imgui =
+    "#include <metal_stdlib>\n"
+    "using namespace metal;\n"
+    "struct params_t {\n"
+    "  float2 disp_size;\n"
+    "};\n"
+    "struct vs_in {\n"
+    "  float2 pos [[attribute(0)]];\n"
+    "  float2 uv [[attribute(1)]];\n"
+    "  float4 color [[attribute(2)]];\n"
+    "};\n"
+    "struct vs_out {\n"
+    "  float4 pos [[position]];\n"
+    "  float2 uv;\n"
+    "  float4 color;\n"
+    "};\n"
+    "vertex vs_out _main(vs_in in [[stage_in]], constant params_t& params [[buffer(0)]]) {\n"
+    "  vs_out out;\n"
+    "  out.pos = float4(((in.pos / params.disp_size)-0.5)*float2(2.0,-2.0), 0.5, 1.0);\n"
+    "  out.uv = in.uv;\n"
+    "  out.color = in.color;\n"
+    "  return out;\n"
+    "}\n";
+const char* fs_src_imgui =
+    "#include <metal_stdlib>\n"
+    "using namespace metal;\n"
+    "struct fs_in {\n"
+    "  float2 uv;\n"
+    "  float4 color;\n"
+    "};\n"
+    "fragment float4 _main(fs_in in [[stage_in]], texture2d<float> tex [[texture(0)]], sampler smp [[sampler(0)]]) {\n"
+    "  return tex.sample(smp, in.uv) * in.color;\n"
+    "}\n";
+#elif defined(SOKOL_D3D11)
+const char* vs_src_imgui =
+    "cbuffer params {\n"
+    "  float2 disp_size;\n"
+    "};\n"
+    "struct vs_in {\n"
+    "  float2 pos: POSITION;\n"
+    "  float2 uv: TEXCOORD0;\n"
+    "  float4 color: COLOR0;\n"
+    "};\n"
+    "struct vs_out {\n"
+    "  float2 uv: TEXCOORD0;\n"
+    "  float4 color: COLOR0;\n"
+    "  float4 pos: SV_Position;\n"
+    "};\n"
+    "vs_out main(vs_in inp) {\n"
+    "  vs_out outp;\n"
+    "  outp.pos = float4(((inp.pos/disp_size)-0.5)*float2(2.0,-2.0), 0.5, 1.0);\n"
+    "  outp.uv = inp.uv;\n"
+    "  outp.color = inp.color;\n"
+    "  return outp;\n"
+    "}\n";
+const char* fs_src_imgui =
+    "Texture2D<float4> tex: register(t0);\n"
+    "sampler smp: register(s0);\n"
+    "float4 main(float2 uv: TEXCOORD0, float4 color: COLOR0): SV_Target0 {\n"
+    "  return tex.Sample(smp, uv) * color;\n"
+    "}\n";
+#else
+#error "No sokol-gfx backend selected"
+#endif
+
+#endif /* UI_IMPL */
+```
 
 ### 5. Add UI init- and rendering-calls to your code
 
-(TODO)
+All debug inspection headers follow the same API pattern (here shown
+with ```sokol_gfx_imgui.h``` as an example):
 
+- a struct to store all state
+- an init-function to initialize this struct to a good state
+- a one-in-all draw-function which is called per frame
+- ...and a discard function called at shutdown
 
+```cpp
+static sg_imgui_t sg_imgui;
 
+void init(void) {
+    ...
+    /* initialize the sokol-gfx debug inspection UI */
+    sg_imgui_init(&sg_imgui)
+    ...
+}
+
+void draw_frame(void) {
+    ...
+    /* draw the debug inspection UI via Dear ImGui calls */
+    sg_imgui_draw(&sg_imgui);
+    ...
+}
+
+void shutdown(void) {
+    ...
+    sg_imgui_discard(&sg_imgui);
+    ...
+}
+```
+
+When running this code, nothing will be rendered because all debug inspection
+windows are in closed state. Opening and closing the windows is done
+directly by toggling public bool members of the state struct.
+
+For instance in with sokol_gfx_imgui.h:
+
+```cpp
+/* open all sokol_gfx_imgui.h windows */
+sg_imgui.buffers.open = true
+sg_imgui.images.open = true;
+sg_imgui.shaders.open = true;
+sg_imgui.pipelines.open = true;
+sg_imgui.passes.open = true;
+sg_imgui.capture.open = true;
+```
+
+Exposing the open state as booleans has been done to make it easier to 
+toggle the window visibility with other ImGui functions. For instance
+you could build a menu like this:
+
+```cpp
+if (ImGui::BeginMainMenuBar()) {
+    if (ImGui::BeginMenu("sokol-gfx")) {
+        ImGui::MenuItem("Buffers", 0, &sg_imgui.buffers.open);
+        ImGui::MenuItem("Images", 0, &sg_imgui.images.open);
+        ImGui::MenuItem("Shaders", 0, &sg_imgui.shaders.open);
+        ImGui::MenuItem("Pipelines", 0, &sg_imgui.pipelines.open);
+        ImGui::MenuItem("Passes", 0, &sg_imgui.passes.open);
+        ImGui::MenuItem("Calls", 0, &sg_imgui.capture.open);
+        ImGui::EndMenu();
+    }
+    ImGui::EndMainMenuBar();
+}
+```
+
+The debug inspection headers also offer more granular drawing functions
+for more flexible integration into your own UI, for example the following
+```sokol_gfx_imgui.h``` functions only draw the window content (inside
+an ```ImGui::BeginChild() / ImGui::EndChild()``` pair:
+
+```cpp
+void sg_imgui_draw_buffers_content(sg_imgui_t* ctx);
+void sg_imgui_draw_images_content(sg_imgui_t* ctx);
+void sg_imgui_draw_shaders_content(sg_imgui_t* ctx);
+void sg_imgui_draw_pipelines_content(sg_imgui_t* ctx);
+void sg_imgui_draw_passes_content(sg_imgui_t* ctx);
+void sg_imgui_draw_capture_content(sg_imgui_t* ctx);
+```

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -185,7 +185,7 @@ _SOKOL_PRIVATE void _sg_imgui_buffer_created(sg_imgui_t* ctx, sg_buffer res_id, 
     SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->buffers.num_slots));
     sg_imgui_buffer_t* buf = &ctx->buffers.slots[slot_index];
     buf->res_id = res_id;
-    _sg_imgui_strcpy(&buf->label, desc->trace_label);
+    _sg_imgui_strcpy(&buf->label, desc->label);
 }
 
 _SOKOL_PRIVATE void _sg_imgui_buffer_destroyed(sg_imgui_t* ctx, int slot_index) {
@@ -198,7 +198,7 @@ _SOKOL_PRIVATE void _sg_imgui_image_created(sg_imgui_t* ctx, sg_image res_id, in
     SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->images.num_slots));
     sg_imgui_image_t* img = &ctx->images.slots[slot_index];
     img->res_id = res_id;
-    _sg_imgui_strcpy(&img->label, desc->trace_label);
+    _sg_imgui_strcpy(&img->label, desc->label);
 }
 
 _SOKOL_PRIVATE void _sg_imgui_image_destroyed(sg_imgui_t* ctx, int slot_index) {
@@ -212,7 +212,7 @@ _SOKOL_PRIVATE void _sg_imgui_shader_created(sg_imgui_t* ctx, sg_shader res_id, 
     sg_imgui_shader_t* shd = &ctx->shaders.slots[slot_index];
     shd->res_id = res_id;
     shd->desc = *desc;
-    _sg_imgui_strcpy(&shd->label, desc->trace_label);
+    _sg_imgui_strcpy(&shd->label, desc->label);
     if (shd->desc.vs.entry) {
         _sg_imgui_strcpy(&shd->vs_entry, shd->desc.vs.entry);
         shd->desc.vs.entry = shd->vs_entry.buf;
@@ -291,7 +291,7 @@ _SOKOL_PRIVATE void _sg_imgui_pipeline_created(sg_imgui_t* ctx, sg_pipeline res_
     SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->pipelines.num_slots));
     sg_imgui_pipeline_t* pip = &ctx->pipelines.slots[slot_index];
     pip->res_id = res_id;
-    _sg_imgui_strcpy(&pip->label, desc->trace_label);
+    _sg_imgui_strcpy(&pip->label, desc->label);
     pip->desc = *desc;
 
     /* copy strings in vertex layout to persistent location */
@@ -387,7 +387,7 @@ _SOKOL_PRIVATE void _sg_imgui_pass_created(sg_imgui_t* ctx, sg_pass res_id, int 
     SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->passes.num_slots));
     sg_imgui_pass_t* pass = &ctx->passes.slots[slot_index];
     pass->res_id = res_id;
-    _sg_imgui_strcpy(&pass->label, desc->trace_label);
+    _sg_imgui_strcpy(&pass->label, desc->label);
 }
 
 _SOKOL_PRIVATE void _sg_imgui_pass_destroyed(sg_imgui_t* ctx, int slot_index) {
@@ -1298,9 +1298,11 @@ _SOKOL_PRIVATE void _sg_imgui_draw_image_panel(sg_imgui_t* ctx, uint32_t sel_id)
             ImGui::Text("Active Slot:   %d", img->active_slot);
             ImGui::Text("Update Frame Index: %d", img->upd_frame_index);
         }
-        ImGui::BeginChild("texture", ImVec2(0, 0), true, ImGuiWindowFlags_HorizontalScrollbar);
-        ImGui::Image((ImTextureID)(intptr_t)sel_id, ImVec2(2*img->width, 2*img->height));
-        ImGui::EndChild();
+        if ((SG_IMAGETYPE_2D == img->type) && !_sg_is_valid_rendertarget_depth_format(img->pixel_format)) {
+            ImGui::BeginChild("texture", ImVec2(0, 0), true, ImGuiWindowFlags_HorizontalScrollbar);
+            ImGui::Image((ImTextureID)(intptr_t)sel_id, ImVec2(2*img->width, 2*img->height));
+            ImGui::EndChild();
+        }
         ImGui::EndChild();
     }
 }

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -281,10 +281,12 @@ typedef struct {
 
 typedef struct {
     int x, y, width, height;
+    bool origin_top_left;
 } sg_imgui_args_apply_viewport_t;
 
 typedef struct {
     int x, y, width, height;
+    bool origin_top_left;
 } sg_imgui_args_apply_scissor_rect_t;
 
 typedef struct {
@@ -419,13 +421,17 @@ typedef struct {
     sg_imgui_args_t args;
 } sg_imgui_capture_item_t;
 
+typedef struct {
+    uint32_t slot_index;
+    sg_imgui_capture_item_t items[SG_IMGUI_MAX_FRAMECAPTURE_ITEMS];
+} sg_imgui_capture_bucket_t;
+
 /* double-buffered call-capture buckets, one bucket is currently recorded,
    the previous bucket is displayed
 */
 typedef struct {
-    int bucket_index;     /* which bucket to record to, 0 or 1 */
-    int slot_index;       /* slot index in bucket */
-    sg_imgui_capture_item_t bucket[2][SG_IMGUI_MAX_FRAMECAPTURE_ITEMS];
+    uint32_t bucket_index;     /* which bucket to record to, 0 or 1 */
+    sg_imgui_capture_bucket_t bucket[2];
 } sg_imgui_framecapture_t;
 
 typedef struct {
@@ -725,10 +731,40 @@ _SOKOL_PRIVATE void _sg_imgui_pass_destroyed(sg_imgui_t* ctx, int slot_index) {
     pass->res_id.id = SG_INVALID_ID;
 }
 
+/*--- command capturing ------------------------------------------------------*/
+_SOKOL_PRIVATE sg_imgui_capture_bucket_t* _sg_imgui_capture_get_write_bucket(sg_imgui_t* ctx) {
+    return &ctx->capture.bucket[ctx->capture.bucket_index & 1];
+}
+
+_SOKOL_PRIVATE const sg_imgui_capture_bucket_t* _sg_imgui_capture_get_read_bucket(sg_imgui_t* ctx) {
+    return &ctx->capture.bucket[(ctx->capture.bucket_index + 1) & 1];
+}
+
+_SOKOL_PRIVATE void _sg_imgui_capture_next_frame(sg_imgui_t* ctx) {
+    ctx->capture.bucket_index = (ctx->capture.bucket_index + 1) & 1;
+    ctx->capture.bucket[ctx->capture.bucket_index].slot_index = 0;
+}
+
+_SOKOL_PRIVATE sg_imgui_capture_item_t* _sg_imgui_capture_next_write_item(sg_imgui_t* ctx) {
+    sg_imgui_capture_bucket_t* bucket = _sg_imgui_capture_get_write_bucket(ctx);
+    if (bucket->slot_index < SG_IMGUI_MAX_FRAMECAPTURE_ITEMS) {
+        return &bucket->items[bucket->slot_index++];
+    }
+    else {
+        return 0;
+    }
+}
+
 /*--- sokol-gfx trace hook functions -----------------------------------------*/
 _SOKOL_PRIVATE void _sg_imgui_query_feature(sg_feature feature, bool result, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_QUERY_FEATURE;
+        item->args.query_feature.feature = feature;
+        item->args.query_feature.result = result;
+    }
     if (ctx->hooks.query_feature) {
         ctx->hooks.query_feature(feature, result, ctx->hooks.user_data);
     }
@@ -737,6 +773,10 @@ _SOKOL_PRIVATE void _sg_imgui_query_feature(sg_feature feature, bool result, voi
 _SOKOL_PRIVATE void _sg_imgui_reset_state_cache(void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_RESET_STATE_CACHE;
+    }
     if (ctx->hooks.reset_state_cache) {
         ctx->hooks.reset_state_cache(ctx->hooks.user_data);
     }
@@ -745,6 +785,11 @@ _SOKOL_PRIVATE void _sg_imgui_reset_state_cache(void* user_data) {
 _SOKOL_PRIVATE void _sg_imgui_make_buffer(const sg_buffer_desc* desc, sg_buffer buf_id, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_MAKE_BUFFER;
+        item->args.make_buffer.result = buf_id;
+    }
     if (ctx->hooks.make_buffer) {
         ctx->hooks.make_buffer(desc, buf_id, ctx->hooks.user_data);
     }
@@ -756,6 +801,11 @@ _SOKOL_PRIVATE void _sg_imgui_make_buffer(const sg_buffer_desc* desc, sg_buffer 
 _SOKOL_PRIVATE void _sg_imgui_make_image(const sg_image_desc* desc, sg_image img_id, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_MAKE_IMAGE;
+        item->args.make_image.result = img_id;
+    }
     if (ctx->hooks.make_image) {
         ctx->hooks.make_image(desc, img_id, ctx->hooks.user_data);
     }
@@ -767,6 +817,11 @@ _SOKOL_PRIVATE void _sg_imgui_make_image(const sg_image_desc* desc, sg_image img
 _SOKOL_PRIVATE void _sg_imgui_make_shader(const sg_shader_desc* desc, sg_shader shd_id, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_MAKE_SHADER;
+        item->args.make_shader.result = shd_id;
+    }
     if (ctx->hooks.make_shader) {
         ctx->hooks.make_shader(desc, shd_id, ctx->hooks.user_data);
     }
@@ -778,6 +833,11 @@ _SOKOL_PRIVATE void _sg_imgui_make_shader(const sg_shader_desc* desc, sg_shader 
 _SOKOL_PRIVATE void _sg_imgui_make_pipeline(const sg_pipeline_desc* desc, sg_pipeline pip_id, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_MAKE_PIPELINE;
+        item->args.make_pipeline.result = pip_id;
+    }
     if (ctx->hooks.make_pipeline) {
         ctx->hooks.make_pipeline(desc, pip_id, ctx->hooks.user_data);
     }
@@ -789,6 +849,11 @@ _SOKOL_PRIVATE void _sg_imgui_make_pipeline(const sg_pipeline_desc* desc, sg_pip
 _SOKOL_PRIVATE void _sg_imgui_make_pass(const sg_pass_desc* desc, sg_pass pass_id, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_MAKE_PASS;
+        item->args.make_pass.result = pass_id;
+    }
     if (ctx->hooks.make_pass) {
         ctx->hooks.make_pass(desc, pass_id, ctx->hooks.user_data);
     }
@@ -800,6 +865,11 @@ _SOKOL_PRIVATE void _sg_imgui_make_pass(const sg_pass_desc* desc, sg_pass pass_i
 _SOKOL_PRIVATE void _sg_imgui_destroy_buffer(sg_buffer buf, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_DESTROY_BUFFER;
+        item->args.destroy_buffer.buffer = buf;
+    }
     if (ctx->hooks.destroy_buffer) {
         ctx->hooks.destroy_buffer(buf, ctx->hooks.user_data);
     }
@@ -811,6 +881,11 @@ _SOKOL_PRIVATE void _sg_imgui_destroy_buffer(sg_buffer buf, void* user_data) {
 _SOKOL_PRIVATE void _sg_imgui_destroy_image(sg_image img, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_DESTROY_IMAGE;
+        item->args.destroy_image.image = img;
+    }
     if (ctx->hooks.destroy_image) {
         ctx->hooks.destroy_image(img, ctx->hooks.user_data);
     }
@@ -822,6 +897,11 @@ _SOKOL_PRIVATE void _sg_imgui_destroy_image(sg_image img, void* user_data) {
 _SOKOL_PRIVATE void _sg_imgui_destroy_shader(sg_shader shd, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_DESTROY_SHADER;
+        item->args.destroy_shader.shader = shd;
+    }
     if (ctx->hooks.destroy_shader) {
         ctx->hooks.destroy_shader(shd, ctx->hooks.user_data);
     }
@@ -833,6 +913,11 @@ _SOKOL_PRIVATE void _sg_imgui_destroy_shader(sg_shader shd, void* user_data) {
 _SOKOL_PRIVATE void _sg_imgui_destroy_pipeline(sg_pipeline pip, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_DESTROY_PIPELINE;
+        item->args.destroy_pipeline.pipeline = pip;
+    }
     if (ctx->hooks.destroy_pipeline) {
         ctx->hooks.destroy_pipeline(pip, ctx->hooks.user_data);
     }
@@ -844,6 +929,11 @@ _SOKOL_PRIVATE void _sg_imgui_destroy_pipeline(sg_pipeline pip, void* user_data)
 _SOKOL_PRIVATE void _sg_imgui_destroy_pass(sg_pass pass, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_DESTROY_PASS;
+        item->args.destroy_pass.pass = pass;
+    }
     if (ctx->hooks.destroy_pass) {
         ctx->hooks.destroy_pass(pass, ctx->hooks.user_data);
     }
@@ -853,192 +943,339 @@ _SOKOL_PRIVATE void _sg_imgui_destroy_pass(sg_pass pass, void* user_data) {
 }
 
 _SOKOL_PRIVATE void _sg_imgui_update_buffer(sg_buffer buf, const void* data_ptr, int data_size, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_UPDATE_BUFFER;
+        item->args.update_buffer.buffer = buf;
+        item->args.update_buffer.data_size = data_size;
+    }
     if (ctx->hooks.update_buffer) {
         ctx->hooks.update_buffer(buf, data_ptr, data_size, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_update_image(sg_image img, const sg_image_content* data, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_UPDATE_IMAGE;
+        item->args.update_image.image = img;
+    }
     if (ctx->hooks.update_image) {
         ctx->hooks.update_image(img, data, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_append_buffer(sg_buffer buf, const void* data_ptr, int data_size, int result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_APPEND_BUFFER;
+        item->args.append_buffer.buffer = buf;
+        item->args.append_buffer.data_size = data_size;
+        item->args.append_buffer.result = result;
+    }
     if (ctx->hooks.append_buffer) {
         ctx->hooks.append_buffer(buf, data_ptr, data_size, result, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_query_buffer_overflow(sg_buffer buf, bool result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_QUERY_BUFFER_OVERFLOW;
+        item->args.query_buffer_overflow.buffer = buf;
+        item->args.query_buffer_overflow.result = result;
+    }
     if (ctx->hooks.query_buffer_overflow) {
         ctx->hooks.query_buffer_overflow(buf, result, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_query_buffer_state(sg_buffer buf, sg_resource_state result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_QUERY_BUFFER_STATE;
+        item->args.query_buffer_state.buffer = buf;
+        item->args.query_buffer_state.result = result;
+    }
     if (ctx->hooks.query_buffer_state) {
         ctx->hooks.query_buffer_state(buf, result, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_query_image_state(sg_image img, sg_resource_state result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_QUERY_IMAGE_STATE;
+        item->args.query_image_state.image = img;
+        item->args.query_image_state.result = result;
+    }
     if (ctx->hooks.query_image_state) {
         ctx->hooks.query_image_state(img, result, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_query_shader_state(sg_shader shd, sg_resource_state result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_QUERY_SHADER_STATE;
+        item->args.query_shader_state.shader = shd;
+        item->args.query_shader_state.result = result;
+    }
     if (ctx->hooks.query_shader_state) {
         ctx->hooks.query_shader_state(shd, result, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_query_pipeline_state(sg_pipeline pip, sg_resource_state result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_QUERY_PIPELINE_STATE;
+        item->args.query_pipeline_state.pipeline = pip;
+        item->args.query_pipeline_state.result = result;
+    }
     if (ctx->hooks.query_pipeline_state) {
         ctx->hooks.query_pipeline_state(pip, result, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_query_pass_state(sg_pass pass, sg_resource_state result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_QUERY_PASS_STATE;
+        item->args.query_pass_state.pass = pass;
+        item->args.query_pass_state.result = result;
+    }
     if (ctx->hooks.query_pass_state) {
         ctx->hooks.query_pass_state(pass, result, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_begin_default_pass(const sg_pass_action* pass_action, int width, int height, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        SOKOL_ASSERT(pass_action);
+        item->cmd = SG_IMGUI_CMD_BEGIN_DEFAULT_PASS;
+        item->args.begin_default_pass.action = *pass_action;
+        item->args.begin_default_pass.width = width;
+        item->args.begin_default_pass.height = height;
+    }
     if (ctx->hooks.begin_default_pass) {
         ctx->hooks.begin_default_pass(pass_action, width, height, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_begin_pass(sg_pass pass, const sg_pass_action* pass_action, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        SOKOL_ASSERT(pass_action);
+        item->cmd = SG_IMGUI_CMD_BEGIN_PASS;
+        item->args.begin_pass.pass = pass;
+        item->args.begin_pass.action = *pass_action;
+    }
     if (ctx->hooks.begin_pass) {
         ctx->hooks.begin_pass(pass, pass_action, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_apply_viewport(int x, int y, int width, int height, bool origin_top_left, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_APPLY_VIEWPORT;
+        item->args.apply_viewport.x = x;
+        item->args.apply_viewport.y = y;
+        item->args.apply_viewport.width = width;
+        item->args.apply_viewport.height = height;
+        item->args.apply_viewport.origin_top_left = origin_top_left;
+    }
     if (ctx->hooks.apply_viewport) {
         ctx->hooks.apply_viewport(x, y, width, height, origin_top_left, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_apply_scissor_rect(int x, int y, int width, int height, bool origin_top_left, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_APPLY_SCISSOR_RECT;
+        item->args.apply_scissor_rect.x = x;
+        item->args.apply_scissor_rect.y = y;
+        item->args.apply_scissor_rect.width = width;
+        item->args.apply_scissor_rect.height = height;
+        item->args.apply_scissor_rect.origin_top_left = origin_top_left;
+    }
     if (ctx->hooks.apply_scissor_rect) {
         ctx->hooks.apply_scissor_rect(x, y, width, height, origin_top_left, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_apply_pipeline(sg_pipeline pip, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_APPLY_PIPELINE;
+        item->args.apply_pipeline.pipeline = pip;
+    }
     if (ctx->hooks.apply_pipeline) {
         ctx->hooks.apply_pipeline(pip, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_apply_bindings(const sg_bindings* bindings, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        SOKOL_ASSERT(bindings);
+        item->cmd = SG_IMGUI_CMD_APPLY_BINDINGS;
+        item->args.apply_bindings.bindings = *bindings;
+    }
     if (ctx->hooks.apply_bindings) {
         ctx->hooks.apply_bindings(bindings, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_apply_uniforms(sg_shader_stage stage, int ub_index, const void* data, int num_bytes, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_APPLY_UNIFORMS;
+        item->args.apply_uniforms.stage = stage;
+        item->args.apply_uniforms.ub_index = ub_index;
+        item->args.apply_uniforms.data = data;
+        item->args.apply_uniforms.num_bytes = num_bytes;
+    }
     if (ctx->hooks.apply_uniforms) {
         ctx->hooks.apply_uniforms(stage, ub_index, data, num_bytes, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_draw(int base_element, int num_elements, int num_instances, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_DRAW;
+        item->args.draw.base_element = base_element;
+        item->args.draw.num_elements = num_elements;
+        item->args.draw.num_instances = num_instances;
+    }
     if (ctx->hooks.draw) {
         ctx->hooks.draw(base_element, num_elements, num_instances, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_end_pass(void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_END_PASS;
+    }
     if (ctx->hooks.end_pass) {
         ctx->hooks.end_pass(ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_commit(void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_COMMIT;
+    }
+    _sg_imgui_capture_next_frame(ctx);
     if (ctx->hooks.commit) {
         ctx->hooks.commit(ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_alloc_buffer(sg_buffer result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_ALLOC_BUFFER;
+        item->args.alloc_buffer.result = result;
+    }
     if (ctx->hooks.alloc_buffer) {
         ctx->hooks.alloc_buffer(result, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_alloc_image(sg_image result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_ALLOC_IMAGE;
+        item->args.alloc_image.result = result;
+    }
     if (ctx->hooks.alloc_image) {
         ctx->hooks.alloc_image(result, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_alloc_shader(sg_shader result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_ALLOC_SHADER;
+        item->args.alloc_shader.result = result;
+    }
     if (ctx->hooks.alloc_shader) {
         ctx->hooks.alloc_shader(result, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_alloc_pipeline(sg_pipeline result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_ALLOC_PIPELINE;
+        item->args.alloc_pipeline.result = result;
+    }
     if (ctx->hooks.alloc_pipeline) {
         ctx->hooks.alloc_pipeline(result, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_alloc_pass(sg_pass result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_ALLOC_PASS;
+        item->args.alloc_pass.result = result;
+    }
     if (ctx->hooks.alloc_pass) {
         ctx->hooks.alloc_pass(result, ctx->hooks.user_data);
     }
@@ -1047,6 +1284,11 @@ _SOKOL_PRIVATE void _sg_imgui_alloc_pass(sg_pass result, void* user_data) {
 _SOKOL_PRIVATE void _sg_imgui_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_INIT_BUFFER;
+        item->args.init_buffer.buffer = buf_id;
+    }
     if (ctx->hooks.init_buffer) {
         ctx->hooks.init_buffer(buf_id, desc, ctx->hooks.user_data);
     }
@@ -1058,6 +1300,11 @@ _SOKOL_PRIVATE void _sg_imgui_init_buffer(sg_buffer buf_id, const sg_buffer_desc
 _SOKOL_PRIVATE void _sg_imgui_init_image(sg_image img_id, const sg_image_desc* desc, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_INIT_IMAGE;
+        item->args.init_image.image = img_id;
+    }
     if (ctx->hooks.init_image) {
         ctx->hooks.init_image(img_id, desc, ctx->hooks.user_data);
     }
@@ -1069,6 +1316,11 @@ _SOKOL_PRIVATE void _sg_imgui_init_image(sg_image img_id, const sg_image_desc* d
 _SOKOL_PRIVATE void _sg_imgui_init_shader(sg_shader shd_id, const sg_shader_desc* desc, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_INIT_SHADER;
+        item->args.init_shader.shader = shd_id;
+    }
     if (ctx->hooks.init_shader) {
         ctx->hooks.init_shader(shd_id, desc, ctx->hooks.user_data);
     }
@@ -1080,6 +1332,11 @@ _SOKOL_PRIVATE void _sg_imgui_init_shader(sg_shader shd_id, const sg_shader_desc
 _SOKOL_PRIVATE void _sg_imgui_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_INIT_PIPELINE;
+        item->args.init_pipeline.pipeline = pip_id;
+    }
     if (ctx->hooks.init_pipeline) {
         ctx->hooks.init_pipeline(pip_id, desc, ctx->hooks.user_data);
     }
@@ -1091,6 +1348,11 @@ _SOKOL_PRIVATE void _sg_imgui_init_pipeline(sg_pipeline pip_id, const sg_pipelin
 _SOKOL_PRIVATE void _sg_imgui_init_pass(sg_pass pass_id, const sg_pass_desc* desc, void* user_data) {
     sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_INIT_PASS;
+        item->args.init_pass.pass = pass_id;
+    }
     if (ctx->hooks.init_pass) {
         ctx->hooks.init_pass(pass_id, desc, ctx->hooks.user_data);
     }
@@ -1100,40 +1362,65 @@ _SOKOL_PRIVATE void _sg_imgui_init_pass(sg_pass pass_id, const sg_pass_desc* des
 }
 
 _SOKOL_PRIVATE void _sg_imgui_fail_buffer(sg_buffer buf_id, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_FAIL_BUFFER;
+        item->args.fail_buffer.buffer = buf_id;
+    }
     if (ctx->hooks.fail_buffer) {
         ctx->hooks.fail_buffer(buf_id, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_fail_image(sg_image img_id, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_FAIL_IMAGE;
+        item->args.fail_image.image = img_id;
+    }
     if (ctx->hooks.fail_image) {
         ctx->hooks.fail_image(img_id, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_fail_shader(sg_shader shd_id, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_FAIL_SHADER;
+        item->args.fail_shader.shader = shd_id;
+    }
     if (ctx->hooks.fail_shader) {
         ctx->hooks.fail_shader(shd_id, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_fail_pipeline(sg_pipeline pip_id, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_FAIL_PIPELINE;
+        item->args.fail_pipeline.pipeline = pip_id;
+    }
     if (ctx->hooks.fail_pipeline) {
         ctx->hooks.fail_pipeline(pip_id, ctx->hooks.user_data);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_fail_pass(sg_pass pass_id, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SG_IMGUI_CMD_FAIL_PASS;
+        item->args.fail_pass.pass = pass_id;
+    }
     if (ctx->hooks.fail_pass) {
         ctx->hooks.fail_pass(pass_id, ctx->hooks.user_data);
     }

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -1259,7 +1259,7 @@ _SOKOL_PRIVATE sg_imgui_str_t _sg_imgui_capture_item_string(sg_imgui_t* ctx, int
 
         case SG_IMGUI_CMD_BEGIN_PASS:
             res_id = _sg_imgui_pass_id_string(ctx, item->args.begin_pass.pass);
-            snprintf(str.buf, len, "%d: sg_begin_pass(pass=%s, pass_action=..", index, res_id.buf);
+            snprintf(str.buf, len, "%d: sg_begin_pass(pass=%s, pass_action=..)", index, res_id.buf);
             break;
 
         case SG_IMGUI_CMD_APPLY_VIEWPORT:
@@ -2627,10 +2627,141 @@ _SOKOL_PRIVATE void _sg_imgui_draw_pass_panel(sg_imgui_t* ctx, uint32_t pass_id)
             }
         }
         else {
-            ImGui::Text("Pass 0x08X no longer alive.");
+            ImGui::Text("Pass 0x%08X no longer alive.", pass_id);
         }
         ImGui::EndChild();
     }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_draw_capture_panel(sg_imgui_t* ctx) {
+    uint32_t sel_item_index = ctx->capture.sel_item;
+    if (sel_item_index >= _sg_imgui_capture_num_read_items(ctx)) {
+        return;
+    }
+    sg_imgui_capture_item_t* item = _sg_imgui_capture_read_item_at(ctx, sel_item_index);
+    ImGui::BeginChild("capture_item", ImVec2(0, 0), false);
+    ImGui::Text("%s", _sg_imgui_capture_item_string(ctx, sel_item_index, item).buf);
+    ImGui::Separator();
+    switch (item->cmd) {
+        case SG_IMGUI_CMD_QUERY_FEATURE:
+            break;
+        case SG_IMGUI_CMD_RESET_STATE_CACHE:
+            break;
+        case SG_IMGUI_CMD_MAKE_BUFFER:
+            _sg_imgui_draw_buffer_panel(ctx, item->args.make_buffer.result.id);
+            break;
+        case SG_IMGUI_CMD_MAKE_IMAGE:
+            _sg_imgui_draw_image_panel(ctx, item->args.make_image.result.id);
+            break;
+        case SG_IMGUI_CMD_MAKE_SHADER:
+            _sg_imgui_draw_shader_panel(ctx, item->args.make_shader.result.id);
+            break;
+        case SG_IMGUI_CMD_MAKE_PIPELINE:
+            _sg_imgui_draw_pipeline_panel(ctx, item->args.make_pipeline.result.id);
+            break;
+        case SG_IMGUI_CMD_MAKE_PASS:
+            _sg_imgui_draw_pass_panel(ctx, item->args.make_pass.result.id);
+            break;
+        case SG_IMGUI_CMD_DESTROY_BUFFER:
+            _sg_imgui_draw_buffer_panel(ctx, item->args.destroy_buffer.buffer.id);
+            break;
+        case SG_IMGUI_CMD_DESTROY_IMAGE:
+            _sg_imgui_draw_image_panel(ctx, item->args.destroy_image.image.id);
+            break;
+        case SG_IMGUI_CMD_DESTROY_SHADER:
+            _sg_imgui_draw_shader_panel(ctx, item->args.destroy_shader.shader.id);
+            break;
+        case SG_IMGUI_CMD_DESTROY_PIPELINE:
+            _sg_imgui_draw_pipeline_panel(ctx, item->args.destroy_pipeline.pipeline.id);
+            break;
+        case SG_IMGUI_CMD_DESTROY_PASS:
+            _sg_imgui_draw_pass_panel(ctx, item->args.destroy_pass.pass.id);
+            break;
+        case SG_IMGUI_CMD_UPDATE_BUFFER:
+            _sg_imgui_draw_buffer_panel(ctx, item->args.update_buffer.buffer.id);
+            break;
+        case SG_IMGUI_CMD_UPDATE_IMAGE:
+            _sg_imgui_draw_image_panel(ctx, item->args.update_image.image.id);
+            break;
+        case SG_IMGUI_CMD_APPEND_BUFFER:
+            _sg_imgui_draw_buffer_panel(ctx, item->args.update_buffer.buffer.id);
+            break;
+        case SG_IMGUI_CMD_QUERY_BUFFER_OVERFLOW:
+        case SG_IMGUI_CMD_QUERY_BUFFER_STATE:
+        case SG_IMGUI_CMD_QUERY_IMAGE_STATE:
+        case SG_IMGUI_CMD_QUERY_SHADER_STATE:
+        case SG_IMGUI_CMD_QUERY_PIPELINE_STATE:
+        case SG_IMGUI_CMD_QUERY_PASS_STATE:
+            break;
+        case SG_IMGUI_CMD_BEGIN_DEFAULT_PASS:
+        case SG_IMGUI_CMD_BEGIN_PASS:
+            ImGui::Text("FIXME");
+            break;
+        case SG_IMGUI_CMD_APPLY_VIEWPORT:
+        case SG_IMGUI_CMD_APPLY_SCISSOR_RECT:
+            break;
+        case SG_IMGUI_CMD_APPLY_PIPELINE:
+            _sg_imgui_draw_pipeline_panel(ctx, item->args.apply_pipeline.pipeline.id);
+            break;
+        case SG_IMGUI_CMD_APPLY_BINDINGS:
+            ImGui::Text("FIXME");
+            break;
+        case SG_IMGUI_CMD_APPLY_UNIFORMS:
+            ImGui::Text("FIXME");
+            break;
+        case SG_IMGUI_CMD_DRAW:
+        case SG_IMGUI_CMD_END_PASS:
+        case SG_IMGUI_CMD_COMMIT:
+            break;
+        case SG_IMGUI_CMD_ALLOC_BUFFER:
+            _sg_imgui_draw_buffer_panel(ctx, item->args.alloc_buffer.result.id);
+            break;
+        case SG_IMGUI_CMD_ALLOC_IMAGE:
+            _sg_imgui_draw_image_panel(ctx, item->args.alloc_image.result.id);
+            break;
+        case SG_IMGUI_CMD_ALLOC_SHADER:
+            _sg_imgui_draw_shader_panel(ctx, item->args.alloc_shader.result.id);
+            break;
+        case SG_IMGUI_CMD_ALLOC_PIPELINE:
+            _sg_imgui_draw_pipeline_panel(ctx, item->args.alloc_pipeline.result.id);
+            break;
+        case SG_IMGUI_CMD_ALLOC_PASS:
+            _sg_imgui_draw_pass_panel(ctx, item->args.alloc_pass.result.id);
+            break;
+        case SG_IMGUI_CMD_INIT_BUFFER:
+            _sg_imgui_draw_buffer_panel(ctx, item->args.init_buffer.buffer.id);
+            break;
+        case SG_IMGUI_CMD_INIT_IMAGE:
+            _sg_imgui_draw_image_panel(ctx, item->args.init_image.image.id);
+            break;
+        case SG_IMGUI_CMD_INIT_SHADER:
+            _sg_imgui_draw_shader_panel(ctx, item->args.init_shader.shader.id);
+            break;
+        case SG_IMGUI_CMD_INIT_PIPELINE:
+            _sg_imgui_draw_pipeline_panel(ctx, item->args.init_pipeline.pipeline.id);
+            break;
+        case SG_IMGUI_CMD_INIT_PASS:
+            _sg_imgui_draw_pass_panel(ctx, item->args.init_pass.pass.id);
+            break;
+        case SG_IMGUI_CMD_FAIL_BUFFER:
+            _sg_imgui_draw_buffer_panel(ctx, item->args.fail_buffer.buffer.id);
+            break;
+        case SG_IMGUI_CMD_FAIL_IMAGE:
+            _sg_imgui_draw_image_panel(ctx, item->args.fail_image.image.id);
+            break;
+        case SG_IMGUI_CMD_FAIL_SHADER:
+            _sg_imgui_draw_shader_panel(ctx, item->args.fail_shader.shader.id);
+            break;
+        case SG_IMGUI_CMD_FAIL_PIPELINE:
+            _sg_imgui_draw_pipeline_panel(ctx, item->args.fail_pipeline.pipeline.id);
+            break;
+        case SG_IMGUI_CMD_FAIL_PASS:
+            _sg_imgui_draw_pass_panel(ctx, item->args.fail_pass.pass.id);
+            break;
+        default:
+            break;
+    }
+    ImGui::EndChild();
 }
 
 /*--- PUBLIC FUNCTIONS -------------------------------------------------------*/
@@ -2903,6 +3034,8 @@ void sg_imgui_draw_passes_content(sg_imgui_t* ctx) {
 void sg_imgui_draw_capture_content(sg_imgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
     _sg_imgui_draw_capture_list(ctx);
+    ImGui::SameLine();
+    _sg_imgui_draw_capture_panel(ctx);
 }
 
 #endif /* SOKOL_IMPL */

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -70,6 +70,36 @@
         anyway, but not doing this may trigger memory leak detection tools.
 
 
+    ALTERNATIVE DRAWING FUNCTIONS:
+    ==============================
+    Instead of the convenient, but all-in-one sg_imgui_draw() function,
+    you can also use the following granular functions which might allow
+    better integration with your existing UI:
+
+    The following functions only render the window *content* (so you
+    can integrate the UI into you own windows):
+
+        void sg_imgui_draw_buffers_content(sg_imgui_t* ctx);
+        void sg_imgui_draw_images_content(sg_imgui_t* ctx);
+        void sg_imgui_draw_shaders_content(sg_imgui_t* ctx);
+        void sg_imgui_draw_pipelines_content(sg_imgui_t* ctx);
+        void sg_imgui_draw_passes_content(sg_imgui_t* ctx);
+        void sg_imgui_draw_capture_content(sg_imgui_t* ctx);
+
+    And these are the 'full window' drawing functions:
+
+        void sg_imgui_draw_buffers_window(sg_imgui_t* ctx);
+        void sg_imgui_draw_images_window(sg_imgui_t* ctx);
+        void sg_imgui_draw_shaders_window(sg_imgui_t* ctx);
+        void sg_imgui_draw_pipelines_window(sg_imgui_t* ctx);
+        void sg_imgui_draw_passes_window(sg_imgui_t* ctx);
+        void sg_imgui_draw_capture_window(sg_imgui_t* ctx);
+
+    Finer-grained drawing functions may be moved to the public API
+    in the future as needed.
+
+
+
     zlib/libpng license
 
     Copyright (c) 2018 Andre Weissflog

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -527,7 +527,11 @@ _SOKOL_PRIVATE void* _sg_imgui_realloc(void* old_ptr, int old_size, int new_size
 _SOKOL_PRIVATE void _sg_imgui_strcpy(sg_imgui_str_t* dst, const char* src) {
     SOKOL_ASSERT(dst);
     if (src) {
+        #if defined(_MSC_VER)
+        strncpy_s(dst->buf, SG_IMGUI_STRBUF_LEN, src, (SG_IMGUI_STRBUF_LEN-1));
+        #else
         strncpy(dst->buf, src, SG_IMGUI_STRBUF_LEN);
+        #endif
         dst->buf[SG_IMGUI_STRBUF_LEN-1] = 0;
     }
     else {
@@ -543,8 +547,9 @@ _SOKOL_PRIVATE sg_imgui_str_t _sg_imgui_make_str(const char* str) {
 
 _SOKOL_PRIVATE const char* _sg_imgui_str_dup(const char* src) {
     SOKOL_ASSERT(src);
-    char* dst = (char*) _sg_imgui_alloc(strlen(src) + 1);
-    strcpy(dst, src);
+    int len = (int) strlen(src) + 1;
+    char* dst = (char*) _sg_imgui_alloc(len);
+    memcpy(dst, src, len);
     return (const char*) dst;
 }
 

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -11,7 +11,65 @@
 
     The implementation must be compiled as C++ or Objective-C++, the
     declaration can be included in plain C sources.
-    
+
+    The sokol_gfx_imgui.h header recognizes the same preprocessor defines
+    that have been set for the actual Sokol headers (for instance
+    SOKOL_IMPL, SOKOL_MALLOC, SOKOL_LOG, etc...).
+
+    STEP BY STEP:
+    =============
+    --- include the sokol_gfx_imgui.h header after the actual Sokol header
+        implementations and the imgui.h header (and make sure this code
+        is compiled as C++ or Objective-C++)
+
+    --- add a Dear ImGui renderer to your application, and the basic
+        per-frame code to render an ImGui UI.
+
+    --- create an sg_imgui_t struct (which must be preserved between frames)
+        and initialize it with:
+
+            sg_imgui_init(&sg_imgui);
+
+    --- somewhere in the per-frame code call:
+
+            sg_imgui_draw(&sg_imgui)
+
+        this won't draw anything yet, since no windows are open.
+
+    --- open and close windows directly by setting the following public
+        booleans in the sg_imgui_t struct:
+
+            sg_imgui.buffers.open = true;
+            sg_imgui.images.open = true;
+            sg_imgui.shaders.open = true;
+            sg_imgui.pipelines.open = true;
+            sg_imgui.passes.open = true;
+            sg_imgui.capture.open = true;
+
+        ...for instance, to control the window visibility through
+        menu items, the following code can be used:
+
+            if (ImGui::BeginMainMenuBar()) {
+                if (ImGui::BeginMenu("sokol-gfx")) {
+                    ImGui::MenuItem("Buffers", 0, &sg_imgui.buffers.open);
+                    ImGui::MenuItem("Images", 0, &sg_imgui.images.open);
+                    ImGui::MenuItem("Shaders", 0, &sg_imgui.shaders.open);
+                    ImGui::MenuItem("Pipelines", 0, &sg_imgui.pipelines.open);
+                    ImGui::MenuItem("Passes", 0, &sg_imgui.passes.open);
+                    ImGui::MenuItem("Calls", 0, &sg_imgui.capture.open);
+                    ImGui::EndMenu();
+                }
+                ImGui::EndMainMenuBar();
+            }
+
+    --- finally before application shutdown, call:
+
+            sg_imgui_discard(&sg_imgui);
+
+        ...this is not strictly necessary because the application exits
+        anyway, but not doing this may trigger memory leak detection tools.
+
+
     zlib/libpng license
 
     Copyright (c) 2018 Andre Weissflog

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -481,6 +481,7 @@ SOKOL_API_DECL void sg_imgui_draw_capture_window(sg_imgui_t* ctx);
 /*=== IMPLEMENTATION =========================================================*/
 #if defined SOKOL_IMPL
 #include <string.h>
+#include <stdio.h>      /* snprintf */
 
 #define _SG_IMGUI_LIST_WIDTH (192)
 

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -45,22 +45,28 @@ extern "C" {
 #define SG_SOKOL_IMGUI_MAX_LABEL_LENGTH (32)
 
 typedef struct {
+    sg_buffer res_id;
     char label[SG_SOKOL_IMGUI_MAX_LABEL_LENGTH];
 } sg_imgui_buffer_t;
 
 typedef struct {
+    sg_image res_id;
     char label[SG_SOKOL_IMGUI_MAX_LABEL_LENGTH];
 } sg_imgui_image_t;
 
 typedef struct {
+    sg_shader res_id;
     char label[SG_SOKOL_IMGUI_MAX_LABEL_LENGTH];
+    sg_shader_desc desc;
 } sg_imgui_shader_t;
 
 typedef struct {
+    sg_pipeline res_id;
     char label[SG_SOKOL_IMGUI_MAX_LABEL_LENGTH];
 } sg_imgui_pipeline_t;
 
 typedef struct {
+    sg_pass res_id;
     char label[SG_SOKOL_IMGUI_MAX_LABEL_LENGTH];
 } sg_imgui_pass_t;
 
@@ -144,9 +150,117 @@ _SOKOL_PRIVATE void _sg_imgui_strcpy(char* dst, const char* src, int maxlen) {
     }
 }
 
+_SOKOL_PRIVATE const char* _sg_imgui_str_dup(const char* src) {
+    SOKOL_ASSERT(src);
+    char* dst = (char*) SOKOL_MALLOC(strlen(src) + 1);
+    strcpy(dst, src);
+    return (const char*) dst;
+}
+
+_SOKOL_PRIVATE const uint8_t* _sg_imgui_bin_dup(const uint8_t* src, int num_bytes) {
+    SOKOL_ASSERT(src && (num_bytes > 0));
+    uint8_t* dst = (uint8_t*) SOKOL_MALLOC(num_bytes);
+    memcpy(dst, src, num_bytes);
+    return (const uint8_t*) dst;
+}
+
+_SOKOL_PRIVATE void _sg_imgui_buffer_created(sg_imgui_t* ctx, sg_buffer res_id, int slot_index, const sg_buffer_desc* desc) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->buffers.num_slots));
+    sg_imgui_buffer_t* buf = &ctx->buffers.slots[slot_index];
+    buf->res_id = res_id;
+    _sg_imgui_strcpy(buf->label, desc->trace_label, sizeof(buf->label));
+}
+
+_SOKOL_PRIVATE void _sg_imgui_buffer_destroyed(sg_imgui_t* ctx, int slot_index) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->buffers.num_slots));
+    sg_imgui_buffer_t* buf = &ctx->buffers.slots[slot_index];
+    buf->res_id.id = SG_INVALID_ID;
+}
+
+_SOKOL_PRIVATE void _sg_imgui_image_created(sg_imgui_t* ctx, sg_image res_id, int slot_index, const sg_image_desc* desc) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->images.num_slots));
+    sg_imgui_image_t* img = &ctx->images.slots[slot_index];
+    img->res_id = res_id;
+    _sg_imgui_strcpy(img->label, desc->trace_label, sizeof(img->label));
+}
+
+_SOKOL_PRIVATE void _sg_imgui_image_destroyed(sg_imgui_t* ctx, int slot_index) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->images.num_slots));
+    sg_imgui_image_t* img = &ctx->images.slots[slot_index];
+    img->res_id.id = SG_INVALID_ID;
+}
+
+_SOKOL_PRIVATE void _sg_imgui_shader_created(sg_imgui_t* ctx, sg_shader res_id, int slot_index, const sg_shader_desc* desc) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->shaders.num_slots));
+    sg_imgui_shader_t* shd = &ctx->shaders.slots[slot_index];
+    shd->res_id = res_id;
+    _sg_imgui_strcpy(shd->label, desc->trace_label, sizeof(shd->label));
+    shd->desc = *desc;
+    if (shd->desc.vs.source) {
+        shd->desc.vs.source = _sg_imgui_str_dup(shd->desc.vs.source);
+    }
+    if (shd->desc.vs.byte_code) {
+        shd->desc.vs.byte_code = _sg_imgui_bin_dup(shd->desc.vs.byte_code, shd->desc.vs.byte_code_size);
+    }
+    if (shd->desc.fs.source) {
+        shd->desc.fs.source = _sg_imgui_str_dup(shd->desc.fs.source);
+    }
+    if (shd->desc.fs.byte_code) {
+        shd->desc.fs.byte_code = _sg_imgui_bin_dup(shd->desc.fs.byte_code, shd->desc.fs.byte_code_size);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_shader_destroyed(sg_imgui_t* ctx, int slot_index) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->shaders.num_slots));
+    sg_imgui_shader_t* shd = &ctx->shaders.slots[slot_index];
+    shd->res_id.id = SG_INVALID_ID;
+    if (shd->desc.vs.source) {
+        SOKOL_FREE((void*)shd->desc.vs.source);
+        shd->desc.vs.source = 0;
+    }
+    if (shd->desc.vs.byte_code) {
+        SOKOL_FREE((void*)shd->desc.vs.byte_code);
+        shd->desc.vs.byte_code = 0;
+    }
+    if (shd->desc.fs.source) {
+        SOKOL_FREE((void*)shd->desc.fs.source);
+        shd->desc.fs.source = 0;
+    }
+    if (shd->desc.fs.byte_code) {
+        SOKOL_FREE((void*)shd->desc.fs.byte_code);
+        shd->desc.fs.byte_code = 0;
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_pipeline_created(sg_imgui_t* ctx, sg_pipeline res_id, int slot_index, const sg_pipeline_desc* desc) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->pipelines.num_slots));
+    sg_imgui_pipeline_t* pip = &ctx->pipelines.slots[slot_index];
+    pip->res_id = res_id;
+    _sg_imgui_strcpy(pip->label, desc->trace_label, sizeof(pip->label));
+}
+
+_SOKOL_PRIVATE void _sg_imgui_pipeline_destroyed(sg_imgui_t* ctx, int slot_index) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->pipelines.num_slots));
+    sg_imgui_pipeline_t* pip = &ctx->pipelines.slots[slot_index];
+    pip->res_id.id = SG_INVALID_ID;
+}
+
+_SOKOL_PRIVATE void _sg_imgui_pass_created(sg_imgui_t* ctx, sg_pass res_id, int slot_index, const sg_pass_desc* desc) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->passes.num_slots));
+    sg_imgui_pass_t* pass = &ctx->passes.slots[slot_index];
+    pass->res_id = res_id;
+    _sg_imgui_strcpy(pass->label, desc->trace_label, sizeof(pass->label));
+}
+
+_SOKOL_PRIVATE void _sg_imgui_pass_destroyed(sg_imgui_t* ctx, int slot_index) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->passes.num_slots));
+    sg_imgui_pass_t* pass = &ctx->passes.slots[slot_index];
+    pass->res_id.id = SG_INVALID_ID;
+}
+
 /*--- sokol-gfx trace hook functions -----------------------------------------*/
 _SOKOL_PRIVATE void _sg_imgui_query_feature(sg_feature feature, bool result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.query_feature) {
         ctx->hooks.query_feature(feature, result, ctx->hooks.user_data);
@@ -154,120 +268,120 @@ _SOKOL_PRIVATE void _sg_imgui_query_feature(sg_feature feature, bool result, voi
 }
 
 _SOKOL_PRIVATE void _sg_imgui_reset_state_cache(void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.reset_state_cache) {
         ctx->hooks.reset_state_cache(ctx->hooks.user_data);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_make_buffer(const sg_buffer_desc* desc, sg_buffer result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sg_imgui_make_buffer(const sg_buffer_desc* desc, sg_buffer buf_id, void* user_data) {
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.make_buffer) {
-        ctx->hooks.make_buffer(desc, result, ctx->hooks.user_data);
+        ctx->hooks.make_buffer(desc, buf_id, ctx->hooks.user_data);
     }
-    if (SG_INVALID_ID != result.id) {
-        int i = _sg_slot_index(result.id);
-        SOKOL_ASSERT((i > 0) && (i < ctx->buffers.num_slots));
-        sg_imgui_buffer_t* buf = &ctx->buffers.slots[i];
-        _sg_imgui_strcpy(buf->label, desc->trace_label, sizeof(buf->label));
+    if (buf_id.id != SG_INVALID_ID) {
+        _sg_imgui_buffer_created(ctx, buf_id, _sg_slot_index(buf_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_make_image(const sg_image_desc* desc, sg_image result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sg_imgui_make_image(const sg_image_desc* desc, sg_image img_id, void* user_data) {
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.make_image) {
-        ctx->hooks.make_image(desc, result, ctx->hooks.user_data);
+        ctx->hooks.make_image(desc, img_id, ctx->hooks.user_data);
     }
-    if (SG_INVALID_ID != result.id) {
-        int i = _sg_slot_index(result.id);
-        SOKOL_ASSERT((i > 0) && (i < ctx->images.num_slots));
-        sg_imgui_image_t* img = &ctx->images.slots[i];
-        _sg_imgui_strcpy(img->label, desc->trace_label, sizeof(img->label));
+    if (img_id.id != SG_INVALID_ID) {
+        _sg_imgui_image_created(ctx, img_id, _sg_slot_index(img_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_make_shader(const sg_shader_desc* desc, sg_shader result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sg_imgui_make_shader(const sg_shader_desc* desc, sg_shader shd_id, void* user_data) {
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.make_shader) {
-        ctx->hooks.make_shader(desc, result, ctx->hooks.user_data);
+        ctx->hooks.make_shader(desc, shd_id, ctx->hooks.user_data);
     }
-    if (SG_INVALID_ID != result.id) {
-        int i = _sg_slot_index(result.id);
-        SOKOL_ASSERT((i > 0) && (i < ctx->shaders.num_slots));
-        sg_imgui_shader_t* shd = &ctx->shaders.slots[i];
-        _sg_imgui_strcpy(shd->label, desc->trace_label, sizeof(shd->label));
+    if (shd_id.id != SG_INVALID_ID) {
+        _sg_imgui_shader_created(ctx, shd_id, _sg_slot_index(shd_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_make_pipeline(const sg_pipeline_desc* desc, sg_pipeline result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sg_imgui_make_pipeline(const sg_pipeline_desc* desc, sg_pipeline pip_id, void* user_data) {
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.make_pipeline) {
-        ctx->hooks.make_pipeline(desc, result, ctx->hooks.user_data);
+        ctx->hooks.make_pipeline(desc, pip_id, ctx->hooks.user_data);
     }
-    if (SG_INVALID_ID != result.id) {
-        int i = _sg_slot_index(result.id);
-        SOKOL_ASSERT((i > 0) && (i < ctx->pipelines.num_slots));
-        sg_imgui_pipeline_t* pip = &ctx->pipelines.slots[i];
-        _sg_imgui_strcpy(pip->label, desc->trace_label, sizeof(pip->label));
+    if (pip_id.id != SG_INVALID_ID) {
+        _sg_imgui_pipeline_created(ctx, pip_id, _sg_slot_index(pip_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_make_pass(const sg_pass_desc* desc, sg_pass result, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sg_imgui_make_pass(const sg_pass_desc* desc, sg_pass pass_id, void* user_data) {
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.make_pass) {
-        ctx->hooks.make_pass(desc, result, ctx->hooks.user_data);
+        ctx->hooks.make_pass(desc, pass_id, ctx->hooks.user_data);
     }
-    if (SG_INVALID_ID != result.id) {
-        int i = _sg_slot_index(result.id);
-        SOKOL_ASSERT((i > 0) && (i < ctx->passes.num_slots));
-        sg_imgui_pass_t* pass = &ctx->passes.slots[i];
-        _sg_imgui_strcpy(pass->label, desc->trace_label, sizeof(pass->label));
+    if (pass_id.id != SG_INVALID_ID) {
+        _sg_imgui_pass_created(ctx, pass_id, _sg_slot_index(pass_id.id), desc);
     }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_destroy_buffer(sg_buffer buf, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.destroy_buffer) {
         ctx->hooks.destroy_buffer(buf, ctx->hooks.user_data);
     }
+    if (buf.id != SG_INVALID_ID) {
+        _sg_imgui_buffer_destroyed(ctx, _sg_slot_index(buf.id));
+    }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_destroy_image(sg_image img, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.destroy_image) {
         ctx->hooks.destroy_image(img, ctx->hooks.user_data);
     }
+    if (img.id != SG_INVALID_ID) {
+        _sg_imgui_image_destroyed(ctx, _sg_slot_index(img.id));
+    }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_destroy_shader(sg_shader shd, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.destroy_shader) {
         ctx->hooks.destroy_shader(shd, ctx->hooks.user_data);
     }
+    if (shd.id != SG_INVALID_ID) {
+        _sg_imgui_shader_destroyed(ctx, _sg_slot_index(shd.id));
+    }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_destroy_pipeline(sg_pipeline pip, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.destroy_pipeline) {
         ctx->hooks.destroy_pipeline(pip, ctx->hooks.user_data);
     }
+    if (pip.id != SG_INVALID_ID) {
+        _sg_imgui_pipeline_destroyed(ctx, _sg_slot_index(pip.id));
+    }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_destroy_pass(sg_pass pass, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.destroy_pass) {
         ctx->hooks.destroy_pass(pass, ctx->hooks.user_data);
+    }
+    if (pass.id != SG_INVALID_ID) {
+        _sg_imgui_pass_destroyed(ctx, _sg_slot_index(pass.id));
     }
 }
 
@@ -464,42 +578,57 @@ _SOKOL_PRIVATE void _sg_imgui_alloc_pass(sg_pass result, void* user_data) {
 }
 
 _SOKOL_PRIVATE void _sg_imgui_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.init_buffer) {
         ctx->hooks.init_buffer(buf_id, desc, ctx->hooks.user_data);
     }
+    if (buf_id.id != SG_INVALID_ID) {
+        _sg_imgui_buffer_created(ctx, buf_id, _sg_slot_index(buf_id.id), desc);
+    }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_init_image(sg_image img_id, const sg_image_desc* desc, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.init_image) {
         ctx->hooks.init_image(img_id, desc, ctx->hooks.user_data);
     }
+    if (img_id.id != SG_INVALID_ID) {
+        _sg_imgui_image_created(ctx, img_id, _sg_slot_index(img_id.id), desc);
+    }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_init_shader(sg_shader shd_id, const sg_shader_desc* desc, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.init_shader) {
         ctx->hooks.init_shader(shd_id, desc, ctx->hooks.user_data);
     }
+    if (shd_id.id != SG_INVALID_ID) {
+        _sg_imgui_shader_created(ctx, shd_id, _sg_slot_index(shd_id.id), desc);
+    }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.init_pipeline) {
         ctx->hooks.init_pipeline(pip_id, desc, ctx->hooks.user_data);
     }
+    if (pip_id.id != SG_INVALID_ID) {
+        _sg_imgui_pipeline_created(ctx, pip_id, _sg_slot_index(pip_id.id), desc);
+    }
 }
 
 _SOKOL_PRIVATE void _sg_imgui_init_pass(sg_pass pass_id, const sg_pass_desc* desc, void* user_data) {
-    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (ctx->hooks.init_pass) {
         ctx->hooks.init_pass(pass_id, desc, ctx->hooks.user_data);
+    }
+    if (pass_id.id != SG_INVALID_ID) {
+        _sg_imgui_pass_created(ctx, pass_id, _sg_slot_index(pass_id.id), desc);
     }
 }
 
@@ -859,6 +988,8 @@ _SOKOL_PRIVATE void _sg_imgui_draw_shader_panel(sg_imgui_t* ctx, uint32_t sel_id
         ImGui::BeginChild("shader", ImVec2(0,0), false);
         ImGui::Text("Label: %s", shd_ui->label[0] ? shd_ui->label : "---");
         _sg_imgui_draw_resource_slot(&shd->slot);
+        ImGui::Separator();
+
         ImGui::EndChild();
     }
 }
@@ -990,23 +1121,48 @@ void sg_imgui_discard(sg_imgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
     ctx->init_tag = 0;
     if (ctx->buffers.slots) {
-        SOKOL_FREE(ctx->buffers.slots);
+        for (int i = 0; i < ctx->buffers.num_slots; i++) {
+            if (ctx->buffers.slots[i].res_id.id != SG_INVALID_ID) {
+                _sg_imgui_buffer_destroyed(ctx, i);
+            }
+        }
+        SOKOL_FREE((void*)ctx->buffers.slots);
         ctx->buffers.slots = 0;
     }
     if (ctx->images.slots) {
-        SOKOL_FREE(ctx->images.slots);
+        for (int i = 0; i < ctx->images.num_slots; i++) {
+            if (ctx->images.slots[i].res_id.id != SG_INVALID_ID) {
+                _sg_imgui_image_destroyed(ctx, i);
+            }
+        }
+        SOKOL_FREE((void*)ctx->images.slots);
         ctx->images.slots = 0;
     }
     if (ctx->shaders.slots) {
-        SOKOL_FREE(ctx->shaders.slots);
+        for (int i = 0; i < ctx->shaders.num_slots; i++) {
+            if (ctx->shaders.slots[i].res_id.id != SG_INVALID_ID) {
+                _sg_imgui_shader_destroyed(ctx, i);
+            }
+        }
+        SOKOL_FREE((void*)ctx->shaders.slots);
         ctx->shaders.slots = 0;
     }
     if (ctx->pipelines.slots) {
-        SOKOL_FREE(ctx->pipelines.slots);
+        for (int i = 0; i < ctx->pipelines.num_slots; i++) {
+            if (ctx->pipelines.slots[i].res_id.id != SG_INVALID_ID) {
+                _sg_imgui_pipeline_destroyed(ctx, i);
+            }
+        }
+        SOKOL_FREE((void*)ctx->pipelines.slots);
         ctx->pipelines.slots = 0;
     }
     if (ctx->passes.slots) {
-        SOKOL_FREE(ctx->passes.slots);
+        for (int i = 0; i < ctx->passes.num_slots; i++) {
+            if (ctx->passes.slots[i].res_id.id != SG_INVALID_ID) {
+                _sg_imgui_pass_destroyed(ctx, i);
+            }
+        }
+        SOKOL_FREE((void*)ctx->passes.slots);
         ctx->passes.slots = 0;
     }
 }

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -1,0 +1,202 @@
+#pragma once
+/*
+    sokol_gfx_imgui.h -- debug-inspection UI for sokol_gfx.h using Dear ImGui
+
+    This is an extension header for sokol_gfx.h, to create the implementation,
+    include sokol_gfx_imgui.h *after* the implementation of sokol_gfx.h
+    (SOKOL_IMPL must be defined).
+
+    You also need to include imgui.h before including the implementation
+    of sokol_gfx_imgui.h.
+
+    The implementation must be compiled as C++ or Objective-C++, the
+    declaration can be included in plain C sources.
+    
+    zlib/libpng license
+
+    Copyright (c) 2018 Andre Weissflog
+
+    This software is provided 'as-is', without any express or implied warranty.
+    In no event will the authors be held liable for any damages arising from the
+    use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+        1. The origin of this software must not be misrepresented; you must not
+        claim that you wrote the original software. If you use this software in a
+        product, an acknowledgment in the product documentation would be
+        appreciated but is not required.
+
+        2. Altered source versions must be plainly marked as such, and must not
+        be misrepresented as being the original software.
+
+        3. This notice may not be removed or altered from any source
+        distribution.
+*/
+#include <stdint.h>
+#include <stdbool.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+typedef struct sg_imgui_buffers_t {
+    bool open;
+} sg_imgui_buffers_t;
+
+typedef struct sg_imgui_images_t {
+    bool open;
+} sg_imgui_images_t;
+
+typedef struct sg_imgui_shaders_t {
+    bool open;
+} sg_imgui_shaders_t;
+
+typedef struct sg_imgui_pipelines_t {
+    bool open;
+} sg_imgui_pipelines_t;
+
+typedef struct sg_imgui_passes_t {
+    bool open;
+} sg_imgui_passes_t;
+
+typedef struct sg_imgui_t {
+    uint32_t init_tag;
+    sg_imgui_buffers_t buffers;
+    sg_imgui_images_t images;
+    sg_imgui_shaders_t shaders;
+    sg_imgui_pipelines_t pipelines;
+    sg_imgui_passes_t passes;
+} sg_imgui_t;
+
+void sg_imgui_init(sg_imgui_t* ctx);
+void sg_imgui_discard(sg_imgui_t* ctx);
+void sg_imgui_draw(sg_imgui_t* ctx);
+
+void sg_imgui_draw_buffers_content(sg_imgui_t* ctx);
+void sg_imgui_draw_images_content(sg_imgui_t* ctx);
+void sg_imgui_draw_shaders_content(sg_imgui_t* ctx);
+void sg_imgui_draw_pipelines_content(sg_imgui_t* ctx);
+void sg_imgui_draw_passes_content(sg_imgui_t* ctx);
+
+void sg_imgui_draw_buffers_window(sg_imgui_t* ctx);
+void sg_imgui_draw_images_window(sg_imgui_t* ctx);
+void sg_imgui_draw_shaders_window(sg_imgui_t* ctx);
+void sg_imgui_draw_pipelines_window(sg_imgui_t* ctx);
+void sg_imgui_draw_passes_window(sg_imgui_t* ctx);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif
+
+/*=== IMPLEMENTATION =========================================================*/
+#if defined SOKOL_IMPL
+
+void sg_imgui_init(sg_imgui_t* ctx) {
+    SOKOL_ASSERT(ctx);
+    memset(ctx, 0, sizeof(sg_imgui_t));
+    ctx->init_tag = 0xABCDABCD;
+}
+
+void sg_imgui_discard(sg_imgui_t* ctx) {
+    SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
+    ctx->init_tag = 0;
+}
+
+void sg_imgui_draw(sg_imgui_t* ctx) {
+    SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
+    sg_imgui_draw_buffers_window(ctx);
+    sg_imgui_draw_images_window(ctx);
+    sg_imgui_draw_shaders_window(ctx);
+    sg_imgui_draw_pipelines_window(ctx);
+    sg_imgui_draw_passes_window(ctx);
+}
+
+void sg_imgui_draw_buffers_window(sg_imgui_t* ctx) {
+    SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
+    if (!ctx->buffers.open) {
+        return;
+    }
+    ImGui::SetNextWindowSize(ImVec2(400, 400), ImGuiSetCond_Once);
+    if (ImGui::Begin("Buffers", &ctx->buffers.open)) {
+        sg_imgui_draw_buffers_content(ctx);
+    }
+    ImGui::End();
+}
+
+void sg_imgui_draw_images_window(sg_imgui_t* ctx) {
+    SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
+    if (!ctx->images.open) {
+        return;
+    }
+    ImGui::SetNextWindowSize(ImVec2(400, 400), ImGuiSetCond_Once);
+    if (ImGui::Begin("Images", &ctx->images.open)) {
+        sg_imgui_draw_images_content(ctx);
+    }
+    ImGui::End();
+}
+
+void sg_imgui_draw_shaders_window(sg_imgui_t* ctx) {
+    SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
+    if (!ctx->shaders.open) {
+        return;
+    }
+    ImGui::SetNextWindowSize(ImVec2(400, 400), ImGuiSetCond_Once);
+    if (ImGui::Begin("Shaders", &ctx->shaders.open)) {
+        sg_imgui_draw_shaders_content(ctx);
+    }
+    ImGui::End();
+}
+
+void sg_imgui_draw_pipelines_window(sg_imgui_t* ctx) {
+    SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
+    if (!ctx->pipelines.open) {
+        return;
+    }
+    ImGui::SetNextWindowSize(ImVec2(400, 400), ImGuiSetCond_Once);
+    if (ImGui::Begin("Pipelines", &ctx->pipelines.open)) {
+        sg_imgui_draw_pipelines_content(ctx);
+    }
+    ImGui::End();
+}
+
+void sg_imgui_draw_passes_window(sg_imgui_t* ctx) {
+    SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
+    if (!ctx->passes.open) {
+        return;
+    }
+    ImGui::SetNextWindowSize(ImVec2(400, 400), ImGuiSetCond_Once);
+    if (ImGui::Begin("Passes", &ctx->passes.open)) {
+        sg_imgui_draw_passes_content(ctx);
+    }
+    ImGui::End();
+}
+
+void sg_imgui_draw_buffers_content(sg_imgui_t* ctx) {
+    SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
+    ImGui::Text("FIXME!");
+}
+
+void sg_imgui_draw_images_content(sg_imgui_t* ctx) {
+    SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
+    ImGui::Text("FIXME!");
+}
+
+void sg_imgui_draw_shaders_content(sg_imgui_t* ctx) {
+    SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
+    ImGui::Text("FIXME!");
+}
+
+void sg_imgui_draw_pipelines_content(sg_imgui_t* ctx) {
+    SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
+    ImGui::Text("FIXME!");
+}
+
+void sg_imgui_draw_passes_content(sg_imgui_t* ctx) {
+    SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
+    ImGui::Text("FIXME!");
+}
+
+#endif /* SOKOL_IMPL */

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -2702,6 +2702,47 @@ _SOKOL_PRIVATE void _sg_imgui_draw_bindings_panel(sg_imgui_t* ctx, const sg_bind
     }
 }
 
+_SOKOL_PRIVATE void _sg_imgui_draw_passaction_panel(sg_imgui_t* ctx, uint32_t pass_id, const sg_pass_action* action) {
+    int num_color_atts = 1;
+    if (SG_INVALID_ID != pass_id) {
+        const _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id);
+        if (pass) {
+            num_color_atts = pass->num_color_atts;
+        }
+    }
+
+    ImGui::Text("Pass Action: ");
+    for (int i = 0; i < num_color_atts; i++) {
+        const sg_color_attachment_action* c_att = &action->colors[i];
+        ImGui::Text("  Color Attachment %d:", i);
+        switch (c_att->action) {
+            case SG_ACTION_LOAD: ImGui::Text("    SG_ACTION_LOAD"); break;
+            case SG_ACTION_DONTCARE: ImGui::Text("    SG_ACTION_DONTCARE"); break;
+            default:
+                ImGui::Text("    SG_ACTION_CLEAR: %.3f, %.3f, %.3f, %.3f",
+                    c_att->val[0],
+                    c_att->val[1],
+                    c_att->val[2],
+                    c_att->val[3]);
+                break;
+        }
+    }
+    const sg_depth_attachment_action* d_att = &action->depth;
+    ImGui::Text("  Depth Attachment:");
+    switch (d_att->action) {
+        case SG_ACTION_LOAD: ImGui::Text("    SG_ACTION_LOAD"); break;
+        case SG_ACTION_DONTCARE: ImGui::Text("    SG_ACTION_DONTCARE"); break;
+        default: ImGui::Text("    SG_ACTION_CLEAR: %.3f", d_att->val); break;
+    }
+    const sg_stencil_attachment_action* s_att = &action->stencil;
+    ImGui::Text("  Stencil Attachment");
+    switch (s_att->action) {
+        case SG_ACTION_LOAD: ImGui::Text("    SG_ACTION_LOAD"); break;
+        case SG_ACTION_DONTCARE: ImGui::Text("    SG_ACTION_DONTCARE"); break;
+        default: ImGui::Text("    SG_ACTION_CLEAR: 0x%02X", s_att->val); break;
+    }
+}
+
 _SOKOL_PRIVATE void _sg_imgui_draw_capture_panel(sg_imgui_t* ctx) {
     uint32_t sel_item_index = ctx->capture.sel_item;
     if (sel_item_index >= _sg_imgui_capture_num_read_items(ctx)) {
@@ -2756,15 +2797,30 @@ _SOKOL_PRIVATE void _sg_imgui_draw_capture_panel(sg_imgui_t* ctx) {
             _sg_imgui_draw_buffer_panel(ctx, item->args.update_buffer.buffer.id);
             break;
         case SG_IMGUI_CMD_QUERY_BUFFER_OVERFLOW:
+            _sg_imgui_draw_buffer_panel(ctx, item->args.query_buffer_overflow.buffer.id);
+            break;
         case SG_IMGUI_CMD_QUERY_BUFFER_STATE:
+            _sg_imgui_draw_buffer_panel(ctx, item->args.query_buffer_state.buffer.id);
+            break;
         case SG_IMGUI_CMD_QUERY_IMAGE_STATE:
+            _sg_imgui_draw_image_panel(ctx, item->args.query_image_state.image.id);
+            break;
         case SG_IMGUI_CMD_QUERY_SHADER_STATE:
+            _sg_imgui_draw_shader_panel(ctx, item->args.query_shader_state.shader.id);
+            break;
         case SG_IMGUI_CMD_QUERY_PIPELINE_STATE:
+            _sg_imgui_draw_pipeline_panel(ctx, item->args.query_pipeline_state.pipeline.id);
+            break;
         case SG_IMGUI_CMD_QUERY_PASS_STATE:
+            _sg_imgui_draw_pass_panel(ctx, item->args.query_pass_state.pass.id);
             break;
         case SG_IMGUI_CMD_BEGIN_DEFAULT_PASS:
+            _sg_imgui_draw_passaction_panel(ctx, SG_INVALID_ID, &item->args.begin_default_pass.action);
+            break;
         case SG_IMGUI_CMD_BEGIN_PASS:
-            ImGui::Text("FIXME");
+            _sg_imgui_draw_passaction_panel(ctx, item->args.begin_pass.pass.id, &item->args.begin_pass.action);
+            ImGui::Separator();
+            _sg_imgui_draw_pass_panel(ctx, item->args.begin_pass.pass.id);
             break;
         case SG_IMGUI_CMD_APPLY_VIEWPORT:
         case SG_IMGUI_CMD_APPLY_SCISSOR_RECT:

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -2174,11 +2174,11 @@ _SOKOL_PRIVATE bool _sg_imgui_draw_resid_link(uint32_t res_id, const char* label
     return res;
 }
 
-_SOKOL_PRIVATE bool _sg_imgui_draw_shader_link(sg_imgui_t* ctx, uint32_t shd_id) {
+_SOKOL_PRIVATE bool _sg_imgui_draw_buffer_link(sg_imgui_t* ctx, uint32_t buf_id) {
     bool retval = false;
-    if (shd_id != SG_INVALID_ID) {
-        const sg_imgui_shader_t* shd_ui = &ctx->shaders.slots[_sg_slot_index(shd_id)];
-        retval = _sg_imgui_draw_resid_link(shd_id, shd_ui->label.buf);
+    if (buf_id != SG_INVALID_ID) {
+        const sg_imgui_buffer_t* buf_ui = &ctx->buffers.slots[_sg_slot_index(buf_id)];
+        retval = _sg_imgui_draw_resid_link(buf_id, buf_ui->label.buf);
     }
     return retval;
 }
@@ -2190,6 +2190,20 @@ _SOKOL_PRIVATE bool _sg_imgui_draw_image_link(sg_imgui_t* ctx, uint32_t img_id) 
         retval = _sg_imgui_draw_resid_link(img_id, img_ui->label.buf);
     }
     return retval;
+}
+
+_SOKOL_PRIVATE bool _sg_imgui_draw_shader_link(sg_imgui_t* ctx, uint32_t shd_id) {
+    bool retval = false;
+    if (shd_id != SG_INVALID_ID) {
+        const sg_imgui_shader_t* shd_ui = &ctx->shaders.slots[_sg_slot_index(shd_id)];
+        retval = _sg_imgui_draw_resid_link(shd_id, shd_ui->label.buf);
+    }
+    return retval;
+}
+
+_SOKOL_PRIVATE void _sg_imgui_show_buffer(sg_imgui_t* ctx, uint32_t buf_id) {
+    ctx->buffers.open = true;
+    ctx->buffers.sel_id = buf_id;
 }
 
 _SOKOL_PRIVATE void _sg_imgui_show_image(sg_imgui_t* ctx, uint32_t img_id) {
@@ -2633,6 +2647,61 @@ _SOKOL_PRIVATE void _sg_imgui_draw_pass_panel(sg_imgui_t* ctx, uint32_t pass_id)
     }
 }
 
+_SOKOL_PRIVATE void _sg_imgui_draw_bindings_panel(sg_imgui_t* ctx, const sg_bindings* bnd) {
+    for (int i = 0; i < SG_MAX_SHADERSTAGE_BUFFERS; i++) {
+        uint32_t buf_id = bnd->vertex_buffers[i].id;
+        if (buf_id != SG_INVALID_ID) {
+            ImGui::Separator();
+            ImGui::Text("Vertex Buffer Slot #%d:", i);
+            ImGui::Text("  Buffer: "); ImGui::SameLine();
+            if (_sg_imgui_draw_buffer_link(ctx, buf_id)) {
+                _sg_imgui_show_buffer(ctx, buf_id);
+            }
+            ImGui::Text("  Offset: %d", bnd->vertex_buffer_offsets[i]);
+        }
+        else {
+            break;
+        }
+    }
+    if (bnd->index_buffer.id != SG_INVALID_ID) {
+        uint32_t buf_id = bnd->index_buffer.id;
+        if (buf_id != SG_INVALID_ID) {
+            ImGui::Separator();
+            ImGui::Text("Index Buffer Slot:");
+            ImGui::Text("  Buffer: "); ImGui::SameLine();
+            if (_sg_imgui_draw_buffer_link(ctx, buf_id)) {
+                _sg_imgui_show_buffer(ctx, buf_id);
+            }
+            ImGui::Text("  Offset: %d", bnd->index_buffer_offset);
+        }
+    }
+    for (int i = 0; i < SG_MAX_SHADERSTAGE_IMAGES; i++) {
+        uint32_t img_id = bnd->vs_images[i].id;
+        if (img_id != SG_INVALID_ID) {
+            ImGui::Separator();
+            ImGui::Text("Vertex Stage Image Slot #%d:", i);
+            ImGui::Text("  Image: "); ImGui::SameLine();
+            if (_sg_imgui_draw_image_link(ctx, img_id)) {
+                _sg_imgui_show_image(ctx, img_id);
+            }
+        }
+        else {
+            break;
+        }
+    }
+    for (int i = 0; i < SG_MAX_SHADERSTAGE_IMAGES; i++) {
+        uint32_t img_id = bnd->fs_images[i].id;
+        if (img_id != SG_INVALID_ID) {
+            ImGui::Separator();
+            ImGui::Text("Fragment Stage Image Slot #%d:", i);
+            ImGui::Text("  Image: "); ImGui::SameLine();
+            if (_sg_imgui_draw_image_link(ctx, img_id)) {
+                _sg_imgui_show_image(ctx, img_id);
+            }
+        }
+    }
+}
+
 _SOKOL_PRIVATE void _sg_imgui_draw_capture_panel(sg_imgui_t* ctx) {
     uint32_t sel_item_index = ctx->capture.sel_item;
     if (sel_item_index >= _sg_imgui_capture_num_read_items(ctx)) {
@@ -2704,7 +2773,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_capture_panel(sg_imgui_t* ctx) {
             _sg_imgui_draw_pipeline_panel(ctx, item->args.apply_pipeline.pipeline.id);
             break;
         case SG_IMGUI_CMD_APPLY_BINDINGS:
-            ImGui::Text("FIXME");
+            _sg_imgui_draw_bindings_panel(ctx, &item->args.apply_bindings.bindings);
             break;
         case SG_IMGUI_CMD_APPLY_UNIFORMS:
             ImGui::Text("FIXME");

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -2,9 +2,9 @@
 /*
     sokol_gfx_imgui.h -- debug-inspection UI for sokol_gfx.h using Dear ImGui
 
-    This is an extension header for sokol_gfx.h, to create the implementation,
-    include sokol_gfx_imgui.h *after* the implementation of sokol_gfx.h
-    (SOKOL_IMPL must be defined).
+    This is an extension header for sokol_gfx.h, this means sokol_gfx_imgui.h
+    must be included *after* sokol_gfx.h both for the implementation
+    and declaration.
 
     You also need to include imgui.h before including the implementation
     of sokol_gfx_imgui.h.
@@ -69,6 +69,7 @@ typedef struct sg_imgui_t {
     sg_imgui_shaders_t shaders;
     sg_imgui_pipelines_t pipelines;
     sg_imgui_passes_t passes;
+    sg_trace_hooks hooks;
 } sg_imgui_t;
 
 void sg_imgui_init(sg_imgui_t* ctx);
@@ -94,10 +95,512 @@ void sg_imgui_draw_passes_window(sg_imgui_t* ctx);
 /*=== IMPLEMENTATION =========================================================*/
 #if defined SOKOL_IMPL
 
+/*--- sokol-gfx trace hook functions -----------------------------------------*/
+_SOKOL_PRIVATE void _sg_imgui_query_feature(sg_feature feature, bool result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.query_feature) {
+        ctx->hooks.query_feature(feature, result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_reset_state_cache(void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.reset_state_cache) {
+        ctx->hooks.reset_state_cache(ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_make_buffer(const sg_buffer_desc* desc, sg_buffer result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.make_buffer) {
+        ctx->hooks.make_buffer(desc, result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_make_image(const sg_image_desc* desc, sg_image result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.make_image) {
+        ctx->hooks.make_image(desc, result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_make_shader(const sg_shader_desc* desc, sg_shader result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.make_shader) {
+        ctx->hooks.make_shader(desc, result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_make_pipeline(const sg_pipeline_desc* desc, sg_pipeline result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.make_pipeline) {
+        ctx->hooks.make_pipeline(desc, result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_make_pass(const sg_pass_desc* desc, sg_pass result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.make_pass) {
+        ctx->hooks.make_pass(desc, result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_destroy_buffer(sg_buffer buf, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.destroy_buffer) {
+        ctx->hooks.destroy_buffer(buf, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_destroy_image(sg_image img, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.destroy_image) {
+        ctx->hooks.destroy_image(img, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_destroy_shader(sg_shader shd, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.destroy_shader) {
+        ctx->hooks.destroy_shader(shd, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_destroy_pipeline(sg_pipeline pip, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.destroy_pipeline) {
+        ctx->hooks.destroy_pipeline(pip, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_destroy_pass(sg_pass pass, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.destroy_pass) {
+        ctx->hooks.destroy_pass(pass, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_update_buffer(sg_buffer buf, const void* data_ptr, int data_size, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.update_buffer) {
+        ctx->hooks.update_buffer(buf, data_ptr, data_size, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_update_image(sg_image img, const sg_image_content* data, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.update_image) {
+        ctx->hooks.update_image(img, data, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_append_buffer(sg_buffer buf, const void* data_ptr, int data_size, int result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.append_buffer) {
+        ctx->hooks.append_buffer(buf, data_ptr, data_size, result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_query_buffer_overflow(sg_buffer buf, bool result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.query_buffer_overflow) {
+        ctx->hooks.query_buffer_overflow(buf, result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_query_buffer_state(sg_buffer buf, sg_resource_state result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.query_buffer_state) {
+        ctx->hooks.query_buffer_state(buf, result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_query_image_state(sg_image img, sg_resource_state result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.query_image_state) {
+        ctx->hooks.query_image_state(img, result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_query_shader_state(sg_shader shd, sg_resource_state result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.query_shader_state) {
+        ctx->hooks.query_shader_state(shd, result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_query_pipeline_state(sg_pipeline pip, sg_resource_state result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.query_pipeline_state) {
+        ctx->hooks.query_pipeline_state(pip, result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_query_pass_state(sg_pass pass, sg_resource_state result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.query_pass_state) {
+        ctx->hooks.query_pass_state(pass, result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_begin_default_pass(const sg_pass_action* pass_action, int width, int height, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.begin_default_pass) {
+        ctx->hooks.begin_default_pass(pass_action, width, height, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_begin_pass(sg_pass pass, const sg_pass_action* pass_action, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.begin_pass) {
+        ctx->hooks.begin_pass(pass, pass_action, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_apply_viewport(int x, int y, int width, int height, bool origin_top_left, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.apply_viewport) {
+        ctx->hooks.apply_viewport(x, y, width, height, origin_top_left, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_apply_scissor_rect(int x, int y, int width, int height, bool origin_top_left, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.apply_scissor_rect) {
+        ctx->hooks.apply_scissor_rect(x, y, width, height, origin_top_left, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_apply_pipeline(sg_pipeline pip, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.apply_pipeline) {
+        ctx->hooks.apply_pipeline(pip, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_apply_bindings(const sg_bindings* bindings, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.apply_bindings) {
+        ctx->hooks.apply_bindings(bindings, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_apply_uniforms(sg_shader_stage stage, int ub_index, const void* data, int num_bytes, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.apply_uniforms) {
+        ctx->hooks.apply_uniforms(stage, ub_index, data, num_bytes, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_draw(int base_element, int num_elements, int num_instances, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.draw) {
+        ctx->hooks.draw(base_element, num_elements, num_instances, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_end_pass(void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.end_pass) {
+        ctx->hooks.end_pass(ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_commit(void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.commit) {
+        ctx->hooks.commit(ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_alloc_buffer(sg_buffer result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.alloc_buffer) {
+        ctx->hooks.alloc_buffer(result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_alloc_image(sg_image result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.alloc_image) {
+        ctx->hooks.alloc_image(result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_alloc_shader(sg_shader result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.alloc_shader) {
+        ctx->hooks.alloc_shader(result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_alloc_pipeline(sg_pipeline result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.alloc_pipeline) {
+        ctx->hooks.alloc_pipeline(result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_alloc_pass(sg_pass result, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.alloc_pass) {
+        ctx->hooks.alloc_pass(result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.init_buffer) {
+        ctx->hooks.init_buffer(buf_id, desc, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_init_image(sg_image img_id, const sg_image_desc* desc, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.init_image) {
+        ctx->hooks.init_image(img_id, desc, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_init_shader(sg_shader shd_id, const sg_shader_desc* desc, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.init_shader) {
+        ctx->hooks.init_shader(shd_id, desc, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.init_pipeline) {
+        ctx->hooks.init_pipeline(pip_id, desc, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_init_pass(sg_pass pass_id, const sg_pass_desc* desc, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.init_pass) {
+        ctx->hooks.init_pass(pass_id, desc, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_fail_buffer(sg_buffer buf_id, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.fail_buffer) {
+        ctx->hooks.fail_buffer(buf_id, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_fail_image(sg_image img_id, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.fail_image) {
+        ctx->hooks.fail_image(img_id, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_fail_shader(sg_shader shd_id, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.fail_shader) {
+        ctx->hooks.fail_shader(shd_id, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_fail_pipeline(sg_pipeline pip_id, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.fail_pipeline) {
+        ctx->hooks.fail_pipeline(pip_id, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_fail_pass(sg_pass pass_id, void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.fail_pass) {
+        ctx->hooks.fail_pass(pass_id, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_err_buffer_pool_exhausted(void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.err_buffer_pool_exhausted) {
+        ctx->hooks.err_buffer_pool_exhausted(ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_err_image_pool_exhausted(void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.err_image_pool_exhausted) {
+        ctx->hooks.err_image_pool_exhausted(ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_err_shader_pool_exhausted(void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.err_shader_pool_exhausted) {
+        ctx->hooks.err_shader_pool_exhausted(ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_err_pipeline_pool_exhausted(void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.err_pipeline_pool_exhausted) {
+        ctx->hooks.err_pipeline_pool_exhausted(ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_err_pass_pool_exhausted(void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.err_pass_pool_exhausted) {
+        ctx->hooks.err_pass_pool_exhausted(ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_err_context_mismatch(void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.err_context_mismatch) {
+        ctx->hooks.err_context_mismatch(ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_err_pass_invalid(void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.err_pass_invalid) {
+        ctx->hooks.err_pass_invalid(ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_err_draw_invalid(void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.err_draw_invalid) {
+        ctx->hooks.err_draw_invalid(ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_err_bindings_invalid(void* user_data) {
+    const sg_imgui_t* ctx = (const sg_imgui_t*) user_data;
+    SOKOL_ASSERT(ctx);
+    if (ctx->hooks.err_bindings_invalid) {
+        ctx->hooks.err_bindings_invalid(ctx->hooks.user_data);
+    }
+}
+
 void sg_imgui_init(sg_imgui_t* ctx) {
     SOKOL_ASSERT(ctx);
     memset(ctx, 0, sizeof(sg_imgui_t));
     ctx->init_tag = 0xABCDABCD;
+
+    /* hook into sokol_gfx functions */
+    sg_trace_hooks hooks;
+    memset(&hooks, 0, sizeof(hooks));
+    hooks.user_data = (void*) ctx;
+    hooks.query_feature = _sg_imgui_query_feature;
+    hooks.reset_state_cache = _sg_imgui_reset_state_cache;
+    hooks.make_buffer = _sg_imgui_make_buffer;
+    hooks.make_image = _sg_imgui_make_image;
+    hooks.make_shader = _sg_imgui_make_shader;
+    hooks.make_pipeline = _sg_imgui_make_pipeline;
+    hooks.make_pass = _sg_imgui_make_pass;
+    hooks.destroy_buffer = _sg_imgui_destroy_buffer;
+    hooks.destroy_image = _sg_imgui_destroy_image;
+    hooks.destroy_shader = _sg_imgui_destroy_shader;
+    hooks.destroy_pipeline = _sg_imgui_destroy_pipeline;
+    hooks.destroy_pass = _sg_imgui_destroy_pass;
+    hooks.update_buffer = _sg_imgui_update_buffer;
+    hooks.update_image = _sg_imgui_update_image;
+    hooks.append_buffer = _sg_imgui_append_buffer;
+    hooks.query_buffer_overflow = _sg_imgui_query_buffer_overflow;
+    hooks.query_buffer_state = _sg_imgui_query_buffer_state;
+    hooks.query_image_state = _sg_imgui_query_image_state;
+    hooks.query_shader_state = _sg_imgui_query_shader_state;
+    hooks.query_pipeline_state = _sg_imgui_query_pipeline_state;
+    hooks.query_pass_state = _sg_imgui_query_pass_state;
+    hooks.begin_default_pass = _sg_imgui_begin_default_pass;
+    hooks.begin_pass = _sg_imgui_begin_pass;
+    hooks.apply_viewport = _sg_imgui_apply_viewport;
+    hooks.apply_scissor_rect = _sg_imgui_apply_scissor_rect;
+    hooks.apply_pipeline = _sg_imgui_apply_pipeline;
+    hooks.apply_bindings = _sg_imgui_apply_bindings;
+    hooks.apply_uniforms = _sg_imgui_apply_uniforms;
+    hooks.draw = _sg_imgui_draw;
+    hooks.end_pass = _sg_imgui_end_pass;
+    hooks.commit = _sg_imgui_commit;
+    hooks.alloc_buffer = _sg_imgui_alloc_buffer;
+    hooks.alloc_image = _sg_imgui_alloc_image;
+    hooks.alloc_shader = _sg_imgui_alloc_shader;
+    hooks.alloc_pipeline = _sg_imgui_alloc_pipeline;
+    hooks.alloc_pass = _sg_imgui_alloc_pass;
+    hooks.init_buffer = _sg_imgui_init_buffer;
+    hooks.init_image = _sg_imgui_init_image;
+    hooks.init_shader = _sg_imgui_init_shader;
+    hooks.init_pipeline = _sg_imgui_init_pipeline;
+    hooks.init_pass = _sg_imgui_init_pass;
+    hooks.fail_buffer = _sg_imgui_fail_buffer;
+    hooks.fail_image = _sg_imgui_fail_image;
+    hooks.fail_shader = _sg_imgui_fail_shader;
+    hooks.fail_pipeline = _sg_imgui_fail_pipeline;
+    hooks.fail_pass = _sg_imgui_fail_pass;
+    hooks.err_buffer_pool_exhausted = _sg_imgui_err_buffer_pool_exhausted;
+    hooks.err_image_pool_exhausted = _sg_imgui_err_image_pool_exhausted;
+    hooks.err_shader_pool_exhausted = _sg_imgui_err_shader_pool_exhausted;
+    hooks.err_pipeline_pool_exhausted = _sg_imgui_err_pipeline_pool_exhausted;
+    hooks.err_pass_pool_exhausted = _sg_imgui_err_pass_pool_exhausted;
+    hooks.err_context_mismatch = _sg_imgui_err_context_mismatch;
+    hooks.err_pass_invalid = _sg_imgui_err_pass_invalid;
+    hooks.err_draw_invalid = _sg_imgui_err_draw_invalid;
+    hooks.err_bindings_invalid = _sg_imgui_err_bindings_invalid;
+    ctx->hooks = sg_install_trace_hooks(&hooks);
 }
 
 void sg_imgui_discard(sg_imgui_t* ctx) {

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -2605,7 +2605,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_buffer_panel(sg_imgui_t* ctx, uint32_t buf_id
             if (buf_ui->desc.usage != SG_USAGE_IMMUTABLE) {
                 ImGui::Separator();
                 ImGui::Text("Num Slots:     %d", buf->num_slots);
-                ImGui::Text("Active Slot:/s   %d", buf->active_slot);
+                ImGui::Text("Active Slot:   %d", buf->active_slot);
                 ImGui::Text("Update Frame Index: %d", buf->update_frame_index);
                 ImGui::Text("Append Frame Index: %d", buf->append_frame_index);
                 ImGui::Text("Append Pos:         %d", buf->append_pos);

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -659,6 +659,66 @@ _SOKOL_PRIVATE const char* _sg_imgui_usage_string(sg_usage u) {
     }
 }
 
+_SOKOL_PRIVATE const char* _sg_imgui_imagetype_string(sg_image_type t) {
+    switch (t) {
+        case SG_IMAGETYPE_2D:       return "SG_IMAGETYPE_2D";
+        case SG_IMAGETYPE_CUBE:     return "SG_IMAGETYPE_CUBE";
+        case SG_IMAGETYPE_3D:       return "SG_IMAGETYPE_3D";
+        case SG_IMAGETYPE_ARRAY:    return "SG_IMAGETYPE_ARRAY";
+        default:                    return "???";
+    }
+}
+
+_SOKOL_PRIVATE const char* _sg_imgui_pixelformat_string(sg_pixel_format fmt) {
+    switch (fmt) {
+        case SG_PIXELFORMAT_NONE:           return "SG_PIXELFORMAT_NONE";
+        case SG_PIXELFORMAT_RGBA8:          return "SG_PIXELFORMAT_RGBA8";
+        case SG_PIXELFORMAT_RGB8:           return "SG_PIXELFORMAT_RGB8";
+        case SG_PIXELFORMAT_RGBA4:          return "SG_PIXELFORMAT_RGBA4";
+        case SG_PIXELFORMAT_R5G6B5:         return "SG_PIXELFORMAT_R5G6B5";
+        case SG_PIXELFORMAT_R5G5B5A1:       return "SG_PIXELFORMAT_R5G5B5A1";
+        case SG_PIXELFORMAT_R10G10B10A2:    return "SG_PIXELFORMAT_R10G10B10A2";
+        case SG_PIXELFORMAT_RGBA32F:        return "SG_PIXELFORMAT_RGBA32F";
+        case SG_PIXELFORMAT_RGBA16F:        return "SG_PIXELFORMAT_RGBA16F";
+        case SG_PIXELFORMAT_R32F:           return "SG_PIXELFORMAT_R32F";
+        case SG_PIXELFORMAT_R16F:           return "SG_PIXELFORMAT_R16F";
+        case SG_PIXELFORMAT_L8:             return "SG_PIXELFORMAT_L8";
+        case SG_PIXELFORMAT_DXT1:           return "SG_PIXELFORMAT_DXT1";
+        case SG_PIXELFORMAT_DXT3:           return "SG_PIXELFORMAT_DXT3";
+        case SG_PIXELFORMAT_DXT5:           return "SG_PIXELFORMAT_DXT5";
+        case SG_PIXELFORMAT_DEPTH:          return "SG_PIXELFORMAT_DEPTH";
+        case SG_PIXELFORMAT_DEPTHSTENCIL:   return "SG_PIXELFORMAT_DEPTHSTENCIL";
+        case SG_PIXELFORMAT_PVRTC2_RGB:     return "SG_PIXELFORMAT_PVRTC2_RGB";
+        case SG_PIXELFORMAT_PVRTC4_RGB:     return "SG_PIXELFORMAT_PVRTC4_RGB";
+        case SG_PIXELFORMAT_PVRTC2_RGBA:    return "SG_PIXELFORMAT_PVRTC2_RGBA";
+        case SG_PIXELFORMAT_PVRTC4_RGBA:    return "SG_PIXELFORMAT_PVRTC4_RGBA";
+        case SG_PIXELFORMAT_ETC2_RGB8:      return "SG_PIXELFORMAT_ETC2_RGB8";
+        case SG_PIXELFORMAT_ETC2_SRGB8:     return "SG_PIXELFORMAT_ETC2_SRGB8";
+        default:                            return "???";
+    }
+}
+
+_SOKOL_PRIVATE const char* _sg_imgui_filter_string(sg_filter f) {
+    switch (f) {
+        case SG_FILTER_NEAREST:                 return "SG_FILTER_NEAREST";
+        case SG_FILTER_LINEAR:                  return "SG_FILTER_LINEAR";
+        case SG_FILTER_NEAREST_MIPMAP_NEAREST:  return "SG_FILTER_NEAREST_MIPMAP_NEAREST";
+        case SG_FILTER_NEAREST_MIPMAP_LINEAR:   return "SG_FILTER_NEAREST_MIPMAP_LINEAR";
+        case SG_FILTER_LINEAR_MIPMAP_NEAREST:   return "SG_FILTER_LINEAR_MIPMAP_NEAREST";
+        case SG_FILTER_LINEAR_MIPMAP_LINEAR:    return "SG_FILTER_LINEAR_MIPMAP_LINEAR";
+        default:                                return "???";
+    }
+}
+
+_SOKOL_PRIVATE const char* _sg_imgui_wrap_string(sg_wrap w) {
+    switch (w) {
+        case SG_WRAP_REPEAT:            return "SG_WRAP_REPEAT";
+        case SG_WRAP_CLAMP_TO_EDGE:     return "SG_WRAP_CLAMP_TO_EDGE";
+        case SG_WRAP_MIRRORED_REPEAT:   return "SG_WRAP_MIRRORED_REPEAT";
+        default:                        return "???";
+    }
+}
+
 _SOKOL_PRIVATE void _sg_imgui_draw_buffer_list(sg_imgui_t* ctx) {
     ImGui::BeginChild("buffer_list", ImVec2(128,0), true);
     for (int i = 1; i < _sg.pools.buffer_pool.size; i++) {
@@ -667,6 +727,62 @@ _SOKOL_PRIVATE void _sg_imgui_draw_buffer_list(sg_imgui_t* ctx) {
             bool selected = ctx->buffers.sel_id == buf->slot.id;
             if (_sg_imgui_draw_resid(buf->slot.id, ctx->buffers.slots[i].label, selected)) {
                 ctx->buffers.sel_id = buf->slot.id;
+            }
+        }
+    }
+    ImGui::EndChild();
+}
+
+_SOKOL_PRIVATE void _sg_imgui_draw_image_list(sg_imgui_t* ctx) {
+    ImGui::BeginChild("image_list", ImVec2(128,0), true);
+    for (int i = 1; i < _sg.pools.image_pool.size; i++) {
+        const _sg_image_t* img = &_sg.pools.images[i];
+        if (img->slot.state != SG_RESOURCESTATE_INITIAL) {
+            bool selected = ctx->images.sel_id == img->slot.id;
+            if (_sg_imgui_draw_resid(img->slot.id, ctx->images.slots[i].label, selected)) {
+                ctx->images.sel_id = img->slot.id;
+            }
+        }
+    }
+    ImGui::EndChild();
+}
+
+_SOKOL_PRIVATE void _sg_imgui_draw_shader_list(sg_imgui_t* ctx) {
+    ImGui::BeginChild("shader_list", ImVec2(128,0), true);
+    for (int i = 1; i < _sg.pools.shader_pool.size; i++) {
+        const _sg_shader_t* shd = &_sg.pools.shaders[i];
+        if (shd->slot.state != SG_RESOURCESTATE_INITIAL) {
+            bool selected = ctx->shaders.sel_id == shd->slot.id;
+            if (_sg_imgui_draw_resid(shd->slot.id, ctx->shaders.slots[i].label, selected)) {
+                ctx->shaders.sel_id = shd->slot.id;
+            }
+        }
+    }
+    ImGui::EndChild();
+}
+
+_SOKOL_PRIVATE void _sg_imgui_draw_pipeline_list(sg_imgui_t* ctx) {
+    ImGui::BeginChild("pipeline_list", ImVec2(128,0), true);
+    for (int i = 1; i < _sg.pools.pipeline_pool.size; i++) {
+        const _sg_pipeline_t* pip = &_sg.pools.pipelines[i];
+        if (pip->slot.state != SG_RESOURCESTATE_INITIAL) {
+            bool selected = ctx->pipelines.sel_id == pip->slot.id;
+            if (_sg_imgui_draw_resid(pip->slot.id, ctx->pipelines.slots[i].label, selected)) {
+                ctx->pipelines.sel_id = pip->slot.id;
+            }
+        }
+    }
+    ImGui::EndChild();
+}
+
+_SOKOL_PRIVATE void _sg_imgui_draw_pass_list(sg_imgui_t* ctx) {
+    ImGui::BeginChild("pass_list", ImVec2(128,0), true);
+    for (int i = 1; i < _sg.pools.pass_pool.size; i++) {
+        const _sg_pass_t* pass = &_sg.pools.passes[i];
+        if (pass->slot.state != SG_RESOURCESTATE_INITIAL) {
+            bool selected = ctx->passes.sel_id == pass->slot.id;
+            if (_sg_imgui_draw_resid(pass->slot.id, ctx->passes.slots[i].label, selected)) {
+                ctx->passes.sel_id = pass->slot.id;
             }
         }
     }
@@ -682,9 +798,9 @@ _SOKOL_PRIVATE void _sg_imgui_draw_buffer_panel(sg_imgui_t* ctx, uint32_t sel_id
         ImGui::Text("Label: %s", buf_ui->label[0] ? buf_ui->label : "---");
         _sg_imgui_draw_resource_slot(&buf->slot);
         ImGui::Separator();
-        ImGui::Text("Size:  %d", buf->size);
         ImGui::Text("Type:  %s", _sg_imgui_buffertype_string(buf->type));
         ImGui::Text("Usage: %s", _sg_imgui_usage_string(buf->usage));
+        ImGui::Text("Size:  %d", buf->size);
         if (buf->usage != SG_USAGE_IMMUTABLE) {
             ImGui::Separator();
             ImGui::Text("Num Slots:     %d", buf->num_slots);
@@ -694,6 +810,79 @@ _SOKOL_PRIVATE void _sg_imgui_draw_buffer_panel(sg_imgui_t* ctx, uint32_t sel_id
             ImGui::Text("Append Pos:         %d", buf->append_pos);
             ImGui::Text("Append Overflow:    %s", buf->append_overflow ? "YES":"NO");
         }
+        ImGui::EndChild();
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_draw_image_panel(sg_imgui_t* ctx, uint32_t sel_id) {
+    if (sel_id != SG_INVALID_ID) {
+        const _sg_image_t* img = _sg_image_at(&_sg.pools, sel_id);
+        const sg_imgui_image_t* img_ui = &ctx->images.slots[_sg_slot_index(sel_id)];
+        ImGui::SameLine();
+        ImGui::BeginChild("image", ImVec2(0,0), false);
+        ImGui::Text("Label: %s", img_ui->label[0] ? img_ui->label : "---");
+        _sg_imgui_draw_resource_slot(&img->slot);
+        ImGui::Separator();
+        ImGui::Text("Type:              %s", _sg_imgui_imagetype_string(img->type));
+        ImGui::Text("Usage:             %s", _sg_imgui_usage_string(img->usage));
+        ImGui::Text("Render Target:     %s", img->render_target ? "YES":"NO");
+        ImGui::Text("Width:             %d", img->width);
+        ImGui::Text("Height:            %d", img->height);
+        ImGui::Text("Depth:             %d", img->depth);
+        ImGui::Text("Num Mipmaps:       %d", img->num_mipmaps);
+        ImGui::Text("Pixel Format:      %s", _sg_imgui_pixelformat_string(img->pixel_format));
+        ImGui::Text("Sample Count:      %d", img->sample_count);
+        ImGui::Text("Min Filter:        %s", _sg_imgui_filter_string(img->min_filter));
+        ImGui::Text("Mag Filter:        %s", _sg_imgui_filter_string(img->mag_filter));
+        ImGui::Text("Wrap U:            %s", _sg_imgui_wrap_string(img->wrap_u));
+        ImGui::Text("Wrap V:            %s", _sg_imgui_wrap_string(img->wrap_v));
+        ImGui::Text("Wrap W:            %s", _sg_imgui_wrap_string(img->wrap_w));
+        ImGui::Text("Max Anisotropy:    %d", img->max_anisotropy);
+        if (img->usage != SG_USAGE_IMMUTABLE) {
+            ImGui::Separator();
+            ImGui::Text("Num Slots:     %d", img->num_slots);
+            ImGui::Text("Active Slot:   %d", img->active_slot);
+            ImGui::Text("Update Frame Index: %d", img->upd_frame_index);
+        }
+        ImGui::BeginChild("texture", ImVec2(0, 0), true, ImGuiWindowFlags_HorizontalScrollbar);
+        ImGui::Image((ImTextureID)(intptr_t)sel_id, ImVec2(2*img->width, 2*img->height));
+        ImGui::EndChild();
+        ImGui::EndChild();
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_draw_shader_panel(sg_imgui_t* ctx, uint32_t sel_id) {
+    if (sel_id != SG_INVALID_ID) {
+        const _sg_shader_t* shd = _sg_shader_at(&_sg.pools, sel_id);
+        const sg_imgui_shader_t* shd_ui = &ctx->shaders.slots[_sg_slot_index(sel_id)];
+        ImGui::SameLine();
+        ImGui::BeginChild("shader", ImVec2(0,0), false);
+        ImGui::Text("Label: %s", shd_ui->label[0] ? shd_ui->label : "---");
+        _sg_imgui_draw_resource_slot(&shd->slot);
+        ImGui::EndChild();
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_draw_pipeline_panel(sg_imgui_t* ctx, uint32_t sel_id) {
+    if (sel_id != SG_INVALID_ID) {
+        const _sg_pipeline_t* pip = _sg_pipeline_at(&_sg.pools, sel_id);
+        const sg_imgui_pipeline_t* pip_ui = &ctx->pipelines.slots[_sg_slot_index(sel_id)];
+        ImGui::SameLine();
+        ImGui::BeginChild("pipeline", ImVec2(0,0), false);
+        ImGui::Text("Label: %s", pip_ui->label[0] ? pip_ui->label : "---");
+        _sg_imgui_draw_resource_slot(&pip->slot);
+        ImGui::EndChild();
+    }
+}
+
+_SOKOL_PRIVATE void _sg_imgui_draw_pass_panel(sg_imgui_t* ctx, uint32_t sel_id) {
+    if (sel_id != SG_INVALID_ID) {
+        const _sg_pass_t* pass = _sg_pass_at(&_sg.pools, sel_id);
+        const sg_imgui_pass_t* pass_ui = &ctx->passes.slots[_sg_slot_index(sel_id)];
+        ImGui::SameLine();
+        ImGui::BeginChild("pass", ImVec2(0,0), false);
+        ImGui::Text("Label: %s", pass_ui->label[0] ? pass_ui->label : "---");
+        _sg_imgui_draw_resource_slot(&pass->slot);
         ImGui::EndChild();
     }
 }
@@ -848,7 +1037,7 @@ void sg_imgui_draw_images_window(sg_imgui_t* ctx) {
     if (!ctx->images.open) {
         return;
     }
-    ImGui::SetNextWindowSize(ImVec2(400, 400), ImGuiSetCond_Once);
+    ImGui::SetNextWindowSize(ImVec2(440, 400), ImGuiSetCond_Once);
     if (ImGui::Begin("Images", &ctx->images.open)) {
         sg_imgui_draw_images_content(ctx);
     }
@@ -860,7 +1049,7 @@ void sg_imgui_draw_shaders_window(sg_imgui_t* ctx) {
     if (!ctx->shaders.open) {
         return;
     }
-    ImGui::SetNextWindowSize(ImVec2(400, 400), ImGuiSetCond_Once);
+    ImGui::SetNextWindowSize(ImVec2(440, 400), ImGuiSetCond_Once);
     if (ImGui::Begin("Shaders", &ctx->shaders.open)) {
         sg_imgui_draw_shaders_content(ctx);
     }
@@ -872,7 +1061,7 @@ void sg_imgui_draw_pipelines_window(sg_imgui_t* ctx) {
     if (!ctx->pipelines.open) {
         return;
     }
-    ImGui::SetNextWindowSize(ImVec2(400, 400), ImGuiSetCond_Once);
+    ImGui::SetNextWindowSize(ImVec2(440, 400), ImGuiSetCond_Once);
     if (ImGui::Begin("Pipelines", &ctx->pipelines.open)) {
         sg_imgui_draw_pipelines_content(ctx);
     }
@@ -884,7 +1073,7 @@ void sg_imgui_draw_passes_window(sg_imgui_t* ctx) {
     if (!ctx->passes.open) {
         return;
     }
-    ImGui::SetNextWindowSize(ImVec2(400, 400), ImGuiSetCond_Once);
+    ImGui::SetNextWindowSize(ImVec2(440, 400), ImGuiSetCond_Once);
     if (ImGui::Begin("Passes", &ctx->passes.open)) {
         sg_imgui_draw_passes_content(ctx);
     }
@@ -899,22 +1088,26 @@ void sg_imgui_draw_buffers_content(sg_imgui_t* ctx) {
 
 void sg_imgui_draw_images_content(sg_imgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    ImGui::Text("FIXME!");
+    _sg_imgui_draw_image_list(ctx);
+    _sg_imgui_draw_image_panel(ctx, ctx->images.sel_id);
 }
 
 void sg_imgui_draw_shaders_content(sg_imgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    ImGui::Text("FIXME!");
+    _sg_imgui_draw_shader_list(ctx);
+    _sg_imgui_draw_shader_panel(ctx, ctx->shaders.sel_id);
 }
 
 void sg_imgui_draw_pipelines_content(sg_imgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    ImGui::Text("FIXME!");
+    _sg_imgui_draw_pipeline_list(ctx);
+    _sg_imgui_draw_pipeline_panel(ctx, ctx->pipelines.sel_id);
 }
 
 void sg_imgui_draw_passes_content(sg_imgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    ImGui::Text("FIXME!");
+    _sg_imgui_draw_pass_list(ctx);
+    _sg_imgui_draw_pass_panel(ctx, ctx->passes.sel_id);
 }
 
 #endif /* SOKOL_IMPL */

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -423,7 +423,6 @@ typedef struct {
 
 typedef struct {
     uint32_t num_items;
-    uint32_t sel_item;
     sg_imgui_capture_item_t items[SG_IMGUI_MAX_FRAMECAPTURE_ITEMS];
 } sg_imgui_capture_bucket_t;
 
@@ -432,7 +431,8 @@ typedef struct {
 */
 typedef struct {
     bool open;
-    uint32_t bucket_index;     /* which bucket to record to, 0 or 1 */
+    uint32_t bucket_index;      /* which bucket to record to, 0 or 1 */
+    uint32_t sel_item;          /* currently selected capture item by index */
     sg_imgui_capture_bucket_t bucket[2];
 } sg_imgui_capture_t;
 
@@ -1098,7 +1098,6 @@ _SOKOL_PRIVATE void _sg_imgui_capture_next_frame(sg_imgui_t* ctx) {
     ctx->capture.bucket_index = (ctx->capture.bucket_index + 1) & 1;
     sg_imgui_capture_bucket_t* bucket = &ctx->capture.bucket[ctx->capture.bucket_index];
     bucket->num_items = 0;
-    bucket->sel_item = 0;
 }
 
 _SOKOL_PRIVATE sg_imgui_capture_item_t* _sg_imgui_capture_next_write_item(sg_imgui_t* ctx) {
@@ -2276,13 +2275,12 @@ _SOKOL_PRIVATE void _sg_imgui_draw_pass_list(sg_imgui_t* ctx) {
 _SOKOL_PRIVATE void _sg_imgui_draw_capture_list(sg_imgui_t* ctx) {
     ImGui::BeginChild("capture_list", ImVec2(_SG_IMGUI_LIST_WIDTH,0), true);
     const uint32_t num_items = _sg_imgui_capture_num_read_items(ctx);
-    sg_imgui_capture_bucket_t* bucket = _sg_imgui_capture_get_read_bucket(ctx);
     for (uint32_t i = 0; i < num_items; i++) {
         const sg_imgui_capture_item_t* item = _sg_imgui_capture_read_item_at(ctx, i);
         sg_imgui_str_t item_string = _sg_imgui_capture_item_string(ctx, i, item);
         ImGui::PushID(i);
-        if (ImGui::Selectable(item_string.buf, bucket->sel_item == i)) {
-            bucket->sel_item = i;
+        if (ImGui::Selectable(item_string.buf, ctx->capture.sel_item == i)) {
+            ctx->capture.sel_item = i;
         }
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip("%s", item_string.buf);

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -59,6 +59,7 @@ typedef struct {
 
 typedef struct {
     sg_image res_id;
+    bool ui_orig_size;
     sg_imgui_str_t label;
 } sg_imgui_image_t;
 
@@ -198,6 +199,7 @@ _SOKOL_PRIVATE void _sg_imgui_image_created(sg_imgui_t* ctx, sg_image res_id, in
     SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->images.num_slots));
     sg_imgui_image_t* img = &ctx->images.slots[slot_index];
     img->res_id = res_id;
+    img->ui_orig_size = true;
     _sg_imgui_strcpy(&img->label, desc->label);
 }
 
@@ -1268,6 +1270,32 @@ _SOKOL_PRIVATE void _sg_imgui_draw_buffer_panel(sg_imgui_t* ctx, uint32_t sel_id
     }
 }
 
+_SOKOL_PRIVATE void _sg_imgui_draw_embedded_image(sg_imgui_t* ctx, uint32_t img_id) {
+    const _sg_image_t* img = _sg_image_at(&_sg.pools, img_id);
+    if ((SG_IMAGETYPE_2D == img->type) && !_sg_is_valid_rendertarget_depth_format(img->pixel_format)) {
+        float w = (float) img->width;
+        float h = (float) img->height;
+        if ((w > 0.5f) && (h > 0.5f)) {
+            sg_imgui_image_t* img_ui = &ctx->images.slots[_sg_slot_index(img_id)];
+            ImVec2 avail = ImGui::GetContentRegionAvail();
+            ImGui::PushID((int)img_id);
+            ImGui::Checkbox("Original Size", &img_ui->ui_orig_size);
+            if (!img_ui->ui_orig_size) {
+                w = (int) avail.x;
+                h = ((float)img->height / (float)img->width) * w;
+            }
+            ImGui::Image((ImTextureID)(intptr_t)img_id, ImVec2(w, h));
+            ImGui::PopID();
+        }
+        else {
+            ImGui::Text("Image has invalid size.");
+        }
+    }
+    else {
+        ImGui::Text("Image not renderable.");
+    }
+}
+
 _SOKOL_PRIVATE void _sg_imgui_draw_image_panel(sg_imgui_t* ctx, uint32_t sel_id) {
     if (sel_id != SG_INVALID_ID) {
         const _sg_image_t* img = _sg_image_at(&_sg.pools, sel_id);
@@ -1276,6 +1304,8 @@ _SOKOL_PRIVATE void _sg_imgui_draw_image_panel(sg_imgui_t* ctx, uint32_t sel_id)
         ImGui::BeginChild("image", ImVec2(0,0), false);
         ImGui::Text("Label: %s", img_ui->label.buf[0] ? img_ui->label.buf : "---");
         _sg_imgui_draw_resource_slot(&img->slot);
+        ImGui::Separator();
+        _sg_imgui_draw_embedded_image(ctx, sel_id);
         ImGui::Separator();
         ImGui::Text("Type:              %s", _sg_imgui_imagetype_string(img->type));
         ImGui::Text("Usage:             %s", _sg_imgui_usage_string(img->usage));
@@ -1297,11 +1327,6 @@ _SOKOL_PRIVATE void _sg_imgui_draw_image_panel(sg_imgui_t* ctx, uint32_t sel_id)
             ImGui::Text("Num Slots:     %d", img->num_slots);
             ImGui::Text("Active Slot:   %d", img->active_slot);
             ImGui::Text("Update Frame Index: %d", img->upd_frame_index);
-        }
-        if ((SG_IMAGETYPE_2D == img->type) && !_sg_is_valid_rendertarget_depth_format(img->pixel_format)) {
-            ImGui::BeginChild("texture", ImVec2(0, 0), true, ImGuiWindowFlags_HorizontalScrollbar);
-            ImGui::Image((ImTextureID)(intptr_t)sel_id, ImVec2(2*img->width, 2*img->height));
-            ImGui::EndChild();
         }
         ImGui::EndChild();
     }

--- a/imgui/sokol_gfx_imgui.h
+++ b/imgui/sokol_gfx_imgui.h
@@ -43,6 +43,8 @@ extern "C" {
 #endif
 
 #define SG_IMGUI_STRBUF_LEN (32)
+/* max number of captured calls per frame */
+#define SG_IMGUI_MAX_FRAMECAPTURE_ITEMS (4096)
 
 /* a small string buffer to store strings coming into sokol_gfx.h via
     the desc structures, these are not guaranteed to be static, so
@@ -91,42 +93,342 @@ typedef struct {
     float ds_image_scale;
 } sg_imgui_pass_t;
 
-typedef struct sg_imgui_buffers_t {
+typedef struct {
     bool open;
     int num_slots;
     uint32_t sel_id;
     sg_imgui_buffer_t* slots;
 } sg_imgui_buffers_t;
 
-typedef struct sg_imgui_images_t {
+typedef struct {
     bool open;
     int num_slots;
     uint32_t sel_id;
     sg_imgui_image_t* slots;
 } sg_imgui_images_t;
 
-typedef struct sg_imgui_shaders_t {
+typedef struct {
     bool open;
     int num_slots;
     uint32_t sel_id;
     sg_imgui_shader_t* slots;
 } sg_imgui_shaders_t;
 
-typedef struct sg_imgui_pipelines_t {
+typedef struct {
     bool open;
     int num_slots;
     uint32_t sel_id;
     sg_imgui_pipeline_t* slots;
 } sg_imgui_pipelines_t;
 
-typedef struct sg_imgui_passes_t {
+typedef struct {
     bool open;
     int num_slots;
     uint32_t sel_id;
     sg_imgui_pass_t* slots;
 } sg_imgui_passes_t;
 
-typedef struct sg_imgui_t {
+typedef enum {
+    SG_IMGUI_CMD_INVALID,
+    SG_IMGUI_CMD_QUERY_FEATURE,
+    SG_IMGUI_CMD_RESET_STATE_CACHE,
+    SG_IMGUI_CMD_MAKE_BUFFER,
+    SG_IMGUI_CMD_MAKE_IMAGE,
+    SG_IMGUI_CMD_MAKE_SHADER,
+    SG_IMGUI_CMD_MAKE_PIPELINE,
+    SG_IMGUI_CMD_MAKE_PASS,
+    SG_IMGUI_CMD_DESTROY_BUFFER,
+    SG_IMGUI_CMD_DESTROY_IMAGE,
+    SG_IMGUI_CMD_DESTROY_SHADER,
+    SG_IMGUI_CMD_DESTROY_PIPELINE,
+    SG_IMGUI_CMD_DESTROY_PASS,
+    SG_IMGUI_CMD_UPDATE_BUFFER,
+    SG_IMGUI_CMD_UPDATE_IMAGE,
+    SG_IMGUI_CMD_APPEND_BUFFER,
+    SG_IMGUI_CMD_QUERY_BUFFER_OVERFLOW,
+    SG_IMGUI_CMD_QUERY_BUFFER_STATE,
+    SG_IMGUI_CMD_QUERY_IMAGE_STATE,
+    SG_IMGUI_CMD_QUERY_SHADER_STATE,
+    SG_IMGUI_CMD_QUERY_PIPELINE_STATE,
+    SG_IMGUI_CMD_QUERY_PASS_STATE,
+    SG_IMGUI_CMD_BEGIN_DEFAULT_PASS,
+    SG_IMGUI_CMD_BEGIN_PASS,
+    SG_IMGUI_CMD_APPLY_VIEWPORT,
+    SG_IMGUI_CMD_APPLY_SCISSOR_RECT,
+    SG_IMGUI_CMD_APPLY_PIPELINE,
+    SG_IMGUI_CMD_APPLY_BINDINGS,
+    SG_IMGUI_CMD_APPLY_UNIFORMS,
+    SG_IMGUI_CMD_DRAW,
+    SG_IMGUI_CMD_END_PASS,
+    SG_IMGUI_CMD_COMMIT,
+    SG_IMGUI_CMD_ALLOC_BUFFER,
+    SG_IMGUI_CMD_ALLOC_IMAGE,
+    SG_IMGUI_CMD_ALLOC_SHADER,
+    SG_IMGUI_CMD_ALLOC_PIPELINE,
+    SG_IMGUI_CMD_ALLOC_PASS,
+    SG_IMGUI_CMD_INIT_BUFFER,
+    SG_IMGUI_CMD_INIT_IMAGE,
+    SG_IMGUI_CMD_INIT_SHADER,
+    SG_IMGUI_CMD_INIT_PIPELINE,
+    SG_IMGUI_CMD_INIT_PASS,
+    SG_IMGUI_CMD_FAIL_BUFFER,
+    SG_IMGUI_CMD_FAIL_IMAGE,
+    SG_IMGUI_CMD_FAIL_SHADER,
+    SG_IMGUI_CMD_FAIL_PIPELINE,
+    SG_IMGUI_CMD_FAIL_PASS,
+} sg_imgui_cmd_t;
+
+typedef struct {
+    sg_feature feature;
+    bool result;
+} sg_imgui_args_query_feature_t;
+
+typedef struct {
+    sg_buffer result;
+} sg_imgui_args_make_buffer_t;
+
+typedef struct {
+    sg_image result;
+} sg_imgui_args_make_image_t;
+
+typedef struct {
+    sg_shader result;
+} sg_imgui_args_make_shader_t;
+
+typedef struct {
+    sg_pipeline result;
+} sg_imgui_args_make_pipeline_t;
+
+typedef struct {
+    sg_pass result;
+} sg_imgui_args_make_pass_t;
+
+typedef struct {
+    sg_buffer buffer;
+} sg_imgui_args_destroy_buffer_t;
+
+typedef struct {
+    sg_image image;
+} sg_imgui_args_destroy_image_t;
+
+typedef struct {
+    sg_shader shader;
+} sg_imgui_args_destroy_shader_t;
+
+typedef struct {
+    sg_pipeline pipeline;
+} sg_imgui_args_destroy_pipeline_t;
+
+typedef struct {
+    sg_pass pass;
+} sg_imgui_args_destroy_pass_t;
+
+typedef struct {
+    sg_buffer buffer;
+    int data_size;
+} sg_imgui_args_update_buffer_t;
+
+typedef struct {
+    sg_image image;
+} sg_imgui_args_update_image_t;
+
+typedef struct {
+    sg_buffer buffer;
+    int data_size;
+    int result;
+} sg_imgui_args_append_buffer_t;
+
+typedef struct {
+    sg_buffer buffer;
+    bool result;
+} sg_imgui_args_query_buffer_overflow_t;
+
+typedef struct {
+    sg_buffer buffer;
+    sg_resource_state result;
+} sg_imgui_args_query_buffer_state_t;
+
+typedef struct {
+    sg_image image;
+    sg_resource_state result;
+} sg_imgui_args_query_image_state_t;
+
+typedef struct {
+    sg_shader shader;
+    sg_resource_state result;
+} sg_imgui_args_query_shader_state_t;
+
+typedef struct {
+    sg_pipeline pipeline;
+    sg_resource_state result;
+} sg_imgui_args_query_pipeline_state_t;
+
+typedef struct {
+    sg_pass pass;
+    sg_resource_state result;
+} sg_imgui_args_query_pass_state_t;
+
+typedef struct {
+    sg_pass_action action;
+    int width;
+    int height;
+} sg_imgui_args_begin_default_pass_t;
+
+typedef struct {
+    sg_pass pass;
+    sg_pass_action action;
+} sg_imgui_args_begin_pass_t;
+
+typedef struct {
+    int x, y, width, height;
+} sg_imgui_args_apply_viewport_t;
+
+typedef struct {
+    int x, y, width, height;
+} sg_imgui_args_apply_scissor_rect_t;
+
+typedef struct {
+    sg_pipeline pipeline;
+} sg_imgui_args_apply_pipeline_t;
+
+typedef struct {
+    sg_bindings bindings;
+} sg_imgui_args_apply_bindings_t;
+
+typedef struct {
+    sg_shader_stage stage;
+    int ub_index;
+    const void* data;
+    int num_bytes;
+} sg_imgui_args_apply_uniforms_t;
+
+typedef struct {
+    int base_element;
+    int num_elements;
+    int num_instances;
+} sg_imgui_args_draw_t;
+
+typedef struct {
+    sg_buffer result;
+} sg_imgui_args_alloc_buffer_t;
+
+typedef struct {
+    sg_image result;
+} sg_imgui_args_alloc_image_t;
+
+typedef struct {
+    sg_shader result;
+} sg_imgui_args_alloc_shader_t;
+
+typedef struct {
+    sg_pipeline result;
+} sg_imgui_args_alloc_pipeline_t;
+
+typedef struct {
+    sg_pass result;
+} sg_imgui_args_alloc_pass_t;
+
+typedef struct {
+    sg_buffer buffer;
+} sg_imgui_args_init_buffer_t;
+
+typedef struct {
+    sg_image image;
+} sg_imgui_args_init_image_t;
+
+typedef struct {
+    sg_shader shader;
+} sg_imgui_args_init_shader_t;
+
+typedef struct {
+    sg_pipeline pipeline;
+} sg_imgui_args_init_pipeline_t;
+
+typedef struct {
+    sg_pass pass;
+} sg_imgui_args_init_pass_t;
+
+typedef struct {
+    sg_buffer buffer;
+} sg_imgui_args_fail_buffer_t;
+
+typedef struct {
+    sg_image image;
+} sg_imgui_args_fail_image_t;
+
+typedef struct {
+    sg_shader shader;
+} sg_imgui_args_fail_shader_t;
+
+typedef struct {
+    sg_pipeline pipeline;
+} sg_imgui_args_fail_pipeline_t;
+
+typedef struct {
+    sg_pass pass;
+} sg_imgui_args_fail_pass_t;
+
+typedef union {
+    sg_imgui_args_query_feature_t query_feature;
+    sg_imgui_args_make_buffer_t make_buffer;
+    sg_imgui_args_make_image_t make_image;
+    sg_imgui_args_make_shader_t make_shader;
+    sg_imgui_args_make_pipeline_t make_pipeline;
+    sg_imgui_args_make_pass_t make_pass;
+    sg_imgui_args_destroy_buffer_t destroy_buffer;
+    sg_imgui_args_destroy_image_t destroy_image;
+    sg_imgui_args_destroy_shader_t destroy_shader;
+    sg_imgui_args_destroy_pipeline_t destroy_pipeline;
+    sg_imgui_args_destroy_pass_t destroy_pass;
+    sg_imgui_args_update_buffer_t update_buffer;
+    sg_imgui_args_update_image_t update_image;
+    sg_imgui_args_append_buffer_t append_buffer;
+    sg_imgui_args_query_buffer_overflow_t query_buffer_overflow;
+    sg_imgui_args_query_buffer_state_t query_buffer_state;
+    sg_imgui_args_query_image_state_t query_image_state;
+    sg_imgui_args_query_shader_state_t query_shader_state;
+    sg_imgui_args_query_pipeline_state_t query_pipeline_state;
+    sg_imgui_args_query_pass_state_t query_pass_state;
+    sg_imgui_args_begin_default_pass_t begin_default_pass;
+    sg_imgui_args_begin_pass_t begin_pass;
+    sg_imgui_args_apply_viewport_t apply_viewport;
+    sg_imgui_args_apply_scissor_rect_t apply_scissor_rect;
+    sg_imgui_args_apply_pipeline_t apply_pipeline;
+    sg_imgui_args_apply_bindings_t apply_bindings;
+    sg_imgui_args_apply_uniforms_t apply_uniforms;
+    sg_imgui_args_draw_t draw;
+    sg_imgui_args_alloc_buffer_t alloc_buffer;
+    sg_imgui_args_alloc_image_t alloc_image;
+    sg_imgui_args_alloc_shader_t alloc_shader;
+    sg_imgui_args_alloc_pipeline_t alloc_pipeline;
+    sg_imgui_args_alloc_pass_t alloc_pass;
+    sg_imgui_args_init_buffer_t init_buffer;
+    sg_imgui_args_init_image_t init_image;
+    sg_imgui_args_init_shader_t init_shader;
+    sg_imgui_args_init_pipeline_t init_pipeline;
+    sg_imgui_args_init_pass_t init_pass;
+    sg_imgui_args_fail_buffer_t fail_buffer;
+    sg_imgui_args_fail_image_t fail_image;
+    sg_imgui_args_fail_shader_t fail_shader;
+    sg_imgui_args_fail_pipeline_t fail_pipeline;
+    sg_imgui_args_fail_pass_t fail_pass;
+} sg_imgui_args_t;
+
+typedef struct {
+    sg_imgui_cmd_t cmd;
+    sg_imgui_args_t args;
+} sg_imgui_capture_item_t;
+
+/* double-buffered call-capture buckets, one bucket is currently recorded,
+   the previous bucket is displayed
+*/
+typedef struct {
+    int bucket_index;     /* which bucket to record to, 0 or 1 */
+    int slot_index;       /* slot index in bucket */
+    sg_imgui_capture_item_t bucket[2][SG_IMGUI_MAX_FRAMECAPTURE_ITEMS];
+} sg_imgui_framecapture_t;
+
+typedef struct {
     uint32_t init_tag;
     sg_imgui_buffers_t buffers;
     sg_imgui_images_t images;
@@ -134,6 +436,7 @@ typedef struct sg_imgui_t {
     sg_imgui_pipelines_t pipelines;
     sg_imgui_passes_t passes;
     sg_trace_hooks hooks;
+    sg_imgui_framecapture_t capture;
 } sg_imgui_t;
 
 void sg_imgui_init(sg_imgui_t* ctx);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -1524,6 +1524,8 @@ typedef struct sg_trace_hooks {
     void (*fail_shader)(sg_shader shd_id, void* user_data);
     void (*fail_pipeline)(sg_pipeline pip_id, void* user_data);
     void (*fail_pass)(sg_pass pass_id, void* user_data);
+    void (*push_debug_group)(const char* name, void* user_data);
+    void (*pop_debug_group)(void* user_data);
     void (*err_buffer_pool_exhausted)(void* user_data);
     void (*err_image_pool_exhausted)(void* user_data);
     void (*err_shader_pool_exhausted)(void* user_data);
@@ -1631,6 +1633,8 @@ SOKOL_API_DECL bool sg_isvalid(void);
 SOKOL_API_DECL bool sg_query_feature(sg_feature feature);
 SOKOL_API_DECL void sg_reset_state_cache(void);
 SOKOL_API_DECL sg_trace_hooks sg_install_trace_hooks(const sg_trace_hooks* trace_hooks);
+SOKOL_API_DECL void sg_push_debug_group(const char* name);
+SOKOL_API_DECL void sg_pop_debug_group(void);
 
 /* resource creation, destruction and updating */
 SOKOL_API_DECL sg_buffer sg_make_buffer(const sg_buffer_desc* desc);
@@ -9962,6 +9966,19 @@ SOKOL_API_IMPL void sg_update_image(sg_image img_id, const sg_image_content* dat
     }
     if (_sg.hooks.update_image) {
         _sg.hooks.update_image(img_id, data, _sg.hooks.user_data);
+    }
+}
+
+SOKOL_API_IMPL void sg_push_debug_group(const char* name) {
+    SOKOL_ASSERT(name);
+    if (_sg.hooks.push_debug_group) {
+        _sg.hooks.push_debug_group(name, _sg.hooks.user_data);
+    }
+}
+
+SOKOL_API_IMPL void sg_pop_debug_group(void) {
+    if (_sg.hooks.pop_debug_group) {
+        _sg.hooks.pop_debug_group(_sg.hooks.user_data);
     }
 }
 

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -1469,61 +1469,62 @@ typedef struct sg_pass_desc {
     new trace hooks to form a proper call chain.
 */
 typedef struct sg_trace_hooks {
-    void (*query_feature)(sg_feature feature, bool result);
-    void (*reset_state_cache)(void);
-    void (*make_buffer)(const sg_buffer_desc* desc, sg_buffer result);
-    void (*make_image)(const sg_image_desc* desc, sg_image result);
-    void (*make_shader)(const sg_shader_desc* desc, sg_shader result);
-    void (*make_pipeline)(const sg_pipeline_desc* desc, sg_pipeline result);
-    void (*make_pass)(const sg_pass_desc* desc, sg_pass result);
-    void (*destroy_buffer)(sg_buffer buf);
-    void (*destroy_image)(sg_image img);
-    void (*destroy_shader)(sg_shader shd);
-    void (*destroy_pipeline)(sg_pipeline pip);
-    void (*destroy_pass)(sg_pass pass);
-    void (*update_buffer)(sg_buffer buf, const void* data_ptr, int data_size);
-    void (*update_image)(sg_image img, const sg_image_content* data);
-    void (*append_buffer)(sg_buffer buf, const void* data_ptr, int data_size, int result);
-    void (*query_buffer_overflow)(sg_buffer buf, bool result);
-    void (*query_buffer_state)(sg_buffer buf, sg_resource_state result);
-    void (*query_image_state)(sg_image img, sg_resource_state result);
-    void (*query_shader_state)(sg_shader shd, sg_resource_state result);
-    void (*query_pipeline_state)(sg_pipeline pip, sg_resource_state result);
-    void (*query_pass_state)(sg_pass pass, sg_resource_state result);
-    void (*begin_default_pass)(const sg_pass_action* pass_action, int width, int height);
-    void (*begin_pass)(sg_pass pass, const sg_pass_action* pass_action);
-    void (*apply_viewport)(int x, int y, int width, int height, bool origin_top_left);
-    void (*apply_scissor_rect)(int x, int y, int width, int height, bool origin_top_left);
-    void (*apply_pipeline)(sg_pipeline pip);
-    void (*apply_bindings)(const sg_bindings* bindings);
-    void (*apply_uniforms)(sg_shader_stage stage, int ub_index, const void* data, int num_bytes);
-    void (*draw)(int base_element, int num_elements, int num_instances);
-    void (*end_pass)(void);
-    void (*commit)(void);
-    void (*alloc_buffer)(sg_buffer result);
-    void (*alloc_image)(sg_image result);
-    void (*alloc_shader)(sg_shader result);
-    void (*alloc_pipeline)(sg_pipeline result);
-    void (*alloc_pass)(sg_pass result);
-    void (*init_buffer)(sg_buffer buf_id, const sg_buffer_desc* desc);
-    void (*init_image)(sg_image img_id, const sg_image_desc* desc);
-    void (*init_shader)(sg_shader shd_id, const sg_shader_desc* desc);
-    void (*init_pipeline)(sg_pipeline pip_id, const sg_pipeline_desc* desc);
-    void (*init_pass)(sg_pass pass_id, const sg_pass_desc* desc);
-    void (*fail_buffer)(sg_buffer buf_id);
-    void (*fail_image)(sg_image img_id);
-    void (*fail_shader)(sg_shader shd_id);
-    void (*fail_pipeline)(sg_pipeline pip_id);
-    void (*fail_pass)(sg_pass pass_id);
-    void (*err_buffer_pool_exhausted)(void);
-    void (*err_image_pool_exhausted)(void);
-    void (*err_shader_pool_exhausted)(void);
-    void (*err_pipeline_pool_exhausted)(void);
-    void (*err_pass_pool_exhausted)(void);
-    void (*err_context_mismatch)(void);
-    void (*err_pass_invalid)(void);
-    void (*err_draw_invalid)(void);
-    void (*err_bindings_invalid)(void);
+    void* user_data;
+    void (*query_feature)(sg_feature feature, bool result, void* user_data);
+    void (*reset_state_cache)(void* user_data);
+    void (*make_buffer)(const sg_buffer_desc* desc, sg_buffer result, void* user_data);
+    void (*make_image)(const sg_image_desc* desc, sg_image result, void* user_data);
+    void (*make_shader)(const sg_shader_desc* desc, sg_shader result, void* user_data);
+    void (*make_pipeline)(const sg_pipeline_desc* desc, sg_pipeline result, void* user_data);
+    void (*make_pass)(const sg_pass_desc* desc, sg_pass result, void* user_data);
+    void (*destroy_buffer)(sg_buffer buf, void* user_data);
+    void (*destroy_image)(sg_image img, void* user_data);
+    void (*destroy_shader)(sg_shader shd, void* user_data);
+    void (*destroy_pipeline)(sg_pipeline pip, void* user_data);
+    void (*destroy_pass)(sg_pass pass, void* user_data);
+    void (*update_buffer)(sg_buffer buf, const void* data_ptr, int data_size, void* user_data);
+    void (*update_image)(sg_image img, const sg_image_content* data, void* user_data);
+    void (*append_buffer)(sg_buffer buf, const void* data_ptr, int data_size, int result, void* user_data);
+    void (*query_buffer_overflow)(sg_buffer buf, bool result, void* user_data);
+    void (*query_buffer_state)(sg_buffer buf, sg_resource_state result, void* user_data);
+    void (*query_image_state)(sg_image img, sg_resource_state result, void* user_data);
+    void (*query_shader_state)(sg_shader shd, sg_resource_state result, void* user_data);
+    void (*query_pipeline_state)(sg_pipeline pip, sg_resource_state result, void* user_data);
+    void (*query_pass_state)(sg_pass pass, sg_resource_state result, void* user_data);
+    void (*begin_default_pass)(const sg_pass_action* pass_action, int width, int height, void* user_data);
+    void (*begin_pass)(sg_pass pass, const sg_pass_action* pass_action, void* user_data);
+    void (*apply_viewport)(int x, int y, int width, int height, bool origin_top_left, void* user_data);
+    void (*apply_scissor_rect)(int x, int y, int width, int height, bool origin_top_left, void* user_data);
+    void (*apply_pipeline)(sg_pipeline pip, void* user_data);
+    void (*apply_bindings)(const sg_bindings* bindings, void* user_data);
+    void (*apply_uniforms)(sg_shader_stage stage, int ub_index, const void* data, int num_bytes, void* user_data);
+    void (*draw)(int base_element, int num_elements, int num_instances, void* user_data);
+    void (*end_pass)(void* user_data);
+    void (*commit)(void* user_data);
+    void (*alloc_buffer)(sg_buffer result, void* user_data);
+    void (*alloc_image)(sg_image result, void* user_data);
+    void (*alloc_shader)(sg_shader result, void* user_data);
+    void (*alloc_pipeline)(sg_pipeline result, void* user_data);
+    void (*alloc_pass)(sg_pass result, void* user_data);
+    void (*init_buffer)(sg_buffer buf_id, const sg_buffer_desc* desc, void* user_data);
+    void (*init_image)(sg_image img_id, const sg_image_desc* desc, void* user_data);
+    void (*init_shader)(sg_shader shd_id, const sg_shader_desc* desc, void* user_data);
+    void (*init_pipeline)(sg_pipeline pip_id, const sg_pipeline_desc* desc, void* user_data);
+    void (*init_pass)(sg_pass pass_id, const sg_pass_desc* desc, void* user_data);
+    void (*fail_buffer)(sg_buffer buf_id, void* user_data);
+    void (*fail_image)(sg_image img_id, void* user_data);
+    void (*fail_shader)(sg_shader shd_id, void* user_data);
+    void (*fail_pipeline)(sg_pipeline pip_id, void* user_data);
+    void (*fail_pass)(sg_pass pass_id, void* user_data);
+    void (*err_buffer_pool_exhausted)(void* user_data);
+    void (*err_image_pool_exhausted)(void* user_data);
+    void (*err_shader_pool_exhausted)(void* user_data);
+    void (*err_pipeline_pool_exhausted)(void* user_data);
+    void (*err_pass_pool_exhausted)(void* user_data);
+    void (*err_context_mismatch)(void* user_data);
+    void (*err_pass_invalid)(void* user_data);
+    void (*err_draw_invalid)(void* user_data);
+    void (*err_bindings_invalid)(void* user_data);
 } sg_trace_hooks;
 
 /*
@@ -9204,7 +9205,7 @@ SOKOL_API_IMPL bool sg_isvalid(void) {
 SOKOL_API_IMPL bool sg_query_feature(sg_feature f) {
     bool res = _sg_query_feature(f);
     if (_sg.hooks.query_feature) {
-        _sg.hooks.query_feature(f, res);
+        _sg.hooks.query_feature(f, res, _sg.hooks.user_data);
     }
     return res;
 }
@@ -9256,7 +9257,7 @@ SOKOL_API_IMPL sg_trace_hooks sg_install_trace_hooks(const sg_trace_hooks* trace
 SOKOL_API_IMPL sg_buffer sg_alloc_buffer(void) {
     sg_buffer res = _sg_alloc_buffer();
     if (_sg.hooks.alloc_buffer) {
-        _sg.hooks.alloc_buffer(res);
+        _sg.hooks.alloc_buffer(res, _sg.hooks.user_data);
     }
     return res;
 }
@@ -9264,7 +9265,7 @@ SOKOL_API_IMPL sg_buffer sg_alloc_buffer(void) {
 SOKOL_API_IMPL sg_image sg_alloc_image(void) {
     sg_image res = _sg_alloc_image();
     if (_sg.hooks.alloc_image) {
-        _sg.hooks.alloc_image(res);
+        _sg.hooks.alloc_image(res, _sg.hooks.user_data);
     }
     return res;
 }
@@ -9272,7 +9273,7 @@ SOKOL_API_IMPL sg_image sg_alloc_image(void) {
 SOKOL_API_IMPL sg_shader sg_alloc_shader(void) {
     sg_shader res = _sg_alloc_shader();
     if (_sg.hooks.alloc_shader) {
-        _sg.hooks.alloc_shader(res);
+        _sg.hooks.alloc_shader(res, _sg.hooks.user_data);
     }
     return res;
 }
@@ -9280,7 +9281,7 @@ SOKOL_API_IMPL sg_shader sg_alloc_shader(void) {
 SOKOL_API_IMPL sg_pipeline sg_alloc_pipeline(void) {
     sg_pipeline res = _sg_alloc_pipeline();
     if (_sg.hooks.alloc_pipeline) {
-        _sg.hooks.alloc_pipeline(res);
+        _sg.hooks.alloc_pipeline(res, _sg.hooks.user_data);
     }
     return res;
 }
@@ -9288,7 +9289,7 @@ SOKOL_API_IMPL sg_pipeline sg_alloc_pipeline(void) {
 SOKOL_API_IMPL sg_pass sg_alloc_pass(void) {
     sg_pass res = _sg_alloc_pass();
     if (_sg.hooks.alloc_pass) {
-        _sg.hooks.alloc_pass(res);
+        _sg.hooks.alloc_pass(res, _sg.hooks.user_data);
     }
     return res;
 }
@@ -9296,35 +9297,35 @@ SOKOL_API_IMPL sg_pass sg_alloc_pass(void) {
 SOKOL_API_IMPL void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc) {
     _sg_init_buffer(buf_id, desc);
     if (_sg.hooks.init_buffer) {
-        _sg.hooks.init_buffer(buf_id, desc);
+        _sg.hooks.init_buffer(buf_id, desc, _sg.hooks.user_data);
     }
 }
 
 SOKOL_API_IMPL void sg_init_image(sg_image img_id, const sg_image_desc* desc) {
     _sg_init_image(img_id, desc);
     if (_sg.hooks.init_image) {
-        _sg.hooks.init_image(img_id, desc);
+        _sg.hooks.init_image(img_id, desc, _sg.hooks.user_data);
     }
 }
 
 SOKOL_API_IMPL void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc) {
     _sg_init_shader(shd_id, desc);
     if (_sg.hooks.init_shader) {
-        _sg.hooks.init_shader(shd_id, desc);
+        _sg.hooks.init_shader(shd_id, desc, _sg.hooks.user_data);
     }
 }
 
 SOKOL_API_IMPL void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc) {
     _sg_init_pipeline(pip_id, desc);
     if (_sg.hooks.init_pipeline) {
-        _sg.hooks.init_pipeline(pip_id, desc);
+        _sg.hooks.init_pipeline(pip_id, desc, _sg.hooks.user_data);
     }
 }
 
 SOKOL_API_IMPL void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc) {
     _sg_init_pass(pass_id, desc);
     if (_sg.hooks.init_pass) {
-        _sg.hooks.init_pass(pass_id, desc);
+        _sg.hooks.init_pass(pass_id, desc, _sg.hooks.user_data);
     }
 }
 
@@ -9336,7 +9337,7 @@ SOKOL_API_IMPL void sg_fail_buffer(sg_buffer buf_id) {
     buf->slot.ctx_id = _sg.active_context.id;
     buf->slot.state = SG_RESOURCESTATE_FAILED;
     if (_sg.hooks.fail_buffer) {
-        _sg.hooks.fail_buffer(buf_id);
+        _sg.hooks.fail_buffer(buf_id, _sg.hooks.user_data);
     }
 }
 
@@ -9347,7 +9348,7 @@ SOKOL_API_IMPL void sg_fail_image(sg_image img_id) {
     img->slot.ctx_id = _sg.active_context.id;
     img->slot.state = SG_RESOURCESTATE_FAILED;
     if (_sg.hooks.fail_image) {
-        _sg.hooks.fail_image(img_id);
+        _sg.hooks.fail_image(img_id, _sg.hooks.user_data);
     }
 }
 
@@ -9358,7 +9359,7 @@ SOKOL_API_IMPL void sg_fail_shader(sg_shader shd_id) {
     shd->slot.ctx_id = _sg.active_context.id;
     shd->slot.state = SG_RESOURCESTATE_FAILED;
     if (_sg.hooks.fail_shader) {
-        _sg.hooks.fail_shader(shd_id);
+        _sg.hooks.fail_shader(shd_id, _sg.hooks.user_data);
     }
 }
 
@@ -9369,7 +9370,7 @@ SOKOL_API_IMPL void sg_fail_pipeline(sg_pipeline pip_id) {
     pip->slot.ctx_id = _sg.active_context.id;
     pip->slot.state = SG_RESOURCESTATE_FAILED;
     if (_sg.hooks.fail_pipeline) {
-        _sg.hooks.fail_pipeline(pip_id);
+        _sg.hooks.fail_pipeline(pip_id, _sg.hooks.user_data);
     }
 }
 
@@ -9380,7 +9381,7 @@ SOKOL_API_IMPL void sg_fail_pass(sg_pass pass_id) {
     pass->slot.ctx_id = _sg.active_context.id;
     pass->slot.state = SG_RESOURCESTATE_FAILED;
     if (_sg.hooks.fail_pass) {
-        _sg.hooks.fail_pass(pass_id);
+        _sg.hooks.fail_pass(pass_id, _sg.hooks.user_data);
     }
 }
 
@@ -9389,7 +9390,7 @@ SOKOL_API_IMPL sg_resource_state sg_query_buffer_state(sg_buffer buf_id) {
     _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
     sg_resource_state res = buf ? buf->slot.state : SG_RESOURCESTATE_INVALID;
     if (_sg.hooks.query_buffer_state) {
-        _sg.hooks.query_buffer_state(buf_id, res);
+        _sg.hooks.query_buffer_state(buf_id, res, _sg.hooks.user_data);
     }
     return res;
 }
@@ -9398,7 +9399,7 @@ SOKOL_API_IMPL sg_resource_state sg_query_image_state(sg_image img_id) {
     _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
     sg_resource_state res = img ? img->slot.state : SG_RESOURCESTATE_INVALID;
     if (_sg.hooks.query_image_state) {
-        _sg.hooks.query_image_state(img_id, res);
+        _sg.hooks.query_image_state(img_id, res, _sg.hooks.user_data);
     }
     return res;
 }
@@ -9407,7 +9408,7 @@ SOKOL_API_IMPL sg_resource_state sg_query_shader_state(sg_shader shd_id) {
     _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
     sg_resource_state res = shd ? shd->slot.state : SG_RESOURCESTATE_INVALID;
     if (_sg.hooks.query_shader_state) {
-        _sg.hooks.query_shader_state(shd_id, res);
+        _sg.hooks.query_shader_state(shd_id, res, _sg.hooks.user_data);
     }
     return res;
 }
@@ -9416,7 +9417,7 @@ SOKOL_API_IMPL sg_resource_state sg_query_pipeline_state(sg_pipeline pip_id) {
     _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
     sg_resource_state res = pip ? pip->slot.state : SG_RESOURCESTATE_INVALID;
     if (_sg.hooks.query_pipeline_state) {
-        _sg.hooks.query_pipeline_state(pip_id, res);
+        _sg.hooks.query_pipeline_state(pip_id, res, _sg.hooks.user_data);
     }
     return res;
 }
@@ -9425,7 +9426,7 @@ SOKOL_API_IMPL sg_resource_state sg_query_pass_state(sg_pass pass_id) {
     _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
     sg_resource_state res = pass ? pass->slot.state : SG_RESOURCESTATE_INVALID;
     if (_sg.hooks.query_pass_state) {
-        _sg.hooks.query_pass_state(pass_id, res);
+        _sg.hooks.query_pass_state(pass_id, res, _sg.hooks.user_data);
     }
     return res;
 }
@@ -9440,83 +9441,83 @@ SOKOL_API_IMPL sg_buffer sg_make_buffer(const sg_buffer_desc* desc) {
     else {
         SOKOL_LOG("buffer pool exhausted!");
         if (_sg.hooks.err_buffer_pool_exhausted) {
-            _sg.hooks.err_buffer_pool_exhausted();
+            _sg.hooks.err_buffer_pool_exhausted(_sg.hooks.user_data);
         }
     }
     if (_sg.hooks.make_buffer) {
-        _sg.hooks.make_buffer(desc, buf_id);
+        _sg.hooks.make_buffer(desc, buf_id, _sg.hooks.user_data);
     }
     return buf_id;
 }
 
 SOKOL_API_IMPL sg_image sg_make_image(const sg_image_desc* desc) {
     SOKOL_ASSERT(desc);
-    sg_image img_id = sg_alloc_image();
+    sg_image img_id = _sg_alloc_image();
     if (img_id.id != SG_INVALID_ID) {
-        sg_init_image(img_id, desc);
+        _sg_init_image(img_id, desc);
     }
     else {
         SOKOL_LOG("image pool exhausted!");
         if (_sg.hooks.err_image_pool_exhausted) {
-            _sg.hooks.err_image_pool_exhausted();
+            _sg.hooks.err_image_pool_exhausted(_sg.hooks.user_data);
         }
     }
     if (_sg.hooks.make_image) {
-        _sg.hooks.make_image(desc, img_id);
+        _sg.hooks.make_image(desc, img_id, _sg.hooks.user_data);
     }
     return img_id;
 }
 
 SOKOL_API_IMPL sg_shader sg_make_shader(const sg_shader_desc* desc) {
     SOKOL_ASSERT(desc);
-    sg_shader shd_id = sg_alloc_shader();
+    sg_shader shd_id = _sg_alloc_shader();
     if (shd_id.id != SG_INVALID_ID) {
-        sg_init_shader(shd_id, desc);
+        _sg_init_shader(shd_id, desc);
     }
     else {
         SOKOL_LOG("shader pool exhausted!");
         if (_sg.hooks.err_shader_pool_exhausted) {
-            _sg.hooks.err_shader_pool_exhausted();
+            _sg.hooks.err_shader_pool_exhausted(_sg.hooks.user_data);
         }
     }
     if (_sg.hooks.make_shader) {
-        _sg.hooks.make_shader(desc, shd_id);
+        _sg.hooks.make_shader(desc, shd_id, _sg.hooks.user_data);
     }
     return shd_id;
 }
 
 SOKOL_API_IMPL sg_pipeline sg_make_pipeline(const sg_pipeline_desc* desc) {
     SOKOL_ASSERT(desc);
-    sg_pipeline pip_id = sg_alloc_pipeline();
+    sg_pipeline pip_id = _sg_alloc_pipeline();
     if (pip_id.id != SG_INVALID_ID) {
-        sg_init_pipeline(pip_id, desc);
+        _sg_init_pipeline(pip_id, desc);
     }
     else {
         SOKOL_LOG("pipeline pool exhausted!");
         if (_sg.hooks.err_pipeline_pool_exhausted) {
-            _sg.hooks.err_pipeline_pool_exhausted();
+            _sg.hooks.err_pipeline_pool_exhausted(_sg.hooks.user_data);
         }
     }
     if (_sg.hooks.make_pipeline) {
-        _sg.hooks.make_pipeline(desc, pip_id);
+        _sg.hooks.make_pipeline(desc, pip_id, _sg.hooks.user_data);
     }
     return pip_id;
 }
 
 SOKOL_API_IMPL sg_pass sg_make_pass(const sg_pass_desc* desc) {
     SOKOL_ASSERT(desc);
-    sg_pass pass_id = sg_alloc_pass();
+    sg_pass pass_id = _sg_alloc_pass();
     if (pass_id.id != SG_INVALID_ID) {
-        sg_init_pass(pass_id, desc);
+        _sg_init_pass(pass_id, desc);
     }
     else {
         SOKOL_LOG("pass pool exhausted!");
         if (_sg.hooks.err_pass_pool_exhausted) {
-            _sg.hooks.err_pass_pool_exhausted();
+            _sg.hooks.err_pass_pool_exhausted(_sg.hooks.user_data);
         }
     }
     if (_sg.hooks.make_pass) {
-        _sg.hooks.make_pass(desc, pass_id);
+        _sg.hooks.make_pass(desc, pass_id, _sg.hooks.user_data);
     }
     return pass_id;
 }
@@ -9533,12 +9534,12 @@ SOKOL_API_IMPL void sg_destroy_buffer(sg_buffer buf_id) {
         else {
             SOKOL_LOG("sg_destroy_buffer: active context mismatch (must be same as for creation)");
             if (_sg.hooks.err_context_mismatch) {
-                _sg.hooks.err_context_mismatch();
+                _sg.hooks.err_context_mismatch(_sg.hooks.user_data);
             }
         }
     }
     if (_sg.hooks.destroy_buffer) {
-        _sg.hooks.destroy_buffer(buf_id);
+        _sg.hooks.destroy_buffer(buf_id, _sg.hooks.user_data);
     }
 }
 
@@ -9553,12 +9554,12 @@ SOKOL_API_IMPL void sg_destroy_image(sg_image img_id) {
         else {
             SOKOL_LOG("sg_destroy_image: active context mismatch (must be same as for creation)");
             if (_sg.hooks.err_context_mismatch) {
-                _sg.hooks.err_context_mismatch();
+                _sg.hooks.err_context_mismatch(_sg.hooks.user_data);
             }
         }
     }
     if (_sg.hooks.destroy_image) {
-        _sg.hooks.destroy_image(img_id);
+        _sg.hooks.destroy_image(img_id, _sg.hooks.user_data);
     }
 }
 
@@ -9573,12 +9574,12 @@ SOKOL_API_IMPL void sg_destroy_shader(sg_shader shd_id) {
         else {
             SOKOL_LOG("sg_destroy_shader: active context mismatch (must be same as for creation)");
             if (_sg.hooks.err_context_mismatch) {
-                _sg.hooks.err_context_mismatch();
+                _sg.hooks.err_context_mismatch(_sg.hooks.user_data);
             }
         }
     }
     if (_sg.hooks.destroy_shader) {
-        _sg.hooks.destroy_shader(shd_id);
+        _sg.hooks.destroy_shader(shd_id, _sg.hooks.user_data);
     }
 }
 
@@ -9593,12 +9594,12 @@ SOKOL_API_IMPL void sg_destroy_pipeline(sg_pipeline pip_id) {
         else {
             SOKOL_LOG("sg_destroy_pipeline: active context mismatch (must be same as for creation)");
             if (_sg.hooks.err_context_mismatch) {
-                _sg.hooks.err_context_mismatch();
+                _sg.hooks.err_context_mismatch(_sg.hooks.user_data);
             }
         }
     }
     if (_sg.hooks.destroy_pipeline) {
-        _sg.hooks.destroy_pipeline(pip_id);
+        _sg.hooks.destroy_pipeline(pip_id, _sg.hooks.user_data);
     }
 }
 
@@ -9613,12 +9614,12 @@ SOKOL_API_IMPL void sg_destroy_pass(sg_pass pass_id) {
         else {
             SOKOL_LOG("sg_destroy_pass: active context mismatch (must be same as for creation)");
             if (_sg.hooks.err_context_mismatch) {
-                _sg.hooks.err_context_mismatch();
+                _sg.hooks.err_context_mismatch(_sg.hooks.user_data);
             }
         }
     }
     if (_sg.hooks.destroy_pass) {
-        _sg.hooks.destroy_pass(pass_id);
+        _sg.hooks.destroy_pass(pass_id, _sg.hooks.user_data);
     }
 }
 
@@ -9631,7 +9632,7 @@ SOKOL_API_IMPL void sg_begin_default_pass(const sg_pass_action* pass_action, int
     _sg.pass_valid = true;
     _sg_begin_pass(0, &pa, width, height);
     if (_sg.hooks.begin_default_pass) {
-        _sg.hooks.begin_default_pass(pass_action, width, height);
+        _sg.hooks.begin_default_pass(pass_action, width, height, _sg.hooks.user_data);
     }
 }
 
@@ -9648,13 +9649,13 @@ SOKOL_API_IMPL void sg_begin_pass(sg_pass pass_id, const sg_pass_action* pass_ac
         const int h = pass->color_atts[0].image->height;
         _sg_begin_pass(pass, &pa, w, h);
         if (_sg.hooks.begin_pass) {
-            _sg.hooks.begin_pass(pass_id, pass_action);
+            _sg.hooks.begin_pass(pass_id, pass_action, _sg.hooks.user_data);
         }
     }
     else {
         _sg.pass_valid = false;
         if (_sg.hooks.err_pass_invalid) {
-            _sg.hooks.err_pass_invalid();
+            _sg.hooks.err_pass_invalid(_sg.hooks.user_data);
         }
     }
 }
@@ -9662,7 +9663,7 @@ SOKOL_API_IMPL void sg_begin_pass(sg_pass pass_id, const sg_pass_action* pass_ac
 SOKOL_API_IMPL void sg_apply_viewport(int x, int y, int width, int height, bool origin_top_left) {
     if (!_sg.pass_valid) {
         if (_sg.hooks.err_pass_invalid) {
-            _sg.hooks.err_pass_invalid();
+            _sg.hooks.err_pass_invalid(_sg.hooks.user_data);
         }
         return;
     }
@@ -9672,7 +9673,7 @@ SOKOL_API_IMPL void sg_apply_viewport(int x, int y, int width, int height, bool 
 SOKOL_API_IMPL void sg_apply_scissor_rect(int x, int y, int width, int height, bool origin_top_left) {
     if (!_sg.pass_valid) {
         if (_sg.hooks.err_pass_invalid) {
-            _sg.hooks.err_pass_invalid();
+            _sg.hooks.err_pass_invalid(_sg.hooks.user_data);
         }
         return;
     }
@@ -9684,13 +9685,13 @@ SOKOL_API_IMPL void sg_apply_pipeline(sg_pipeline pip_id) {
     if (!_sg_validate_apply_pipeline(pip_id)) {
         _sg.next_draw_valid = false;
         if (_sg.hooks.err_draw_invalid) {
-            _sg.hooks.err_draw_invalid();
+            _sg.hooks.err_draw_invalid(_sg.hooks.user_data);
         }
         return;
     }
     if (!_sg.pass_valid) {
         if (_sg.hooks.err_pass_invalid) {
-            _sg.hooks.err_pass_invalid();
+            _sg.hooks.err_pass_invalid(_sg.hooks.user_data);
         }
         return;
     }
@@ -9701,7 +9702,7 @@ SOKOL_API_IMPL void sg_apply_pipeline(sg_pipeline pip_id) {
     SOKOL_ASSERT(pip->shader && (pip->shader->slot.id == pip->shader_id.id));
     _sg_apply_pipeline(pip);
     if (_sg.hooks.apply_pipeline) {
-        _sg.hooks.apply_pipeline(pip_id);
+        _sg.hooks.apply_pipeline(pip_id, _sg.hooks.user_data);
     }
 }
 
@@ -9711,7 +9712,7 @@ SOKOL_API_IMPL void sg_apply_bindings(const sg_bindings* bind) {
     if (!_sg_validate_apply_bindings(bind)) {
         _sg.next_draw_valid = false;
         if (_sg.hooks.err_draw_invalid) {
-            _sg.hooks.err_draw_invalid();
+            _sg.hooks.err_draw_invalid(_sg.hooks.user_data);
         }
         return;
     }
@@ -9772,12 +9773,12 @@ SOKOL_API_IMPL void sg_apply_bindings(const sg_bindings* bind) {
         int ib_offset = bind->index_buffer_offset;
         _sg_apply_bindings(pip, vbs, vb_offsets, num_vbs, ib, ib_offset, vs_imgs, num_vs_imgs, fs_imgs, num_fs_imgs);
         if (_sg.hooks.apply_bindings) {
-            _sg.hooks.apply_bindings(bind);
+            _sg.hooks.apply_bindings(bind, _sg.hooks.user_data);
         }
     }
     else {
         if (_sg.hooks.err_draw_invalid) {
-            _sg.hooks.err_draw_invalid();
+            _sg.hooks.err_draw_invalid(_sg.hooks.user_data);
         }
     }
 }
@@ -9789,24 +9790,24 @@ SOKOL_API_IMPL void sg_apply_uniforms(sg_shader_stage stage, int ub_index, const
     if (!_sg_validate_apply_uniforms(stage, ub_index, data, num_bytes)) {
         _sg.next_draw_valid = false;
         if (_sg.hooks.err_draw_invalid) {
-            _sg.hooks.err_draw_invalid();
+            _sg.hooks.err_draw_invalid(_sg.hooks.user_data);
         }
         return;
     }
     if (!_sg.pass_valid) {
         if (_sg.hooks.err_pass_invalid) {
-            _sg.hooks.err_pass_invalid();
+            _sg.hooks.err_pass_invalid(_sg.hooks.user_data);
         }
         return;
     }
     if (!_sg.next_draw_valid) {
         if (_sg.hooks.err_draw_invalid) {
-            _sg.hooks.err_draw_invalid();
+            _sg.hooks.err_draw_invalid(_sg.hooks.user_data);
         }
     }
     _sg_apply_uniforms(stage, ub_index, data, num_bytes);
     if (_sg.hooks.apply_uniforms) {
-        _sg.hooks.apply_uniforms(stage, ub_index, data, num_bytes);
+        _sg.hooks.apply_uniforms(stage, ub_index, data, num_bytes, _sg.hooks.user_data);
     }
 }
 
@@ -9818,32 +9819,32 @@ SOKOL_API_IMPL void sg_draw(int base_element, int num_elements, int num_instance
     #endif
     if (!_sg.pass_valid) {
         if (_sg.hooks.err_pass_invalid) {
-            _sg.hooks.err_pass_invalid();
+            _sg.hooks.err_pass_invalid(_sg.hooks.user_data);
         }
         return;
     }
     if (!_sg.next_draw_valid) {
         if (_sg.hooks.err_draw_invalid) {
-            _sg.hooks.err_draw_invalid();
+            _sg.hooks.err_draw_invalid(_sg.hooks.user_data);
         }
         return;
     }
     if (!_sg.bindings_valid) {
         if (_sg.hooks.err_bindings_invalid) {
-            _sg.hooks.err_bindings_invalid();
+            _sg.hooks.err_bindings_invalid(_sg.hooks.user_data);
         }
         return;
     }
     _sg_draw(base_element, num_elements, num_instances);
     if (_sg.hooks.draw) {
-        _sg.hooks.draw(base_element, num_elements, num_instances);
+        _sg.hooks.draw(base_element, num_elements, num_instances, _sg.hooks.user_data);
     }
 }
 
 SOKOL_API_IMPL void sg_end_pass(void) {
     if (!_sg.pass_valid) {
         if (_sg.hooks.err_pass_invalid) {
-            _sg.hooks.err_pass_invalid();
+            _sg.hooks.err_pass_invalid(_sg.hooks.user_data);
         }
         return;
     }
@@ -9852,14 +9853,14 @@ SOKOL_API_IMPL void sg_end_pass(void) {
     _sg.cur_pipeline.id = SG_INVALID_ID;
     _sg.pass_valid = false;
     if (_sg.hooks.end_pass) {
-        _sg.hooks.end_pass();
+        _sg.hooks.end_pass(_sg.hooks.user_data);
     }
 }
 
 SOKOL_API_IMPL void sg_commit(void) {
     _sg_commit();
     if (_sg.hooks.commit) {
-        _sg.hooks.commit();
+        _sg.hooks.commit(_sg.hooks.user_data);
     }
     _sg.frame_index++;
 }
@@ -9867,7 +9868,7 @@ SOKOL_API_IMPL void sg_commit(void) {
 SOKOL_API_IMPL void sg_reset_state_cache(void) {
     _sg_reset_state_cache();
     if (_sg.hooks.reset_state_cache) {
-        _sg.hooks.reset_state_cache();
+        _sg.hooks.reset_state_cache(_sg.hooks.user_data);
     }
 }
 
@@ -9885,7 +9886,7 @@ SOKOL_API_IMPL void sg_update_buffer(sg_buffer buf_id, const void* data, int num
         }
     }
     if (_sg.hooks.update_buffer) {
-        _sg.hooks.update_buffer(buf_id, data, num_bytes);
+        _sg.hooks.update_buffer(buf_id, data, num_bytes, _sg.hooks.user_data);
     }
 }
 
@@ -9920,7 +9921,7 @@ SOKOL_API_IMPL int sg_append_buffer(sg_buffer buf_id, const void* data, int num_
         result = 0;
     }
     if (_sg.hooks.append_buffer) {
-        _sg.hooks.append_buffer(buf_id, data, num_bytes, result);
+        _sg.hooks.append_buffer(buf_id, data, num_bytes, result, _sg.hooks.user_data);
     }
     return result;
 }
@@ -9929,7 +9930,7 @@ SOKOL_API_IMPL bool sg_query_buffer_overflow(sg_buffer buf_id) {
     _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
     bool result = buf ? buf->append_overflow : false;
     if (_sg.hooks.query_buffer_overflow) {
-        _sg.hooks.query_buffer_overflow(buf_id, result);
+        _sg.hooks.query_buffer_overflow(buf_id, result, _sg.hooks.user_data);
     }
     return result;
 }
@@ -9944,7 +9945,7 @@ SOKOL_API_IMPL void sg_update_image(sg_image img_id, const sg_image_content* dat
         }
     }
     if (_sg.hooks.update_image) {
-        _sg.hooks.update_image(img_id, data);
+        _sg.hooks.update_image(img_id, data, _sg.hooks.user_data);
     }
 }
 

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -43,6 +43,7 @@
     SOKOL_UNREACHABLE() - a guard macro for unreachable code (default: assert(false))
     SOKOL_API_DECL      - public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
+    SOKOL_TRACE_HOOKS   - enable trace hook callbacks (search below for TRACE HOOKS)
 
     If you want to compile without deprecated structs and functions,
     define:
@@ -348,6 +349,35 @@
     For more information, check out the multiwindow-glfw sample:
 
     https://github.com/floooh/sokol-samples/blob/master/glfw/multiwindow-glfw.c
+
+    TRACE HOOKS:
+    ============
+    sokol_gfx.h optionally allows to install "trace hook" callbacks for
+    each public API functions. When a public API function is called, and
+    a trace hook callback has been installed for this function, the
+    callback will be invoked with the parameters and result of the function.
+    This is useful for things like debugging- and profiling-tools, or
+    keeping track of resource creation and destruction.
+
+    To use the trace hook feature:
+
+    --- Define SOKOL_TRACE_HOOKS before including the implementation.
+
+    --- Setup an sg_trace_hooks structure with your callback function
+        pointers (keep all function pointers you're not interested
+        in zero-initialized), optionally set the user_data member
+        in the sg_trace_hooks struct.
+
+    --- Install the trace hooks by calling sg_install_trace_hooks(),
+        the return value of this function is another sg_trace_hooks
+        struct which contains the previously set of trace hooks.
+        You should keep this struct around, and call those previous
+        functions pointers from your own trace callbacks for proper
+        chaining.
+
+    As an example of how trace hooks are used, have a look at the
+    imgui/sokol_gfx_imgui.h header which implements a realtime
+    debugging UI for sokol_gfx.h on top of Dear ImGui.
 
     TODO:
     ====

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -8901,7 +8901,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_pipeline(sg_pipeline pip_id) {
 
 _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bindings) {
     #if !defined(SOKOL_DEBUG)
-        _SOKOL_UNUSED(bind);
+        _SOKOL_UNUSED(bindings);
         return true;
     #else
         SOKOL_VALIDATE_BEGIN();

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -9690,6 +9690,9 @@ SOKOL_API_IMPL void sg_apply_viewport(int x, int y, int width, int height, bool 
         }
         return;
     }
+    if (_sg.hooks.apply_viewport) {
+        _sg.hooks.apply_viewport(x, y, width, height, origin_top_left, _sg.hooks.user_data);
+    }
     _sg_apply_viewport(x, y, width, height, origin_top_left);
 }
 
@@ -9699,6 +9702,9 @@ SOKOL_API_IMPL void sg_apply_scissor_rect(int x, int y, int width, int height, b
             _sg.hooks.err_pass_invalid(_sg.hooks.user_data);
         }
         return;
+    }
+    if (_sg.hooks.apply_scissor_rect) {
+        _sg.hooks.apply_scissor_rect(x, y, width, height, origin_top_left, _sg.hooks.user_data);
     }
     _sg_apply_scissor_rect(x, y, width, height, origin_top_left);
 }

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -1072,14 +1072,15 @@ typedef struct sg_bindings {
 
     The default configuration is:
 
-    .size:      0       (this *must* be set to a valid size in bytes)
-    .type:      SG_BUFFERTYPE_VERTEXBUFFER
-    .usage:     SG_USAGE_IMMUTABLE
-    .content    0
+    .size:          0       (this *must* be set to a valid size in bytes)
+    .type:          SG_BUFFERTYPE_VERTEXBUFFER
+    .usage:         SG_USAGE_IMMUTABLE
+    .content        0
+    .trace_label    0       (optional string label for trace hooks)
 
-    Buffers with the SG_USAGE_IMMUTABLE usage *must* fill the buffer
-    with initial data (.content must point to a data chunk with
-    exactly .size bytes).
+    The dbg_label will be ignored by sokol_gfx.h, it is only useful
+    when hooking into sg_make_buffer() or sg_init_buffer() via
+    the sg_install_trace_hook
 
     ADVANCED TOPIC: Injecting native 3D-API buffers:
 
@@ -1110,6 +1111,7 @@ typedef struct sg_buffer_desc {
     sg_buffer_type type;
     sg_usage usage;
     const void* content;
+    const char* trace_label;
     /* GL specific */
     uint32_t gl_buffers[SG_NUM_INFLIGHT_FRAMES];
     /* Metal specific */
@@ -1174,6 +1176,7 @@ typedef struct sg_image_content {
     .min_lod            0.0f
     .max_lod            FLT_MAX
     .content            an sg_image_content struct to define the initial content
+    .trace_label        0       (optional string label for trace hooks)
 
     SG_IMAGETYPE_ARRAY and SG_IMAGETYPE_3D are not supported on
     WebGL/GLES2, use sg_query_feature(SG_FEATURE_IMAGETYPE_ARRAY) and
@@ -1219,6 +1222,7 @@ typedef struct sg_image_desc {
     float min_lod;
     float max_lod;
     sg_image_content content;
+    const char* trace_label;
     /* GL specific */
     uint32_t gl_textures[SG_NUM_INFLIGHT_FRAMES];
     /* Metal specific */
@@ -1265,6 +1269,7 @@ typedef struct sg_shader_desc {
     uint32_t _start_canary;
     sg_shader_stage_desc vs;
     sg_shader_stage_desc fs;
+    const char* trace_label;
     uint32_t _end_canary;
 } sg_shader_desc;
 
@@ -1340,6 +1345,7 @@ typedef struct sg_shader_desc {
         .depth_bias:                    0.0f
         .depth_bias_slope_scale:        0.0f
         .depth_bias_clamp:              0.0f
+    .trace_label        0       (optional string label for trace hooks)
 */
 typedef struct sg_buffer_layout_desc {
     int stride;
@@ -1413,6 +1419,7 @@ typedef struct sg_pipeline_desc {
     sg_depth_stencil_state depth_stencil;
     sg_blend_state blend;
     sg_rasterizer_state rasterizer;
+    const char* trace_label;
     uint32_t _end_canary;
 } sg_pipeline_desc;
 
@@ -1453,6 +1460,7 @@ typedef struct sg_pass_desc {
     uint32_t _start_canary;
     sg_attachment_desc color_attachments[SG_MAX_COLOR_ATTACHMENTS];
     sg_attachment_desc depth_stencil_attachment;
+    const char* trace_label;
     uint32_t _end_canary;
 } sg_pass_desc;
 

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -1072,11 +1072,11 @@ typedef struct sg_bindings {
 
     The default configuration is:
 
-    .size:          0       (this *must* be set to a valid size in bytes)
-    .type:          SG_BUFFERTYPE_VERTEXBUFFER
-    .usage:         SG_USAGE_IMMUTABLE
-    .content        0
-    .trace_label    0       (optional string label for trace hooks)
+    .size:      0       (this *must* be set to a valid size in bytes)
+    .type:      SG_BUFFERTYPE_VERTEXBUFFER
+    .usage:     SG_USAGE_IMMUTABLE
+    .content    0
+    .label      0       (optional string label for trace hooks)
 
     The dbg_label will be ignored by sokol_gfx.h, it is only useful
     when hooking into sg_make_buffer() or sg_init_buffer() via
@@ -1111,7 +1111,7 @@ typedef struct sg_buffer_desc {
     sg_buffer_type type;
     sg_usage usage;
     const void* content;
-    const char* trace_label;
+    const char* label;
     /* GL specific */
     uint32_t gl_buffers[SG_NUM_INFLIGHT_FRAMES];
     /* Metal specific */
@@ -1176,7 +1176,7 @@ typedef struct sg_image_content {
     .min_lod            0.0f
     .max_lod            FLT_MAX
     .content            an sg_image_content struct to define the initial content
-    .trace_label        0       (optional string label for trace hooks)
+    .label              0       (optional string label for trace hooks)
 
     SG_IMAGETYPE_ARRAY and SG_IMAGETYPE_3D are not supported on
     WebGL/GLES2, use sg_query_feature(SG_FEATURE_IMAGETYPE_ARRAY) and
@@ -1222,7 +1222,7 @@ typedef struct sg_image_desc {
     float min_lod;
     float max_lod;
     sg_image_content content;
-    const char* trace_label;
+    const char* label;
     /* GL specific */
     uint32_t gl_textures[SG_NUM_INFLIGHT_FRAMES];
     /* Metal specific */
@@ -1269,7 +1269,7 @@ typedef struct sg_shader_desc {
     uint32_t _start_canary;
     sg_shader_stage_desc vs;
     sg_shader_stage_desc fs;
-    const char* trace_label;
+    const char* label;
     uint32_t _end_canary;
 } sg_shader_desc;
 
@@ -1345,7 +1345,7 @@ typedef struct sg_shader_desc {
         .depth_bias:                    0.0f
         .depth_bias_slope_scale:        0.0f
         .depth_bias_clamp:              0.0f
-    .trace_label        0       (optional string label for trace hooks)
+    .label  0       (optional string label for trace hooks)
 */
 typedef struct sg_buffer_layout_desc {
     int stride;
@@ -1419,7 +1419,7 @@ typedef struct sg_pipeline_desc {
     sg_depth_stencil_state depth_stencil;
     sg_blend_state blend;
     sg_rasterizer_state rasterizer;
-    const char* trace_label;
+    const char* label;
     uint32_t _end_canary;
 } sg_pipeline_desc;
 
@@ -1460,7 +1460,7 @@ typedef struct sg_pass_desc {
     uint32_t _start_canary;
     sg_attachment_desc color_attachments[SG_MAX_COLOR_ATTACHMENTS];
     sg_attachment_desc depth_stencil_attachment;
-    const char* trace_label;
+    const char* label;
     uint32_t _end_canary;
 } sg_pass_desc;
 


### PR DESCRIPTION
This PR adds optional debugging UI extension headers (or rather: currently only one for sokol_gfx.h called sokol_gfx_imgui.h).

sokol_gfx.h gets a new API function to install callback functions for tracing the public sokol_gfx.h API calls.

TODO:

- [x] in sokol_gfx_imgui.h: add the error callback functions to the frame capture
- [x] write proper usage documentation in sokol_gfx_imgui.h
- [x] add a README.md to the imgui subdirectory, which generally explains how to use the debug UI headers
- [x] sokol_gfx.h: disable trace hook code by default, enable via config define, and wrap the hook calls into a macro.
- [x] sokol_gfx.h: add documentation about trace hooks
- [x] test if variadic macros work on VS2015
- [x] update the "Updates" section in the main README