### PR TITLE
sokol_gfx: cache texture slots per shader on GL backend

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2923,6 +2923,7 @@ typedef struct {
         GLuint prog;
         _sg_gl_shader_attr_t attrs[SG_MAX_VERTEX_ATTRIBUTES];
         _sg_gl_shader_stage_t stage[SG_NUM_SHADER_STAGES];
+        int texture_slots[SG_MAX_SHADERSTAGE_IMAGES];
     } gl;
 } _sg_gl_shader_t;
 typedef _sg_gl_shader_t _sg_shader_t;
@@ -6435,6 +6436,13 @@ _SOKOL_PRIVATE void _sg_gl_apply_pipeline(_sg_pipeline_t* pip) {
     }
 }
 
+_SOKOL_PRIVATE void _sg_gl_shader_texture_slot(_sg_shader_t* shd, GLint loc, int slot) {
+    if(shd->gl.texture_slots[loc] != slot) {
+        shd->gl.texture_slots[loc] = slot;
+        glUniform1i(loc, slot);
+    }
+}
+
 _SOKOL_PRIVATE void _sg_gl_apply_bindings(
     _sg_pipeline_t* pip,
     _sg_buffer_t** vbs, const int* vb_offsets, int num_vbs,
@@ -6462,7 +6470,7 @@ _SOKOL_PRIVATE void _sg_gl_apply_bindings(
                 const GLuint gl_tex = img->gl.tex[img->cmn.active_slot];
                 SOKOL_ASSERT(img && img->gl.target);
                 SOKOL_ASSERT((gl_shd_img->gl_tex_slot != -1) && gl_tex);
-                glUniform1i(gl_shd_img->gl_loc, gl_shd_img->gl_tex_slot);
+                _sg_gl_shader_texture_slot(pip->shader, gl_shd_img->gl_loc, gl_shd_img->gl_tex_slot);
                 _sg_gl_bind_texture(gl_shd_img->gl_tex_slot, img->gl.target, gl_tex);
             }
         }


### PR DESCRIPTION
This skip unnecessary calls to `glUniform1i` when binding different textures in a shader program under GL backend. This was proposed on #308

Note I take advantage of that a new allocated shaders is initialized to zeros by sokol pool allocator, so `texture_slots` should be all zeros. And that GLSL spec states that program uniforms variables are always initialized to zeros, so this means all slots are 0 for new shaders on both sokol cache and GL program. I also take advatange that the uniform values in a shader persists until linked again to cache per shader.