### PR TITLE
sokol_gfx: cache active textures on GL backend

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3002,6 +3002,7 @@ typedef struct {
     int cur_ib_offset;
     GLenum cur_primitive_type;
     GLenum cur_index_type;
+    GLenum cur_active_texture;
     _sg_pipeline_t* cur_pipeline;
     sg_pipeline cur_pipeline_id;
 } _sg_gl_state_cache_t;
@@ -5277,10 +5278,18 @@ _SOKOL_PRIVATE void _sg_gl_restore_buffer_binding(GLenum target) {
     }
 }
 
+_SOKOL_PRIVATE void _sg_gl_active_texture(GLenum texture) {
+    if (_sg.gl.cache.cur_active_texture != texture) {
+        _sg.gl.cache.cur_active_texture = texture;
+        glActiveTexture(texture);
+    }
+}
+
 _SOKOL_PRIVATE void _sg_gl_clear_texture_bindings(bool force) {
     for (int i = 0; (i < SG_MAX_SHADERSTAGE_IMAGES) && (i < _sg.gl.max_combined_texture_image_units); i++) {
         if (force || (_sg.gl.cache.textures[i].texture != 0)) {
-            glActiveTexture(GL_TEXTURE0 + i);
+            GLenum gl_texture_slot = GL_TEXTURE0 + i;
+            glActiveTexture(gl_texture_slot);
             glBindTexture(GL_TEXTURE_2D, 0);
             glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
             #if !defined(SOKOL_GLES2)
@@ -5291,6 +5300,7 @@ _SOKOL_PRIVATE void _sg_gl_clear_texture_bindings(bool force) {
             #endif
             _sg.gl.cache.textures[i].target = 0;
             _sg.gl.cache.textures[i].texture = 0;
+            _sg.gl.cache.cur_active_texture = gl_texture_slot;
         }
     }
 }
@@ -5306,7 +5316,7 @@ _SOKOL_PRIVATE void _sg_gl_bind_texture(int slot_index, GLenum target, GLuint te
     }
     _sg_gl_texture_bind_slot* slot = &_sg.gl.cache.textures[slot_index];
     if ((slot->target != target) || (slot->texture != texture)) {
-        glActiveTexture(GL_TEXTURE0 + slot_index);
+        _sg_gl_active_texture(GL_TEXTURE0 + slot_index);
         /* if the target has changed, clear the previous binding on that target */
         if ((target != slot->target) && (slot->target != 0)) {
             glBindTexture(slot->target, 0);


### PR DESCRIPTION
This is an optimization on GL backend to avoid redundant calls to glActiveTexture when binding different textures. This slightly improves my FPS on my benchmark tests with sokol_gfx using GLCORE33. As pointed in #308