### PR TITLE
Do not register animation frame if frame callback is not set

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2836,7 +2836,12 @@ _SOKOL_PRIVATE void _sapp_run(const sapp_desc* desc) {
     emscripten_set_touchcancel_callback(_sapp.html5_canvas_name, 0, true, _sapp_emsc_touch_cb);
     emscripten_set_webglcontextlost_callback(_sapp.html5_canvas_name, 0, true, _sapp_emsc_context_cb);
     emscripten_set_webglcontextrestored_callback(_sapp.html5_canvas_name, 0, true, _sapp_emsc_context_cb);
-    emscripten_request_animation_frame_loop(_sapp_emsc_frame, 0);
+
+    if (_sapp.desc.frame_cb || _sapp.desc.frame_userdata_cb) {
+      emscripten_request_animation_frame_loop(_sapp_emsc_frame, 0);
+    } else {
+      _sapp_call_init();
+    }
 
     sapp_js_hook_beforeunload();
 


### PR DESCRIPTION
Hi @floooh 
As you probably know js-dos works in synchronous mode, and used asyncify for drawing. In my special case frame callback is useless, and I does not provide it. Of course you current code will work without error, but I am worry about useless listener registration. 

I am not sure if I need to set `_sapp.first_frame = false`, and `_sapp.frame_count = 1`  in else branch. I totally if agree if you dislike proposed changes. I think I can do them locally anyway, if nothing will break.

