### PR TITLE
Add support for srgb texture creation in sokol_app.

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -719,6 +719,7 @@ typedef struct sapp_desc {
     bool alpha;                         /* whether the framebuffer should have an alpha channel (ignored on some platforms) */
     const char* window_title;           /* the window title as UTF-8 encoded string */
     bool user_cursor;                   /* if true, user is expected to manage cursor image in SAPP_EVENTTYPE_UPDATE_CURSOR */
+    bool color_format_srgb;             /* if true, creates backbuffer with sRGB format */
 
     const char* html5_canvas_name;      /* the name (id) of the HTML5 canvas element, default is "canvas" */
     bool html5_canvas_resize;           /* if true, the HTML5 canvas size is set to sapp_desc.width/height, otherwise canvas size is tracked */
@@ -1033,6 +1034,7 @@ _SOKOL_PRIVATE void _sapp_init_state(const sapp_desc* desc) {
     _sapp.framebuffer_height = _sapp.window_height;
     _sapp.sample_count = _sapp_def(_sapp.desc.sample_count, 1);
     _sapp.swap_interval = _sapp_def(_sapp.desc.swap_interval, 1);
+    _sapp.color_format_srgb = _sapp_def(_sapp.desc.color_format_srgb, false);
     _sapp.html5_canvas_name = _sapp_def(_sapp.desc.html5_canvas_name, "canvas");
     _sapp.html5_ask_leave_site = _sapp.desc.html5_ask_leave_site;
     if (_sapp.desc.window_title) {

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -927,6 +927,7 @@ typedef struct {
     int sample_count;
     int swap_interval;
     float dpi_scale;
+    bool color_format_srgb;
     bool gles2_fallback;
     bool first_frame;
     bool init_called;
@@ -1332,7 +1333,7 @@ _SOKOL_PRIVATE void _sapp_macos_frame(void) {
         _sapp_view_obj.preferredFramesPerSecond = 60 / _sapp.swap_interval;
         _sapp_view_obj.delegate = _sapp_macos_mtk_view_dlg_obj;
         _sapp_view_obj.device = _sapp_mtl_device_obj;
-        _sapp_view_obj.colorPixelFormat = MTLPixelFormatBGRA8Unorm;
+        _sapp_view_obj.colorPixelFormat = _sapp.color_format_srgb ? MTLPixelFormatBGRA8Unorm_sRGB : MTLPixelFormatBGRA8Unorm;
         _sapp_view_obj.depthStencilPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
         _sapp_view_obj.sampleCount = _sapp.sample_count;
         _sapp_macos_window_obj.contentView = _sapp_view_obj;
@@ -3526,7 +3527,7 @@ _SOKOL_PRIVATE void _sapp_d3d11_create_device_and_swapchain(void) {
     DXGI_SWAP_CHAIN_DESC* sc_desc = &_sapp_dxgi_swap_chain_desc;
     sc_desc->BufferDesc.Width = _sapp.framebuffer_width;
     sc_desc->BufferDesc.Height = _sapp.framebuffer_height;
-    sc_desc->BufferDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+    sc_desc->BufferDesc.Format = _sapp.color_format_srgb ? DXGI_FORMAT_B8G8R8A8_UNORM_SRGB : DXGI_FORMAT_B8G8R8A8_UNORM;
     sc_desc->BufferDesc.RefreshRate.Numerator = 60;
     sc_desc->BufferDesc.RefreshRate.Denominator = 1;
     sc_desc->OutputWindow = _sapp_win32_hwnd;


### PR DESCRIPTION
Currently it supports Direct3D11 and Metal, not sure how it would work on OpenGL/GLES.