### PR TITLE
Fix _sapp_android_init_egl() failure on Xiaomi Redmi 6A device 

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4528,6 +4528,11 @@ _SOKOL_PRIVATE bool _sapp_android_init_egl(void) {
     EGLint alpha_size = _sapp.desc.alpha ? 8 : 0;
     const EGLint cfg_attributes[] = {
         EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+#if defined(SOKOL_GLES3)
+		EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
+#else	
+		EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+#endif
         EGL_RED_SIZE, 8,
         EGL_GREEN_SIZE, 8,
         EGL_BLUE_SIZE, 8,

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -1519,14 +1519,14 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
 
     for (int i = 0; i < SAUDIO_NUM_BUFFERS; ++i) {
         const int buffer_size_bytes = sizeof(int16_t) * _saudio.num_channels * _saudio.buffer_frames;
-        _saudio.backend.output_buffers[i] = SOKOL_MALLOC(buffer_size_bytes);
+        _saudio.backend.output_buffers[i] = (int16_t *)SOKOL_MALLOC(buffer_size_bytes);
         SOKOL_ASSERT(_saudio.backend.output_buffers[i]);
         memset(_saudio.backend.output_buffers[i], 0x0, buffer_size_bytes);
     }
 
     {
         const int buffer_size_bytes = _saudio.bytes_per_frame * _saudio.buffer_frames;
-        _saudio.backend.src_buffer = SOKOL_MALLOC(buffer_size_bytes);
+        _saudio.backend.src_buffer = (float *)SOKOL_MALLOC(buffer_size_bytes);
         SOKOL_ASSERT(_saudio.backend.src_buffer);
         memset(_saudio.backend.src_buffer, 0x0, buffer_size_bytes);
     }


### PR DESCRIPTION
This failure might also happen on other Android devices.