### PR TITLE
sokol_gfx: skip GL binding restore when there is no applied pipeline

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -5272,10 +5272,16 @@ _SOKOL_PRIVATE void _sg_gl_store_buffer_binding(GLenum target) {
 
 _SOKOL_PRIVATE void _sg_gl_restore_buffer_binding(GLenum target) {
     if (target == GL_ARRAY_BUFFER) {
-        _sg_gl_bind_buffer(target, _sg.gl.cache.stored_vertex_buffer);
+        if(_sg.gl.cache.stored_vertex_buffer != 0) {
+            /* we only care restoring valid ids */
+            _sg_gl_bind_buffer(target, _sg.gl.cache.stored_vertex_buffer);
+        }
     }
     else {
-        _sg_gl_bind_buffer(target, _sg.gl.cache.stored_index_buffer);
+        if(_sg.gl.cache.stored_index_buffer != 0) {
+            /* we only care restoring valid ids */
+            _sg_gl_bind_buffer(target, _sg.gl.cache.stored_index_buffer);
+        }
     }
 }
 
@@ -5339,7 +5345,10 @@ _SOKOL_PRIVATE void _sg_gl_store_texture_binding(int slot_index) {
 _SOKOL_PRIVATE void _sg_gl_restore_texture_binding(int slot_index) {
     SOKOL_ASSERT(slot_index < SG_MAX_SHADERSTAGE_IMAGES);
     const _sg_gl_texture_bind_slot* slot = &_sg.gl.cache.stored_texture;
-    _sg_gl_bind_texture(slot_index, slot->target, slot->texture);
+    if(slot->texture != 0) {
+        /* we only care restoring valid ids */
+        _sg_gl_bind_texture(slot_index, slot->target, slot->texture);
+    }
 }
 
 _SOKOL_PRIVATE void _sg_gl_setup_backend(const sg_desc* desc) {


### PR DESCRIPTION
Currently every time `sg_update_buffer` or `sg_update_texture` is called the current resource is stored, the new one is bound and later the old one is restored. However this generate 2 extra GL state changes that could be omitted when you are updating resources outside a render pass. For example look this table, you can see 3 `glBindBuffer` calls, but 2 of them could have been omitted.

![](https://gyazo.com/4192b03b973d50457e20e915db82f0f2.png)

My approach in my test case is to call `sg_update_buffer` and later apply bindings and draw, this scheme for instance is used in `sokol_gl`.

The store and restore system from what I understood is only there for using the update functions after a pipeline was applied.

This PR takes advantage that in `sg_commit` function the current buffer and texture bindings are set to 0, then on the next frame we can skip restores on 0 resource ids until we have a valid resource id to restore, the first valid resource id will only happen in the first `sg_apply_bindings` in the frame.
 