### PR TITLE
FIX: warning: jump to label 'error' crosses initialization of 'REFERENCE_TIME dur'

### DIFF
--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -1117,6 +1117,7 @@ _SOKOL_PRIVATE void _saudio_wasapi_release(void) {
 }
 
 _SOKOL_PRIVATE bool _saudio_backend_init(void) {
+    REFERENCE_TIME dur;
     if (FAILED(CoInitializeEx(0, COINIT_MULTITHREADED))) {
         SOKOL_LOG("sokol_audio wasapi: CoInitializeEx failed");
         return false;
@@ -1157,7 +1158,7 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
     fmt.wBitsPerSample = 16;
     fmt.nBlockAlign = (fmt.nChannels * fmt.wBitsPerSample) / 8;
     fmt.nAvgBytesPerSec = fmt.nSamplesPerSec * fmt.nBlockAlign;
-    REFERENCE_TIME dur = (REFERENCE_TIME)
+    dur = (REFERENCE_TIME)
         (((double)_saudio.buffer_frames) / (((double)_saudio.sample_rate) * (1.0/10000000.0)));
     if (FAILED(IAudioClient_Initialize(_saudio.backend.audio_client,
         AUDCLNT_SHAREMODE_SHARED,


### PR DESCRIPTION
Fixes this warning:

In file included from sokol-samples\libs\sokol\sokol.c:12:0:
sokol/sokol_audio.h: In function 'bool _saudio_backend_init()':
sokol/sokol_audio.h:1201:1: warning: jump to label 'error' [-fpermissive]
 error:
 ^~~~~
sokol/sokol_audio.h:1127:14: note:   from here
         goto error;
              ^~~~~
sokol/sokol_audio.h:1160:20: note:   crosses initialization of 'REFERENCE_TIME dur'
     REFERENCE_TIME dur = (REFERENCE_TIME)