### PR TITLE
FIX: warning: comparison between 'sg_shader_stage {aka enum sg_shader_stage}' and 'enum<unnamed>'

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -6743,7 +6743,7 @@ _SOKOL_PRIVATE void _sg_apply_uniforms(sg_shader_stage stage_index, int ub_index
     _SOKOL_UNUSED(num_bytes);
     SOKOL_ASSERT(_sg.d3d11.ctx && _sg.d3d11.in_pass);
     SOKOL_ASSERT(data && (num_bytes > 0));
-    SOKOL_ASSERT((stage_index >= 0) && (stage_index < SG_NUM_SHADER_STAGES));
+    SOKOL_ASSERT((stage_index >= 0) && (stage_index < (sg_shader_stage)SG_NUM_SHADER_STAGES));
     SOKOL_ASSERT((ub_index >= 0) && (ub_index < SG_MAX_SHADERSTAGE_UBS));
     SOKOL_ASSERT(_sg.d3d11.cur_pipeline && _sg.d3d11.cur_pipeline->slot.id == _sg.d3d11.cur_pipeline_id.id);
     SOKOL_ASSERT(_sg.d3d11.cur_pipeline->shader && _sg.d3d11.cur_pipeline->shader->slot.id == _sg.d3d11.cur_pipeline->shader_id.id);


### PR DESCRIPTION
Fixes warning:
```
In file included from sokol/sokol_app.h:859:0,
                 from sokol-samples\libs\sokol\sokol.c:9:
sokol/sokol_gfx.h: In function 'void _sg_apply_uniforms(sg_shader_stage, int, const void*, int)':
sokol/sokol_gfx.h:6746:55: warning: comparison between 'sg_shader_stage {aka enum sg_shader_stage}' and 'enum<unnamed>' [-Wenum-compare]
     SOKOL_ASSERT((stage_index >= 0) && (stage_index < SG_NUM_SHADER_STAGES));
                                                       ^
sokol/sokol_gfx.h:6746:5: note: in expansion of macro 'SOKOL_ASSERT'
     SOKOL_ASSERT((stage_index >= 0) && (stage_index < SG_NUM_SHADER_STAGES));
```

Note that I used casting as I noticed, that you don't want to use named enum probably:
https://github.com/floooh/sokol/blob/5cf362abac281dcf0f1bf7805e5fe58f01296e36/sokol_gfx.h#L540-L555