### PR TITLE
Implement clamp-to-border color as optional feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Sokol (Сокол)**: Russian for Falcon, a smaller and more nimble
 bird of prey than the Eagle (Орёл, Oryol)
 
-[See what's new](#updates) (**28-Aug-2019**: sokol_cimgui.h merged into sokol_imgui.h)
+[See what's new](#updates) (**08-Sep-2019**: clamp-to-border texture sampling in sokol_gfx.h)
 
 [Live Samples](https://floooh.github.io/sokol-html5/index.html) via WASM.
 
@@ -459,6 +459,24 @@ Mainly some "missing features" for desktop apps:
 - implement an alternative WebAudio backend using Audio Worklets and WASM threads
 
 # Updates
+
+- **08-Sep-2019**: sokol_gfx.h now supports clamp-to-border texture sampling:
+    - the enum ```sg_wrap``` has a new member ```SG_WRAP_CLAMP_TO_BORDER```
+    - there's a new enum ```sg_border_color```
+    - the struct ```sg_image_desc``` has a new member ```sg_border_color border_color```
+    - new feature flag in ```sg_features```: ```image_clamp_to_border```
+Note the following caveats:
+    - clamp-to-border is only supported on a subset of platforms, support can
+    be checked at runtime via ```sg_query_features().image_clamp_to_border```
+    (D3D11, desktop-GL and macOS-Metal support clamp-to-border,
+    all other platforms don't)
+    - there are three hardwired border colors: transparent-black,
+    opaque-black and opaque-white (modern 3D APIs have moved away from
+    a freely programmable border color)
+    - if clamp-to-border is not supported, sampling will fall back to
+    clamp-to-edge without a validation warning
+Thanks to @martincohen for suggesting the feature and providing the initial
+D3D11 implementation!
 
 - **31-Aug-2019**: The header **sokol_gfx_cimgui.h** has been merged into
 [**sokol_gfx_imgui.h**](https://github.com/floooh/sokol/blob/master/util/sokol_gfx_imgui.h).

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -3112,6 +3112,8 @@ typedef int  GLint;
 #define GL_MAX_3D_TEXTURE_SIZE 0x8073
 #define GL_MAX_ARRAY_TEXTURE_LAYERS 0x88FF
 #define GL_MAX_VERTEX_ATTRIBS 0x8869
+#define GL_CLAMP_TO_BORDER 0x812D
+#define GL_TEXTURE_BORDER_COLOR 0x1004
 
 typedef void  (GL_APIENTRY *PFN_glBindVertexArray)(GLuint array);
 static PFN_glBindVertexArray _sapp_glBindVertexArray;
@@ -3273,6 +3275,8 @@ typedef void  (GL_APIENTRY *PFN_glBlendColor)(GLfloat red, GLfloat green, GLfloa
 static PFN_glBlendColor _sapp_glBlendColor;
 typedef void  (GL_APIENTRY *PFN_glTexParameterf)(GLenum target, GLenum pname, GLfloat param);
 static PFN_glTexParameterf _sapp_glTexParameterf;
+typedef void  (GL_APIENTRY *PFN_glTexParameterfv)(GLenum target, GLenum pname, GLfloat* params);
+static PFN_glTexParameterfv _sapp_glTexParameterfv;
 typedef void  (GL_APIENTRY *PFN_glGetShaderInfoLog)(GLuint shader, GLsizei bufSize, GLsizei * length, GLchar * infoLog);
 static PFN_glGetShaderInfoLog _sapp_glGetShaderInfoLog;
 typedef void  (GL_APIENTRY *PFN_glDepthFunc)(GLenum func);
@@ -3394,6 +3398,7 @@ _SOKOL_PRIVATE  void _sapp_win32_gl_loadfuncs(void) {
     _SAPP_GLPROC(glClearColor);
     _SAPP_GLPROC(glBlendColor);
     _SAPP_GLPROC(glTexParameterf);
+    _SAPP_GLPROC(glTexParameterfv);
     _SAPP_GLPROC(glGetShaderInfoLog);
     _SAPP_GLPROC(glDepthFunc);
     _SAPP_GLPROC(glStencilOp);
@@ -3488,6 +3493,7 @@ _SOKOL_PRIVATE  void _sapp_win32_gl_loadfuncs(void) {
 #define glClearColor _sapp_glClearColor
 #define glBlendColor _sapp_glBlendColor
 #define glTexParameterf _sapp_glTexParameterf
+#define glTexParameterfv _sapp_glTexParameterfv
 #define glGetShaderInfoLog _sapp_glGetShaderInfoLog
 #define glDepthFunc _sapp_glDepthFunc
 #define glStencilOp _sapp_glStencilOp

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -6963,7 +6963,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_create_image(_sg_image_t* img, const sg_ima
             case SG_BORDERCOLOR_OPAQUE_WHITE:
                 for (int i = 0; i < 4; i++) {
                     d3d11_smp_desc.BorderColor[i] = 1.0f;
-                    break;
+                }
                 break;
             default:
                 /* opaque black */

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -941,8 +941,18 @@ _SOKOL_PRIVATE const char* _sg_imgui_wrap_string(sg_wrap w) {
     switch (w) {
         case SG_WRAP_REPEAT:            return "SG_WRAP_REPEAT";
         case SG_WRAP_CLAMP_TO_EDGE:     return "SG_WRAP_CLAMP_TO_EDGE";
+        case SG_WRAP_CLAMP_TO_BORDER:   return "SG_WRAP_CLAMP_TO_BORDER";
         case SG_WRAP_MIRRORED_REPEAT:   return "SG_WRAP_MIRRORED_REPEAT";
         default:                        return "???";
+    }
+}
+
+_SOKOL_PRIVATE const char* _sg_imgui_bordercolor_string(sg_border_color bc) {
+    switch (bc) {
+        case SG_BORDERCOLOR_TRANSPARENT_BLACK:  return "SG_BORDERCOLOR_TRANSPARENT_BLACK";
+        case SG_BORDERCOLOR_OPAQUE_BLACK:       return "SG_BORDERCOLOR_OPAQUE_BLACK";
+        case SG_BORDERCOLOR_OPAQUE_WHITE:       return "SG_BORDERCOLOR_OPAQUE_WHITE";
+        default:                                return "???";
     }
 }
 
@@ -2707,6 +2717,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_image_panel(sg_imgui_t* ctx, sg_image img) {
             igText("Wrap U:            %s", _sg_imgui_wrap_string(desc->wrap_u));
             igText("Wrap V:            %s", _sg_imgui_wrap_string(desc->wrap_v));
             igText("Wrap W:            %s", _sg_imgui_wrap_string(desc->wrap_w));
+            igText("Border Color:      %s", _sg_imgui_bordercolor_string(desc->border_color));
             igText("Max Anisotropy:    %d", desc->max_anisotropy);
             igText("Min LOD:           %.3f", desc->min_lod);
             igText("Max LOD:           %.3f", desc->max_lod);
@@ -3316,6 +3327,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_caps_panel(sg_imgui_t* ctx) {
     igText("    msaa_render_targets: %s", _sg_imgui_bool_string(f.msaa_render_targets));
     igText("    imagetype_3d: %s", _sg_imgui_bool_string(f.imagetype_3d));
     igText("    imagetype_array: %s", _sg_imgui_bool_string(f.imagetype_array));
+    igText("    clamp_to_border: %s", _sg_imgui_bool_string(f.clamp_to_border));
     sg_limits l = sg_query_limits();
     igText("\nLimits:\n");
     igText("    max_image_size_2d: %d", l.max_image_size_2d);

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -3327,7 +3327,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_caps_panel(sg_imgui_t* ctx) {
     igText("    msaa_render_targets: %s", _sg_imgui_bool_string(f.msaa_render_targets));
     igText("    imagetype_3d: %s", _sg_imgui_bool_string(f.imagetype_3d));
     igText("    imagetype_array: %s", _sg_imgui_bool_string(f.imagetype_array));
-    igText("    clamp_to_border: %s", _sg_imgui_bool_string(f.clamp_to_border));
+    igText("    image_clamp_to_border: %s", _sg_imgui_bool_string(f.image_clamp_to_border));
     sg_limits l = sg_query_limits();
     igText("\nLimits:\n");
     igText("    max_image_size_2d: %d", l.max_image_size_2d);


### PR DESCRIPTION
- new sg_features item: image_clamp_to_border
- new UV wrap mode: SG_WRAP_CLAMP_TO_BORDER
- new enum: sg_border_color with 3 hardwired border colors (transparent, black, white)
- new sg_image_desc item: sg_border_color border_color

Only works in GLCORE33, METAL_MACOS and D3D11.