### PR TITLE
sokol_gfx.h: Cleanup resource 'unbinding' behaviour...

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2867,6 +2867,7 @@ typedef int  GLint;
 #define GL_POINTS 0x0000
 #define GL_ONE_MINUS_SRC_COLOR 0x0301
 #define GL_MIRRORED_REPEAT 0x8370
+#define GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS 0x8B4D
 
 typedef void  (GL_APIENTRY *PFN_glBindVertexArray)(GLuint array);
 static PFN_glBindVertexArray _sapp_glBindVertexArray;


### PR DESCRIPTION
This implements the following new "clarifications" in the resource binding behaviour:

- in the GL backend: creating or updating a resource restores the previous resource binding (this may have behaved wrong before when a resource was created or updated between a call to sg_apply_bindings() / sg_update_...() and sg_draw()

- in sg_commit(), make sure to unbind all resources that were bound in the frame (just to prevent any accidental resource leaks)

- sg_apply_bindings() will still NOT unbind any "unused" resource slots, this is too much hassle in the GL backend. Instead this happens at the end of the frame in sg_commit().

- minor GL backend fix: any attempts to bind a texture to a too high slot number (GL_MAX_COMBINED_IMAGE_UNITS) will be silently dropped (before this would have produced a GL error... however this would only be an issue for very old GLES2 implementations which are only guaranteed to have 8 texture slots).

"Correct code" shouldn't require any changes.