### PR TITLE
[sokol_app.h] Windows linker/lib pragmas for command line compilation

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -3271,6 +3271,20 @@ _SOKOL_PRIVATE const _sapp_gl_fbconfig* _sapp_gl_choose_fbconfig(const _sapp_gl_
 
 #pragma comment (linker, "/subsystem:windows")
 
+#if (defined(WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
+#pragma comment (lib, "WindowsApp.lib")
+#else
+#pragma comment (lib, "user32.lib")
+#if defined(SOKOL_D3D11)
+#pragma comment (lib, "dxgi.lib")
+#pragma comment (lib, "d3d11.lib")
+#pragma comment (lib, "dxguid.lib")
+#endif
+#if defined(SOKOL_GLCORE33)
+#pragma comment (lib, "gdi32.lib")
+#endif
+#endif
+
 #if defined(SOKOL_D3D11)
 #ifndef D3D11_NO_HELPERS
 #define D3D11_NO_HELPERS
@@ -3284,14 +3298,6 @@ _SOKOL_PRIVATE const _sapp_gl_fbconfig* _sapp_gl_choose_fbconfig(const _sapp_gl_
 #include <windows.h>
 #include <d3d11.h>
 #include <dxgi.h>
-#if (defined(WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
-#pragma comment (lib, "WindowsApp.lib")
-#else
-#pragma comment (lib, "user32.lib")
-#pragma comment (lib, "dxgi.lib")
-#pragma comment (lib, "d3d11.lib")
-#pragma comment (lib, "dxguid.lib")
-#endif
 #endif
 
 /* see https://github.com/floooh/sokol/issues/138 */

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -3269,6 +3269,8 @@ _SOKOL_PRIVATE const _sapp_gl_fbconfig* _sapp_gl_choose_fbconfig(const _sapp_gl_
 #include <shellapi.h>
 #pragma comment (lib, "Shell32.lib")
 
+#pragma comment (linker, "/subsystem:windows")
+
 #if defined(SOKOL_D3D11)
 #ifndef D3D11_NO_HELPERS
 #define D3D11_NO_HELPERS


### PR DESCRIPTION
1. Added `#pragma comment (linker, "/subsystem:windows")` to avoid having to specify this on the command line (works with cl.exe and clang)
2. Added `#pragma comment (lib, "user32.lib")` for both `SOKOL_D3D11` and `SOKOL_GLCORE33`
3. Added `#pragma comment (lib, "gdi32.lib")` for `SOKOL_GLCORE33`