### PR TITLE
Improve `sokol_app.h` support for `SOKOL_GLCORE33` on Windows

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -3267,6 +3267,7 @@ _SOKOL_PRIVATE const _sapp_gl_fbconfig* _sapp_gl_choose_fbconfig(const _sapp_gl_
 #include <windows.h>
 #include <windowsx.h>
 #include <shellapi.h>
+#pragma comment (linker, "/subsystem:windows")
 #pragma comment (lib, "gdi32.lib")
 #pragma comment (lib, "user32.lib")
 #pragma comment (lib, "Shell32.lib")

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -3267,6 +3267,8 @@ _SOKOL_PRIVATE const _sapp_gl_fbconfig* _sapp_gl_choose_fbconfig(const _sapp_gl_
 #include <windows.h>
 #include <windowsx.h>
 #include <shellapi.h>
+#pragma comment (lib, "gdi32.lib")
+#pragma comment (lib, "user32.lib")
 #pragma comment (lib, "Shell32.lib")
 
 #if defined(SOKOL_D3D11)
@@ -3285,7 +3287,6 @@ _SOKOL_PRIVATE const _sapp_gl_fbconfig* _sapp_gl_choose_fbconfig(const _sapp_gl_
 #if (defined(WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
 #pragma comment (lib, "WindowsApp.lib")
 #else
-#pragma comment (lib, "user32.lib")
 #pragma comment (lib, "dxgi.lib")
 #pragma comment (lib, "d3d11.lib")
 #pragma comment (lib, "dxguid.lib")


### PR DESCRIPTION
Two small adjustments to `sokol_app.h`:

1. Add `#pragma comment (linker, "/subsystem:windows")` to streamline command line compilation.
2. Link with `gdi32.lib` and `user32.lib` in `_WIN32` builds to support `SOKOL_GLCORE33`.