### PR TITLE
Compute feature check support

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2514,6 +2514,7 @@ typedef struct {
     bool valid;
     ID3D11Device* dev;
     ID3D11DeviceContext* ctx;
+    D3D_FEATURE_LEVEL feature_level;
     const void* (*rtv_cb)(void);
     const void* (*dsv_cb)(void);
     bool in_pass;
@@ -5691,6 +5692,7 @@ _SOKOL_PRIVATE void _sg_setup_backend(const sg_desc* desc) {
     _sg.d3d11.valid = true;
     _sg.d3d11.dev = (ID3D11Device*) desc->d3d11_device;
     _sg.d3d11.ctx = (ID3D11DeviceContext*) desc->d3d11_device_context;
+    _sg.d3d11.feature_level = _sg.d3d11.dev->GetFeatureLevel();
     _sg.d3d11.rtv_cb = desc->d3d11_render_target_view_cb;
     _sg.d3d11.dsv_cb = desc->d3d11_depth_stencil_view_cb;
 }
@@ -5712,6 +5714,8 @@ _SOKOL_PRIVATE bool _sg_query_feature(sg_feature f) {
         case SG_FEATURE_IMAGETYPE_3D:
         case SG_FEATURE_IMAGETYPE_ARRAY:
             return true;
+        case SG_FEATURE_COMPUTE:
+            return _sg.d3d11.feature_level >= D3D_FEATURE_LEVEL_10_0;
         default:
             return false;
     }
@@ -7354,6 +7358,7 @@ _SOKOL_PRIVATE bool _sg_query_feature(sg_feature f) {
         case SG_FEATURE_MULTIPLE_RENDER_TARGET:
         case SG_FEATURE_IMAGETYPE_3D:
         case SG_FEATURE_IMAGETYPE_ARRAY:
+        case SG_FEATURE_COMPUTE:
             return true;
         default:
             return false;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -543,6 +543,7 @@ typedef enum sg_feature {
     SG_FEATURE_MULTIPLE_RENDER_TARGET,
     SG_FEATURE_IMAGETYPE_3D,
     SG_FEATURE_IMAGETYPE_ARRAY,
+    SG_FEATURE_COMPUTE,
 
     SG_NUM_FEATURES
 } sg_feature;
@@ -4028,6 +4029,10 @@ _SOKOL_PRIVATE void _sg_setup_backend(const sg_desc* desc) {
                 _sg.gl.ext_anisotropic = true;
                 continue;
             }
+            else if (strstr(ext, "_compute_shader")) {
+                _sg.gl.features[SG_FEATURE_COMPUTE] = true;
+                continue;
+            }
         }
     #elif defined(SOKOL_GLES3)
         const char* ext = (const char*) glGetString(GL_EXTENSIONS);
@@ -4057,6 +4062,8 @@ _SOKOL_PRIVATE void _sg_setup_backend(const sg_desc* desc) {
             strstr(ext, "_compressed_texture_atc");
         _sg.gl.ext_anisotropic =
             strstr(ext, "_texture_filter_anisotropic");
+        _sg.gl.features[SG_FEATURE_COMPUTE] =
+            strstr(ext, "_compute_shader");
     #elif defined(SOKOL_GLES2)
         const char* ext = (const char*) glGetString(GL_EXTENSIONS);
         _sg.gl.features[SG_FEATURE_INSTANCING] =


### PR DESCRIPTION
This add initial feature for compute check in order to support compute as WebGL 2.0 is gaining support as well (https://github.com/9ballsyndrome/WebGL_Compute_shader).
After will add new flag to create texture with different usage (shader read, shader write, render target).

Tell me what you think