### PR TITLE
sokol_time: Support the ESP8266 embedded hardware

### DIFF
--- a/sokol_time.h
+++ b/sokol_time.h
@@ -164,6 +164,10 @@ typedef struct {
     double start;
 } _stm_state_t;
 #else /* anything else, this will need more care for non-Linux platforms */
+#ifdef ESP8266
+// On the ESP8266, clock_gettime ignores the first argument and CLOCK_MONOTONIC isn't defined
+#define CLOCK_MONOTONIC 0
+#endif
 #include <time.h>
 typedef struct {
     uint32_t initialized;


### PR DESCRIPTION
... okay so I know from testing that this _works_. I'm not convinced this is actually a good idea though (especially supporting a specific microcontroller in the upstream library), especially because if someone really wants to use this they can just do

```
#define SOKOL_IMPL
#define CLOCK_MONOTONIC 0
#include <sokol_time.h>
```
in the implementation file.

... feel completely free to not merge this. I'm completely unconvinced this is a good idea, but, I mean, it works? I think? Like, 99% sure.