### PR TITLE
Programmatic quit for sokol_app.h

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -3895,14 +3895,12 @@ _SOKOL_PRIVATE LRESULT CALLBACK _sapp_win32_wndproc(HWND hWnd, UINT uMsg, WPARAM
                     /* if window should be closed and event handling is enabled, give user code
                         a change to intervene via sapp_deny_quit()
                     */
-                   _sapp.quit_requested = true;
-                   if (_sapp_events_enabled()) {
-                       _sapp_win32_app_event(SAPP_EVENTTYPE_QUIT_REQUESTED);
-                   }
-                   /* if user code hasn't intervened, quit the app */
-                   if (_sapp.quit_requested) {
-                       _sapp.quit_ordered = true;
-                   }
+                    _sapp.quit_requested = true;
+                    _sapp_win32_app_event(SAPP_EVENTTYPE_QUIT_REQUESTED);
+                    /* if user code hasn't intervened, quit the app */
+                    if (_sapp.quit_requested) {
+                        _sapp.quit_ordered = true;
+                    }
                 }
                 if (_sapp.quit_ordered) {
                     PostQuitMessage(0);

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1332,9 +1332,7 @@ _SOKOL_PRIVATE void _sapp_macos_app_event(sapp_event_type type) {
            a chance to intervene via sapp_deny_quit()
         */
         _sapp.quit_requested = true;
-        if (_sapp_events_enabled()) {
-            _sapp_macos_app_event(SAPP_EVENTTYPE_QUIT_REQUESTED);
-        }
+        _sapp_macos_app_event(SAPP_EVENTTYPE_QUIT_REQUESTED);
         /* user code hasn't intervened, quit the app */
         if (_sapp.quit_requested) {
             _sapp.quit_ordered = true;


### PR DESCRIPTION
This adds a new event and functions to implement 'programmatic quit' to sokol_app.h:

- allow to intercept a pending quit via window close button or "Alt-F4" (e.g to pop up a "Really quit? Yes/No" dialog box)
- request a "soft quit" (same as clicking the window close button)
- order a "hard quit"

One new event and 3 new functions:

- ```SAPP_EVENTTYPE_QUIT_REQUESTED```: This will be sent when the user clicks the window close button, or calls the new function ```sapp_request_quit()```. If the event isn't handled, the application will quit as usual. If the quit should be intercepted, the event handling code must call the new function ```sapp_deny_quit()```.
- ```sapp_request_quit()```: The user code can call this function at any time to initiate a "soft quit" (causing the event ```SAPP_EVENTTYPE_QUIT_REQUESTED``` to be sent)
- ```sapp_quit()```: The user code can call this function to "order" a hard quit. This will not send the ```SAPP_EVENTTYPE_QUIT_REQUESTED``` event. The "Ok" button in a "really quit?" dialog box might call the ```sapp_quit()``` function.
- ```sapp_cancel_quit()```: This functions cancels a pending quit initiated by the user or via ```sapp_request_quit()```, this is usually called in the event handler code for ```SAPP_EVENTTYPE_QUIT_REQUESTED```.