### PR TITLE
support none full mipmap chian

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -5554,6 +5554,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_image(_sg_image_t* img, const sg_
                 GLenum gl_mag_filter = _sg_gl_filter(img->cmn.mag_filter);
                 glTexParameteri(img->gl.target, GL_TEXTURE_MIN_FILTER, gl_min_filter);
                 glTexParameteri(img->gl.target, GL_TEXTURE_MAG_FILTER, gl_mag_filter);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, img->cmn.num_mipmaps - 1);
                 if (_sg.gl.ext_anisotropic && (img->cmn.max_anisotropy > 1)) {
                     GLint max_aniso = (GLint) img->cmn.max_anisotropy;
                     if (max_aniso > _sg.gl.max_anisotropy) {


### PR DESCRIPTION
I added GL_TEXTURE_MAX_LEVEL to sokol_gfx.h to support none full mipmap chain. Without out this fix, the textures are rendered as black.

https://gamedev.stackexchange.com/questions/84398/texture-is-black-when-manually-building-mipmap

https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml