### PR TITLE
added `#define NOMINMAX`, removed redundant `#include <windows.h>`

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -3263,6 +3263,8 @@ _SOKOL_PRIVATE const _sapp_gl_fbconfig* _sapp_gl_choose_fbconfig(const _sapp_gl_
 #if defined(_WIN32)
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
 #define NOMINMAX
 #endif
 #include <windows.h>

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -3263,6 +3263,7 @@ _SOKOL_PRIVATE const _sapp_gl_fbconfig* _sapp_gl_choose_fbconfig(const _sapp_gl_
 #if defined(_WIN32)
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #endif
 #include <windows.h>
 #include <windowsx.h>
@@ -3297,7 +3298,6 @@ _SOKOL_PRIVATE const _sapp_gl_fbconfig* _sapp_gl_choose_fbconfig(const _sapp_gl_
 #ifndef COBJMACROS
 #define COBJMACROS
 #endif
-#include <windows.h>
 #include <d3d11.h>
 #include <dxgi.h>
 #endif

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -469,6 +469,9 @@ inline void saudio_setup(const saudio_desc& desc) { return saudio_setup(&desc); 
     #ifndef WIN32_LEAN_AND_MEAN
     #define WIN32_LEAN_AND_MEAN
     #endif
+    #ifndef NOMINMAX
+    #define NOMINMAX
+    #endif
     #include <windows.h>
     #include <synchapi.h>
     #pragma comment (lib, "kernel32.lib")

--- a/sokol_fetch.h
+++ b/sokol_fetch.h
@@ -1002,6 +1002,9 @@ inline void sfetch_setup(const sfetch_desc_t& desc) { return sfetch_setup(&desc)
     #ifndef WIN32_LEAN_AND_MEAN
     #define WIN32_LEAN_AND_MEAN
     #endif
+    #ifndef NOMINMAX
+    #define NOMINMAX
+    #endif
     #include <windows.h>
     #define _SFETCH_PLATFORM_WINDOWS (1)
     #define _SFETCH_PLATFORM_EMSCRIPTEN (0)

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2463,7 +2463,9 @@ inline void sg_init_pass(sg_pass pass_id, const sg_pass_desc& desc) { return sg_
     #ifndef WIN32_LEAN_AND_MEAN
     #define WIN32_LEAN_AND_MEAN
     #endif
-    #include <windows.h>
+    #ifndef NOMINMAX
+    #define NOMINMAX
+    #endif
     #include <d3d11.h>
     #include <d3dcompiler.h>
     #if (defined(WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))


### PR DESCRIPTION
Just some minor cleanup.  Curious how you feel about `NOMINMAX`.  Seems important to me because without it, `<windows.h>` stomps any variant of `min()`, and `max()` with a macro.