### PR TITLE
sokol_gfx: skip unecessary GL calls when we don't care about depth/stencil buffer

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -6127,7 +6127,7 @@ _SOKOL_PRIVATE void _sg_gl_begin_pass(_sg_pass_t* pass, const sg_pass_action* ac
         _sg.gl.cache.blend.color_write_mask = SG_COLORMASK_RGBA;
         glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
     }
-    if (!_sg.gl.cache.ds.depth_write_enabled) {
+    if (!_sg.gl.cache.ds.depth_write_enabled && action->depth.action != SG_ACTION_DONTCARE) {
         need_pip_cache_flush = true;
         _sg.gl.cache.ds.depth_write_enabled = true;
         glDepthMask(GL_TRUE);
@@ -6137,7 +6137,7 @@ _SOKOL_PRIVATE void _sg_gl_begin_pass(_sg_pass_t* pass, const sg_pass_action* ac
         _sg.gl.cache.ds.depth_compare_func = SG_COMPAREFUNC_ALWAYS;
         glDepthFunc(GL_ALWAYS);
     }
-    if (_sg.gl.cache.ds.stencil_write_mask != 0xFF) {
+    if (_sg.gl.cache.ds.stencil_write_mask != 0xFF && action->stencil.action != SG_ACTION_DONTCARE) {
         need_pip_cache_flush = true;
         _sg.gl.cache.ds.stencil_write_mask = 0xFF;
         glStencilMask(0xFF);


### PR DESCRIPTION
I was doing some benchmarks and noticed by tracing all GL calls that `glDepthMask` and `glStencilMask` is called twice every frame even though I do not use them at all. So this commit skip calling then when the depth/stencil action is `SG_ACTION_DONTCARE` in `_sg_gl_begin_pass`.  This effectively removes any call to both functions on my tests.