### PR TITLE
Move vertex-attr names/semantics from sg_pipeline_desc to sg_shader_desc

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Sokol (Сокол)**: Russian for Falcon, a smaller and more nimble
 bird of prey than the Eagle (Орёл, Oryol)
 
-[See what's new](#updates)
+[See what's new](#updates) (**26-Apr-2019**: breaking change in sokol_gfx.h)
 
 Minimalistic header-only cross-platform libs in C:
 
@@ -94,8 +94,8 @@ int main() {
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
         .vs.source =
             "#version 330\n"
-            "in vec4 position;\n"
-            "in vec4 color0;\n"
+            "layout(location=0) in vec4 position;\n"
+            "layout(location=1) in vec4 color0;\n"
             "out vec4 color;\n"
             "void main() {\n"
             "  gl_Position = position;\n"
@@ -115,8 +115,8 @@ int main() {
         .shader = shd,
         .layout = {
             .attrs = {
-                [0] = { .name="position", .format=SG_VERTEXFORMAT_FLOAT3 },
-                [1] = { .name="color0", .format=SG_VERTEXFORMAT_FLOAT4 }
+                [0].format=SG_VERTEXFORMAT_FLOAT3,
+                [1].format=SG_VERTEXFORMAT_FLOAT4
             }
         }
     });
@@ -399,15 +399,104 @@ Mainly some "missing features" for desktop apps:
 
 - implement an alternative WebAudio backend using Audio Worklets and WASM threads
 
-## Potential new sokol headers:
-
-- system clipboard support
-- query filesystem standard locations
-- simple file access API (at least async file/URL loading)
-- gamepad support
-- simple cross-platform touch gesture recognition
-
 # Updates
+
+- **26-Apr-2019** Small but breaking change in **sokol_gfx.h** how the vertex
+layout definition in sg_pipeline_desc works:
+
+    Vertex component names and semantics (needed by the GLES2 and D3D11 backends) have moved from ```sg_pipeline_desc``` into ```sg_shader_desc```.
+    
+    This may seem like a rather pointless small detail to change, expecially
+    for breaking existing code, but the whole thing will make a bit more
+    sense when the new shader-cross-compiler will be integrated which I'm
+    currently working on (here: https://github.com/floooh/sokol-tools).
+    
+    While working on getting reflection data out of the shaders (e.g. what
+    uniform blocks and textures the shader uses), it occured to me that
+    vertex-attribute-names and -semantics are actually part of the reflection
+    info and belong to the shader, not to the vertex layout in the pipeline
+    object (which only describes how the incoming vertex data maps to
+    vertex-component **slots**. Instead of (optionally) mapping this
+    association through a name, the pipeline's vertex layout is now always
+    strictly defined in terms of numeric 'bind slots' for **all** sokol_gfx.h
+    backends. For 3D APIs where the vertex component slot isn't explicitely
+    defined in the shader language (GLES2/WebGL, D3D11, and optionally
+    GLES3/GL), the shader merely offers a lookup table how vertex-layout
+    slot-indices map to names/semantics (and the underlying 3D API than maps
+    those names back to slot indices, which shows that Metal and GL made the
+    right choice defining the slots right in the shader).
+
+    Here's how the code changes (taken from the triangle-sapp.c sample):
+
+    **OLD**:
+    ```c
+    /* create a shader */
+    sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .vs.source = vs_src,
+        .fs.source = fs_src,
+    });
+
+    /* create a pipeline object (default render states are fine for triangle) */
+    pip = sg_make_pipeline(&(sg_pipeline_desc){
+        /* if the vertex layout doesn't have gaps, don't need to provide strides and offsets */
+        .shader = shd,
+        .layout = {
+            .attrs = {
+                [0] = { .name="position", .sem_name="POS", .format=SG_VERTEXFORMAT_FLOAT3 },
+                [1] = { .name="color0", .sem_name="COLOR", .format=SG_VERTEXFORMAT_FLOAT4 }
+            }
+        },
+    });
+    ```
+
+    **NEW**:
+    ```c
+        /* create a shader */
+        sg_shader shd = sg_make_shader(&(sg_shader_desc){
+            .attrs = {
+                [0] = { .name="position", .sem_name="POS" },
+                [1] = { .name="color0", .sem_name="COLOR" }
+            },
+            .vs.source = vs_src,
+            .fs.source = fs_src,
+        });
+
+        /* create a pipeline object (default render states are fine for triangle) */
+        pip = sg_make_pipeline(&(sg_pipeline_desc){
+            /* if the vertex layout doesn't have gaps, don't need to provide strides and offsets */
+            .shader = shd,
+            .layout = {
+                .attrs = {
+                    [0].format=SG_VERTEXFORMAT_FLOAT3,
+                    [1].format=SG_VERTEXFORMAT_FLOAT4
+                }
+            },
+        });
+    ```
+
+    ```sg_shader_desc``` has a new embedded struct ```attrs``` which
+    contains a vertex attribute _name_ (for GLES2/WebGL) and
+    _sem_name/sem_index_ (for D3D11). For the Metal backend this struct is
+    ignored completely, and for GLES3/GL it is optional, and not required
+    when the vertex shader inputs are annotated with ```layout(location=N)```.
+
+    The remaining attribute description members in ```sg_pipeline_desc``` are:
+    - **.format**: the format of input vertex data (this can be different
+          from the vertex shader's inputs when data is extended during
+          vertex fetch (e.g. input can be vec3 while the vertex shader
+          expects vec4)
+    - **.offset**: optional offset of the vertex component data (not needed
+          when the input vertex has no gaps between the components)
+    - **.buffer**: the vertex buffer bind slot if the vertex data is coming
+          from different buffers
+
+    Also check out the various samples:
+
+    - for GLSL (explicit slots via ```layout(location=N)```): https://github.com/floooh/sokol-samples/tree/master/glfw
+    - for D3D11 (semantic names/indices): https://github.com/floooh/sokol-samples/tree/master/d3d11
+    - for GLES2: (vertex attribute names): https://github.com/floooh/sokol-samples/tree/master/html5
+    - for Metal: (explicit slots): https://github.com/floooh/sokol-samples/tree/master/metal
+    - ...and all of the above combined: https://github.com/floooh/sokol-samples/tree/master/sapp
 
 - **19-Apr-2019** I have replaced the rather inflexible render-state handling
 in **sokol_gl.h** with a *pipeline stack* (like the GL matrix stack, but with

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2877,12 +2877,6 @@ _SOKOL_PRIVATE void _sg_strcpy(_sg_str_t* dst, const char* src) {
     }
 }
 
-_SOKOL_PRIVATE _sg_str_t _sg_make_str(const char* str) {
-    _sg_str_t res;
-    _sg_strcpy(&res, str);
-    return res;
-}
-
 /* return byte size of a vertex format */
 _SOKOL_PRIVATE int _sg_vertexformat_bytesize(sg_vertex_format fmt) {
     switch (fmt) {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -8778,7 +8778,7 @@ _SOKOL_PRIVATE bool _sg_validate_shader_desc(const sg_shader_desc* desc) {
         SOKOL_VALIDATE(desc->_start_canary == 0, _SG_VALIDATE_SHADERDESC_CANARY);
         SOKOL_VALIDATE(desc->_end_canary == 0, _SG_VALIDATE_SHADERDESC_CANARY);
         #if defined(SOKOL_GLES2)
-            SOKOL_VALIDATE(0 != desc->attrs[0].name, _SG_VALIDATE_SHADERDESC_ATTR_NAME);
+            SOKOL_VALIDATE(0 != desc->attrs[0].name, _SG_VALIDATE_SHADERDESC_ATTR_NAMES);
         #elif defined(SOKOL_D3D11)
             SOKOL_VALIDATE(0 != desc->attrs[0].sem_name, _SG_VALIDATE_SHADERDESC_ATTR_SEMANTICS);
         #endif

--- a/util/sokol_gl.h
+++ b/util/sokol_gl.h
@@ -1314,22 +1314,16 @@ static void _sgl_init_pipeline(sgl_pipeline pip_id, const sg_pipeline_desc* in_d
     desc.layout.buffers[0].stride = sizeof(_sgl_vertex_t);
     {
         sg_vertex_attr_desc* pos = &desc.layout.attrs[0];
-        pos->name = "position";
-        pos->sem_name = "POSITION";
         pos->offset = offsetof(_sgl_vertex_t, pos);
         pos->format = SG_VERTEXFORMAT_FLOAT3;
     }
     {
         sg_vertex_attr_desc* uv = &desc.layout.attrs[1];
-        uv->name = "texcoord0";
-        uv->sem_name = "TEXCOORD";
         uv->offset = offsetof(_sgl_vertex_t, uv);
         uv->format = SG_VERTEXFORMAT_FLOAT2;
     }
     {
         sg_vertex_attr_desc* rgba = &desc.layout.attrs[2];
-        rgba->name = "color0";
-        rgba->sem_name = "COLOR";
         rgba->offset = offsetof(_sgl_vertex_t, rgba);
         rgba->format = SG_VERTEXFORMAT_UBYTE4N;
     }
@@ -1769,6 +1763,12 @@ SOKOL_API_IMPL void sgl_setup(const sgl_desc_t* desc) {
 
     sg_shader_desc shd_desc;
     memset(&shd_desc, 0, sizeof(shd_desc));
+    shd_desc.attrs[0].name = "position";
+    shd_desc.attrs[1].name = "texcoord0";
+    shd_desc.attrs[2].name = "color0";
+    shd_desc.attrs[0].sem_name = "POSITION";
+    shd_desc.attrs[1].sem_name = "TEXCOORD";
+    shd_desc.attrs[2].sem_name = "COLOR";
     sg_shader_uniform_block_desc* ub = &shd_desc.vs.uniform_blocks[0];
     ub->size = sizeof(_sgl_uniform_t);
     ub->uniforms[0].name = "mvp";

--- a/util/sokol_gl.h
+++ b/util/sokol_gl.h
@@ -130,7 +130,8 @@
             - shader
             - vertex layout
             - color- and depth-pixel-formats
-            - sample count
+            - primitive type (lines, triangles, ...)
+            - MSAA sample count
         Those will be filled in by sgl_make_pipeline(). Note that each
         call to sgl_make_pipeline() needs to create several sokol-gfx
         pipeline objects (one for each primitive type).

--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -755,6 +755,12 @@ SOKOL_API_IMPL void simgui_setup(const simgui_desc_t* desc) {
     ub.size = sizeof(_simgui_vs_params_t);
     ub.uniforms[0].name = "disp_size";
     ub.uniforms[0].type = SG_UNIFORMTYPE_FLOAT2;
+    shd_desc.attrs[0].name = "position";
+    shd_desc.attrs[0].sem_name = "POSITION";
+    shd_desc.attrs[1].name = "texcoord0";
+    shd_desc.attrs[1].sem_name  = "TEXCOORD";
+    shd_desc.attrs[2].name  = "color0";
+    shd_desc.attrs[2].sem_name  = "COLOR";
     shd_desc.fs.images[0].name = "tex";
     shd_desc.fs.images[0].type = SG_IMAGETYPE_2D;
     #if defined(SOKOL_D3D11)
@@ -774,24 +780,18 @@ SOKOL_API_IMPL void simgui_setup(const simgui_desc_t* desc) {
     pip_desc.layout.buffers[0].stride = sizeof(ImDrawVert);
     {
         auto& attr = pip_desc.layout.attrs[0];
-        attr.name       = "position";
-        attr.sem_name   = "POSITION";
-        attr.offset     = offsetof(ImDrawVert, pos);
-        attr.format     = SG_VERTEXFORMAT_FLOAT2;
+        attr.offset = offsetof(ImDrawVert, pos);
+        attr.format = SG_VERTEXFORMAT_FLOAT2;
     }
     {
         auto& attr = pip_desc.layout.attrs[1];
-        attr.name       = "texcoord0";
-        attr.sem_name   = "TEXCOORD";
-        attr.offset     = offsetof(ImDrawVert, uv);
-        attr.format     = SG_VERTEXFORMAT_FLOAT2;
+        attr.offset = offsetof(ImDrawVert, uv);
+        attr.format = SG_VERTEXFORMAT_FLOAT2;
     }
     {
         auto& attr = pip_desc.layout.attrs[2];
-        attr.name       = "color0";
-        attr.sem_name   = "COLOR";
-        attr.offset     = offsetof(ImDrawVert, col);
-        attr.format     = SG_VERTEXFORMAT_UBYTE4N;
+        attr.offset = offsetof(ImDrawVert, col);
+        attr.format = SG_VERTEXFORMAT_UBYTE4N;
     }
     pip_desc.shader = _simgui.shd;
     pip_desc.index_type = SG_INDEXTYPE_UINT16;


### PR DESCRIPTION
...makes a lot more sense, especially with the upcoming shader code-generation.