### PR TITLE
include dpi scale 1.5 in high dpi

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -7811,7 +7811,7 @@ SOKOL_API_IMPL int sapp_height(void) {
 }
 
 SOKOL_API_IMPL bool sapp_high_dpi(void) {
-    return _sapp.desc.high_dpi && (_sapp.dpi_scale > 1.5f);
+    return _sapp.desc.high_dpi && (_sapp.dpi_scale >= 1.5f);
 }
 
 SOKOL_API_IMPL float sapp_dpi_scale(void) {


### PR DESCRIPTION

Very minor tweak: A dpi of exactly 1.5 is fairly common and I think it should be considered a high dpi screen? Most 4k screens run at 150% in Win10 for instance.