### PR TITLE
Add SOKOL_DLL support to all headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,11 @@ Mainly some "missing features" for desktop apps:
 
 # Updates
 
+- **04-Jun-2019**: All sokol headers now recognize a config-define ```SOKOL_DLL```
+  if sokol should be compiled into a DLL (when used with ```SOKOL_IMPL```)
+  or used as a DLL. On Windows, this will prepend the public function declarations
+  with ```__declspec(dllexport)``` or ```__declspec(dllimport)```.
+
 - **31-May-2019**: if you're working with emscripten and fips, please note the
   following changes:
 

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -25,6 +25,14 @@
 
     SOKOL_DEBUG         - by default this is defined if _DEBUG is defined
 
+    If sokol_app.h is compiled as a DLL, define the following before
+    including the declaration or implementation:
+
+    SOKOL_DLL
+
+    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    or __declspec(dllimport) as needed.
+
     Portions of the Windows and Linux GL initialization and event code have been
     taken from GLFW (http://www.glfw.org/)
 
@@ -389,7 +397,13 @@
 #include <stdbool.h>
 
 #ifndef SOKOL_API_DECL
-    #define SOKOL_API_DECL extern
+#if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
+#define SOKOL_API_DECL __declspec(dllexport)
+#elif defined(_WIN32) && defined(SOKOL_DLL)
+#define SOKOL_API_DECL __declspec(dllimport)
+#else
+#define SOKOL_API_DECL extern
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/sokol_args.h
+++ b/sokol_args.h
@@ -18,6 +18,14 @@
     SOKOL_API_DECL      - public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
 
+    If sokol_args.h is compiled as a DLL, define the following before
+    including the declaration or implementation:
+
+    SOKOL_DLL
+
+    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    or __declspec(dllimport) as needed.
+
     OVERVIEW
     ========
     sokol_args.h provides a simple unified argument parsing API for WebAssembly and
@@ -239,7 +247,13 @@
 #include <stdbool.h>
 
 #ifndef SOKOL_API_DECL
-    #define SOKOL_API_DECL extern
+#if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
+#define SOKOL_API_DECL __declspec(dllexport)
+#elif defined(_WIN32) && defined(SOKOL_DLL)
+#define SOKOL_API_DECL __declspec(dllimport)
+#else
+#define SOKOL_API_DECL extern
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -19,6 +19,14 @@
     SOKOL_API_DECL      - public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
 
+    If sokol_audio.h is compiled as a DLL, define the following before
+    including the declaration or implementation:
+
+    SOKOL_DLL
+
+    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    or __declspec(dllimport) as needed.
+
     FEATURE OVERVIEW
     ================
     You provide a mono- or stereo-stream of 32-bit float samples, which
@@ -359,7 +367,13 @@
 #include <stdbool.h>
 
 #ifndef SOKOL_API_DECL
-    #define SOKOL_API_DECL extern
+#if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
+#define SOKOL_API_DECL __declspec(dllexport)
+#elif defined(_WIN32) && defined(SOKOL_DLL)
+#define SOKOL_API_DECL __declspec(dllimport)
+#else
+#define SOKOL_API_DECL extern
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -41,6 +41,14 @@
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
     SOKOL_TRACE_HOOKS   - enable trace hook callbacks (search below for TRACE HOOKS)
 
+    If you want to compile sokol_gfx.h is compiled as a DLL, define
+    the following before including the declaration or implementation:
+
+    SOKOL_DLL
+
+    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    or __declspec(dllimport) as needed.
+
     If you want to compile without deprecated structs and functions,
     define:
 
@@ -479,7 +487,13 @@
 #include <stdbool.h>
 
 #ifndef SOKOL_API_DECL
-    #define SOKOL_API_DECL extern
+#if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
+#define SOKOL_API_DECL __declspec(dllexport)
+#elif defined(_WIN32) && defined(SOKOL_DLL)
+#define SOKOL_API_DECL __declspec(dllimport)
+#else
+#define SOKOL_API_DECL extern
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -41,8 +41,8 @@
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
     SOKOL_TRACE_HOOKS   - enable trace hook callbacks (search below for TRACE HOOKS)
 
-    If you want to compile sokol_gfx.h is compiled as a DLL, define
-    the following before including the declaration or implementation:
+    If sokol_gfx.h is compiled as a DLL, define the following before
+    including the declaration or implementation:
 
     SOKOL_DLL
 

--- a/sokol_time.h
+++ b/sokol_time.h
@@ -14,6 +14,14 @@
     SOKOL_API_DECL      - public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
 
+    If sokol_time.h is compiled as a DLL, define the following before
+    including the declaration or implementation:
+
+    SOKOL_DLL
+
+    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    or __declspec(dllimport) as needed.
+
     void stm_setup();
         Call once before any other functions to initialize sokol_time
         (this calls for instance QueryPerformanceFrequency on Windows)
@@ -85,7 +93,13 @@
 #include <stdint.h>
 
 #ifndef SOKOL_API_DECL
-    #define SOKOL_API_DECL extern
+#if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
+#define SOKOL_API_DECL __declspec(dllexport)
+#elif defined(_WIN32) && defined(SOKOL_DLL)
+#define SOKOL_API_DECL __declspec(dllimport)
+#else
+#define SOKOL_API_DECL extern
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/util/sokol_cimgui.h
+++ b/util/sokol_cimgui.h
@@ -29,6 +29,14 @@
     SOKOL_API_DECL      - public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
 
+    If sokol_cimgui.h is compiled as a DLL, define the following before
+    including the declaration or implementation:
+
+    SOKOL_DLL
+
+    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    or __declspec(dllimport) as needed.
+
     Include the following headers before sokol_imgui.h (both before including
     the declaration and implementation):
 
@@ -173,7 +181,13 @@
 #endif
 
 #ifndef SOKOL_API_DECL
+#if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
+#define SOKOL_API_DECL __declspec(dllexport)
+#elif defined(_WIN32) && defined(SOKOL_DLL)
+#define SOKOL_API_DECL __declspec(dllimport)
+#else
 #define SOKOL_API_DECL extern
+#endif
 #endif
 
 typedef struct scimgui_desc_t {

--- a/util/sokol_gfx_cimgui.h
+++ b/util/sokol_gfx_cimgui.h
@@ -27,7 +27,7 @@
 
     ...before including the sokol_gfx.h implementation.
 
-    Before including the sokol_gfx_imgui.h implementation, optionally
+    Before including the sokol_gfx_cimgui.h implementation, optionally
     override the following macros:
 
         SOKOL_ASSERT(c)     -- your own assert macro, default: assert(c)
@@ -37,6 +37,14 @@
         SOKOL_FREE(p)       -- your own memory free function, default: free(p)
         SOKOL_API_DECL      - public function declaration prefix (default: extern)
         SOKOL_API_IMPL      - public function implementation prefix (default: -)
+
+    If sokol_gfx_cimgui.h is compiled as a DLL, define the following before
+    including the declaration or implementation:
+
+    SOKOL_DLL
+
+    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    or __declspec(dllimport) as needed.
 
     STEP BY STEP:
     =============
@@ -148,7 +156,13 @@
 #endif
 
 #ifndef SOKOL_API_DECL
+#if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
+#define SOKOL_API_DECL __declspec(dllexport)
+#elif defined(_WIN32) && defined(SOKOL_DLL)
+#define SOKOL_API_DECL __declspec(dllimport)
+#else
 #define SOKOL_API_DECL extern
+#endif
 #endif
 
 #if defined(__cplusplus)
@@ -690,7 +704,7 @@ _SOKOL_PRIVATE void _sg_cimgui_snprintf(sg_cimgui_str_t* dst, const char* fmt, .
     SOKOL_ASSERT(dst);
     va_list args;
     va_start(args, fmt);
-    vsnprintf(dst->buf, sizeof(dst->buf), fmt, args); 
+    vsnprintf(dst->buf, sizeof(dst->buf), fmt, args);
     dst->buf[sizeof(dst->buf)-1] = 0;
     va_end(args);
 }
@@ -1282,7 +1296,7 @@ _SOKOL_PRIVATE sg_cimgui_str_t _sg_cimgui_capture_item_string(sg_cimgui_t* ctx, 
                 _sg_cimgui_feature_string(item->args.query_feature.feature),
                 _sg_cimgui_bool_string(item->args.query_feature.result));
             break;
-        
+
         case sg_cimgui_CMD_RESET_STATE_CACHE:
             _sg_cimgui_snprintf(&str, "%d: sg_reset_state_cache()", index);
             break;
@@ -2817,7 +2831,7 @@ _SOKOL_PRIVATE void _sg_cimgui_draw_pipeline_panel(sg_cimgui_t* ctx, sg_pipeline
             if (igTreeNodeStr("Vertex Layout")) {
                 _sg_cimgui_draw_vertex_layout(&pip_ui->desc.layout);
                 igTreePop();
-            } 
+            }
             if (igTreeNodeStr("Depth Stencil State")) {
                 _sg_cimgui_draw_depth_stencil_state(&pip_ui->desc.depth_stencil);
                 igTreePop();

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -40,6 +40,14 @@
         SOKOL_API_DECL      - public function declaration prefix (default: extern)
         SOKOL_API_IMPL      - public function implementation prefix (default: -)
 
+    If sokol_gfx_imgui.h is compiled as a DLL, define the following before
+    including the declaration or implementation:
+
+    SOKOL_DLL
+
+    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    or __declspec(dllimport) as needed.
+
     STEP BY STEP:
     =============
     --- create an sg_imgui_t struct (which must be preserved between frames)
@@ -150,7 +158,13 @@
 #endif
 
 #ifndef SOKOL_API_DECL
+#if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
+#define SOKOL_API_DECL __declspec(dllexport)
+#elif defined(_WIN32) && defined(SOKOL_DLL)
+#define SOKOL_API_DECL __declspec(dllimport)
+#else
 #define SOKOL_API_DECL extern
+#endif
 #endif
 
 #if defined(__cplusplus)

--- a/util/sokol_gl.h
+++ b/util/sokol_gl.h
@@ -29,11 +29,19 @@
     SOKOL_LOG(msg)      - your own logging function (default: puts(msg))
     SOKOL_UNREACHABLE() - a guard macro for unreachable code (default: assert(false))
 
+    If sokol_gl.h is compiled as a DLL, define the following before
+    including the declaration or implementation:
+
+    SOKOL_DLL
+
+    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    or __declspec(dllimport) as needed.
+
     Include the following headers before including sokol_gl.h:
 
         sokol_gfx.h
 
-    Matrix functions are taken from MESA and Regal.
+    Matrix functions have been taken from MESA and Regal.
 
     FEATURE OVERVIEW:
     =================
@@ -416,7 +424,13 @@
 #endif
 
 #ifndef SOKOL_API_DECL
-    #define SOKOL_API_DECL extern
+#if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
+#define SOKOL_API_DECL __declspec(dllexport)
+#elif defined(_WIN32) && defined(SOKOL_DLL)
+#define SOKOL_API_DECL __declspec(dllimport)
+#else
+#define SOKOL_API_DECL extern
+#endif
 #endif
 
 /* sokol_gl pipeline handle (created with sgl_make_pipeline()) */

--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -31,6 +31,14 @@
     SOKOL_API_DECL      - public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
 
+    If sokol_imgui.h is compiled as a DLL, define the following before
+    including the declaration or implementation:
+
+    SOKOL_DLL
+
+    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    or __declspec(dllimport) as needed.
+
     Include the following headers before sokol_imgui.h (both before including
     the declaration and implementation):
 
@@ -180,7 +188,13 @@
 #endif
 
 #ifndef SOKOL_API_DECL
+#if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
+#define SOKOL_API_DECL __declspec(dllexport)
+#elif defined(_WIN32) && defined(SOKOL_DLL)
+#define SOKOL_API_DECL __declspec(dllimport)
+#else
 #define SOKOL_API_DECL extern
+#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
On Windows, this adds __declspec(dllexport) or __declspec(dllimport) to all function declarations so that the sokol headers can be compiled into a DLL.

Fixes #160 .