### PR TITLE
sokol_app.h internal code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simple
 [STB-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt)
 cross-platform libraries for C and C++, written in C.
 
-[See what's new](#updates) (**22-Jun-2020**: sokol_app.h: fullscreen support on Linux
+[See what's new](#updates) (**13-Jul-2020**: ObjC ARC is now optional, plus internal cleanup
 
 [Live Samples](https://floooh.github.io/sokol-html5/index.html) via WASM.
 
@@ -460,6 +460,48 @@ Mainly some "missing features" for desktop apps:
 
 # Updates
 
+- **13-Jul-2020**:
+    - On macOS and iOS, sokol_app.h and sokol_gfx.h can now be compiled with
+      ARC (Automatic Reference Counting) **disabled** (previously ARC had to be
+      enabled). I will generally switch to testing with ARC disabled from now
+      on.
+    - Compiling with ARC enabled is still supported but with a little caveat:
+      if you're compiling sokol_app.h or sokol_gfx.h in ObjC mode (not ObjC++
+      mode) *AND* ARC is enabled, then the Xcode version must be more recent
+      than before (the language feature ```__has_feature(objc_arc_fields)```
+      must be supported, which I think has been added in Xcode 10.2, I couldn't
+      find this mentioned in any Xcode release notes though). Compiling with
+      ARC disabled should also work on older Xcode versions though.
+    - Various internal code cleanup things:
+        - The remaining 'top-level' static ObjC id variables in the sokol_gfx.h
+        Metal backend have been moved into the global static state structure
+        (that's the reason why __has_feature(objc_arc_fields) is required now
+        when compiling with ARC)
+        - sokol_app.h had the same 'structural cleanup' as sokol_gfx.h in
+        January, all internal data has been merged into a single big
+        state structure, backend specific data has been moved closer to
+        each other in the header, and backend-specific structures and functions
+        have been named more consistently for better 'searchability'
+        - The 'mini GL' loader in the sokol_app.h Win32+WGL backend has
+        been rewritten to use X-Macros which killed a lot of redundant and
+        error-prone lines of code
+        - All macOS and iOS code has been revised and cleaned up
+        - On macOS a workaround for a (what looks like) post-Catalina NSOpenGLView
+        issue has been added: if the sokol_app.h window doesn't fit on
+        screen (and was thus 'clamped' by Cocoa) *AND* the content-size was
+        not set to native Retina resolution, the initial content size was
+        reported as if it was in Retina resolution. This caused an empty screen
+        to be rendered in the imgui-sapp demo. The workaround is to hook into
+        the NSOpenGLView reshape event at which point the reported content
+        size is correct.
+        - On macOS and iOS, the various 'view delegate' objects have been removed,
+        and rendering happens instead in the subclasses of MTKView, GLKView
+        and NSOpenGLView.
+        - On macOS and iOS, there's now proper cleanup code in the
+        applicationWillTerminate callback (although note that on iOS this function isn't
+        guaranteed to be called, because an application can also simply be
+        killed by the operating system.
+
 - **22-Jun-2020**: The X11/GLX backend in sokol_app.h now has (soft-)fullscreen
 support, bringing the feature on par with Windows and macOS. Many thanks to
 @medvednikov for the PR!
@@ -470,7 +512,7 @@ sokol_gfx.h D3D11 backend:
       (previously shader model 5.0 which caused problems with some older
       Intel GPUs still in use, see this issue: https://github.com/floooh/sokol/issues/179)
     - A new string item ```const char* d3d11_target``` in ```sg_shader_stage_desc``` now allows
-      to pass in the D3D shader model for compiling shaders. This defaults to 
+      to pass in the D3D shader model for compiling shaders. This defaults to
       "vs_4_0" for the vertex shader stage and "ps_4_0" for the fragment shader stage.
       The minimal DX shader model for use with the sokol_gfx.h D3D11 backend is
       shader model 4.0, because that's the first shader model supporting

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2630,7 +2630,7 @@ _SOKOL_PRIVATE void _sapp_macos_app_event(sapp_event_type type) {
 - (BOOL)isOpaque {
     return YES;
 }
-- (BOOL)canBecomeKey {
+- (BOOL)canBecomeKeyView {
     return YES;
 }
 - (BOOL)acceptsFirstResponder {

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2594,12 +2594,10 @@ _SOKOL_PRIVATE void _sapp_macos_app_event(sapp_event_type type) {
 
 - (void)drawRect:(NSRect)rect {
     _SOKOL_UNUSED(rect);
-    @autoreleasepool {
-        _sapp_macos_frame();
-        #if !defined(SOKOL_METAL)
-        [[_sapp.macos.view openGLContext] flushBuffer];
-        #endif
-    }
+    _sapp_macos_frame();
+    #if !defined(SOKOL_METAL)
+    [[_sapp.macos.view openGLContext] flushBuffer];
+    #endif
 }
 
 - (BOOL)isOpaque {
@@ -3097,9 +3095,7 @@ _SOKOL_PRIVATE void _sapp_ios_touch_event(sapp_event_type type, NSSet<UITouch *>
 @implementation _sapp_ios_view
 - (void)drawRect:(CGRect)rect {
     _SOKOL_UNUSED(rect);
-    @autoreleasepool {
-        _sapp_ios_frame();
-    }
+    _sapp_ios_frame();
 }
 - (BOOL)isOpaque {
     return YES;

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1114,7 +1114,6 @@ inline int sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #ifdef _MSC_VER
         #pragma warning(push)
         #pragma warning(disable:4201)   /* nonstandard extension used: nameless struct/union */
-        #pragma warning(disable:4115)   /* named type definition in parentheses */
         #pragma warning(disable:4054)   /* 'type cast': from function pointer */
         #pragma warning(disable:4055)   /* 'type cast': from data pointer */
         #pragma warning(disable:4505)   /* unreferenced local function has been removed */
@@ -2154,7 +2153,6 @@ _SOKOL_PRIVATE void _sapp_frame(void) {
 /*== MacOS/iOS ===============================================================*/
 #if defined(_SAPP_APPLE)
 
-// FIXME: support non-ARC builds one day
 #if __has_feature(objc_arc)
 #define _SAPP_OBJC_RELEASE(obj) { obj = nil; }
 #else
@@ -2847,7 +2845,6 @@ _SOKOL_PRIVATE void _sapp_ios_run(const sapp_desc* desc) {
     static int argc = 1;
     static char* argv[] = { (char*)"sokol_app" };
     UIApplicationMain(argc, argv, nil, NSStringFromClass([_sapp_app_delegate class]));
-    _sapp_discard_state();
 }
 
 /* iOS entry function */

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -963,16 +963,6 @@ inline int sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 #ifdef SOKOL_IMPL
 #define SOKOL_APP_IMPL_INCLUDED (1)
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4201)   /* nonstandard extension used: nameless struct/union */
-#pragma warning(disable:4115)   /* named type definition in parentheses */
-#pragma warning(disable:4054)   /* 'type cast': from function pointer */
-#pragma warning(disable:4055)   /* 'type cast': from data pointer */
-#pragma warning(disable:4505)   /* unreferenced local function has been removed */
-#pragma warning(disable:4115)   /* /W4: 'ID3D11ModuleInstance': named type definition in parentheses (in d3d11.h) */
-#endif
-
 #include <string.h> /* memset */
 
 /* check if the config defines are alright */
@@ -1115,47 +1105,56 @@ inline int sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #include <emscripten/emscripten.h>
     #include <emscripten/html5.h>
 #elif defined(_SAPP_WIN32)
+    #ifdef _MSC_VER
+        #pragma warning(push)
+        #pragma warning(disable:4201)   /* nonstandard extension used: nameless struct/union */
+        #pragma warning(disable:4115)   /* named type definition in parentheses */
+        #pragma warning(disable:4054)   /* 'type cast': from function pointer */
+        #pragma warning(disable:4055)   /* 'type cast': from data pointer */
+        #pragma warning(disable:4505)   /* unreferenced local function has been removed */
+        #pragma warning(disable:4115)   /* /W4: 'ID3D11ModuleInstance': named type definition in parentheses (in d3d11.h) */
+    #endif
     #ifndef WIN32_LEAN_AND_MEAN
-    #define WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
     #endif
     #ifndef NOMINMAX
-    #define NOMINMAX
+        #define NOMINMAX
     #endif
     #include <windows.h>
     #include <windowsx.h>
     #include <shellapi.h>
     #pragma comment (lib, "Shell32.lib")
     #if !defined(SOKOL_WIN32_FORCE_MAIN)
-    #pragma comment (linker, "/subsystem:windows")
+        #pragma comment (linker, "/subsystem:windows")
     #endif
     #if (defined(WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
-    #pragma comment (lib, "WindowsApp.lib")
+        #pragma comment (lib, "WindowsApp.lib")
     #else
-    #pragma comment (lib, "user32.lib")
+        #pragma comment (lib, "user32.lib")
+        #if defined(SOKOL_D3D11)
+            #pragma comment (lib, "dxgi.lib")
+            #pragma comment (lib, "d3d11.lib")
+            #pragma comment (lib, "dxguid.lib")
+        #endif
+        #if defined(SOKOL_GLCORE33)
+            #pragma comment (lib, "gdi32.lib")
+        #endif
+    #endif
     #if defined(SOKOL_D3D11)
-    #pragma comment (lib, "dxgi.lib")
-    #pragma comment (lib, "d3d11.lib")
-    #pragma comment (lib, "dxguid.lib")
-    #endif
-    #if defined(SOKOL_GLCORE33)
-    #pragma comment (lib, "gdi32.lib")
-    #endif
-    #endif
-    #if defined(SOKOL_D3D11)
-    #ifndef D3D11_NO_HELPERS
-    #define D3D11_NO_HELPERS
-    #endif
-    #ifndef CINTERFACE
-    #define CINTERFACE
-    #endif
-    #ifndef COBJMACROS
-    #define COBJMACROS
-    #endif
-    #include <d3d11.h>
-    #include <dxgi.h>
+        #ifndef D3D11_NO_HELPERS
+            #define D3D11_NO_HELPERS
+        #endif
+        #ifndef CINTERFACE
+            #define CINTERFACE
+        #endif
+        #ifndef COBJMACROS
+            #define COBJMACROS
+        #endif
+        #include <d3d11.h>
+        #include <dxgi.h>
     #endif
     #ifndef WM_MOUSEHWHEEL /* see https://github.com/floooh/sokol/issues/138 */
-    #define WM_MOUSEHWHEEL (0x020E)
+        #define WM_MOUSEHWHEEL (0x020E)
     #endif
 #elif defined(_SAPP_ANDROID)
     #include <pthread.h>
@@ -1222,6 +1221,198 @@ inline int sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #define GLX_CONTEXT_RELEASE_BEHAVIOR_FLUSH_ARB 0x2098
 #endif
 
+/*== MACOS DECLARATIONS ======================================================*/
+#if defined(_SAPP_MACOS)
+typedef struct {
+    uint32_t flags_changed_store;
+} _sapp_macos_t;
+
+@interface _sapp_macos_app_delegate : NSObject<NSApplicationDelegate>
+@end
+@interface _sapp_macos_window_delegate : NSObject<NSWindowDelegate>
+@end
+#if defined(SOKOL_METAL)
+    @interface _sapp_macos_mtk_view_dlg : NSObject<MTKViewDelegate>
+    @end
+    @interface _sapp_macos_view : MTKView
+    {
+        NSTrackingArea* trackingArea;
+    }
+    @end
+#elif defined(SOKOL_GLCORE33)
+    @interface _sapp_macos_view : NSOpenGLView
+    {
+        NSTrackingArea* trackingArea;
+    }
+    - (void)timerFired:(id)sender;
+    - (void)prepareOpenGL;
+    - (void)drawRect:(NSRect)bounds;
+    @end
+#endif // SOKOL_GLCORE33
+
+#endif // _SAPP_MACOS
+
+/*== IOS DECLARATIONS ========================================================*/
+#if defined(_SAPP_IOS)
+typedef struct {
+    bool suspended;
+} _sapp_ios_t;
+
+@interface _sapp_app_delegate : NSObject<UIApplicationDelegate>
+@end
+@interface _sapp_textfield_dlg : NSObject<UITextFieldDelegate>
+- (void)keyboardWasShown:(NSNotification*)notif;
+- (void)keyboardWillBeHidden:(NSNotification*)notif;
+- (void)keyboardDidChangeFrame:(NSNotification*)notif;
+@end
+#if defined(SOKOL_METAL)
+    @interface _sapp_ios_mtk_view_dlg : NSObject<MTKViewDelegate>
+    @end
+    @interface _sapp_ios_view : MTKView;
+    @end
+#else
+    @interface _sapp_ios_glk_view_dlg : NSObject<GLKViewDelegate>
+    @end
+    @interface _sapp_ios_view : GLKView
+    @end
+#endif
+
+#endif // _SAPP_IOS
+
+/*== EMSCRIPTEN DECLARATIONS =================================================*/
+#if defined(_SAPP_EMSCRIPTEN)
+typedef struct {
+    bool textfield_created;
+    bool wants_show_keyboard;
+    bool wants_hide_keyboard;
+    #if defined(SOKOL_WGPU)
+    struct {
+        int state;
+        WGPUDevice device;
+        WGPUSwapChain swapchain;
+        WGPUTextureFormat render_format;
+        WGPUTexture msaa_tex;
+        WGPUTexture depth_stencil_tex;
+        WGPUTextureView swapchain_view;
+        WGPUTextureView msaa_view;
+        WGPUTextureView depth_stencil_view;
+    } wgpu;
+    #endif
+} _sapp_emsc_t;
+#endif // _SAPP_EMSCROPTEN
+
+/*== WIN32 DECLARATIONS ======================================================*/
+#if defined(_SAPP_WIN32)
+
+#ifndef DPI_ENUMS_DECLARED
+typedef enum PROCESS_DPI_AWARENESS
+{
+    PROCESS_DPI_UNAWARE = 0,
+    PROCESS_SYSTEM_DPI_AWARE = 1,
+    PROCESS_PER_MONITOR_DPI_AWARE = 2
+} PROCESS_DPI_AWARENESS;
+typedef enum MONITOR_DPI_TYPE {
+    MDT_EFFECTIVE_DPI = 0,
+    MDT_ANGULAR_DPI = 1,
+    MDT_RAW_DPI = 2,
+    MDT_DEFAULT = MDT_EFFECTIVE_DPI
+} MONITOR_DPI_TYPE;
+#endif /*DPI_ENUMS_DECLARED*/
+
+typedef BOOL(WINAPI * SETPROCESSDPIAWARE_T)(void);
+typedef HRESULT(WINAPI * SETPROCESSDPIAWARENESS_T)(PROCESS_DPI_AWARENESS);
+typedef HRESULT(WINAPI * GETDPIFORMONITOR_T)(HMONITOR, MONITOR_DPI_TYPE, UINT*, UINT*);
+
+typedef struct {
+    HWND hwnd;
+    HDC dc;
+    bool in_create_window;
+    bool iconified;
+    struct {
+        bool aware;
+        float content_scale;
+        float window_scale;
+        float mouse_scale;
+        SETPROCESSDPIAWARE_T setprocessdpiaware;
+        SETPROCESSDPIAWARENESS_T setprocessdpiawareness;
+        GETDPIFORMONITOR_T getdpiformonitor;
+    } dpi;
+} _sapp_win32_t;
+
+#if defined(SOKOL_D3D11)
+typedef struct {
+    ID3D11Device* device;
+    ID3D11DeviceContext* device_context;
+    ID3D11Texture2D* rt;
+    ID3D11RenderTargetView* rtv;
+    ID3D11Texture2D* ds;
+    ID3D11DepthStencilView* dsv;
+    DXGI_SWAP_CHAIN_DESC swap_chain_desc;
+    IDXGISwapChain* swap_chain;
+} _sapp_d3d11_t;
+#endif
+
+#if defined(SOKOL_GLCORE33)
+#define WGL_NUMBER_PIXEL_FORMATS_ARB 0x2000
+#define WGL_SUPPORT_OPENGL_ARB 0x2010
+#define WGL_DRAW_TO_WINDOW_ARB 0x2001
+#define WGL_PIXEL_TYPE_ARB 0x2013
+#define WGL_TYPE_RGBA_ARB 0x202b
+#define WGL_ACCELERATION_ARB 0x2003
+#define WGL_NO_ACCELERATION_ARB 0x2025
+#define WGL_RED_BITS_ARB 0x2015
+#define WGL_GREEN_BITS_ARB 0x2017
+#define WGL_BLUE_BITS_ARB 0x2019
+#define WGL_ALPHA_BITS_ARB 0x201b
+#define WGL_DEPTH_BITS_ARB 0x2022
+#define WGL_STENCIL_BITS_ARB 0x2023
+#define WGL_DOUBLE_BUFFER_ARB 0x2011
+#define WGL_SAMPLES_ARB 0x2042
+#define WGL_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB 0x00000002
+#define WGL_CONTEXT_PROFILE_MASK_ARB 0x9126
+#define WGL_CONTEXT_CORE_PROFILE_BIT_ARB 0x00000001
+#define WGL_CONTEXT_MAJOR_VERSION_ARB 0x2091
+#define WGL_CONTEXT_MINOR_VERSION_ARB 0x2092
+#define WGL_CONTEXT_FLAGS_ARB 0x2094
+#define ERROR_INVALID_VERSION_ARB 0x2095
+#define ERROR_INVALID_PROFILE_ARB 0x2096
+#define ERROR_INCOMPATIBLE_DEVICE_CONTEXTS_ARB 0x2054
+typedef BOOL (WINAPI * PFNWGLSWAPINTERVALEXTPROC)(int);
+typedef BOOL (WINAPI * PFNWGLGETPIXELFORMATATTRIBIVARBPROC)(HDC,int,int,UINT,const int*,int*);
+typedef const char* (WINAPI * PFNWGLGETEXTENSIONSSTRINGEXTPROC)(void);
+typedef const char* (WINAPI * PFNWGLGETEXTENSIONSSTRINGARBPROC)(HDC);
+typedef HGLRC (WINAPI * PFNWGLCREATECONTEXTATTRIBSARBPROC)(HDC,HGLRC,const int*);
+typedef HGLRC (WINAPI * PFN_wglCreateContext)(HDC);
+typedef BOOL (WINAPI * PFN_wglDeleteContext)(HGLRC);
+typedef PROC (WINAPI * PFN_wglGetProcAddress)(LPCSTR);
+typedef HDC (WINAPI * PFN_wglGetCurrentDC)(void);
+typedef BOOL (WINAPI * PFN_wglMakeCurrent)(HDC,HGLRC);
+
+typedef struct {
+    HINSTANCE opengl32;
+    HGLRC gl_ctx;
+    PFN_wglCreateContext CreateContext;
+    PFN_wglDeleteContext DeleteContext;
+    PFN_wglGetProcAddress GetProcAddress;
+    PFN_wglGetCurrentDC GetCurrentDC;
+    PFN_wglMakeCurrent MakeCurrent;
+    PFNWGLSWAPINTERVALEXTPROC SwapIntervalEXT;
+    PFNWGLGETPIXELFORMATATTRIBIVARBPROC GetPixelFormatAttribivARB;
+    PFNWGLGETEXTENSIONSSTRINGEXTPROC GetExtensionsStringEXT;
+    PFNWGLGETEXTENSIONSSTRINGARBPROC GetExtensionsStringARB;
+    PFNWGLCREATECONTEXTATTRIBSARBPROC CreateContextAttribsARB;
+    bool ext_swap_control;
+    bool arb_multisample;
+    bool arb_pixel_format;
+    bool arb_create_context;
+    bool arb_create_context_profile;
+    HWND msg_hwnd;
+    HDC msg_dc;
+} _sapp_wgl_t;
+#endif // SOKOL_GLCORE33
+
+#endif // _SAPP_WIN32
+
 /*== COMMON DECLARATIONS =====================================================*/
 
 /* helper macros */
@@ -1235,7 +1426,7 @@ inline int sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 #define _SAPP_PIXELFORMAT_DEPTH (41)
 #define _SAPP_PIXELFORMAT_DEPTH_STENCIL (42)
 
-typedef struct {
+static struct {
     bool valid;
     int window_width;
     int window_height;
@@ -1267,8 +1458,21 @@ typedef struct {
     bool clipboard_enabled;
     int clipboard_size;
     char* clipboard;
-} _sapp_state;
-static _sapp_state _sapp;
+    #if defined(_SAPP_MACOS)
+        _sapp_macos_t macos;
+    #elif defined(_SAPP_IOS)
+        _sapp_ios_t ios;
+    #elif defined(_SAPP_EMSCRIPTEN)
+        _sapp_emsc_t emsc;
+    #elif defined(_SAPP_WIN32)
+        _sapp_win32_t win32;
+        #if defined(SOKOL_D3D11)
+            _sapp_d3d11_t d3d11;
+        #elif defined(SOKOL_GLCORE33)
+            _sapp_wgl_t wgl;
+        #endif
+    #endif
+} _sapp;
 
 _SOKOL_PRIVATE void _sapp_fail(const char* msg) {
     if (_sapp.desc.fail_cb) {
@@ -1430,35 +1634,12 @@ _SOKOL_PRIVATE void _sapp_frame(void) {
 }
 
 /*== MacOS/iOS ===============================================================*/
-
 #if defined(_SAPP_APPLE)
 
 /*== MacOS ===================================================================*/
 #if defined(_SAPP_MACOS)
 
-@interface _sapp_macos_app_delegate : NSObject<NSApplicationDelegate>
-@end
-@interface _sapp_macos_window_delegate : NSObject<NSWindowDelegate>
-@end
-#if defined(SOKOL_METAL)
-@interface _sapp_macos_mtk_view_dlg : NSObject<MTKViewDelegate>
-@end
-@interface _sapp_macos_view : MTKView
-{
-    NSTrackingArea* trackingArea;
-}
-@end
-#elif defined(SOKOL_GLCORE33)
-@interface _sapp_macos_view : NSOpenGLView
-{
-    NSTrackingArea* trackingArea;
-}
-- (void)timerFired:(id)sender;
-- (void)prepareOpenGL;
-- (void)drawRect:(NSRect)bounds;
-@end
-#endif
-
+// FIXME: put all ObjC objects into an NSMutableArray and reference through indices!
 static NSWindow* _sapp_macos_window_obj;
 static _sapp_macos_window_delegate* _sapp_macos_win_dlg_obj;
 static _sapp_macos_app_delegate* _sapp_macos_app_dlg_obj;
@@ -1470,7 +1651,6 @@ static id<MTLDevice> _sapp_mtl_device_obj;
 static NSOpenGLPixelFormat* _sapp_macos_glpixelformat_obj;
 static NSTimer* _sapp_macos_timer_obj;
 #endif
-static uint32_t _sapp_macos_flags_changed_store;
 
 _SOKOL_PRIVATE void _sapp_macos_init_keytable(void) {
     _sapp.keycodes[0x1D] = SAPP_KEYCODE_0;
@@ -2008,9 +2188,9 @@ _SOKOL_PRIVATE void _sapp_macos_app_event(sapp_event_type type) {
         _sapp_macos_mod(event.modifierFlags));
 }
 - (void)flagsChanged:(NSEvent*)event {
-    const uint32_t old_f = _sapp_macos_flags_changed_store;
+    const uint32_t old_f = _sapp.macos.flags_changed_store;
     const uint32_t new_f = event.modifierFlags;
-    _sapp_macos_flags_changed_store = new_f;
+    _sapp.macos.flags_changed_store = new_f;
     sapp_keycode key_code = SAPP_KEYCODE_INVALID;
     bool down = false;
     if ((new_f ^ old_f) & NSEventModifierFlagShift) {
@@ -2083,26 +2263,7 @@ const char* _sapp_macos_get_clipboard_string(void) {
 /*== iOS =====================================================================*/
 #if defined(_SAPP_IOS)
 
-@interface _sapp_app_delegate : NSObject<UIApplicationDelegate>
-@end
-@interface _sapp_textfield_dlg : NSObject<UITextFieldDelegate>
-- (void)keyboardWasShown:(NSNotification*)notif;
-- (void)keyboardWillBeHidden:(NSNotification*)notif;
-- (void)keyboardDidChangeFrame:(NSNotification*)notif;
-@end
-#if defined(SOKOL_METAL)
-@interface _sapp_ios_mtk_view_dlg : NSObject<MTKViewDelegate>
-@end
-@interface _sapp_ios_view : MTKView;
-@end
-#else
-@interface _sapp_ios_glk_view_dlg : NSObject<GLKViewDelegate>
-@end
-@interface _sapp_ios_view : GLKView
-@end
-#endif
-
-static bool _sapp_ios_suspended;
+// FIXME: put all ObjC objects into an NSMutableArray and reference through indices!
 static UIWindow* _sapp_ios_window_obj;
 static _sapp_ios_view* _sapp_view_obj;
 static UITextField* _sapp_ios_textfield_obj;
@@ -2284,15 +2445,15 @@ _SOKOL_PRIVATE void _sapp_ios_show_keyboard(bool shown) {
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application {
-    if (!_sapp_ios_suspended) {
-        _sapp_ios_suspended = true;
+    if (!_sapp.ios.suspended) {
+        _sapp.ios.suspended = true;
         _sapp_ios_app_event(SAPP_EVENTTYPE_SUSPENDED);
     }
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
-    if (_sapp_ios_suspended) {
-        _sapp_ios_suspended = false;
+    if (_sapp.ios.suspended) {
+        _sapp.ios.suspended = false;
         _sapp_ios_app_event(SAPP_EVENTTYPE_RESUMED);
     }
 }
@@ -2439,25 +2600,6 @@ _SOKOL_PRIVATE void _sapp_ios_touch_event(sapp_event_type type, NSSet<UITouch *>
 /*== EMSCRIPTEN ==============================================================*/
 #if defined(_SAPP_EMSCRIPTEN)
 
-static struct {
-    bool textfield_created;
-    bool wants_show_keyboard;
-    bool wants_hide_keyboard;
-    #if defined(SOKOL_WGPU)
-    struct {
-        int state;
-        WGPUDevice device;
-        WGPUSwapChain swapchain;
-        WGPUTextureFormat render_format;
-        WGPUTexture msaa_tex;
-        WGPUTexture depth_stencil_tex;
-        WGPUTextureView swapchain_view;
-        WGPUTextureView msaa_view;
-        WGPUTextureView depth_stencil_view;
-    } wgpu;
-    #endif
-} _sapp_emsc;
-
 /* this function is called from a JS event handler when the user hides
     the onscreen keyboard pressing the 'dismiss keyboard key'
 */
@@ -2560,22 +2702,22 @@ _SOKOL_PRIVATE void _sapp_emsc_set_clipboard_string(const char* str) {
     the request will be ignored by the browser
 */
 _SOKOL_PRIVATE void _sapp_emsc_update_keyboard_state(void) {
-    if (_sapp_emsc.wants_show_keyboard) {
+    if (_sapp.emsc.wants_show_keyboard) {
         /* create input text field on demand */
-        if (!_sapp_emsc.textfield_created) {
-            _sapp_emsc.textfield_created = true;
+        if (!_sapp.emsc.textfield_created) {
+            _sapp.emsc.textfield_created = true;
             sapp_js_create_textfield();
         }
         /* focus the text input field, this will bring up the keyboard */
         _sapp.onscreen_keyboard_shown = true;
-        _sapp_emsc.wants_show_keyboard = false;
+        _sapp.emsc.wants_show_keyboard = false;
         sapp_js_focus_textfield();
     }
-    if (_sapp_emsc.wants_hide_keyboard) {
+    if (_sapp.emsc.wants_hide_keyboard) {
         /* unfocus the text input field */
-        if (_sapp_emsc.textfield_created) {
+        if (_sapp.emsc.textfield_created) {
             _sapp.onscreen_keyboard_shown = false;
-            _sapp_emsc.wants_hide_keyboard = false;
+            _sapp.emsc.wants_hide_keyboard = false;
             sapp_js_unfocus_textfield();
         }
     }
@@ -2587,10 +2729,10 @@ _SOKOL_PRIVATE void _sapp_emsc_update_keyboard_state(void) {
 */
 _SOKOL_PRIVATE void _sapp_emsc_show_keyboard(bool show) {
     if (show) {
-        _sapp_emsc.wants_show_keyboard = true;
+        _sapp.emsc.wants_show_keyboard = true;
     }
     else {
-        _sapp_emsc.wants_hide_keyboard = true;
+        _sapp.emsc.wants_hide_keyboard = true;
     }
 }
 
@@ -3096,11 +3238,11 @@ _SOKOL_PRIVATE void _sapp_emsc_webgl_init(void) {
 
 /* called when the asynchronous WebGPU device + swapchain init code in JS has finished */
 EMSCRIPTEN_KEEPALIVE void _sapp_emsc_wgpu_ready(int device_id, int swapchain_id, int swapchain_fmt) {
-    SOKOL_ASSERT(0 == _sapp_emsc.wgpu.device);
-    _sapp_emsc.wgpu.device = (WGPUDevice) device_id;
-    _sapp_emsc.wgpu.swapchain = (WGPUSwapChain) swapchain_id;
-    _sapp_emsc.wgpu.render_format = (WGPUTextureFormat) swapchain_fmt;
-    _sapp_emsc.wgpu.state = _SAPP_EMSC_WGPU_STATE_READY;
+    SOKOL_ASSERT(0 == _sapp.emsc.wgpu.device);
+    _sapp.emsc.wgpu.device = (WGPUDevice) device_id;
+    _sapp.emsc.wgpu.swapchain = (WGPUSwapChain) swapchain_id;
+    _sapp.emsc.wgpu.render_format = (WGPUTextureFormat) swapchain_fmt;
+    _sapp.emsc.wgpu.state = _SAPP_EMSC_WGPU_STATE_READY;
 }
 
 /* embedded JS function to handle all the asynchronous WebGPU setup */
@@ -3128,12 +3270,12 @@ EM_JS(void, _sapp_emsc_wgpu_init, (), {
 });
 
 _SOKOL_PRIVATE void _sapp_emsc_wgpu_surfaces_create(void) {
-    SOKOL_ASSERT(_sapp_emsc.wgpu.device);
-    SOKOL_ASSERT(_sapp_emsc.wgpu.swapchain);
-    SOKOL_ASSERT(0 == _sapp_emsc.wgpu.depth_stencil_tex);
-    SOKOL_ASSERT(0 == _sapp_emsc.wgpu.depth_stencil_view);
-    SOKOL_ASSERT(0 == _sapp_emsc.wgpu.msaa_tex);
-    SOKOL_ASSERT(0 == _sapp_emsc.wgpu.msaa_view);
+    SOKOL_ASSERT(_sapp.emsc.wgpu.device);
+    SOKOL_ASSERT(_sapp.emsc.wgpu.swapchain);
+    SOKOL_ASSERT(0 == _sapp.emsc.wgpu.depth_stencil_tex);
+    SOKOL_ASSERT(0 == _sapp.emsc.wgpu.depth_stencil_view);
+    SOKOL_ASSERT(0 == _sapp.emsc.wgpu.msaa_tex);
+    SOKOL_ASSERT(0 == _sapp.emsc.wgpu.msaa_view);
 
     WGPUTextureDescriptor ds_desc;
     memset(&ds_desc, 0, sizeof(ds_desc));
@@ -3146,8 +3288,8 @@ _SOKOL_PRIVATE void _sapp_emsc_wgpu_surfaces_create(void) {
     ds_desc.format = WGPUTextureFormat_Depth24PlusStencil8;
     ds_desc.mipLevelCount = 1;
     ds_desc.sampleCount = _sapp.sample_count;
-    _sapp_emsc.wgpu.depth_stencil_tex = wgpuDeviceCreateTexture(_sapp_emsc.wgpu.device, &ds_desc);
-    _sapp_emsc.wgpu.depth_stencil_view = wgpuTextureCreateView(_sapp_emsc.wgpu.depth_stencil_tex, 0);
+    _sapp.emsc.wgpu.depth_stencil_tex = wgpuDeviceCreateTexture(_sapp.emsc.wgpu.device, &ds_desc);
+    _sapp.emsc.wgpu.depth_stencil_view = wgpuTextureCreateView(_sapp.emsc.wgpu.depth_stencil_tex, 0);
 
     if (_sapp.sample_count > 1) {
         WGPUTextureDescriptor msaa_desc;
@@ -3158,38 +3300,38 @@ _SOKOL_PRIVATE void _sapp_emsc_wgpu_surfaces_create(void) {
         msaa_desc.size.height = (uint32_t) _sapp.framebuffer_height;
         msaa_desc.size.depth = 1;
         msaa_desc.arrayLayerCount = 1;
-        msaa_desc.format = _sapp_emsc.wgpu.render_format;
+        msaa_desc.format = _sapp.emsc.wgpu.render_format;
         msaa_desc.mipLevelCount = 1;
         msaa_desc.sampleCount = _sapp.sample_count;
-        _sapp_emsc.wgpu.msaa_tex = wgpuDeviceCreateTexture(_sapp_emsc.wgpu.device, &msaa_desc);
-        _sapp_emsc.wgpu.msaa_view = wgpuTextureCreateView(_sapp_emsc.wgpu.msaa_tex, 0);
+        _sapp.emsc.wgpu.msaa_tex = wgpuDeviceCreateTexture(_sapp.emsc.wgpu.device, &msaa_desc);
+        _sapp.emsc.wgpu.msaa_view = wgpuTextureCreateView(_sapp.emsc.wgpu.msaa_tex, 0);
     }
 }
 
 _SOKOL_PRIVATE void _sapp_emsc_wgpu_surfaces_discard(void) {
-    if (_sapp_emsc.wgpu.msaa_tex) {
-        wgpuTextureRelease(_sapp_emsc.wgpu.msaa_tex);
-        _sapp_emsc.wgpu.msaa_tex = 0;
+    if (_sapp.emsc.wgpu.msaa_tex) {
+        wgpuTextureRelease(_sapp.emsc.wgpu.msaa_tex);
+        _sapp.emsc.wgpu.msaa_tex = 0;
     }
-    if (_sapp_emsc.wgpu.msaa_view) {
-        wgpuTextureViewRelease(_sapp_emsc.wgpu.msaa_view);
-        _sapp_emsc.wgpu.msaa_view = 0;
+    if (_sapp.emsc.wgpu.msaa_view) {
+        wgpuTextureViewRelease(_sapp.emsc.wgpu.msaa_view);
+        _sapp.emsc.wgpu.msaa_view = 0;
     }
-    if (_sapp_emsc.wgpu.depth_stencil_tex) {
-        wgpuTextureRelease(_sapp_emsc.wgpu.depth_stencil_tex);
-        _sapp_emsc.wgpu.depth_stencil_tex = 0;
+    if (_sapp.emsc.wgpu.depth_stencil_tex) {
+        wgpuTextureRelease(_sapp.emsc.wgpu.depth_stencil_tex);
+        _sapp.emsc.wgpu.depth_stencil_tex = 0;
     }
-    if (_sapp_emsc.wgpu.depth_stencil_view) {
-        wgpuTextureViewRelease(_sapp_emsc.wgpu.depth_stencil_view);
-        _sapp_emsc.wgpu.depth_stencil_view = 0;
+    if (_sapp.emsc.wgpu.depth_stencil_view) {
+        wgpuTextureViewRelease(_sapp.emsc.wgpu.depth_stencil_view);
+        _sapp.emsc.wgpu.depth_stencil_view = 0;
     }
 }
 
 _SOKOL_PRIVATE void _sapp_emsc_wgpu_next_frame(void) {
-    if (_sapp_emsc.wgpu.swapchain_view) {
-        wgpuTextureViewRelease(_sapp_emsc.wgpu.swapchain_view);
+    if (_sapp.emsc.wgpu.swapchain_view) {
+        wgpuTextureViewRelease(_sapp.emsc.wgpu.swapchain_view);
     }
-    _sapp_emsc.wgpu.swapchain_view = wgpuSwapChainGetCurrentTextureView(_sapp_emsc.wgpu.swapchain);
+    _sapp.emsc.wgpu.swapchain_view = wgpuSwapChainGetCurrentTextureView(_sapp.emsc.wgpu.swapchain);
 }
 #endif
 
@@ -3251,14 +3393,14 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_frame(double time, void* userData) {
             the asynchronous WebGPU device and swapchain initialization is still
             in progress
         */
-        switch (_sapp_emsc.wgpu.state) {
+        switch (_sapp.emsc.wgpu.state) {
             case _SAPP_EMSC_WGPU_STATE_INITIAL:
                 /* async JS init hasn't finished yet */
                 break;
             case _SAPP_EMSC_WGPU_STATE_READY:
                 /* perform post-async init stuff */
                 _sapp_emsc_wgpu_surfaces_create();
-                _sapp_emsc.wgpu.state = _SAPP_EMSC_WGPU_STATE_RUNNING;
+                _sapp.emsc.wgpu.state = _SAPP_EMSC_WGPU_STATE_RUNNING;
                 break;
             case _SAPP_EMSC_WGPU_STATE_RUNNING:
                 /* a regular frame */
@@ -3288,7 +3430,6 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_frame(double time, void* userData) {
 }
 
 _SOKOL_PRIVATE void _sapp_run(const sapp_desc* desc) {
-    memset(&_sapp_emsc, 0, sizeof(_sapp_emsc));
     _sapp_init_state(desc);
     _sapp_emsc_keytable_init();
     double w, h;
@@ -3443,122 +3584,6 @@ _SOKOL_PRIVATE const _sapp_gl_fbconfig* _sapp_gl_choose_fbconfig(const _sapp_gl_
 
 /*== WINDOWS ==================================================================*/
 #if defined(_SAPP_WIN32)
-
-#ifndef DPI_ENUMS_DECLARED
-typedef enum PROCESS_DPI_AWARENESS
-{
-    PROCESS_DPI_UNAWARE = 0,
-    PROCESS_SYSTEM_DPI_AWARE = 1,
-    PROCESS_PER_MONITOR_DPI_AWARE = 2
-} PROCESS_DPI_AWARENESS;
-typedef enum MONITOR_DPI_TYPE {
-    MDT_EFFECTIVE_DPI = 0,
-    MDT_ANGULAR_DPI = 1,
-    MDT_RAW_DPI = 2,
-    MDT_DEFAULT = MDT_EFFECTIVE_DPI
-} MONITOR_DPI_TYPE;
-#endif /*DPI_ENUMS_DECLARED*/
-
-static HWND _sapp_win32_hwnd;
-static HDC _sapp_win32_dc;
-static bool _sapp_win32_in_create_window;
-static bool _sapp_win32_dpi_aware;
-static float _sapp_win32_content_scale;
-static float _sapp_win32_window_scale;
-static float _sapp_win32_mouse_scale;
-static bool _sapp_win32_iconified;
-typedef BOOL(WINAPI * SETPROCESSDPIAWARE_T)(void);
-typedef HRESULT(WINAPI * SETPROCESSDPIAWARENESS_T)(PROCESS_DPI_AWARENESS);
-typedef HRESULT(WINAPI * GETDPIFORMONITOR_T)(HMONITOR, MONITOR_DPI_TYPE, UINT*, UINT*);
-static SETPROCESSDPIAWARE_T _sapp_win32_setprocessdpiaware;
-static SETPROCESSDPIAWARENESS_T _sapp_win32_setprocessdpiawareness;
-static GETDPIFORMONITOR_T _sapp_win32_getdpiformonitor;
-#if defined(SOKOL_D3D11)
-static ID3D11Device* _sapp_d3d11_device;
-static ID3D11DeviceContext* _sapp_d3d11_device_context;
-static DXGI_SWAP_CHAIN_DESC _sapp_dxgi_swap_chain_desc;
-static IDXGISwapChain* _sapp_dxgi_swap_chain;
-static ID3D11Texture2D* _sapp_d3d11_rt;
-static ID3D11RenderTargetView* _sapp_d3d11_rtv;
-static ID3D11Texture2D* _sapp_d3d11_ds;
-static ID3D11DepthStencilView* _sapp_d3d11_dsv;
-#endif
-#define WGL_NUMBER_PIXEL_FORMATS_ARB 0x2000
-#define WGL_SUPPORT_OPENGL_ARB 0x2010
-#define WGL_DRAW_TO_WINDOW_ARB 0x2001
-#define WGL_PIXEL_TYPE_ARB 0x2013
-#define WGL_TYPE_RGBA_ARB 0x202b
-#define WGL_ACCELERATION_ARB 0x2003
-#define WGL_NO_ACCELERATION_ARB 0x2025
-#define WGL_RED_BITS_ARB 0x2015
-#define WGL_RED_SHIFT_ARB 0x2016
-#define WGL_GREEN_BITS_ARB 0x2017
-#define WGL_GREEN_SHIFT_ARB 0x2018
-#define WGL_BLUE_BITS_ARB 0x2019
-#define WGL_BLUE_SHIFT_ARB 0x201a
-#define WGL_ALPHA_BITS_ARB 0x201b
-#define WGL_ALPHA_SHIFT_ARB 0x201c
-#define WGL_ACCUM_BITS_ARB 0x201d
-#define WGL_ACCUM_RED_BITS_ARB 0x201e
-#define WGL_ACCUM_GREEN_BITS_ARB 0x201f
-#define WGL_ACCUM_BLUE_BITS_ARB 0x2020
-#define WGL_ACCUM_ALPHA_BITS_ARB 0x2021
-#define WGL_DEPTH_BITS_ARB 0x2022
-#define WGL_STENCIL_BITS_ARB 0x2023
-#define WGL_AUX_BUFFERS_ARB 0x2024
-#define WGL_STEREO_ARB 0x2012
-#define WGL_DOUBLE_BUFFER_ARB 0x2011
-#define WGL_SAMPLES_ARB 0x2042
-#define WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB 0x20a9
-#define WGL_CONTEXT_DEBUG_BIT_ARB 0x00000001
-#define WGL_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB 0x00000002
-#define WGL_CONTEXT_PROFILE_MASK_ARB 0x9126
-#define WGL_CONTEXT_CORE_PROFILE_BIT_ARB 0x00000001
-#define WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB 0x00000002
-#define WGL_CONTEXT_MAJOR_VERSION_ARB 0x2091
-#define WGL_CONTEXT_MINOR_VERSION_ARB 0x2092
-#define WGL_CONTEXT_FLAGS_ARB 0x2094
-#define WGL_CONTEXT_ROBUST_ACCESS_BIT_ARB 0x00000004
-#define WGL_LOSE_CONTEXT_ON_RESET_ARB 0x8252
-#define WGL_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB 0x8256
-#define WGL_NO_RESET_NOTIFICATION_ARB 0x8261
-#define WGL_CONTEXT_RELEASE_BEHAVIOR_ARB 0x2097
-#define WGL_CONTEXT_RELEASE_BEHAVIOR_NONE_ARB 0
-#define WGL_CONTEXT_RELEASE_BEHAVIOR_FLUSH_ARB 0x2098
-#define WGL_COLORSPACE_EXT 0x309d
-#define WGL_COLORSPACE_SRGB_EXT 0x3089
-#define ERROR_INVALID_VERSION_ARB 0x2095
-#define ERROR_INVALID_PROFILE_ARB 0x2096
-#define ERROR_INCOMPATIBLE_DEVICE_CONTEXTS_ARB 0x2054
-typedef BOOL (WINAPI * PFNWGLSWAPINTERVALEXTPROC)(int);
-typedef BOOL (WINAPI * PFNWGLGETPIXELFORMATATTRIBIVARBPROC)(HDC,int,int,UINT,const int*,int*);
-typedef const char* (WINAPI * PFNWGLGETEXTENSIONSSTRINGEXTPROC)(void);
-typedef const char* (WINAPI * PFNWGLGETEXTENSIONSSTRINGARBPROC)(HDC);
-typedef HGLRC (WINAPI * PFNWGLCREATECONTEXTATTRIBSARBPROC)(HDC,HGLRC,const int*);
-typedef HGLRC (WINAPI * PFN_wglCreateContext)(HDC);
-typedef BOOL (WINAPI * PFN_wglDeleteContext)(HGLRC);
-typedef PROC (WINAPI * PFN_wglGetProcAddress)(LPCSTR);
-typedef HDC (WINAPI * PFN_wglGetCurrentDC)(void);
-typedef BOOL (WINAPI * PFN_wglMakeCurrent)(HDC,HGLRC);
-static HINSTANCE _sapp_opengl32;
-static HGLRC _sapp_gl_ctx;
-static PFN_wglCreateContext _sapp_wglCreateContext;
-static PFN_wglDeleteContext _sapp_wglDeleteContext;
-static PFN_wglGetProcAddress _sapp_wglGetProcAddress;
-static PFN_wglGetCurrentDC _sapp_wglGetCurrentDC;
-static PFN_wglMakeCurrent _sapp_wglMakeCurrent;
-static PFNWGLSWAPINTERVALEXTPROC _sapp_SwapIntervalEXT;
-static PFNWGLGETPIXELFORMATATTRIBIVARBPROC _sapp_GetPixelFormatAttribivARB;
-static PFNWGLGETEXTENSIONSSTRINGEXTPROC _sapp_GetExtensionsStringEXT;
-static PFNWGLGETEXTENSIONSSTRINGARBPROC _sapp_GetExtensionsStringARB;
-static PFNWGLCREATECONTEXTATTRIBSARBPROC _sapp_CreateContextAttribsARB;
-static bool _sapp_ext_swap_control;
-static bool _sapp_arb_multisample;
-static bool _sapp_arb_pixel_format;
-static bool _sapp_arb_create_context;
-static bool _sapp_arb_create_context_profile;
-static HWND _sapp_win32_msg_hwnd;
-static HDC _sapp_win32_msg_dc;
 
 /* NOTE: the optional GL loader only contains the GL constants and functions required for sokol_gfx.h, if you need
 more, you'll need to use you own gl header-generator/loader
@@ -3986,9 +4011,9 @@ typedef void  (GL_APIENTRY *PFN_glCullFace)(GLenum mode);
 static PFN_glCullFace _sapp_glCullFace;
 
 _SOKOL_PRIVATE void* _sapp_win32_glgetprocaddr(const char* name) {
-    void* proc_addr = (void*) _sapp_wglGetProcAddress(name);
+    void* proc_addr = (void*) _sapp.wgl.GetProcAddress(name);
     if (0 == proc_addr) {
-        proc_addr = (void*) GetProcAddress(_sapp_opengl32, name);
+        proc_addr = (void*) GetProcAddress(_sapp.wgl.opengl32, name);
     }
     SOKOL_ASSERT(proc_addr);
     return proc_addr;
@@ -3997,8 +4022,8 @@ _SOKOL_PRIVATE void* _sapp_win32_glgetprocaddr(const char* name) {
 #define _SAPP_GLPROC(name) _sapp_ ## name = (PFN_ ## name) _sapp_win32_glgetprocaddr(#name)
 
 _SOKOL_PRIVATE  void _sapp_win32_gl_loadfuncs(void) {
-    SOKOL_ASSERT(_sapp_wglGetProcAddress);
-    SOKOL_ASSERT(_sapp_opengl32);
+    SOKOL_ASSERT(_sapp.wgl.GetProcAddress);
+    SOKOL_ASSERT(_sapp.wgl.opengl32);
     _SAPP_GLPROC(glBindVertexArray);
     _SAPP_GLPROC(glFramebufferTextureLayer);
     _SAPP_GLPROC(glGenFramebuffers);
@@ -4196,13 +4221,13 @@ _SOKOL_PRIVATE  void _sapp_win32_gl_loadfuncs(void) {
 #if defined(SOKOL_D3D11)
 #define _SAPP_SAFE_RELEASE(class, obj) if (obj) { class##_Release(obj); obj=0; }
 _SOKOL_PRIVATE void _sapp_d3d11_create_device_and_swapchain(void) {
-    DXGI_SWAP_CHAIN_DESC* sc_desc = &_sapp_dxgi_swap_chain_desc;
+    DXGI_SWAP_CHAIN_DESC* sc_desc = &_sapp.d3d11.swap_chain_desc;
     sc_desc->BufferDesc.Width = _sapp.framebuffer_width;
     sc_desc->BufferDesc.Height = _sapp.framebuffer_height;
     sc_desc->BufferDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
     sc_desc->BufferDesc.RefreshRate.Numerator = 60;
     sc_desc->BufferDesc.RefreshRate.Denominator = 1;
-    sc_desc->OutputWindow = _sapp_win32_hwnd;
+    sc_desc->OutputWindow = _sapp.win32.hwnd;
     sc_desc->Windowed = true;
     sc_desc->SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
     sc_desc->BufferCount = 1;
@@ -4223,30 +4248,30 @@ _SOKOL_PRIVATE void _sapp_d3d11_create_device_and_swapchain(void) {
         0,                              /* FeatureLevels */
         D3D11_SDK_VERSION,              /* SDKVersion */
         sc_desc,                        /* pSwapChainDesc */
-        &_sapp_dxgi_swap_chain,         /* ppSwapChain */
-        &_sapp_d3d11_device,            /* ppDevice */
+        &_sapp.d3d11.swap_chain,        /* ppSwapChain */
+        &_sapp.d3d11.device,            /* ppDevice */
         &feature_level,                 /* pFeatureLevel */
-        &_sapp_d3d11_device_context);   /* ppImmediateContext */
+        &_sapp.d3d11.device_context);   /* ppImmediateContext */
     _SOKOL_UNUSED(hr);
-    SOKOL_ASSERT(SUCCEEDED(hr) && _sapp_dxgi_swap_chain && _sapp_d3d11_device && _sapp_d3d11_device_context);
+    SOKOL_ASSERT(SUCCEEDED(hr) && _sapp.d3d11.swap_chain && _sapp.d3d11.device && _sapp.d3d11.device_context);
 }
 
 _SOKOL_PRIVATE void _sapp_d3d11_destroy_device_and_swapchain(void) {
-    _SAPP_SAFE_RELEASE(IDXGISwapChain, _sapp_dxgi_swap_chain);
-    _SAPP_SAFE_RELEASE(ID3D11DeviceContext, _sapp_d3d11_device_context);
-    _SAPP_SAFE_RELEASE(ID3D11Device, _sapp_d3d11_device);
+    _SAPP_SAFE_RELEASE(IDXGISwapChain, _sapp.d3d11.swap_chain);
+    _SAPP_SAFE_RELEASE(ID3D11DeviceContext, _sapp.d3d11.device_context);
+    _SAPP_SAFE_RELEASE(ID3D11Device, _sapp.d3d11.device);
 }
 
 _SOKOL_PRIVATE void _sapp_d3d11_create_default_render_target(void) {
     HRESULT hr;
     #ifdef __cplusplus
-    hr = IDXGISwapChain_GetBuffer(_sapp_dxgi_swap_chain, 0, IID_ID3D11Texture2D, (void**)&_sapp_d3d11_rt);
+    hr = IDXGISwapChain_GetBuffer(_sapp.d3d11.swap_chain, 0, IID_ID3D11Texture2D, (void**)&_sapp.d3d11.rt);
     #else
-    hr = IDXGISwapChain_GetBuffer(_sapp_dxgi_swap_chain, 0, &IID_ID3D11Texture2D, (void**)&_sapp_d3d11_rt);
+    hr = IDXGISwapChain_GetBuffer(_sapp.d3d11.swap_chain, 0, &IID_ID3D11Texture2D, (void**)&_sapp.d3d11.rt);
     #endif
-    SOKOL_ASSERT(SUCCEEDED(hr) && _sapp_d3d11_rt);
-    hr = ID3D11Device_CreateRenderTargetView(_sapp_d3d11_device, (ID3D11Resource*)_sapp_d3d11_rt, NULL, &_sapp_d3d11_rtv);
-    SOKOL_ASSERT(SUCCEEDED(hr) && _sapp_d3d11_rtv);
+    SOKOL_ASSERT(SUCCEEDED(hr) && _sapp.d3d11.rt);
+    hr = ID3D11Device_CreateRenderTargetView(_sapp.d3d11.device, (ID3D11Resource*)_sapp.d3d11.rt, NULL, &_sapp.d3d11.rtv);
+    SOKOL_ASSERT(SUCCEEDED(hr) && _sapp.d3d11.rtv);
     D3D11_TEXTURE2D_DESC ds_desc;
     memset(&ds_desc, 0, sizeof(ds_desc));
     ds_desc.Width = _sapp.framebuffer_width;
@@ -4254,30 +4279,30 @@ _SOKOL_PRIVATE void _sapp_d3d11_create_default_render_target(void) {
     ds_desc.MipLevels = 1;
     ds_desc.ArraySize = 1;
     ds_desc.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
-    ds_desc.SampleDesc = _sapp_dxgi_swap_chain_desc.SampleDesc;
+    ds_desc.SampleDesc = _sapp.d3d11.swap_chain_desc.SampleDesc;
     ds_desc.Usage = D3D11_USAGE_DEFAULT;
     ds_desc.BindFlags = D3D11_BIND_DEPTH_STENCIL;
-    hr = ID3D11Device_CreateTexture2D(_sapp_d3d11_device, &ds_desc, NULL, &_sapp_d3d11_ds);
-    SOKOL_ASSERT(SUCCEEDED(hr) && _sapp_d3d11_ds);
+    hr = ID3D11Device_CreateTexture2D(_sapp.d3d11.device, &ds_desc, NULL, &_sapp.d3d11.ds);
+    SOKOL_ASSERT(SUCCEEDED(hr) && _sapp.d3d11.ds);
     D3D11_DEPTH_STENCIL_VIEW_DESC dsv_desc;
     memset(&dsv_desc, 0, sizeof(dsv_desc));
     dsv_desc.Format = ds_desc.Format;
     dsv_desc.ViewDimension = _sapp.sample_count > 1 ? D3D11_DSV_DIMENSION_TEXTURE2DMS : D3D11_DSV_DIMENSION_TEXTURE2D;
-    hr = ID3D11Device_CreateDepthStencilView(_sapp_d3d11_device, (ID3D11Resource*)_sapp_d3d11_ds, &dsv_desc, &_sapp_d3d11_dsv);
-    SOKOL_ASSERT(SUCCEEDED(hr) && _sapp_d3d11_dsv);
+    hr = ID3D11Device_CreateDepthStencilView(_sapp.d3d11.device, (ID3D11Resource*)_sapp.d3d11.ds, &dsv_desc, &_sapp.d3d11.dsv);
+    SOKOL_ASSERT(SUCCEEDED(hr) && _sapp.d3d11.dsv);
 }
 
 _SOKOL_PRIVATE void _sapp_d3d11_destroy_default_render_target(void) {
-    _SAPP_SAFE_RELEASE(ID3D11Texture2D, _sapp_d3d11_rt);
-    _SAPP_SAFE_RELEASE(ID3D11RenderTargetView, _sapp_d3d11_rtv);
-    _SAPP_SAFE_RELEASE(ID3D11Texture2D, _sapp_d3d11_ds);
-    _SAPP_SAFE_RELEASE(ID3D11DepthStencilView, _sapp_d3d11_dsv);
+    _SAPP_SAFE_RELEASE(ID3D11Texture2D, _sapp.d3d11.rt);
+    _SAPP_SAFE_RELEASE(ID3D11RenderTargetView, _sapp.d3d11.rtv);
+    _SAPP_SAFE_RELEASE(ID3D11Texture2D, _sapp.d3d11.ds);
+    _SAPP_SAFE_RELEASE(ID3D11DepthStencilView, _sapp.d3d11.dsv);
 }
 
 _SOKOL_PRIVATE void _sapp_d3d11_resize_default_render_target(void) {
-    if (_sapp_dxgi_swap_chain) {
+    if (_sapp.d3d11.swap_chain) {
         _sapp_d3d11_destroy_default_render_target();
-        IDXGISwapChain_ResizeBuffers(_sapp_dxgi_swap_chain, 1, _sapp.framebuffer_width, _sapp.framebuffer_height, DXGI_FORMAT_B8G8R8A8_UNORM, 0);
+        IDXGISwapChain_ResizeBuffers(_sapp.d3d11.swap_chain, 1, _sapp.framebuffer_width, _sapp.framebuffer_height, DXGI_FORMAT_B8G8R8A8_UNORM, 0);
         _sapp_d3d11_create_default_render_target();
     }
 }
@@ -4285,23 +4310,23 @@ _SOKOL_PRIVATE void _sapp_d3d11_resize_default_render_target(void) {
 
 #if defined(SOKOL_GLCORE33)
 _SOKOL_PRIVATE void _sapp_wgl_init(void) {
-    _sapp_opengl32 = LoadLibraryA("opengl32.dll");
-    if (!_sapp_opengl32) {
+    _sapp.wgl.opengl32 = LoadLibraryA("opengl32.dll");
+    if (!_sapp.wgl.opengl32) {
         _sapp_fail("Failed to load opengl32.dll\n");
     }
-    SOKOL_ASSERT(_sapp_opengl32);
-    _sapp_wglCreateContext = (PFN_wglCreateContext) GetProcAddress(_sapp_opengl32, "wglCreateContext");
-    SOKOL_ASSERT(_sapp_wglCreateContext);
-    _sapp_wglDeleteContext = (PFN_wglDeleteContext) GetProcAddress(_sapp_opengl32, "wglDeleteContext");
-    SOKOL_ASSERT(_sapp_wglDeleteContext);
-    _sapp_wglGetProcAddress = (PFN_wglGetProcAddress) GetProcAddress(_sapp_opengl32, "wglGetProcAddress");
-    SOKOL_ASSERT(_sapp_wglGetProcAddress);
-    _sapp_wglGetCurrentDC = (PFN_wglGetCurrentDC) GetProcAddress(_sapp_opengl32, "wglGetCurrentDC");
-    SOKOL_ASSERT(_sapp_wglGetCurrentDC);
-    _sapp_wglMakeCurrent = (PFN_wglMakeCurrent) GetProcAddress(_sapp_opengl32, "wglMakeCurrent");
-    SOKOL_ASSERT(_sapp_wglMakeCurrent);
+    SOKOL_ASSERT(_sapp.wgl.opengl32);
+    _sapp.wgl.CreateContext = (PFN_wglCreateContext) GetProcAddress(_sapp.wgl.opengl32, "wglCreateContext");
+    SOKOL_ASSERT(_sapp.wgl.CreateContext);
+    _sapp.wgl.DeleteContext = (PFN_wglDeleteContext) GetProcAddress(_sapp.wgl.opengl32, "wglDeleteContext");
+    SOKOL_ASSERT(_sapp.wgl.DeleteContext);
+    _sapp.wgl.GetProcAddress = (PFN_wglGetProcAddress) GetProcAddress(_sapp.wgl.opengl32, "wglGetProcAddress");
+    SOKOL_ASSERT(_sapp.wgl.GetProcAddress);
+    _sapp.wgl.GetCurrentDC = (PFN_wglGetCurrentDC) GetProcAddress(_sapp.wgl.opengl32, "wglGetCurrentDC");
+    SOKOL_ASSERT(_sapp.wgl.GetCurrentDC);
+    _sapp.wgl.MakeCurrent = (PFN_wglMakeCurrent) GetProcAddress(_sapp.wgl.opengl32, "wglMakeCurrent");
+    SOKOL_ASSERT(_sapp.wgl.MakeCurrent);
 
-    _sapp_win32_msg_hwnd = CreateWindowExW(WS_EX_OVERLAPPEDWINDOW,
+    _sapp.wgl.msg_hwnd = CreateWindowExW(WS_EX_OVERLAPPEDWINDOW,
         L"SOKOLAPP",
         L"sokol-app message window",
         WS_CLIPSIBLINGS|WS_CLIPCHILDREN,
@@ -4309,25 +4334,25 @@ _SOKOL_PRIVATE void _sapp_wgl_init(void) {
         NULL, NULL,
         GetModuleHandleW(NULL),
         NULL);
-    if (!_sapp_win32_msg_hwnd) {
+    if (!_sapp.wgl.msg_hwnd) {
         _sapp_fail("Win32: failed to create helper window!\n");
     }
-    ShowWindow(_sapp_win32_msg_hwnd, SW_HIDE);
+    ShowWindow(_sapp.wgl.msg_hwnd, SW_HIDE);
     MSG msg;
-    while (PeekMessageW(&msg, _sapp_win32_msg_hwnd, 0, 0, PM_REMOVE)) {
+    while (PeekMessageW(&msg, _sapp.wgl.msg_hwnd, 0, 0, PM_REMOVE)) {
         TranslateMessage(&msg);
         DispatchMessageW(&msg);
     }
-    _sapp_win32_msg_dc = GetDC(_sapp_win32_msg_hwnd);
-    if (!_sapp_win32_msg_dc) {
+    _sapp.wgl.msg_dc = GetDC(_sapp.wgl.msg_hwnd);
+    if (!_sapp.wgl.msg_dc) {
         _sapp_fail("Win32: failed to obtain helper window DC!\n");
     }
 }
 
 _SOKOL_PRIVATE void _sapp_wgl_shutdown(void) {
-    SOKOL_ASSERT(_sapp_opengl32 && _sapp_win32_msg_hwnd);
-    DestroyWindow(_sapp_win32_msg_hwnd); _sapp_win32_msg_hwnd = 0;
-    FreeLibrary(_sapp_opengl32); _sapp_opengl32 = 0;
+    SOKOL_ASSERT(_sapp.wgl.opengl32 && _sapp.wgl.msg_hwnd);
+    DestroyWindow(_sapp.wgl.msg_hwnd); _sapp.wgl.msg_hwnd = 0;
+    FreeLibrary(_sapp.wgl.opengl32); _sapp.wgl.opengl32 = 0;
 }
 
 _SOKOL_PRIVATE bool _sapp_wgl_has_ext(const char* ext, const char* extensions) {
@@ -4351,16 +4376,16 @@ _SOKOL_PRIVATE bool _sapp_wgl_has_ext(const char* ext, const char* extensions) {
 
 _SOKOL_PRIVATE bool _sapp_wgl_ext_supported(const char* ext) {
     SOKOL_ASSERT(ext);
-    if (_sapp_GetExtensionsStringEXT) {
-        const char* extensions = _sapp_GetExtensionsStringEXT();
+    if (_sapp.wgl.GetExtensionsStringEXT) {
+        const char* extensions = _sapp.wgl.GetExtensionsStringEXT();
         if (extensions) {
             if (_sapp_wgl_has_ext(ext, extensions)) {
                 return true;
             }
         }
     }
-    if (_sapp_GetExtensionsStringARB) {
-        const char* extensions = _sapp_GetExtensionsStringARB(_sapp_wglGetCurrentDC());
+    if (_sapp.wgl.GetExtensionsStringARB) {
+        const char* extensions = _sapp.wgl.GetExtensionsStringARB(_sapp.wgl.GetCurrentDC());
         if (extensions) {
             if (_sapp_wgl_has_ext(ext, extensions)) {
                 return true;
@@ -4371,7 +4396,7 @@ _SOKOL_PRIVATE bool _sapp_wgl_ext_supported(const char* ext) {
 }
 
 _SOKOL_PRIVATE void _sapp_wgl_load_extensions(void) {
-    SOKOL_ASSERT(_sapp_win32_msg_dc);
+    SOKOL_ASSERT(_sapp.wgl.msg_dc);
     PIXELFORMATDESCRIPTOR pfd;
     memset(&pfd, 0, sizeof(pfd));
     pfd.nSize = sizeof(pfd);
@@ -4379,42 +4404,42 @@ _SOKOL_PRIVATE void _sapp_wgl_load_extensions(void) {
     pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
     pfd.iPixelType = PFD_TYPE_RGBA;
     pfd.cColorBits = 24;
-    if (!SetPixelFormat(_sapp_win32_msg_dc, ChoosePixelFormat(_sapp_win32_msg_dc, &pfd), &pfd)) {
+    if (!SetPixelFormat(_sapp.wgl.msg_dc, ChoosePixelFormat(_sapp.wgl.msg_dc, &pfd), &pfd)) {
         _sapp_fail("WGL: failed to set pixel format for dummy context\n");
     }
-    HGLRC rc = _sapp_wglCreateContext(_sapp_win32_msg_dc);
+    HGLRC rc = _sapp.wgl.CreateContext(_sapp.wgl.msg_dc);
     if (!rc) {
         _sapp_fail("WGL: Failed to create dummy context\n");
     }
-    if (!_sapp_wglMakeCurrent(_sapp_win32_msg_dc, rc)) {
+    if (!_sapp.wgl.MakeCurrent(_sapp.wgl.msg_dc, rc)) {
         _sapp_fail("WGL: Failed to make context current\n");
     }
-    _sapp_GetExtensionsStringEXT = (PFNWGLGETEXTENSIONSSTRINGEXTPROC) _sapp_wglGetProcAddress("wglGetExtensionsStringEXT");
-    _sapp_GetExtensionsStringARB = (PFNWGLGETEXTENSIONSSTRINGARBPROC) _sapp_wglGetProcAddress("wglGetExtensionsStringARB");
-    _sapp_CreateContextAttribsARB = (PFNWGLCREATECONTEXTATTRIBSARBPROC) _sapp_wglGetProcAddress("wglCreateContextAttribsARB");
-    _sapp_SwapIntervalEXT = (PFNWGLSWAPINTERVALEXTPROC) _sapp_wglGetProcAddress("wglSwapIntervalEXT");
-    _sapp_GetPixelFormatAttribivARB = (PFNWGLGETPIXELFORMATATTRIBIVARBPROC) _sapp_wglGetProcAddress("wglGetPixelFormatAttribivARB");
-    _sapp_arb_multisample = _sapp_wgl_ext_supported("WGL_ARB_multisample");
-    _sapp_arb_create_context = _sapp_wgl_ext_supported("WGL_ARB_create_context");
-    _sapp_arb_create_context_profile = _sapp_wgl_ext_supported("WGL_ARB_create_context_profile");
-    _sapp_ext_swap_control = _sapp_wgl_ext_supported("WGL_EXT_swap_control");
-    _sapp_arb_pixel_format = _sapp_wgl_ext_supported("WGL_ARB_pixel_format");
-    _sapp_wglMakeCurrent(_sapp_win32_msg_dc, 0);
-    _sapp_wglDeleteContext(rc);
+    _sapp.wgl.GetExtensionsStringEXT = (PFNWGLGETEXTENSIONSSTRINGEXTPROC) _sapp.wgl.GetProcAddress("wglGetExtensionsStringEXT");
+    _sapp.wgl.GetExtensionsStringARB = (PFNWGLGETEXTENSIONSSTRINGARBPROC) _sapp.wgl.GetProcAddress("wglGetExtensionsStringARB");
+    _sapp.wgl.CreateContextAttribsARB = (PFNWGLCREATECONTEXTATTRIBSARBPROC) _sapp.wgl.GetProcAddress("wglCreateContextAttribsARB");
+    _sapp.wgl.SwapIntervalEXT = (PFNWGLSWAPINTERVALEXTPROC) _sapp.wgl.GetProcAddress("wglSwapIntervalEXT");
+    _sapp.wgl.GetPixelFormatAttribivARB = (PFNWGLGETPIXELFORMATATTRIBIVARBPROC) _sapp.wgl.GetProcAddress("wglGetPixelFormatAttribivARB");
+    _sapp.wgl.arb_multisample = _sapp_wgl_ext_supported("WGL_ARB_multisample");
+    _sapp.wgl.arb_create_context = _sapp_wgl_ext_supported("WGL_ARB_create_context");
+    _sapp.wgl.arb_create_context_profile = _sapp_wgl_ext_supported("WGL_ARB_create_context_profile");
+    _sapp.wgl.ext_swap_control = _sapp_wgl_ext_supported("WGL_EXT_swap_control");
+    _sapp.wgl.arb_pixel_format = _sapp_wgl_ext_supported("WGL_ARB_pixel_format");
+    _sapp.wgl.MakeCurrent(_sapp.wgl.msg_dc, 0);
+    _sapp.wgl.DeleteContext(rc);
 }
 
 _SOKOL_PRIVATE int _sapp_wgl_attrib(int pixel_format, int attrib) {
-    SOKOL_ASSERT(_sapp_arb_pixel_format);
+    SOKOL_ASSERT(_sapp.wgl.arb_pixel_format);
     int value = 0;
-    if (!_sapp_GetPixelFormatAttribivARB(_sapp_win32_dc, pixel_format, 0, 1, &attrib, &value)) {
+    if (!_sapp.wgl.GetPixelFormatAttribivARB(_sapp.win32.dc, pixel_format, 0, 1, &attrib, &value)) {
         _sapp_fail("WGL: Failed to retrieve pixel format attribute\n");
     }
     return value;
 }
 
 _SOKOL_PRIVATE int _sapp_wgl_find_pixel_format(void) {
-    SOKOL_ASSERT(_sapp_win32_dc);
-    SOKOL_ASSERT(_sapp_arb_pixel_format);
+    SOKOL_ASSERT(_sapp.win32.dc);
+    SOKOL_ASSERT(_sapp.wgl.arb_pixel_format);
     const _sapp_gl_fbconfig* closest;
 
     int native_count = _sapp_wgl_attrib(1, WGL_NUMBER_PIXEL_FORMATS_ARB);
@@ -4442,7 +4467,7 @@ _SOKOL_PRIVATE int _sapp_wgl_find_pixel_format(void) {
         if (_sapp_wgl_attrib(n, WGL_DOUBLE_BUFFER_ARB)) {
             u->doublebuffer = true;
         }
-        if (_sapp_arb_multisample) {
+        if (_sapp.arb.multisample) {
             u->samples = _sapp_wgl_attrib(n, WGL_SAMPLES_ARB);
         }
         u->handle = n;
@@ -4474,16 +4499,16 @@ _SOKOL_PRIVATE void _sapp_wgl_create_context(void) {
         _sapp_fail("WGL: Didn't find matching pixel format.\n");
     }
     PIXELFORMATDESCRIPTOR pfd;
-    if (!DescribePixelFormat(_sapp_win32_dc, pixel_format, sizeof(pfd), &pfd)) {
+    if (!DescribePixelFormat(_sapp.win32.dc, pixel_format, sizeof(pfd), &pfd)) {
         _sapp_fail("WGL: Failed to retrieve PFD for selected pixel format!\n");
     }
-    if (!SetPixelFormat(_sapp_win32_dc, pixel_format, &pfd)) {
+    if (!SetPixelFormat(_sapp.win32.dc, pixel_format, &pfd)) {
         _sapp_fail("WGL: Failed to set selected pixel format!\n");
     }
-    if (!_sapp_arb_create_context) {
+    if (!_sapp.wgl.arb_create_context) {
         _sapp_fail("WGL: ARB_create_context required!\n");
     }
-    if (!_sapp_arb_create_context_profile) {
+    if (!_sapp.wgl.arb_create_context_profile) {
         _sapp_fail("WGL: ARB_create_context_profile required!\n");
     }
     const int attrs[] = {
@@ -4493,8 +4518,8 @@ _SOKOL_PRIVATE void _sapp_wgl_create_context(void) {
         WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_CORE_PROFILE_BIT_ARB,
         0, 0
     };
-    _sapp_gl_ctx = _sapp_CreateContextAttribsARB(_sapp_win32_dc, 0, attrs);
-    if (!_sapp_gl_ctx) {
+    _sapp.wgl.gl_ctx = _sapp.wgl.CreateContextAttribsARB(_sapp.win32.dc, 0, attrs);
+    if (!_sapp.wgl.gl_ctx) {
         const DWORD err = GetLastError();
         if (err == (0xc0070000 | ERROR_INVALID_VERSION_ARB)) {
             _sapp_fail("WGL: Driver does not support OpenGL version 3.3\n");
@@ -4509,23 +4534,23 @@ _SOKOL_PRIVATE void _sapp_wgl_create_context(void) {
             _sapp_fail("WGL: Failed to create OpenGL context");
         }
     }
-    _sapp_wglMakeCurrent(_sapp_win32_dc, _sapp_gl_ctx);
-    if (_sapp_ext_swap_control) {
+    _sapp.wgl.MakeCurrent(_sapp.win32.dc, _sapp.wgl.gl_ctx);
+    if (_sapp.wgl.ext_swap_control) {
         /* FIXME: DwmIsCompositionEnabled() (see GLFW) */
-        _sapp_SwapIntervalEXT(_sapp.swap_interval);
+        _sapp.wgl.SwapIntervalEXT(_sapp.swap_interval);
     }
 }
 
 _SOKOL_PRIVATE void _sapp_wgl_destroy_context(void) {
-    SOKOL_ASSERT(_sapp_gl_ctx);
-    _sapp_wglDeleteContext(_sapp_gl_ctx);
-    _sapp_gl_ctx = 0;
+    SOKOL_ASSERT(_sapp.wgl.gl_ctx);
+    _sapp.wgl.DeleteContext(_sapp.wgl.gl_ctx);
+    _sapp.wgl.gl_ctx = 0;
 }
 
 _SOKOL_PRIVATE void _sapp_wgl_swap_buffers(void) {
-    SOKOL_ASSERT(_sapp_win32_dc);
+    SOKOL_ASSERT(_sapp.win32.dc);
     /* FIXME: DwmIsCompositionEnabled? (see GLFW) */
-    SwapBuffers(_sapp_win32_dc);
+    SwapBuffers(_sapp.win32.dc);
 }
 #endif /* SOKOL_GLCORE33 */
 
@@ -4551,7 +4576,7 @@ _SOKOL_PRIVATE bool _sapp_win32_wide_to_utf8(const wchar_t* src, char* dst, int 
 }
 
 _SOKOL_PRIVATE void _sapp_win32_toggle_fullscreen(void) {
-    HMONITOR monitor = MonitorFromWindow(_sapp_win32_hwnd, MONITOR_DEFAULTTONEAREST);
+    HMONITOR monitor = MonitorFromWindow(_sapp.win32.hwnd, MONITOR_DEFAULTTONEAREST);
     MONITORINFO minfo;
     memset(&minfo, 0, sizeof(minfo));
     minfo.cbSize = sizeof(MONITORINFO);
@@ -4567,8 +4592,8 @@ _SOKOL_PRIVATE void _sapp_win32_toggle_fullscreen(void) {
     _sapp.fullscreen = !_sapp.fullscreen;
     if (!_sapp.fullscreen) {
         win_style = WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_SIZEBOX;
-        rect.right = (int) ((float)_sapp.desc.width * _sapp_win32_window_scale);
-        rect.bottom = (int) ((float)_sapp.desc.height * _sapp_win32_window_scale);
+        rect.right = (int) ((float)_sapp.desc.width * _sapp.win32.window_scale);
+        rect.bottom = (int) ((float)_sapp.desc.height * _sapp.win32.window_scale);
     }
     else {
         win_style = WS_POPUP | WS_SYSMENU | WS_VISIBLE;
@@ -4583,8 +4608,8 @@ _SOKOL_PRIVATE void _sapp_win32_toggle_fullscreen(void) {
         rect.top = (monitor_h - win_height) / 2;
     }
 
-    SetWindowLongPtr(_sapp_win32_hwnd, GWL_STYLE, win_style);
-    SetWindowPos(_sapp_win32_hwnd, HWND_TOP, mr.left + rect.left, mr.top + rect.top, win_width, win_height, SWP_SHOWWINDOW | SWP_FRAMECHANGED);
+    SetWindowLongPtr(_sapp.win32.hwnd, GWL_STYLE, win_style);
+    SetWindowPos(_sapp.win32.hwnd, HWND_TOP, mr.left + rect.left, mr.top + rect.top, win_width, win_height, SWP_SHOWWINDOW | SWP_FRAMECHANGED);
 }
 
 _SOKOL_PRIVATE void _sapp_win32_show_mouse(bool shown) {
@@ -4724,11 +4749,11 @@ _SOKOL_PRIVATE void _sapp_win32_init_keytable(void) {
 /* updates current window and framebuffer size from the window's client rect, returns true if size has changed */
 _SOKOL_PRIVATE bool _sapp_win32_update_dimensions(void) {
     RECT rect;
-    if (GetClientRect(_sapp_win32_hwnd, &rect)) {
-        _sapp.window_width = (int)((float)(rect.right - rect.left) / _sapp_win32_window_scale);
-        _sapp.window_height = (int)((float)(rect.bottom - rect.top) / _sapp_win32_window_scale);
-        const int fb_width = (int)((float)_sapp.window_width * _sapp_win32_content_scale);
-        const int fb_height = (int)((float)_sapp.window_height * _sapp_win32_content_scale);
+    if (GetClientRect(_sapp.win32.hwnd, &rect)) {
+        _sapp.window_width = (int)((float)(rect.right - rect.left) / _sapp.win32.window_scale);
+        _sapp.window_height = (int)((float)(rect.bottom - rect.top) / _sapp.win32.window_scale);
+        const int fb_width = (int)((float)_sapp.window_width * _sapp.win32.content_scale);
+        const int fb_height = (int)((float)_sapp.window_height * _sapp.win32.content_scale);
         if ((fb_width != _sapp.framebuffer_width) || (fb_height != _sapp.framebuffer_height)) {
             _sapp.framebuffer_width = fb_width;
             _sapp.framebuffer_height = fb_height;
@@ -4825,7 +4850,7 @@ _SOKOL_PRIVATE void _sapp_win32_app_event(sapp_event_type type) {
 
 _SOKOL_PRIVATE LRESULT CALLBACK _sapp_win32_wndproc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
     /* FIXME: refresh rendering during resize with a WM_TIMER event */
-    if (!_sapp_win32_in_create_window) {
+    if (!_sapp.win32.in_create_window) {
         switch (uMsg) {
             case WM_CLOSE:
                 /* only give user a chance to intervene when sapp_quit() wasn't already called */
@@ -4863,8 +4888,8 @@ _SOKOL_PRIVATE LRESULT CALLBACK _sapp_win32_wndproc(HWND hWnd, UINT uMsg, WPARAM
             case WM_SIZE:
                 {
                     const bool iconified = wParam == SIZE_MINIMIZED;
-                    if (iconified != _sapp_win32_iconified) {
-                        _sapp_win32_iconified = iconified;
+                    if (iconified != _sapp.win32.iconified) {
+                        _sapp.win32.iconified = iconified;
                         if (iconified) {
                             _sapp_win32_app_event(SAPP_EVENTTYPE_ICONIFIED);
                         }
@@ -4901,15 +4926,15 @@ _SOKOL_PRIVATE LRESULT CALLBACK _sapp_win32_wndproc(HWND hWnd, UINT uMsg, WPARAM
                 _sapp_win32_mouse_event(SAPP_EVENTTYPE_MOUSE_UP, SAPP_MOUSEBUTTON_MIDDLE);
                 break;
             case WM_MOUSEMOVE:
-                _sapp.mouse_x = (float)GET_X_LPARAM(lParam) * _sapp_win32_mouse_scale;
-                _sapp.mouse_y = (float)GET_Y_LPARAM(lParam) * _sapp_win32_mouse_scale;
+                _sapp.mouse_x = (float)GET_X_LPARAM(lParam) * _sapp.win32.mouse_scale;
+                _sapp.mouse_y = (float)GET_Y_LPARAM(lParam) * _sapp.win32.mouse_scale;
                 if (!_sapp.win32_mouse_tracked) {
                     _sapp.win32_mouse_tracked = true;
                     TRACKMOUSEEVENT tme;
                     memset(&tme, 0, sizeof(tme));
                     tme.cbSize = sizeof(tme);
                     tme.dwFlags = TME_LEAVE;
-                    tme.hwndTrack = _sapp_win32_hwnd;
+                    tme.hwndTrack = _sapp.win32.hwnd;
                     TrackMouseEvent(&tme);
                     _sapp_win32_mouse_event(SAPP_EVENTTYPE_MOUSE_ENTER, SAPP_MOUSEBUTTON_INVALID);
                 }
@@ -4964,14 +4989,14 @@ _SOKOL_PRIVATE void _sapp_win32_create_window(void) {
     }
     else {
         win_style = WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_SIZEBOX;
-        rect.right = (int) ((float)_sapp.window_width * _sapp_win32_window_scale);
-        rect.bottom = (int) ((float)_sapp.window_height * _sapp_win32_window_scale);
+        rect.right = (int) ((float)_sapp.window_width * _sapp.win32.window_scale);
+        rect.bottom = (int) ((float)_sapp.window_height * _sapp.win32.window_scale);
     }
     AdjustWindowRectEx(&rect, win_style, FALSE, win_ex_style);
     const int win_width = rect.right - rect.left;
     const int win_height = rect.bottom - rect.top;
-    _sapp_win32_in_create_window = true;
-    _sapp_win32_hwnd = CreateWindowExW(
+    _sapp.win32.in_create_window = true;
+    _sapp.win32.hwnd = CreateWindowExW(
         win_ex_style,               /* dwExStyle */
         L"SOKOLAPP",                /* lpClassName */
         _sapp.window_title_wide,    /* lpWindowName */
@@ -4984,68 +5009,68 @@ _SOKOL_PRIVATE void _sapp_win32_create_window(void) {
         NULL,                       /* hMenu */
         GetModuleHandle(NULL),      /* hInstance */
         NULL);                      /* lParam */
-    ShowWindow(_sapp_win32_hwnd, SW_SHOW);
-    _sapp_win32_in_create_window = false;
-    _sapp_win32_dc = GetDC(_sapp_win32_hwnd);
-    SOKOL_ASSERT(_sapp_win32_dc);
+    ShowWindow(_sapp.win32.hwnd, SW_SHOW);
+    _sapp.win32.in_create_window = false;
+    _sapp.win32.dc = GetDC(_sapp.win32.hwnd);
+    SOKOL_ASSERT(_sapp.win32.dc);
     _sapp_win32_update_dimensions();
 }
 
 _SOKOL_PRIVATE void _sapp_win32_destroy_window(void) {
-    DestroyWindow(_sapp_win32_hwnd); _sapp_win32_hwnd = 0;
+    DestroyWindow(_sapp.win32.hwnd); _sapp.win32.hwnd = 0;
     UnregisterClassW(L"SOKOLAPP", GetModuleHandleW(NULL));
 }
 
 _SOKOL_PRIVATE void _sapp_win32_init_dpi(void) {
-    SOKOL_ASSERT(0 == _sapp_win32_setprocessdpiaware);
-    SOKOL_ASSERT(0 == _sapp_win32_setprocessdpiawareness);
-    SOKOL_ASSERT(0 == _sapp_win32_getdpiformonitor);
+    SOKOL_ASSERT(0 == _sapp.win32.setprocessdpiaware);
+    SOKOL_ASSERT(0 == _sapp.win32.setprocessdpiawareness);
+    SOKOL_ASSERT(0 == _sapp.win32.getdpiformonitor);
     HINSTANCE user32 = LoadLibraryA("user32.dll");
     if (user32) {
-        _sapp_win32_setprocessdpiaware = (SETPROCESSDPIAWARE_T) GetProcAddress(user32, "SetProcessDPIAware");
+        _sapp.win32.setprocessdpiaware = (SETPROCESSDPIAWARE_T) GetProcAddress(user32, "SetProcessDPIAware");
     }
     HINSTANCE shcore = LoadLibraryA("shcore.dll");
     if (shcore) {
-        _sapp_win32_setprocessdpiawareness = (SETPROCESSDPIAWARENESS_T) GetProcAddress(shcore, "SetProcessDpiAwareness");
-        _sapp_win32_getdpiformonitor = (GETDPIFORMONITOR_T) GetProcAddress(shcore, "GetDpiForMonitor");
+        _sapp.win32.setprocessdpiawareness = (SETPROCESSDPIAWARENESS_T) GetProcAddress(shcore, "SetProcessDpiAwareness");
+        _sapp.win32.getdpiformonitor = (GETDPIFORMONITOR_T) GetProcAddress(shcore, "GetDpiForMonitor");
     }
-    if (_sapp_win32_setprocessdpiawareness) {
+    if (_sapp.win32.setprocessdpiawareness) {
         /* if the app didn't request HighDPI rendering, let Windows do the upscaling */
         PROCESS_DPI_AWARENESS process_dpi_awareness = PROCESS_SYSTEM_DPI_AWARE;
-        _sapp_win32_dpi_aware = true;
+        _sapp.win32.dpi.aware = true;
         if (!_sapp.desc.high_dpi) {
             process_dpi_awareness = PROCESS_DPI_UNAWARE;
-            _sapp_win32_dpi_aware = false;
+            _sapp.win32.dpi.aware = false;
         }
-        _sapp_win32_setprocessdpiawareness(process_dpi_awareness);
+        _sapp.win32.dpi.setprocessdpiawareness(process_dpi_awareness);
     }
-    else if (_sapp_win32_setprocessdpiaware) {
-        _sapp_win32_setprocessdpiaware();
-        _sapp_win32_dpi_aware = true;
+    else if (_sapp.win32.setprocessdpiaware) {
+        _sapp.win32.setprocessdpiaware();
+        _sapp.win32.dpi.aware = true;
     }
     /* get dpi scale factor for main monitor */
-    if (_sapp_win32_getdpiformonitor && _sapp_win32_dpi_aware) {
+    if (_sapp.win32.getdpiformonitor && _sapp.win32.dpi.aware) {
         POINT pt = { 1, 1 };
         HMONITOR hm = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
         UINT dpix, dpiy;
-        HRESULT hr = _sapp_win32_getdpiformonitor(hm, MDT_EFFECTIVE_DPI, &dpix, &dpiy);
+        HRESULT hr = _sapp.win32.getdpiformonitor(hm, MDT_EFFECTIVE_DPI, &dpix, &dpiy);
         _SOKOL_UNUSED(hr);
         SOKOL_ASSERT(SUCCEEDED(hr));
         /* clamp window scale to an integer factor */
-        _sapp_win32_window_scale = (float)dpix / 96.0f;
+        _sapp.win32.window_scale = (float)dpix / 96.0f;
     }
     else {
-        _sapp_win32_window_scale = 1.0f;
+        _sapp.win32.window_scale = 1.0f;
     }
     if (_sapp.desc.high_dpi) {
-        _sapp_win32_content_scale = _sapp_win32_window_scale;
-        _sapp_win32_mouse_scale = 1.0f;
+        _sapp.win32.content_scale = _sapp.win32.window_scale;
+        _sapp.win32.mouse_scale = 1.0f;
     }
     else {
-        _sapp_win32_content_scale = 1.0f;
-        _sapp_win32_mouse_scale = 1.0f / _sapp_win32_window_scale;
+        _sapp.win32.content_scale = 1.0f;
+        _sapp.win32.mouse_scale = 1.0f / _sapp.win32.window_scale;
     }
-    _sapp.dpi_scale = _sapp_win32_content_scale;
+    _sapp.dpi_scale = _sapp.win32.content_scale;
     if (user32) {
         FreeLibrary(user32);
     }
@@ -5056,7 +5081,7 @@ _SOKOL_PRIVATE void _sapp_win32_init_dpi(void) {
 
 _SOKOL_PRIVATE bool _sapp_win32_set_clipboard_string(const char* str) {
     SOKOL_ASSERT(str);
-    SOKOL_ASSERT(_sapp_win32_hwnd);
+    SOKOL_ASSERT(_sapp.win32.hwnd);
     SOKOL_ASSERT(_sapp.clipboard_enabled && (_sapp.clipboard_size > 0));
 
     wchar_t* wchar_buf = 0;
@@ -5074,7 +5099,7 @@ _SOKOL_PRIVATE bool _sapp_win32_set_clipboard_string(const char* str) {
     }
     GlobalUnlock(wchar_buf);
     wchar_buf = 0;
-    if (!OpenClipboard(_sapp_win32_hwnd)) {
+    if (!OpenClipboard(_sapp.win32.hwnd)) {
         goto error;
     }
     EmptyClipboard();
@@ -5094,8 +5119,8 @@ error:
 
 _SOKOL_PRIVATE const char* _sapp_win32_get_clipboard_string(void) {
     SOKOL_ASSERT(_sapp.clipboard_enabled && _sapp.clipboard);
-    SOKOL_ASSERT(_sapp_win32_hwnd);
-    if (!OpenClipboard(_sapp_win32_hwnd)) {
+    SOKOL_ASSERT(_sapp.win32.hwnd);
+    if (!OpenClipboard(_sapp.win32.hwnd)) {
         /* silently ignore any errors and just return the current
            content of the local clipboard buffer
         */
@@ -5152,8 +5177,8 @@ _SOKOL_PRIVATE void _sapp_run(const sapp_desc* desc) {
         }
         _sapp_frame();
         #if defined(SOKOL_D3D11)
-            IDXGISwapChain_Present(_sapp_dxgi_swap_chain, _sapp.swap_interval, 0);
-            if (IsIconic(_sapp_win32_hwnd)) {
+            IDXGISwapChain_Present(_sapp.d3d11.swap_chain, _sapp.swap_interval, 0);
+            if (IsIconic(_sapp.win32.hwnd)) {
                 Sleep(16 * _sapp.swap_interval);
             }
         #endif
@@ -5168,7 +5193,7 @@ _SOKOL_PRIVATE void _sapp_run(const sapp_desc* desc) {
             _sapp_win32_app_event(SAPP_EVENTTYPE_RESIZED);
         }
         if (_sapp.quit_requested) {
-            PostMessage(_sapp_win32_hwnd, WM_CLOSE, 0, 0);
+            PostMessage(_sapp.win32.hwnd, WM_CLOSE, 0, 0);
         }
     }
     _sapp_call_cleanup();
@@ -7221,7 +7246,7 @@ _SOKOL_PRIVATE void _sapp_x11_set_fullscreen(bool enable) {
                                 0, 1, 0);
         }
         else {
-            const int _NET_WM_STATE_REMOVE = 0; 
+            const int _NET_WM_STATE_REMOVE = 0;
             _sapp_x11_send_event(_sapp_x11_NET_WM_STATE,
                                 _NET_WM_STATE_REMOVE,
                                 _sapp_x11_NET_WM_STATE_FULLSCREEN,
@@ -7841,7 +7866,7 @@ SOKOL_API_IMPL int sapp_width(void) {
 
 SOKOL_API_IMPL int sapp_color_format(void) {
     #if defined(_SAPP_EMSCRIPTEN) && defined(SOKOL_WGPU)
-        switch (_sapp_emsc.wgpu.render_format) {
+        switch (_sapp.emsc.wgpu.render_format) {
             case WGPUTextureFormat_RGBA8Unorm:
                 return _SAPP_PIXELFORMAT_RGBA8;
             case WGPUTextureFormat_BGRA8Unorm:
@@ -8036,7 +8061,7 @@ SOKOL_API_IMPL const void* sapp_ios_get_window(void) {
 SOKOL_API_IMPL const void* sapp_d3d11_get_device(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(SOKOL_D3D11)
-        return _sapp_d3d11_device;
+        return _sapp.d3d11.device;
     #else
         return 0;
     #endif
@@ -8045,7 +8070,7 @@ SOKOL_API_IMPL const void* sapp_d3d11_get_device(void) {
 SOKOL_API_IMPL const void* sapp_d3d11_get_device_context(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(SOKOL_D3D11)
-        return _sapp_d3d11_device_context;
+        return _sapp.d3d11.device_context;
     #else
         return 0;
     #endif
@@ -8054,7 +8079,7 @@ SOKOL_API_IMPL const void* sapp_d3d11_get_device_context(void) {
 SOKOL_API_IMPL const void* sapp_d3d11_get_render_target_view(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(SOKOL_D3D11)
-        return _sapp_d3d11_rtv;
+        return _sapp.d3d11.rtv;
     #else
         return 0;
     #endif
@@ -8063,7 +8088,7 @@ SOKOL_API_IMPL const void* sapp_d3d11_get_render_target_view(void) {
 SOKOL_API_IMPL const void* sapp_d3d11_get_depth_stencil_view(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(SOKOL_D3D11)
-        return _sapp_d3d11_dsv;
+        return _sapp.d3d11.dsv;
     #else
         return 0;
     #endif
@@ -8072,7 +8097,7 @@ SOKOL_API_IMPL const void* sapp_d3d11_get_depth_stencil_view(void) {
 SOKOL_API_IMPL const void* sapp_win32_get_hwnd(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(_SAPP_WIN32)
-        return _sapp_win32_hwnd;
+        return _sapp.win32.hwnd;
     #else
         return 0;
     #endif
@@ -8081,7 +8106,7 @@ SOKOL_API_IMPL const void* sapp_win32_get_hwnd(void) {
 SOKOL_API_IMPL const void* sapp_wgpu_get_device(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(_SAPP_EMSCRIPTEN) && defined(SOKOL_WGPU)
-        return (const void*) _sapp_emsc.wgpu.device;
+        return (const void*) _sapp.emsc.wgpu.device;
     #else
         return 0;
     #endif
@@ -8091,10 +8116,10 @@ SOKOL_API_IMPL const void* sapp_wgpu_get_render_view(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(_SAPP_EMSCRIPTEN) && defined(SOKOL_WGPU)
         if (_sapp.sample_count > 1) {
-            return (const void*) _sapp_emsc.wgpu.msaa_view;
+            return (const void*) _sapp.emsc.wgpu.msaa_view;
         }
         else {
-            return (const void*) _sapp_emsc.wgpu.swapchain_view;
+            return (const void*) _sapp.emsc.wgpu.swapchain_view;
         }
     #else
         return 0;
@@ -8105,7 +8130,7 @@ SOKOL_API_IMPL const void* sapp_wgpu_get_resolve_view(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(_SAPP_EMSCRIPTEN) && defined(SOKOL_WGPU)
         if (_sapp.sample_count > 1) {
-            return (const void*) _sapp_emsc.wgpu.swapchain_view;
+            return (const void*) _sapp.emsc.wgpu.swapchain_view;
         }
         else {
             return 0;
@@ -8118,7 +8143,7 @@ SOKOL_API_IMPL const void* sapp_wgpu_get_resolve_view(void) {
 SOKOL_API_IMPL const void* sapp_wgpu_get_depth_stencil_view(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(_SAPP_EMSCRIPTEN) && defined(SOKOL_WGPU)
-        return (const void*) _sapp_emsc.wgpu.depth_stencil_view;
+        return (const void*) _sapp.emsc.wgpu.depth_stencil_view;
     #else
         return 0;
     #endif

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1080,9 +1080,11 @@ inline int sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 
 /*== PLATFORM SPECIFIC INCLUDES AND DEFINES ==================================*/
 #if defined(_SAPP_APPLE)
+    #if defined(SOKOL_METAL)
+        #import <Metal/Metal.h>
+        #import <MetalKit/MetalKit.h>
+    #endif
     #if defined(_SAPP_MACOS)
-            #import <Metal/Metal.h>
-            #import <MetalKit/MetalKit.h>
         #if !defined(SOKOL_METAL)
             #ifndef GL_SILENCE_DEPRECATION
             #define GL_SILENCE_DEPRECATION
@@ -1152,8 +1154,7 @@ inline int sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #include <d3d11.h>
     #include <dxgi.h>
     #endif
-    /* see https://github.com/floooh/sokol/issues/138 */
-    #ifndef WM_MOUSEHWHEEL
+    #ifndef WM_MOUSEHWHEEL /* see https://github.com/floooh/sokol/issues/138 */
     #define WM_MOUSEHWHEEL (0x020E)
     #endif
 #elif defined(_SAPP_ANDROID)
@@ -1182,7 +1183,6 @@ inline int sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #include <GL/gl.h>
     #include <dlfcn.h> /* dlopen, dlsym, dlclose */
     #include <limits.h> /* LONG_MAX */
-
     #define GLX_VENDOR 1
     #define GLX_RGBA_BIT 0x00000001
     #define GLX_WINDOW_BIT 0x00000001

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1830,108 +1830,108 @@ typedef int  GLint;
 
 // X Macro list of GL function names and signatures
 #define _SAPP_GL_FUNCS \
-    _SAPP_XMACRO(glBindVertexArray,                 void (GL_APIENTRY *PFN_glBindVertexArray)(GLuint array)) \
-    _SAPP_XMACRO(glFramebufferTextureLayer,         void (GL_APIENTRY *PFN_glFramebufferTextureLayer)(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer)) \
-    _SAPP_XMACRO(glGenFramebuffers,                 void (GL_APIENTRY *PFN_glGenFramebuffers)(GLsizei n, GLuint * framebuffers)) \
-    _SAPP_XMACRO(glBindFramebuffer,                 void (GL_APIENTRY *PFN_glBindFramebuffer)(GLenum target, GLuint framebuffer)) \
-    _SAPP_XMACRO(glBindRenderbuffer,                void (GL_APIENTRY *PFN_glBindRenderbuffer)(GLenum target, GLuint renderbuffer)) \
-    _SAPP_XMACRO(glGetStringi,                      const GLubyte * (GL_APIENTRY *PFN_glGetStringi)(GLenum name, GLuint index)) \
-    _SAPP_XMACRO(glClearBufferfi,                   void (GL_APIENTRY *PFN_glClearBufferfi)(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil)) \
-    _SAPP_XMACRO(glClearBufferfv,                   void (GL_APIENTRY *PFN_glClearBufferfv)(GLenum buffer, GLint drawbuffer, const GLfloat * value)) \
-    _SAPP_XMACRO(glClearBufferuiv,                  void (GL_APIENTRY *PFN_glClearBufferuiv)(GLenum buffer, GLint drawbuffer, const GLuint * value)) \
-    _SAPP_XMACRO(glDeleteRenderbuffers,             void (GL_APIENTRY *PFN_glDeleteRenderbuffers)(GLsizei n, const GLuint * renderbuffers)) \
-    _SAPP_XMACRO(glUniform4fv,                      void (GL_APIENTRY *PFN_glUniform4fv)(GLint location, GLsizei count, const GLfloat * value)) \
-    _SAPP_XMACRO(glUniform2fv,                      void (GL_APIENTRY *PFN_glUniform2fv)(GLint location, GLsizei count, const GLfloat * value)) \
-    _SAPP_XMACRO(glUseProgram,                      void (GL_APIENTRY *PFN_glUseProgram)(GLuint program)) \
-    _SAPP_XMACRO(glShaderSource,                    void (GL_APIENTRY *PFN_glShaderSource)(GLuint shader, GLsizei count, const GLchar *const* string, const GLint * length)) \
-    _SAPP_XMACRO(glLinkProgram,                     void (GL_APIENTRY *PFN_glLinkProgram)(GLuint program)) \
-    _SAPP_XMACRO(glGetUniformLocation,              GLint (GL_APIENTRY *PFN_glGetUniformLocation)(GLuint program, const GLchar * name)) \
-    _SAPP_XMACRO(glGetShaderiv,                     void (GL_APIENTRY *PFN_glGetShaderiv)(GLuint shader, GLenum pname, GLint * params)) \
-    _SAPP_XMACRO(glGetProgramInfoLog,               void (GL_APIENTRY *PFN_glGetProgramInfoLog)(GLuint program, GLsizei bufSize, GLsizei * length, GLchar * infoLog)) \
-    _SAPP_XMACRO(glGetAttribLocation,               GLint(GL_APIENTRY *PFN_glGetAttribLocation)(GLuint program, const GLchar * name)) \
-    _SAPP_XMACRO(glDisableVertexAttribArray,        void (GL_APIENTRY *PFN_glDisableVertexAttribArray)(GLuint index)) \
-    _SAPP_XMACRO(glDeleteShader,                    void (GL_APIENTRY *PFN_glDeleteShader)(GLuint shader)) \
-    _SAPP_XMACRO(glDeleteProgram,                   void (GL_APIENTRY *PFN_glDeleteProgram)(GLuint program)) \
-    _SAPP_XMACRO(glCompileShader,                   void (GL_APIENTRY *PFN_glCompileShader)(GLuint shader)) \
-    _SAPP_XMACRO(glStencilFuncSeparate,             void (GL_APIENTRY *PFN_glStencilFuncSeparate)(GLenum face, GLenum func, GLint ref, GLuint mask)) \
-    _SAPP_XMACRO(glStencilOpSeparate,               void (GL_APIENTRY *PFN_glStencilOpSeparate)(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass)) \
-    _SAPP_XMACRO(glRenderbufferStorageMultisample,  void (GL_APIENTRY *PFN_glRenderbufferStorageMultisample)(GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height)) \
-    _SAPP_XMACRO(glDrawBuffers,                     void (GL_APIENTRY *PFN_glDrawBuffers)(GLsizei n, const GLenum * bufs)) \
-    _SAPP_XMACRO(glVertexAttribDivisor,             void (GL_APIENTRY *PFN_glVertexAttribDivisor)(GLuint index, GLuint divisor)) \
-    _SAPP_XMACRO(glBufferSubData,                   void (GL_APIENTRY *PFN_glBufferSubData)(GLenum target, GLintptr offset, GLsizeiptr size, const void * data)) \
-    _SAPP_XMACRO(glGenBuffers,                      void (GL_APIENTRY *PFN_glGenBuffers)(GLsizei n, GLuint * buffers)) \
-    _SAPP_XMACRO(glCheckFramebufferStatus,          GLenum (GL_APIENTRY *PFN_glCheckFramebufferStatus)(GLenum target)) \
-    _SAPP_XMACRO(glFramebufferRenderbuffer,         void (GL_APIENTRY *PFN_glFramebufferRenderbuffer)(GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer)) \
-    _SAPP_XMACRO(glCompressedTexImage2D,            void (GL_APIENTRY *PFN_glCompressedTexImage2D)(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, const void * data)) \
-    _SAPP_XMACRO(glCompressedTexImage3D,            void (GL_APIENTRY *PFN_glCompressedTexImage3D)(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, const void * data)) \
-    _SAPP_XMACRO(glActiveTexture,                   void (GL_APIENTRY *PFN_glActiveTexture)(GLenum texture)) \
-    _SAPP_XMACRO(glTexSubImage3D,                   void (GL_APIENTRY *PFN_glTexSubImage3D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const void * pixels)) \
-    _SAPP_XMACRO(glUniformMatrix4fv,                void (GL_APIENTRY *PFN_glUniformMatrix4fv)(GLint location, GLsizei count, GLboolean transpose, const GLfloat * value)) \
-    _SAPP_XMACRO(glRenderbufferStorage,             void (GL_APIENTRY *PFN_glRenderbufferStorage)(GLenum target, GLenum internalformat, GLsizei width, GLsizei height)) \
-    _SAPP_XMACRO(glGenTextures,                     void (GL_APIENTRY *PFN_glGenTextures)(GLsizei n, GLuint * textures)) \
-    _SAPP_XMACRO(glPolygonOffset,                   void (GL_APIENTRY *PFN_glPolygonOffset)(GLfloat factor, GLfloat units)) \
-    _SAPP_XMACRO(glDrawElements,                    void (GL_APIENTRY *PFN_glDrawElements)(GLenum mode, GLsizei count, GLenum type, const void * indices)) \
-    _SAPP_XMACRO(glDeleteFramebuffers,              void (GL_APIENTRY *PFN_glDeleteFramebuffers)(GLsizei n, const GLuint * framebuffers)) \
-    _SAPP_XMACRO(glBlendEquationSeparate,           void (GL_APIENTRY *PFN_glBlendEquationSeparate)(GLenum modeRGB, GLenum modeAlpha)) \
-    _SAPP_XMACRO(glDeleteTextures,                  void (GL_APIENTRY *PFN_glDeleteTextures)(GLsizei n, const GLuint * textures)) \
-    _SAPP_XMACRO(glGetProgramiv,                    void (GL_APIENTRY *PFN_glGetProgramiv)(GLuint program, GLenum pname, GLint * params)) \
-    _SAPP_XMACRO(glBindTexture,                     void (GL_APIENTRY *PFN_glBindTexture)(GLenum target, GLuint texture)) \
-    _SAPP_XMACRO(glTexImage3D,                      void (GL_APIENTRY *PFN_glTexImage3D)(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const void * pixels)) \
-    _SAPP_XMACRO(glCreateShader,                    GLuint (GL_APIENTRY *PFN_glCreateShader)(GLenum type)) \
-    _SAPP_XMACRO(glTexSubImage2D,                   void (GL_APIENTRY *PFN_glTexSubImage2D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const void * pixels)) \
-    _SAPP_XMACRO(glClearDepth,                      void (GL_APIENTRY *PFN_glClearDepth)(GLdouble depth)) \
-    _SAPP_XMACRO(glFramebufferTexture2D,            void (GL_APIENTRY *PFN_glFramebufferTexture2D)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level)) \
-    _SAPP_XMACRO(glCreateProgram,                   GLuint (GL_APIENTRY *PFN_glCreateProgram)(void)) \
-    _SAPP_XMACRO(glViewport,                        void (GL_APIENTRY *PFN_glViewport)(GLint x, GLint y, GLsizei width, GLsizei height)) \
-    _SAPP_XMACRO(glDeleteBuffers,                   void (GL_APIENTRY *PFN_glDeleteBuffers)(GLsizei n, const GLuint * buffers)) \
-    _SAPP_XMACRO(glDrawArrays,                      void (GL_APIENTRY *PFN_glDrawArrays)(GLenum mode, GLint first, GLsizei count)) \
-    _SAPP_XMACRO(glDrawElementsInstanced,           void (GL_APIENTRY *PFN_glDrawElementsInstanced)(GLenum mode, GLsizei count, GLenum type, const void * indices, GLsizei instancecount)) \
-    _SAPP_XMACRO(glVertexAttribPointer,             void (GL_APIENTRY *PFN_glVertexAttribPointer)(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void * pointer)) \
-    _SAPP_XMACRO(glUniform1i,                       void (GL_APIENTRY *PFN_glUniform1i)(GLint location, GLint v0)) \
-    _SAPP_XMACRO(glDisable,                         void (GL_APIENTRY *PFN_glDisable)(GLenum cap)) \
-    _SAPP_XMACRO(glColorMask,                       void (GL_APIENTRY *PFN_glColorMask)(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha)) \
-    _SAPP_XMACRO(glBindBuffer,                      void (GL_APIENTRY *PFN_glBindBuffer)(GLenum target, GLuint buffer)) \
-    _SAPP_XMACRO(glDeleteVertexArrays,              void (GL_APIENTRY *PFN_glDeleteVertexArrays)(GLsizei n, const GLuint * arrays)) \
-    _SAPP_XMACRO(glDepthMask,                       void (GL_APIENTRY *PFN_glDepthMask)(GLboolean flag)) \
-    _SAPP_XMACRO(glDrawArraysInstanced,             void (GL_APIENTRY *PFN_glDrawArraysInstanced)(GLenum mode, GLint first, GLsizei count, GLsizei instancecount)) \
-    _SAPP_XMACRO(glClearStencil,                    void (GL_APIENTRY *PFN_glClearStencil)(GLint s)) \
-    _SAPP_XMACRO(glScissor,                         void (GL_APIENTRY *PFN_glScissor)(GLint x, GLint y, GLsizei width, GLsizei height)) \
-    _SAPP_XMACRO(glUniform3fv,                      void (GL_APIENTRY *PFN_glUniform3fv)(GLint location, GLsizei count, const GLfloat * value)) \
-    _SAPP_XMACRO(glGenRenderbuffers,                void (GL_APIENTRY *PFN_glGenRenderbuffers)(GLsizei n, GLuint * renderbuffers)) \
-    _SAPP_XMACRO(glBufferData,                      void (GL_APIENTRY *PFN_glBufferData)(GLenum target, GLsizeiptr size, const void * data, GLenum usage)) \
-    _SAPP_XMACRO(glBlendFuncSeparate,               void (GL_APIENTRY *PFN_glBlendFuncSeparate)(GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha, GLenum dfactorAlpha)) \
-    _SAPP_XMACRO(glTexParameteri,                   void (GL_APIENTRY *PFN_glTexParameteri)(GLenum target, GLenum pname, GLint param)) \
-    _SAPP_XMACRO(glGetIntegerv,                     void (GL_APIENTRY *PFN_glGetIntegerv)(GLenum pname, GLint * data)) \
-    _SAPP_XMACRO(glEnable,                          void (GL_APIENTRY *PFN_glEnable)(GLenum cap)) \
-    _SAPP_XMACRO(glBlitFramebuffer,                 void (GL_APIENTRY *PFN_glBlitFramebuffer)(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter)) \
-    _SAPP_XMACRO(glStencilMask,                     void (GL_APIENTRY *PFN_glStencilMask)(GLuint mask)) \
-    _SAPP_XMACRO(glAttachShader,                    void (GL_APIENTRY *PFN_glAttachShader)(GLuint program, GLuint shader)) \
-    _SAPP_XMACRO(glGetError,                        GLenum (GL_APIENTRY *PFN_glGetError)(void)) \
-    _SAPP_XMACRO(glClearColor,                      void (GL_APIENTRY *PFN_glClearColor)(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)) \
-    _SAPP_XMACRO(glBlendColor,                      void (GL_APIENTRY *PFN_glBlendColor)(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)) \
-    _SAPP_XMACRO(glTexParameterf,                   void (GL_APIENTRY *PFN_glTexParameterf)(GLenum target, GLenum pname, GLfloat param)) \
-    _SAPP_XMACRO(glTexParameterfv,                  void (GL_APIENTRY *PFN_glTexParameterfv)(GLenum target, GLenum pname, GLfloat* params)) \
-    _SAPP_XMACRO(glGetShaderInfoLog,                void (GL_APIENTRY *PFN_glGetShaderInfoLog)(GLuint shader, GLsizei bufSize, GLsizei * length, GLchar * infoLog)) \
-    _SAPP_XMACRO(glDepthFunc,                       void (GL_APIENTRY *PFN_glDepthFunc)(GLenum func)) \
-    _SAPP_XMACRO(glStencilOp ,                      void  (GL_APIENTRY *PFN_glStencilOp)(GLenum fail, GLenum zfail, GLenum zpass)) \
-    _SAPP_XMACRO(glStencilFunc,                     void  (GL_APIENTRY *PFN_glStencilFunc)(GLenum func, GLint ref, GLuint mask)) \
-    _SAPP_XMACRO(glEnableVertexAttribArray,         void  (GL_APIENTRY *PFN_glEnableVertexAttribArray)(GLuint index)) \
-    _SAPP_XMACRO(glBlendFunc,                       void  (GL_APIENTRY *PFN_glBlendFunc)(GLenum sfactor, GLenum dfactor)) \
-    _SAPP_XMACRO(glUniform1fv,                      void  (GL_APIENTRY *PFN_glUniform1fv)(GLint location, GLsizei count, const GLfloat * value)) \
-    _SAPP_XMACRO(glReadBuffer,                      void  (GL_APIENTRY *PFN_glReadBuffer)(GLenum src)) \
-    _SAPP_XMACRO(glClear,                           void  (GL_APIENTRY *PFN_glClear)(GLbitfield mask)) \
-    _SAPP_XMACRO(glTexImage2D,                      void  (GL_APIENTRY *PFN_glTexImage2D)(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void * pixels)) \
-    _SAPP_XMACRO(glGenVertexArrays,                 void  (GL_APIENTRY *PFN_glGenVertexArrays)(GLsizei n, GLuint * arrays)) \
-    _SAPP_XMACRO(glFrontFace,                       void  (GL_APIENTRY *PFN_glFrontFace)(GLenum mode)) \
-    _SAPP_XMACRO(glCullFace,                        void  (GL_APIENTRY *PFN_glCullFace)(GLenum mode))
+    _SAPP_XMACRO(glBindVertexArray,                 void, (GLuint array)) \
+    _SAPP_XMACRO(glFramebufferTextureLayer,         void, (GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer)) \
+    _SAPP_XMACRO(glGenFramebuffers,                 void, (GLsizei n, GLuint * framebuffers)) \
+    _SAPP_XMACRO(glBindFramebuffer,                 void, (GLenum target, GLuint framebuffer)) \
+    _SAPP_XMACRO(glBindRenderbuffer,                void, (GLenum target, GLuint renderbuffer)) \
+    _SAPP_XMACRO(glGetStringi,                      const GLubyte *, (GLenum name, GLuint index)) \
+    _SAPP_XMACRO(glClearBufferfi,                   void, (GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil)) \
+    _SAPP_XMACRO(glClearBufferfv,                   void, (GLenum buffer, GLint drawbuffer, const GLfloat * value)) \
+    _SAPP_XMACRO(glClearBufferuiv,                  void, (GLenum buffer, GLint drawbuffer, const GLuint * value)) \
+    _SAPP_XMACRO(glDeleteRenderbuffers,             void, (GLsizei n, const GLuint * renderbuffers)) \
+    _SAPP_XMACRO(glUniform4fv,                      void, (GLint location, GLsizei count, const GLfloat * value)) \
+    _SAPP_XMACRO(glUniform2fv,                      void, (GLint location, GLsizei count, const GLfloat * value)) \
+    _SAPP_XMACRO(glUseProgram,                      void, (GLuint program)) \
+    _SAPP_XMACRO(glShaderSource,                    void, (GLuint shader, GLsizei count, const GLchar *const* string, const GLint * length)) \
+    _SAPP_XMACRO(glLinkProgram,                     void, (GLuint program)) \
+    _SAPP_XMACRO(glGetUniformLocation,              GLint, (GLuint program, const GLchar * name)) \
+    _SAPP_XMACRO(glGetShaderiv,                     void, (GLuint shader, GLenum pname, GLint * params)) \
+    _SAPP_XMACRO(glGetProgramInfoLog,               void, (GLuint program, GLsizei bufSize, GLsizei * length, GLchar * infoLog)) \
+    _SAPP_XMACRO(glGetAttribLocation,               GLint, (GLuint program, const GLchar * name)) \
+    _SAPP_XMACRO(glDisableVertexAttribArray,        void, (GLuint index)) \
+    _SAPP_XMACRO(glDeleteShader,                    void, (GLuint shader)) \
+    _SAPP_XMACRO(glDeleteProgram,                   void, (GLuint program)) \
+    _SAPP_XMACRO(glCompileShader,                   void, (GLuint shader)) \
+    _SAPP_XMACRO(glStencilFuncSeparate,             void, (GLenum face, GLenum func, GLint ref, GLuint mask)) \
+    _SAPP_XMACRO(glStencilOpSeparate,               void, (GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass)) \
+    _SAPP_XMACRO(glRenderbufferStorageMultisample,  void, (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height)) \
+    _SAPP_XMACRO(glDrawBuffers,                     void, (GLsizei n, const GLenum * bufs)) \
+    _SAPP_XMACRO(glVertexAttribDivisor,             void, (GLuint index, GLuint divisor)) \
+    _SAPP_XMACRO(glBufferSubData,                   void, (GLenum target, GLintptr offset, GLsizeiptr size, const void * data)) \
+    _SAPP_XMACRO(glGenBuffers,                      void, (GLsizei n, GLuint * buffers)) \
+    _SAPP_XMACRO(glCheckFramebufferStatus,          GLenum, (GLenum target)) \
+    _SAPP_XMACRO(glFramebufferRenderbuffer,         void, (GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer)) \
+    _SAPP_XMACRO(glCompressedTexImage2D,            void, (GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, const void * data)) \
+    _SAPP_XMACRO(glCompressedTexImage3D,            void, (GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, const void * data)) \
+    _SAPP_XMACRO(glActiveTexture,                   void, (GLenum texture)) \
+    _SAPP_XMACRO(glTexSubImage3D,                   void, (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const void * pixels)) \
+    _SAPP_XMACRO(glUniformMatrix4fv,                void, (GLint location, GLsizei count, GLboolean transpose, const GLfloat * value)) \
+    _SAPP_XMACRO(glRenderbufferStorage,             void, (GLenum target, GLenum internalformat, GLsizei width, GLsizei height)) \
+    _SAPP_XMACRO(glGenTextures,                     void, (GLsizei n, GLuint * textures)) \
+    _SAPP_XMACRO(glPolygonOffset,                   void, (GLfloat factor, GLfloat units)) \
+    _SAPP_XMACRO(glDrawElements,                    void, (GLenum mode, GLsizei count, GLenum type, const void * indices)) \
+    _SAPP_XMACRO(glDeleteFramebuffers,              void, (GLsizei n, const GLuint * framebuffers)) \
+    _SAPP_XMACRO(glBlendEquationSeparate,           void, (GLenum modeRGB, GLenum modeAlpha)) \
+    _SAPP_XMACRO(glDeleteTextures,                  void, (GLsizei n, const GLuint * textures)) \
+    _SAPP_XMACRO(glGetProgramiv,                    void, (GLuint program, GLenum pname, GLint * params)) \
+    _SAPP_XMACRO(glBindTexture,                     void, (GLenum target, GLuint texture)) \
+    _SAPP_XMACRO(glTexImage3D,                      void, (GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const void * pixels)) \
+    _SAPP_XMACRO(glCreateShader,                    GLuint, (GLenum type)) \
+    _SAPP_XMACRO(glTexSubImage2D,                   void, (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const void * pixels)) \
+    _SAPP_XMACRO(glClearDepth,                      void, (GLdouble depth)) \
+    _SAPP_XMACRO(glFramebufferTexture2D,            void, (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level)) \
+    _SAPP_XMACRO(glCreateProgram,                   GLuint, (void)) \
+    _SAPP_XMACRO(glViewport,                        void, (GLint x, GLint y, GLsizei width, GLsizei height)) \
+    _SAPP_XMACRO(glDeleteBuffers,                   void, (GLsizei n, const GLuint * buffers)) \
+    _SAPP_XMACRO(glDrawArrays,                      void, (GLenum mode, GLint first, GLsizei count)) \
+    _SAPP_XMACRO(glDrawElementsInstanced,           void, (GLenum mode, GLsizei count, GLenum type, const void * indices, GLsizei instancecount)) \
+    _SAPP_XMACRO(glVertexAttribPointer,             void, (GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void * pointer)) \
+    _SAPP_XMACRO(glUniform1i,                       void, (GLint location, GLint v0)) \
+    _SAPP_XMACRO(glDisable,                         void, (GLenum cap)) \
+    _SAPP_XMACRO(glColorMask,                       void, (GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha)) \
+    _SAPP_XMACRO(glBindBuffer,                      void, (GLenum target, GLuint buffer)) \
+    _SAPP_XMACRO(glDeleteVertexArrays,              void, (GLsizei n, const GLuint * arrays)) \
+    _SAPP_XMACRO(glDepthMask,                       void, (GLboolean flag)) \
+    _SAPP_XMACRO(glDrawArraysInstanced,             void, (GLenum mode, GLint first, GLsizei count, GLsizei instancecount)) \
+    _SAPP_XMACRO(glClearStencil,                    void, (GLint s)) \
+    _SAPP_XMACRO(glScissor,                         void, (GLint x, GLint y, GLsizei width, GLsizei height)) \
+    _SAPP_XMACRO(glUniform3fv,                      void, (GLint location, GLsizei count, const GLfloat * value)) \
+    _SAPP_XMACRO(glGenRenderbuffers,                void, (GLsizei n, GLuint * renderbuffers)) \
+    _SAPP_XMACRO(glBufferData,                      void, (GLenum target, GLsizeiptr size, const void * data, GLenum usage)) \
+    _SAPP_XMACRO(glBlendFuncSeparate,               void, (GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha, GLenum dfactorAlpha)) \
+    _SAPP_XMACRO(glTexParameteri,                   void, (GLenum target, GLenum pname, GLint param)) \
+    _SAPP_XMACRO(glGetIntegerv,                     void, (GLenum pname, GLint * data)) \
+    _SAPP_XMACRO(glEnable,                          void, (GLenum cap)) \
+    _SAPP_XMACRO(glBlitFramebuffer,                 void, (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter)) \
+    _SAPP_XMACRO(glStencilMask,                     void, (GLuint mask)) \
+    _SAPP_XMACRO(glAttachShader,                    void, (GLuint program, GLuint shader)) \
+    _SAPP_XMACRO(glGetError,                        GLenum, (void)) \
+    _SAPP_XMACRO(glClearColor,                      void, (GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)) \
+    _SAPP_XMACRO(glBlendColor,                      void, (GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)) \
+    _SAPP_XMACRO(glTexParameterf,                   void, (GLenum target, GLenum pname, GLfloat param)) \
+    _SAPP_XMACRO(glTexParameterfv,                  void, (GLenum target, GLenum pname, GLfloat* params)) \
+    _SAPP_XMACRO(glGetShaderInfoLog,                void, (GLuint shader, GLsizei bufSize, GLsizei * length, GLchar * infoLog)) \
+    _SAPP_XMACRO(glDepthFunc,                       void, (GLenum func)) \
+    _SAPP_XMACRO(glStencilOp ,                      void, (GLenum fail, GLenum zfail, GLenum zpass)) \
+    _SAPP_XMACRO(glStencilFunc,                     void, (GLenum func, GLint ref, GLuint mask)) \
+    _SAPP_XMACRO(glEnableVertexAttribArray,         void, (GLuint index)) \
+    _SAPP_XMACRO(glBlendFunc,                       void, (GLenum sfactor, GLenum dfactor)) \
+    _SAPP_XMACRO(glUniform1fv,                      void, (GLint location, GLsizei count, const GLfloat * value)) \
+    _SAPP_XMACRO(glReadBuffer,                      void, (GLenum src)) \
+    _SAPP_XMACRO(glClear,                           void, (GLbitfield mask)) \
+    _SAPP_XMACRO(glTexImage2D,                      void, (GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void * pixels)) \
+    _SAPP_XMACRO(glGenVertexArrays,                 void, (GLsizei n, GLuint * arrays)) \
+    _SAPP_XMACRO(glFrontFace,                       void, (GLenum mode)) \
+    _SAPP_XMACRO(glCullFace,                        void, (GLenum mode))
 
 // generate GL function pointer typedefs
-#define _SAPP_XMACRO(func, proto) typedef proto;
+#define _SAPP_XMACRO(name, ret, args) typedef ret (GL_APIENTRY* PFN_ ## name) args;
 _SAPP_GL_FUNCS
 #undef _SAPP_XMACRO
 
 // generate GL function pointers
-#define _SAPP_XMACRO(func, proto) static PFN_ ## func func;
+#define _SAPP_XMACRO(name, ret, args) static PFN_ ## name name;
 _SAPP_GL_FUNCS
 #undef _SAPP_XMACRO
 
@@ -1949,7 +1949,7 @@ _SOKOL_PRIVATE void* _sapp_win32_glgetprocaddr(const char* name) {
 _SOKOL_PRIVATE  void _sapp_win32_gl_loadfuncs(void) {
     SOKOL_ASSERT(_sapp.wgl.GetProcAddress);
     SOKOL_ASSERT(_sapp.wgl.opengl32);
-    #define _SAPP_XMACRO(func, proto) func = (PFN_ ## func) _sapp_win32_glgetprocaddr(#func);
+    #define _SAPP_XMACRO(name, ret, args) name = (PFN_ ## name) _sapp_win32_glgetprocaddr(#name);
     _SAPP_GL_FUNCS
     #undef _SAPP_XMACRO
 }

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -3939,195 +3939,114 @@ typedef int  GLint;
 #define GL_TEXTURE_BORDER_COLOR 0x1004
 #define GL_CURRENT_PROGRAM 0x8B8D
 
-typedef void  (GL_APIENTRY *PFN_glBindVertexArray)(GLuint array);
-static PFN_glBindVertexArray _sapp_glBindVertexArray;
-typedef void  (GL_APIENTRY *PFN_glFramebufferTextureLayer)(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer);
-static PFN_glFramebufferTextureLayer _sapp_glFramebufferTextureLayer;
-typedef void  (GL_APIENTRY *PFN_glGenFramebuffers)(GLsizei n, GLuint * framebuffers);
-static PFN_glGenFramebuffers _sapp_glGenFramebuffers;
-typedef void  (GL_APIENTRY *PFN_glBindFramebuffer)(GLenum target, GLuint framebuffer);
-static PFN_glBindFramebuffer _sapp_glBindFramebuffer;
-typedef void  (GL_APIENTRY *PFN_glBindRenderbuffer)(GLenum target, GLuint renderbuffer);
-static PFN_glBindRenderbuffer _sapp_glBindRenderbuffer;
-typedef const GLubyte * (GL_APIENTRY *PFN_glGetStringi)(GLenum name, GLuint index);
-static PFN_glGetStringi _sapp_glGetStringi;
-typedef void  (GL_APIENTRY *PFN_glClearBufferfi)(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil);
-static PFN_glClearBufferfi _sapp_glClearBufferfi;
-typedef void  (GL_APIENTRY *PFN_glClearBufferfv)(GLenum buffer, GLint drawbuffer, const GLfloat * value);
-static PFN_glClearBufferfv _sapp_glClearBufferfv;
-typedef void  (GL_APIENTRY *PFN_glClearBufferuiv)(GLenum buffer, GLint drawbuffer, const GLuint * value);
-static PFN_glClearBufferuiv _sapp_glClearBufferuiv;
-typedef void  (GL_APIENTRY *PFN_glDeleteRenderbuffers)(GLsizei n, const GLuint * renderbuffers);
-static PFN_glDeleteRenderbuffers _sapp_glDeleteRenderbuffers;
-typedef void  (GL_APIENTRY *PFN_glUniform4fv)(GLint location, GLsizei count, const GLfloat * value);
-static PFN_glUniform4fv _sapp_glUniform4fv;
-typedef void  (GL_APIENTRY *PFN_glUniform2fv)(GLint location, GLsizei count, const GLfloat * value);
-static PFN_glUniform2fv _sapp_glUniform2fv;
-typedef void  (GL_APIENTRY *PFN_glUseProgram)(GLuint program);
-static PFN_glUseProgram _sapp_glUseProgram;
-typedef void  (GL_APIENTRY *PFN_glShaderSource)(GLuint shader, GLsizei count, const GLchar *const* string, const GLint * length);
-static PFN_glShaderSource _sapp_glShaderSource;
-typedef void  (GL_APIENTRY *PFN_glLinkProgram)(GLuint program);
-static PFN_glLinkProgram _sapp_glLinkProgram;
-typedef GLint (GL_APIENTRY *PFN_glGetUniformLocation)(GLuint program, const GLchar * name);
-static PFN_glGetUniformLocation _sapp_glGetUniformLocation;
-typedef void  (GL_APIENTRY *PFN_glGetShaderiv)(GLuint shader, GLenum pname, GLint * params);
-static PFN_glGetShaderiv _sapp_glGetShaderiv;
-typedef void  (GL_APIENTRY *PFN_glGetProgramInfoLog)(GLuint program, GLsizei bufSize, GLsizei * length, GLchar * infoLog);
-static PFN_glGetProgramInfoLog _sapp_glGetProgramInfoLog;
-typedef GLint (GL_APIENTRY *PFN_glGetAttribLocation)(GLuint program, const GLchar * name);
-static PFN_glGetAttribLocation _sapp_glGetAttribLocation;
-typedef void  (GL_APIENTRY *PFN_glDisableVertexAttribArray)(GLuint index);
-static PFN_glDisableVertexAttribArray _sapp_glDisableVertexAttribArray;
-typedef void  (GL_APIENTRY *PFN_glDeleteShader)(GLuint shader);
-static PFN_glDeleteShader _sapp_glDeleteShader;
-typedef void  (GL_APIENTRY *PFN_glDeleteProgram)(GLuint program);
-static PFN_glDeleteProgram _sapp_glDeleteProgram;
-typedef void  (GL_APIENTRY *PFN_glCompileShader)(GLuint shader);
-static PFN_glCompileShader _sapp_glCompileShader;
-typedef void  (GL_APIENTRY *PFN_glStencilFuncSeparate)(GLenum face, GLenum func, GLint ref, GLuint mask);
-static PFN_glStencilFuncSeparate _sapp_glStencilFuncSeparate;
-typedef void  (GL_APIENTRY *PFN_glStencilOpSeparate)(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass);
-static PFN_glStencilOpSeparate _sapp_glStencilOpSeparate;
-typedef void  (GL_APIENTRY *PFN_glRenderbufferStorageMultisample)(GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
-static PFN_glRenderbufferStorageMultisample _sapp_glRenderbufferStorageMultisample;
-typedef void  (GL_APIENTRY *PFN_glDrawBuffers)(GLsizei n, const GLenum * bufs);
-static PFN_glDrawBuffers _sapp_glDrawBuffers;
-typedef void  (GL_APIENTRY *PFN_glVertexAttribDivisor)(GLuint index, GLuint divisor);
-static PFN_glVertexAttribDivisor _sapp_glVertexAttribDivisor;
-typedef void  (GL_APIENTRY *PFN_glBufferSubData)(GLenum target, GLintptr offset, GLsizeiptr size, const void * data);
-static PFN_glBufferSubData _sapp_glBufferSubData;
-typedef void  (GL_APIENTRY *PFN_glGenBuffers)(GLsizei n, GLuint * buffers);
-static PFN_glGenBuffers _sapp_glGenBuffers;
-typedef GLenum (GL_APIENTRY *PFN_glCheckFramebufferStatus)(GLenum target);
-static PFN_glCheckFramebufferStatus _sapp_glCheckFramebufferStatus;
-typedef void  (GL_APIENTRY *PFN_glFramebufferRenderbuffer)(GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer);
-static PFN_glFramebufferRenderbuffer _sapp_glFramebufferRenderbuffer;
-typedef void  (GL_APIENTRY *PFN_glCompressedTexImage2D)(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, const void * data);
-static PFN_glCompressedTexImage2D _sapp_glCompressedTexImage2D;
-typedef void  (GL_APIENTRY *PFN_glCompressedTexImage3D)(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, const void * data);
-static PFN_glCompressedTexImage3D _sapp_glCompressedTexImage3D;
-typedef void  (GL_APIENTRY *PFN_glActiveTexture)(GLenum texture);
-static PFN_glActiveTexture _sapp_glActiveTexture;
-typedef void  (GL_APIENTRY *PFN_glTexSubImage3D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const void * pixels);
-static PFN_glTexSubImage3D _sapp_glTexSubImage3D;
-typedef void  (GL_APIENTRY *PFN_glUniformMatrix4fv)(GLint location, GLsizei count, GLboolean transpose, const GLfloat * value);
-static PFN_glUniformMatrix4fv _sapp_glUniformMatrix4fv;
-typedef void  (GL_APIENTRY *PFN_glRenderbufferStorage)(GLenum target, GLenum internalformat, GLsizei width, GLsizei height);
-static PFN_glRenderbufferStorage _sapp_glRenderbufferStorage;
-typedef void  (GL_APIENTRY *PFN_glGenTextures)(GLsizei n, GLuint * textures);
-static PFN_glGenTextures _sapp_glGenTextures;
-typedef void  (GL_APIENTRY *PFN_glPolygonOffset)(GLfloat factor, GLfloat units);
-static PFN_glPolygonOffset _sapp_glPolygonOffset;
-typedef void  (GL_APIENTRY *PFN_glDrawElements)(GLenum mode, GLsizei count, GLenum type, const void * indices);
-static PFN_glDrawElements _sapp_glDrawElements;
-typedef void  (GL_APIENTRY *PFN_glDeleteFramebuffers)(GLsizei n, const GLuint * framebuffers);
-static PFN_glDeleteFramebuffers _sapp_glDeleteFramebuffers;
-typedef void  (GL_APIENTRY *PFN_glBlendEquationSeparate)(GLenum modeRGB, GLenum modeAlpha);
-static PFN_glBlendEquationSeparate _sapp_glBlendEquationSeparate;
-typedef void  (GL_APIENTRY *PFN_glDeleteTextures)(GLsizei n, const GLuint * textures);
-static PFN_glDeleteTextures _sapp_glDeleteTextures;
-typedef void  (GL_APIENTRY *PFN_glGetProgramiv)(GLuint program, GLenum pname, GLint * params);
-static PFN_glGetProgramiv _sapp_glGetProgramiv;
-typedef void  (GL_APIENTRY *PFN_glBindTexture)(GLenum target, GLuint texture);
-static PFN_glBindTexture _sapp_glBindTexture;
-typedef void  (GL_APIENTRY *PFN_glTexImage3D)(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const void * pixels);
-static PFN_glTexImage3D _sapp_glTexImage3D;
-typedef GLuint (GL_APIENTRY *PFN_glCreateShader)(GLenum type);
-static PFN_glCreateShader _sapp_glCreateShader;
-typedef void  (GL_APIENTRY *PFN_glTexSubImage2D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const void * pixels);
-static PFN_glTexSubImage2D _sapp_glTexSubImage2D;
-typedef void  (GL_APIENTRY *PFN_glClearDepth)(GLdouble depth);
-static PFN_glClearDepth _sapp_glClearDepth;
-typedef void  (GL_APIENTRY *PFN_glFramebufferTexture2D)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
-static PFN_glFramebufferTexture2D _sapp_glFramebufferTexture2D;
-typedef GLuint (GL_APIENTRY *PFN_glCreateProgram)();
-static PFN_glCreateProgram _sapp_glCreateProgram;
-typedef void  (GL_APIENTRY *PFN_glViewport)(GLint x, GLint y, GLsizei width, GLsizei height);
-static PFN_glViewport _sapp_glViewport;
-typedef void  (GL_APIENTRY *PFN_glDeleteBuffers)(GLsizei n, const GLuint * buffers);
-static PFN_glDeleteBuffers _sapp_glDeleteBuffers;
-typedef void  (GL_APIENTRY *PFN_glDrawArrays)(GLenum mode, GLint first, GLsizei count);
-static PFN_glDrawArrays _sapp_glDrawArrays;
-typedef void  (GL_APIENTRY *PFN_glDrawElementsInstanced)(GLenum mode, GLsizei count, GLenum type, const void * indices, GLsizei instancecount);
-static PFN_glDrawElementsInstanced _sapp_glDrawElementsInstanced;
-typedef void  (GL_APIENTRY *PFN_glVertexAttribPointer)(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void * pointer);
-static PFN_glVertexAttribPointer _sapp_glVertexAttribPointer;
-typedef void  (GL_APIENTRY *PFN_glUniform1i)(GLint location, GLint v0);
-static PFN_glUniform1i _sapp_glUniform1i;
-typedef void  (GL_APIENTRY *PFN_glDisable)(GLenum cap);
-static PFN_glDisable _sapp_glDisable;
-typedef void  (GL_APIENTRY *PFN_glColorMask)(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha);
-static PFN_glColorMask _sapp_glColorMask;
-typedef void  (GL_APIENTRY *PFN_glBindBuffer)(GLenum target, GLuint buffer);
-static PFN_glBindBuffer _sapp_glBindBuffer;
-typedef void  (GL_APIENTRY *PFN_glDeleteVertexArrays)(GLsizei n, const GLuint * arrays);
-static PFN_glDeleteVertexArrays _sapp_glDeleteVertexArrays;
-typedef void  (GL_APIENTRY *PFN_glDepthMask)(GLboolean flag);
-static PFN_glDepthMask _sapp_glDepthMask;
-typedef void  (GL_APIENTRY *PFN_glDrawArraysInstanced)(GLenum mode, GLint first, GLsizei count, GLsizei instancecount);
-static PFN_glDrawArraysInstanced _sapp_glDrawArraysInstanced;
-typedef void  (GL_APIENTRY *PFN_glClearStencil)(GLint s);
-static PFN_glClearStencil _sapp_glClearStencil;
-typedef void  (GL_APIENTRY *PFN_glScissor)(GLint x, GLint y, GLsizei width, GLsizei height);
-static PFN_glScissor _sapp_glScissor;
-typedef void  (GL_APIENTRY *PFN_glUniform3fv)(GLint location, GLsizei count, const GLfloat * value);
-static PFN_glUniform3fv _sapp_glUniform3fv;
-typedef void  (GL_APIENTRY *PFN_glGenRenderbuffers)(GLsizei n, GLuint * renderbuffers);
-static PFN_glGenRenderbuffers _sapp_glGenRenderbuffers;
-typedef void  (GL_APIENTRY *PFN_glBufferData)(GLenum target, GLsizeiptr size, const void * data, GLenum usage);
-static PFN_glBufferData _sapp_glBufferData;
-typedef void  (GL_APIENTRY *PFN_glBlendFuncSeparate)(GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha, GLenum dfactorAlpha);
-static PFN_glBlendFuncSeparate _sapp_glBlendFuncSeparate;
-typedef void  (GL_APIENTRY *PFN_glTexParameteri)(GLenum target, GLenum pname, GLint param);
-static PFN_glTexParameteri _sapp_glTexParameteri;
-typedef void  (GL_APIENTRY *PFN_glGetIntegerv)(GLenum pname, GLint * data);
-static PFN_glGetIntegerv _sapp_glGetIntegerv;
-typedef void  (GL_APIENTRY *PFN_glEnable)(GLenum cap);
-static PFN_glEnable _sapp_glEnable;
-typedef void  (GL_APIENTRY *PFN_glBlitFramebuffer)(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
-static PFN_glBlitFramebuffer _sapp_glBlitFramebuffer;
-typedef void  (GL_APIENTRY *PFN_glStencilMask)(GLuint mask);
-static PFN_glStencilMask _sapp_glStencilMask;
-typedef void  (GL_APIENTRY *PFN_glAttachShader)(GLuint program, GLuint shader);
-static PFN_glAttachShader _sapp_glAttachShader;
-typedef GLenum (GL_APIENTRY *PFN_glGetError)();
-static PFN_glGetError _sapp_glGetError;
-typedef void  (GL_APIENTRY *PFN_glClearColor)(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha);
-static PFN_glClearColor _sapp_glClearColor;
-typedef void  (GL_APIENTRY *PFN_glBlendColor)(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha);
-static PFN_glBlendColor _sapp_glBlendColor;
-typedef void  (GL_APIENTRY *PFN_glTexParameterf)(GLenum target, GLenum pname, GLfloat param);
-static PFN_glTexParameterf _sapp_glTexParameterf;
-typedef void  (GL_APIENTRY *PFN_glTexParameterfv)(GLenum target, GLenum pname, GLfloat* params);
-static PFN_glTexParameterfv _sapp_glTexParameterfv;
-typedef void  (GL_APIENTRY *PFN_glGetShaderInfoLog)(GLuint shader, GLsizei bufSize, GLsizei * length, GLchar * infoLog);
-static PFN_glGetShaderInfoLog _sapp_glGetShaderInfoLog;
-typedef void  (GL_APIENTRY *PFN_glDepthFunc)(GLenum func);
-static PFN_glDepthFunc _sapp_glDepthFunc;
-typedef void  (GL_APIENTRY *PFN_glStencilOp)(GLenum fail, GLenum zfail, GLenum zpass);
-static PFN_glStencilOp _sapp_glStencilOp;
-typedef void  (GL_APIENTRY *PFN_glStencilFunc)(GLenum func, GLint ref, GLuint mask);
-static PFN_glStencilFunc _sapp_glStencilFunc;
-typedef void  (GL_APIENTRY *PFN_glEnableVertexAttribArray)(GLuint index);
-static PFN_glEnableVertexAttribArray _sapp_glEnableVertexAttribArray;
-typedef void  (GL_APIENTRY *PFN_glBlendFunc)(GLenum sfactor, GLenum dfactor);
-static PFN_glBlendFunc _sapp_glBlendFunc;
-typedef void  (GL_APIENTRY *PFN_glUniform1fv)(GLint location, GLsizei count, const GLfloat * value);
-static PFN_glUniform1fv _sapp_glUniform1fv;
-typedef void  (GL_APIENTRY *PFN_glReadBuffer)(GLenum src);
-static PFN_glReadBuffer _sapp_glReadBuffer;
-typedef void  (GL_APIENTRY *PFN_glClear)(GLbitfield mask);
-static PFN_glClear _sapp_glClear;
-typedef void  (GL_APIENTRY *PFN_glTexImage2D)(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void * pixels);
-static PFN_glTexImage2D _sapp_glTexImage2D;
-typedef void  (GL_APIENTRY *PFN_glGenVertexArrays)(GLsizei n, GLuint * arrays);
-static PFN_glGenVertexArrays _sapp_glGenVertexArrays;
-typedef void  (GL_APIENTRY *PFN_glFrontFace)(GLenum mode);
-static PFN_glFrontFace _sapp_glFrontFace;
-typedef void  (GL_APIENTRY *PFN_glCullFace)(GLenum mode);
-static PFN_glCullFace _sapp_glCullFace;
+// X Macro list of GL function names and signatures
+#define _SAPP_GL_FUNCS \
+    _SAPP_XMACRO(glBindVertexArray,                 void (GL_APIENTRY *PFN_glBindVertexArray)(GLuint array)) \
+    _SAPP_XMACRO(glFramebufferTextureLayer,         void (GL_APIENTRY *PFN_glFramebufferTextureLayer)(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer)) \
+    _SAPP_XMACRO(glGenFramebuffers,                 void (GL_APIENTRY *PFN_glGenFramebuffers)(GLsizei n, GLuint * framebuffers)) \
+    _SAPP_XMACRO(glBindFramebuffer,                 void (GL_APIENTRY *PFN_glBindFramebuffer)(GLenum target, GLuint framebuffer)) \
+    _SAPP_XMACRO(glBindRenderbuffer,                void (GL_APIENTRY *PFN_glBindRenderbuffer)(GLenum target, GLuint renderbuffer)) \
+    _SAPP_XMACRO(glGetStringi,                      const GLubyte * (GL_APIENTRY *PFN_glGetStringi)(GLenum name, GLuint index)) \
+    _SAPP_XMACRO(glClearBufferfi,                   void (GL_APIENTRY *PFN_glClearBufferfi)(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil)) \
+    _SAPP_XMACRO(glClearBufferfv,                   void (GL_APIENTRY *PFN_glClearBufferfv)(GLenum buffer, GLint drawbuffer, const GLfloat * value)) \
+    _SAPP_XMACRO(glClearBufferuiv,                  void (GL_APIENTRY *PFN_glClearBufferuiv)(GLenum buffer, GLint drawbuffer, const GLuint * value)) \
+    _SAPP_XMACRO(glDeleteRenderbuffers,             void (GL_APIENTRY *PFN_glDeleteRenderbuffers)(GLsizei n, const GLuint * renderbuffers)) \
+    _SAPP_XMACRO(glUniform4fv,                      void (GL_APIENTRY *PFN_glUniform4fv)(GLint location, GLsizei count, const GLfloat * value)) \
+    _SAPP_XMACRO(glUniform2fv,                      void (GL_APIENTRY *PFN_glUniform2fv)(GLint location, GLsizei count, const GLfloat * value)) \
+    _SAPP_XMACRO(glUseProgram,                      void (GL_APIENTRY *PFN_glUseProgram)(GLuint program)) \
+    _SAPP_XMACRO(glShaderSource,                    void (GL_APIENTRY *PFN_glShaderSource)(GLuint shader, GLsizei count, const GLchar *const* string, const GLint * length)) \
+    _SAPP_XMACRO(glLinkProgram,                     void (GL_APIENTRY *PFN_glLinkProgram)(GLuint program)) \
+    _SAPP_XMACRO(glGetUniformLocation,              GLint (GL_APIENTRY *PFN_glGetUniformLocation)(GLuint program, const GLchar * name)) \
+    _SAPP_XMACRO(glGetShaderiv,                     void (GL_APIENTRY *PFN_glGetShaderiv)(GLuint shader, GLenum pname, GLint * params)) \
+    _SAPP_XMACRO(glGetProgramInfoLog,               void (GL_APIENTRY *PFN_glGetProgramInfoLog)(GLuint program, GLsizei bufSize, GLsizei * length, GLchar * infoLog)) \
+    _SAPP_XMACRO(glGetAttribLocation,               GLint(GL_APIENTRY *PFN_glGetAttribLocation)(GLuint program, const GLchar * name)) \
+    _SAPP_XMACRO(glDisableVertexAttribArray,        void (GL_APIENTRY *PFN_glDisableVertexAttribArray)(GLuint index)) \
+    _SAPP_XMACRO(glDeleteShader,                    void (GL_APIENTRY *PFN_glDeleteShader)(GLuint shader)) \
+    _SAPP_XMACRO(glDeleteProgram,                   void (GL_APIENTRY *PFN_glDeleteProgram)(GLuint program)) \
+    _SAPP_XMACRO(glCompileShader,                   void (GL_APIENTRY *PFN_glCompileShader)(GLuint shader)) \
+    _SAPP_XMACRO(glStencilFuncSeparate,             void (GL_APIENTRY *PFN_glStencilFuncSeparate)(GLenum face, GLenum func, GLint ref, GLuint mask)) \
+    _SAPP_XMACRO(glStencilOpSeparate,               void (GL_APIENTRY *PFN_glStencilOpSeparate)(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass)) \
+    _SAPP_XMACRO(glRenderbufferStorageMultisample,  void (GL_APIENTRY *PFN_glRenderbufferStorageMultisample)(GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height)) \
+    _SAPP_XMACRO(glDrawBuffers,                     void (GL_APIENTRY *PFN_glDrawBuffers)(GLsizei n, const GLenum * bufs)) \
+    _SAPP_XMACRO(glVertexAttribDivisor,             void (GL_APIENTRY *PFN_glVertexAttribDivisor)(GLuint index, GLuint divisor)) \
+    _SAPP_XMACRO(glBufferSubData,                   void (GL_APIENTRY *PFN_glBufferSubData)(GLenum target, GLintptr offset, GLsizeiptr size, const void * data)) \
+    _SAPP_XMACRO(glGenBuffers,                      void (GL_APIENTRY *PFN_glGenBuffers)(GLsizei n, GLuint * buffers)) \
+    _SAPP_XMACRO(glCheckFramebufferStatus,          GLenum (GL_APIENTRY *PFN_glCheckFramebufferStatus)(GLenum target)) \
+    _SAPP_XMACRO(glFramebufferRenderbuffer,         void (GL_APIENTRY *PFN_glFramebufferRenderbuffer)(GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer)) \
+    _SAPP_XMACRO(glCompressedTexImage2D,            void (GL_APIENTRY *PFN_glCompressedTexImage2D)(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, const void * data)) \
+    _SAPP_XMACRO(glCompressedTexImage3D,            void (GL_APIENTRY *PFN_glCompressedTexImage3D)(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, const void * data)) \
+    _SAPP_XMACRO(glActiveTexture,                   void (GL_APIENTRY *PFN_glActiveTexture)(GLenum texture)) \
+    _SAPP_XMACRO(glTexSubImage3D,                   void (GL_APIENTRY *PFN_glTexSubImage3D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const void * pixels)) \
+    _SAPP_XMACRO(glUniformMatrix4fv,                void (GL_APIENTRY *PFN_glUniformMatrix4fv)(GLint location, GLsizei count, GLboolean transpose, const GLfloat * value)) \
+    _SAPP_XMACRO(glRenderbufferStorage,             void (GL_APIENTRY *PFN_glRenderbufferStorage)(GLenum target, GLenum internalformat, GLsizei width, GLsizei height)) \
+    _SAPP_XMACRO(glGenTextures,                     void (GL_APIENTRY *PFN_glGenTextures)(GLsizei n, GLuint * textures)) \
+    _SAPP_XMACRO(glPolygonOffset,                   void (GL_APIENTRY *PFN_glPolygonOffset)(GLfloat factor, GLfloat units)) \
+    _SAPP_XMACRO(glDrawElements,                    void (GL_APIENTRY *PFN_glDrawElements)(GLenum mode, GLsizei count, GLenum type, const void * indices)) \
+    _SAPP_XMACRO(glDeleteFramebuffers,              void (GL_APIENTRY *PFN_glDeleteFramebuffers)(GLsizei n, const GLuint * framebuffers)) \
+    _SAPP_XMACRO(glBlendEquationSeparate,           void (GL_APIENTRY *PFN_glBlendEquationSeparate)(GLenum modeRGB, GLenum modeAlpha)) \
+    _SAPP_XMACRO(glDeleteTextures,                  void (GL_APIENTRY *PFN_glDeleteTextures)(GLsizei n, const GLuint * textures)) \
+    _SAPP_XMACRO(glGetProgramiv,                    void (GL_APIENTRY *PFN_glGetProgramiv)(GLuint program, GLenum pname, GLint * params)) \
+    _SAPP_XMACRO(glBindTexture,                     void (GL_APIENTRY *PFN_glBindTexture)(GLenum target, GLuint texture)) \
+    _SAPP_XMACRO(glTexImage3D,                      void (GL_APIENTRY *PFN_glTexImage3D)(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const void * pixels)) \
+    _SAPP_XMACRO(glCreateShader,                    GLuint (GL_APIENTRY *PFN_glCreateShader)(GLenum type)) \
+    _SAPP_XMACRO(glTexSubImage2D,                   void (GL_APIENTRY *PFN_glTexSubImage2D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const void * pixels)) \
+    _SAPP_XMACRO(glClearDepth,                      void (GL_APIENTRY *PFN_glClearDepth)(GLdouble depth)) \
+    _SAPP_XMACRO(glFramebufferTexture2D,            void (GL_APIENTRY *PFN_glFramebufferTexture2D)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level)) \
+    _SAPP_XMACRO(glCreateProgram,                   GLuint (GL_APIENTRY *PFN_glCreateProgram)(void)) \
+    _SAPP_XMACRO(glViewport,                        void (GL_APIENTRY *PFN_glViewport)(GLint x, GLint y, GLsizei width, GLsizei height)) \
+    _SAPP_XMACRO(glDeleteBuffers,                   void (GL_APIENTRY *PFN_glDeleteBuffers)(GLsizei n, const GLuint * buffers)) \
+    _SAPP_XMACRO(glDrawArrays,                      void (GL_APIENTRY *PFN_glDrawArrays)(GLenum mode, GLint first, GLsizei count)) \
+    _SAPP_XMACRO(glDrawElementsInstanced,           void (GL_APIENTRY *PFN_glDrawElementsInstanced)(GLenum mode, GLsizei count, GLenum type, const void * indices, GLsizei instancecount)) \
+    _SAPP_XMACRO(glVertexAttribPointer,             void (GL_APIENTRY *PFN_glVertexAttribPointer)(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void * pointer)) \
+    _SAPP_XMACRO(glUniform1i,                       void (GL_APIENTRY *PFN_glUniform1i)(GLint location, GLint v0)) \
+    _SAPP_XMACRO(glDisable,                         void (GL_APIENTRY *PFN_glDisable)(GLenum cap)) \
+    _SAPP_XMACRO(glColorMask,                       void (GL_APIENTRY *PFN_glColorMask)(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha)) \
+    _SAPP_XMACRO(glBindBuffer,                      void (GL_APIENTRY *PFN_glBindBuffer)(GLenum target, GLuint buffer)) \
+    _SAPP_XMACRO(glDeleteVertexArrays,              void (GL_APIENTRY *PFN_glDeleteVertexArrays)(GLsizei n, const GLuint * arrays)) \
+    _SAPP_XMACRO(glDepthMask,                       void (GL_APIENTRY *PFN_glDepthMask)(GLboolean flag)) \
+    _SAPP_XMACRO(glDrawArraysInstanced,             void (GL_APIENTRY *PFN_glDrawArraysInstanced)(GLenum mode, GLint first, GLsizei count, GLsizei instancecount)) \
+    _SAPP_XMACRO(glClearStencil,                    void (GL_APIENTRY *PFN_glClearStencil)(GLint s)) \
+    _SAPP_XMACRO(glScissor,                         void (GL_APIENTRY *PFN_glScissor)(GLint x, GLint y, GLsizei width, GLsizei height)) \
+    _SAPP_XMACRO(glUniform3fv,                      void (GL_APIENTRY *PFN_glUniform3fv)(GLint location, GLsizei count, const GLfloat * value)) \
+    _SAPP_XMACRO(glGenRenderbuffers,                void (GL_APIENTRY *PFN_glGenRenderbuffers)(GLsizei n, GLuint * renderbuffers)) \
+    _SAPP_XMACRO(glBufferData,                      void (GL_APIENTRY *PFN_glBufferData)(GLenum target, GLsizeiptr size, const void * data, GLenum usage)) \
+    _SAPP_XMACRO(glBlendFuncSeparate,               void (GL_APIENTRY *PFN_glBlendFuncSeparate)(GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha, GLenum dfactorAlpha)) \
+    _SAPP_XMACRO(glTexParameteri,                   void (GL_APIENTRY *PFN_glTexParameteri)(GLenum target, GLenum pname, GLint param)) \
+    _SAPP_XMACRO(glGetIntegerv,                     void (GL_APIENTRY *PFN_glGetIntegerv)(GLenum pname, GLint * data)) \
+    _SAPP_XMACRO(glEnable,                          void (GL_APIENTRY *PFN_glEnable)(GLenum cap)) \
+    _SAPP_XMACRO(glBlitFramebuffer,                 void (GL_APIENTRY *PFN_glBlitFramebuffer)(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter)) \
+    _SAPP_XMACRO(glStencilMask,                     void (GL_APIENTRY *PFN_glStencilMask)(GLuint mask)) \
+    _SAPP_XMACRO(glAttachShader,                    void (GL_APIENTRY *PFN_glAttachShader)(GLuint program, GLuint shader)) \
+    _SAPP_XMACRO(glGetError,                        GLenum (GL_APIENTRY *PFN_glGetError)(void)) \
+    _SAPP_XMACRO(glClearColor,                      void (GL_APIENTRY *PFN_glClearColor)(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)) \
+    _SAPP_XMACRO(glBlendColor,                      void (GL_APIENTRY *PFN_glBlendColor)(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)) \
+    _SAPP_XMACRO(glTexParameterf,                   void (GL_APIENTRY *PFN_glTexParameterf)(GLenum target, GLenum pname, GLfloat param)) \
+    _SAPP_XMACRO(glTexParameterfv,                  void (GL_APIENTRY *PFN_glTexParameterfv)(GLenum target, GLenum pname, GLfloat* params)) \
+    _SAPP_XMACRO(glGetShaderInfoLog,                void (GL_APIENTRY *PFN_glGetShaderInfoLog)(GLuint shader, GLsizei bufSize, GLsizei * length, GLchar * infoLog)) \
+    _SAPP_XMACRO(glDepthFunc,                       void (GL_APIENTRY *PFN_glDepthFunc)(GLenum func)) \
+    _SAPP_XMACRO(glStencilOp ,                      void  (GL_APIENTRY *PFN_glStencilOp)(GLenum fail, GLenum zfail, GLenum zpass)) \
+    _SAPP_XMACRO(glStencilFunc,                     void  (GL_APIENTRY *PFN_glStencilFunc)(GLenum func, GLint ref, GLuint mask)) \
+    _SAPP_XMACRO(glEnableVertexAttribArray,         void  (GL_APIENTRY *PFN_glEnableVertexAttribArray)(GLuint index)) \
+    _SAPP_XMACRO(glBlendFunc,                       void  (GL_APIENTRY *PFN_glBlendFunc)(GLenum sfactor, GLenum dfactor)) \
+    _SAPP_XMACRO(glUniform1fv,                      void  (GL_APIENTRY *PFN_glUniform1fv)(GLint location, GLsizei count, const GLfloat * value)) \
+    _SAPP_XMACRO(glReadBuffer,                      void  (GL_APIENTRY *PFN_glReadBuffer)(GLenum src)) \
+    _SAPP_XMACRO(glClear,                           void  (GL_APIENTRY *PFN_glClear)(GLbitfield mask)) \
+    _SAPP_XMACRO(glTexImage2D,                      void  (GL_APIENTRY *PFN_glTexImage2D)(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void * pixels)) \
+    _SAPP_XMACRO(glGenVertexArrays,                 void  (GL_APIENTRY *PFN_glGenVertexArrays)(GLsizei n, GLuint * arrays)) \
+    _SAPP_XMACRO(glFrontFace,                       void  (GL_APIENTRY *PFN_glFrontFace)(GLenum mode)) \
+    _SAPP_XMACRO(glCullFace,                        void  (GL_APIENTRY *PFN_glCullFace)(GLenum mode))
 
+// generate GL function pointer typedefs
+#define _SAPP_XMACRO(func, proto) typedef proto;
+_SAPP_GL_FUNCS
+#undef _SAPP_XMACRO
+
+// generate GL function pointers
+#define _SAPP_XMACRO(func, proto) static PFN_ ## func func;
+_SAPP_GL_FUNCS
+#undef _SAPP_XMACRO
+
+// helper function to lookup GL functions in GL DLL
 _SOKOL_PRIVATE void* _sapp_win32_glgetprocaddr(const char* name) {
     void* proc_addr = (void*) _sapp.wgl.GetProcAddress(name);
     if (0 == proc_addr) {
@@ -4137,204 +4056,17 @@ _SOKOL_PRIVATE void* _sapp_win32_glgetprocaddr(const char* name) {
     return proc_addr;
 }
 
-#define _SAPP_GLPROC(name) _sapp_ ## name = (PFN_ ## name) _sapp_win32_glgetprocaddr(#name)
-
+// populate GL function pointers
 _SOKOL_PRIVATE  void _sapp_win32_gl_loadfuncs(void) {
     SOKOL_ASSERT(_sapp.wgl.GetProcAddress);
     SOKOL_ASSERT(_sapp.wgl.opengl32);
-    _SAPP_GLPROC(glBindVertexArray);
-    _SAPP_GLPROC(glFramebufferTextureLayer);
-    _SAPP_GLPROC(glGenFramebuffers);
-    _SAPP_GLPROC(glBindFramebuffer);
-    _SAPP_GLPROC(glBindRenderbuffer);
-    _SAPP_GLPROC(glGetStringi);
-    _SAPP_GLPROC(glClearBufferfi);
-    _SAPP_GLPROC(glClearBufferfv);
-    _SAPP_GLPROC(glClearBufferuiv);
-    _SAPP_GLPROC(glDeleteRenderbuffers);
-    _SAPP_GLPROC(glUniform4fv);
-    _SAPP_GLPROC(glUniform2fv);
-    _SAPP_GLPROC(glUseProgram);
-    _SAPP_GLPROC(glShaderSource);
-    _SAPP_GLPROC(glLinkProgram);
-    _SAPP_GLPROC(glGetUniformLocation);
-    _SAPP_GLPROC(glGetShaderiv);
-    _SAPP_GLPROC(glGetProgramInfoLog);
-    _SAPP_GLPROC(glGetAttribLocation);
-    _SAPP_GLPROC(glDisableVertexAttribArray);
-    _SAPP_GLPROC(glDeleteShader);
-    _SAPP_GLPROC(glDeleteProgram);
-    _SAPP_GLPROC(glCompileShader);
-    _SAPP_GLPROC(glStencilFuncSeparate);
-    _SAPP_GLPROC(glStencilOpSeparate);
-    _SAPP_GLPROC(glRenderbufferStorageMultisample);
-    _SAPP_GLPROC(glDrawBuffers);
-    _SAPP_GLPROC(glVertexAttribDivisor);
-    _SAPP_GLPROC(glBufferSubData);
-    _SAPP_GLPROC(glGenBuffers);
-    _SAPP_GLPROC(glCheckFramebufferStatus);
-    _SAPP_GLPROC(glFramebufferRenderbuffer);
-    _SAPP_GLPROC(glCompressedTexImage2D);
-    _SAPP_GLPROC(glCompressedTexImage3D);
-    _SAPP_GLPROC(glActiveTexture);
-    _SAPP_GLPROC(glTexSubImage3D);
-    _SAPP_GLPROC(glUniformMatrix4fv);
-    _SAPP_GLPROC(glRenderbufferStorage);
-    _SAPP_GLPROC(glGenTextures);
-    _SAPP_GLPROC(glPolygonOffset);
-    _SAPP_GLPROC(glDrawElements);
-    _SAPP_GLPROC(glDeleteFramebuffers);
-    _SAPP_GLPROC(glBlendEquationSeparate);
-    _SAPP_GLPROC(glDeleteTextures);
-    _SAPP_GLPROC(glGetProgramiv);
-    _SAPP_GLPROC(glBindTexture);
-    _SAPP_GLPROC(glTexImage3D);
-    _SAPP_GLPROC(glCreateShader);
-    _SAPP_GLPROC(glTexSubImage2D);
-    _SAPP_GLPROC(glClearDepth);
-    _SAPP_GLPROC(glFramebufferTexture2D);
-    _SAPP_GLPROC(glCreateProgram);
-    _SAPP_GLPROC(glViewport);
-    _SAPP_GLPROC(glDeleteBuffers);
-    _SAPP_GLPROC(glDrawArrays);
-    _SAPP_GLPROC(glDrawElementsInstanced);
-    _SAPP_GLPROC(glVertexAttribPointer);
-    _SAPP_GLPROC(glUniform1i);
-    _SAPP_GLPROC(glDisable);
-    _SAPP_GLPROC(glColorMask);
-    _SAPP_GLPROC(glBindBuffer);
-    _SAPP_GLPROC(glDeleteVertexArrays);
-    _SAPP_GLPROC(glDepthMask);
-    _SAPP_GLPROC(glDrawArraysInstanced);
-    _SAPP_GLPROC(glClearStencil);
-    _SAPP_GLPROC(glScissor);
-    _SAPP_GLPROC(glUniform3fv);
-    _SAPP_GLPROC(glGenRenderbuffers);
-    _SAPP_GLPROC(glBufferData);
-    _SAPP_GLPROC(glBlendFuncSeparate);
-    _SAPP_GLPROC(glTexParameteri);
-    _SAPP_GLPROC(glGetIntegerv);
-    _SAPP_GLPROC(glEnable);
-    _SAPP_GLPROC(glBlitFramebuffer);
-    _SAPP_GLPROC(glStencilMask);
-    _SAPP_GLPROC(glAttachShader);
-    _SAPP_GLPROC(glGetError);
-    _SAPP_GLPROC(glClearColor);
-    _SAPP_GLPROC(glBlendColor);
-    _SAPP_GLPROC(glTexParameterf);
-    _SAPP_GLPROC(glTexParameterfv);
-    _SAPP_GLPROC(glGetShaderInfoLog);
-    _SAPP_GLPROC(glDepthFunc);
-    _SAPP_GLPROC(glStencilOp);
-    _SAPP_GLPROC(glStencilFunc);
-    _SAPP_GLPROC(glEnableVertexAttribArray);
-    _SAPP_GLPROC(glBlendFunc);
-    _SAPP_GLPROC(glUniform1fv);
-    _SAPP_GLPROC(glReadBuffer);
-    _SAPP_GLPROC(glClear);
-    _SAPP_GLPROC(glTexImage2D);
-    _SAPP_GLPROC(glGenVertexArrays);
-    _SAPP_GLPROC(glFrontFace);
-    _SAPP_GLPROC(glCullFace);
+    #define _SAPP_XMACRO(func, proto) func = (PFN_ ## func) _sapp_win32_glgetprocaddr(#func);
+    _SAPP_GL_FUNCS
+    #undef _SAPP_XMACRO
 }
-#define glBindVertexArray _sapp_glBindVertexArray
-#define glFramebufferTextureLayer _sapp_glFramebufferTextureLayer
-#define glGenFramebuffers _sapp_glGenFramebuffers
-#define glBindFramebuffer _sapp_glBindFramebuffer
-#define glBindRenderbuffer _sapp_glBindRenderbuffer
-#define glGetStringi _sapp_glGetStringi
-#define glClearBufferfi _sapp_glClearBufferfi
-#define glClearBufferfv _sapp_glClearBufferfv
-#define glClearBufferuiv _sapp_glClearBufferuiv
-#define glDeleteRenderbuffers _sapp_glDeleteRenderbuffers
-#define glUniform4fv _sapp_glUniform4fv
-#define glUniform2fv _sapp_glUniform2fv
-#define glUseProgram _sapp_glUseProgram
-#define glShaderSource _sapp_glShaderSource
-#define glLinkProgram _sapp_glLinkProgram
-#define glGetUniformLocation _sapp_glGetUniformLocation
-#define glGetShaderiv _sapp_glGetShaderiv
-#define glGetProgramInfoLog _sapp_glGetProgramInfoLog
-#define glGetAttribLocation _sapp_glGetAttribLocation
-#define glDisableVertexAttribArray _sapp_glDisableVertexAttribArray
-#define glDeleteShader _sapp_glDeleteShader
-#define glDeleteProgram _sapp_glDeleteProgram
-#define glCompileShader _sapp_glCompileShader
-#define glStencilFuncSeparate _sapp_glStencilFuncSeparate
-#define glStencilOpSeparate _sapp_glStencilOpSeparate
-#define glRenderbufferStorageMultisample _sapp_glRenderbufferStorageMultisample
-#define glDrawBuffers _sapp_glDrawBuffers
-#define glVertexAttribDivisor _sapp_glVertexAttribDivisor
-#define glBufferSubData _sapp_glBufferSubData
-#define glGenBuffers _sapp_glGenBuffers
-#define glCheckFramebufferStatus _sapp_glCheckFramebufferStatus
-#define glFramebufferRenderbuffer _sapp_glFramebufferRenderbuffer
-#define glCompressedTexImage2D _sapp_glCompressedTexImage2D
-#define glCompressedTexImage3D _sapp_glCompressedTexImage3D
-#define glActiveTexture _sapp_glActiveTexture
-#define glTexSubImage3D _sapp_glTexSubImage3D
-#define glUniformMatrix4fv _sapp_glUniformMatrix4fv
-#define glRenderbufferStorage _sapp_glRenderbufferStorage
-#define glGenTextures _sapp_glGenTextures
-#define glPolygonOffset _sapp_glPolygonOffset
-#define glDrawElements _sapp_glDrawElements
-#define glDeleteFramebuffers _sapp_glDeleteFramebuffers
-#define glBlendEquationSeparate _sapp_glBlendEquationSeparate
-#define glDeleteTextures _sapp_glDeleteTextures
-#define glGetProgramiv _sapp_glGetProgramiv
-#define glBindTexture _sapp_glBindTexture
-#define glTexImage3D _sapp_glTexImage3D
-#define glCreateShader _sapp_glCreateShader
-#define glTexSubImage2D _sapp_glTexSubImage2D
-#define glClearDepth _sapp_glClearDepth
-#define glFramebufferTexture2D _sapp_glFramebufferTexture2D
-#define glCreateProgram _sapp_glCreateProgram
-#define glViewport _sapp_glViewport
-#define glDeleteBuffers _sapp_glDeleteBuffers
-#define glDrawArrays _sapp_glDrawArrays
-#define glDrawElementsInstanced _sapp_glDrawElementsInstanced
-#define glVertexAttribPointer _sapp_glVertexAttribPointer
-#define glUniform1i _sapp_glUniform1i
-#define glDisable _sapp_glDisable
-#define glColorMask _sapp_glColorMask
-#define glBindBuffer _sapp_glBindBuffer
-#define glDeleteVertexArrays _sapp_glDeleteVertexArrays
-#define glDepthMask _sapp_glDepthMask
-#define glDrawArraysInstanced _sapp_glDrawArraysInstanced
-#define glClearStencil _sapp_glClearStencil
-#define glScissor _sapp_glScissor
-#define glUniform3fv _sapp_glUniform3fv
-#define glGenRenderbuffers _sapp_glGenRenderbuffers
-#define glBufferData _sapp_glBufferData
-#define glBlendFuncSeparate _sapp_glBlendFuncSeparate
-#define glTexParameteri _sapp_glTexParameteri
-#define glGetIntegerv _sapp_glGetIntegerv
-#define glEnable _sapp_glEnable
-#define glBlitFramebuffer _sapp_glBlitFramebuffer
-#define glStencilMask _sapp_glStencilMask
-#define glAttachShader _sapp_glAttachShader
-#define glGetError _sapp_glGetError
-#define glClearColor _sapp_glClearColor
-#define glBlendColor _sapp_glBlendColor
-#define glTexParameterf _sapp_glTexParameterf
-#define glTexParameterfv _sapp_glTexParameterfv
-#define glGetShaderInfoLog _sapp_glGetShaderInfoLog
-#define glDepthFunc _sapp_glDepthFunc
-#define glStencilOp _sapp_glStencilOp
-#define glStencilFunc _sapp_glStencilFunc
-#define glEnableVertexAttribArray _sapp_glEnableVertexAttribArray
-#define glBlendFunc _sapp_glBlendFunc
-#define glUniform1fv _sapp_glUniform1fv
-#define glReadBuffer _sapp_glReadBuffer
-#define glClear _sapp_glClear
-#define glTexImage2D _sapp_glTexImage2D
-#define glGenVertexArrays _sapp_glGenVertexArrays
-#define glFrontFace _sapp_glFrontFace
-#define glCullFace _sapp_glCullFace
 
-#endif /* SOKOL_WIN32_NO_GL_LOADER */
-
-#endif /* SOKOL_GLCORE33 */
+#endif // SOKOL_WIN32_NO_GL_LOADER
+#endif // SOKOL_GLCORE33
 
 #if defined(SOKOL_D3D11)
 #define _SAPP_SAFE_RELEASE(class, obj) if (obj) { class##_Release(obj); obj=0; }

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -63,6 +63,9 @@
     GL header-generator/loader instead, define SOKOL_WIN32_NO_GL_LOADER
     before including the implementation part of sokol_app.h.
 
+    To make use of the integrated GL loader, simply include the sokol_app.h
+    implementation before the sokol_gfx.h implementation.
+
     For example code, see https://github.com/floooh/sokol-samples/tree/master/sapp
 
     FEATURE OVERVIEW
@@ -1592,6 +1595,368 @@ static struct {
     #endif
 } _sapp;
 
+/*=== OPTIONAL MINI GL LOADER FOR WIN32/WGL ==================================*/
+#if defined(_SAPP_WIN32) && defined(SOKOL_GLCORE33) && !defined(SOKOL_WIN32_NO_GL_LOADER)
+#define __gl_h_ 1
+#define __gl32_h_ 1
+#define __gl31_h_ 1
+#define __GL_H__ 1
+#define __glext_h_ 1
+#define __GLEXT_H_ 1
+#define __gltypes_h_ 1
+#define __glcorearb_h_ 1
+#define __gl_glcorearb_h_ 1
+#define GL_APIENTRY APIENTRY
+
+typedef unsigned int  GLenum;
+typedef unsigned int  GLuint;
+typedef int  GLsizei;
+typedef char  GLchar;
+typedef ptrdiff_t  GLintptr;
+typedef ptrdiff_t  GLsizeiptr;
+typedef double  GLclampd;
+typedef unsigned short  GLushort;
+typedef unsigned char  GLubyte;
+typedef unsigned char  GLboolean;
+typedef uint64_t  GLuint64;
+typedef double  GLdouble;
+typedef unsigned short  GLhalf;
+typedef float  GLclampf;
+typedef unsigned int  GLbitfield;
+typedef signed char  GLbyte;
+typedef short  GLshort;
+typedef void  GLvoid;
+typedef int64_t  GLint64;
+typedef float  GLfloat;
+typedef struct __GLsync * GLsync;
+typedef int  GLint;
+#define GL_INT_2_10_10_10_REV 0x8D9F
+#define GL_R32F 0x822E
+#define GL_PROGRAM_POINT_SIZE 0x8642
+#define GL_STENCIL_ATTACHMENT 0x8D20
+#define GL_DEPTH_ATTACHMENT 0x8D00
+#define GL_COLOR_ATTACHMENT2 0x8CE2
+#define GL_COLOR_ATTACHMENT0 0x8CE0
+#define GL_R16F 0x822D
+#define GL_COLOR_ATTACHMENT22 0x8CF6
+#define GL_DRAW_FRAMEBUFFER 0x8CA9
+#define GL_FRAMEBUFFER_COMPLETE 0x8CD5
+#define GL_NUM_EXTENSIONS 0x821D
+#define GL_INFO_LOG_LENGTH 0x8B84
+#define GL_VERTEX_SHADER 0x8B31
+#define GL_INCR 0x1E02
+#define GL_DYNAMIC_DRAW 0x88E8
+#define GL_STATIC_DRAW 0x88E4
+#define GL_TEXTURE_CUBE_MAP_POSITIVE_Z 0x8519
+#define GL_TEXTURE_CUBE_MAP 0x8513
+#define GL_FUNC_SUBTRACT 0x800A
+#define GL_FUNC_REVERSE_SUBTRACT 0x800B
+#define GL_CONSTANT_COLOR 0x8001
+#define GL_DECR_WRAP 0x8508
+#define GL_R8 0x8229
+#define GL_LINEAR_MIPMAP_LINEAR 0x2703
+#define GL_ELEMENT_ARRAY_BUFFER 0x8893
+#define GL_SHORT 0x1402
+#define GL_DEPTH_TEST 0x0B71
+#define GL_TEXTURE_CUBE_MAP_NEGATIVE_Y 0x8518
+#define GL_LINK_STATUS 0x8B82
+#define GL_TEXTURE_CUBE_MAP_POSITIVE_Y 0x8517
+#define GL_SAMPLE_ALPHA_TO_COVERAGE 0x809E
+#define GL_RGBA16F 0x881A
+#define GL_CONSTANT_ALPHA 0x8003
+#define GL_READ_FRAMEBUFFER 0x8CA8
+#define GL_TEXTURE0 0x84C0
+#define GL_TEXTURE_MIN_LOD 0x813A
+#define GL_CLAMP_TO_EDGE 0x812F
+#define GL_UNSIGNED_SHORT_5_6_5 0x8363
+#define GL_TEXTURE_WRAP_R 0x8072
+#define GL_UNSIGNED_SHORT_5_5_5_1 0x8034
+#define GL_NEAREST_MIPMAP_NEAREST 0x2700
+#define GL_UNSIGNED_SHORT_4_4_4_4 0x8033
+#define GL_SRC_ALPHA_SATURATE 0x0308
+#define GL_STREAM_DRAW 0x88E0
+#define GL_ONE 1
+#define GL_NEAREST_MIPMAP_LINEAR 0x2702
+#define GL_RGB10_A2 0x8059
+#define GL_RGBA8 0x8058
+#define GL_COLOR_ATTACHMENT1 0x8CE1
+#define GL_RGBA4 0x8056
+#define GL_RGB8 0x8051
+#define GL_ARRAY_BUFFER 0x8892
+#define GL_STENCIL 0x1802
+#define GL_TEXTURE_2D 0x0DE1
+#define GL_DEPTH 0x1801
+#define GL_FRONT 0x0404
+#define GL_STENCIL_BUFFER_BIT 0x00000400
+#define GL_REPEAT 0x2901
+#define GL_RGBA 0x1908
+#define GL_TEXTURE_CUBE_MAP_POSITIVE_X 0x8515
+#define GL_DECR 0x1E03
+#define GL_FRAGMENT_SHADER 0x8B30
+#define GL_FLOAT 0x1406
+#define GL_TEXTURE_MAX_LOD 0x813B
+#define GL_DEPTH_COMPONENT 0x1902
+#define GL_ONE_MINUS_DST_ALPHA 0x0305
+#define GL_COLOR 0x1800
+#define GL_TEXTURE_2D_ARRAY 0x8C1A
+#define GL_TRIANGLES 0x0004
+#define GL_UNSIGNED_BYTE 0x1401
+#define GL_TEXTURE_MAG_FILTER 0x2800
+#define GL_ONE_MINUS_CONSTANT_ALPHA 0x8004
+#define GL_NONE 0
+#define GL_SRC_COLOR 0x0300
+#define GL_BYTE 0x1400
+#define GL_TEXTURE_CUBE_MAP_NEGATIVE_Z 0x851A
+#define GL_LINE_STRIP 0x0003
+#define GL_TEXTURE_3D 0x806F
+#define GL_CW 0x0900
+#define GL_LINEAR 0x2601
+#define GL_RENDERBUFFER 0x8D41
+#define GL_GEQUAL 0x0206
+#define GL_COLOR_BUFFER_BIT 0x00004000
+#define GL_RGBA32F 0x8814
+#define GL_BLEND 0x0BE2
+#define GL_ONE_MINUS_SRC_ALPHA 0x0303
+#define GL_ONE_MINUS_CONSTANT_COLOR 0x8002
+#define GL_TEXTURE_WRAP_T 0x2803
+#define GL_TEXTURE_WRAP_S 0x2802
+#define GL_TEXTURE_MIN_FILTER 0x2801
+#define GL_LINEAR_MIPMAP_NEAREST 0x2701
+#define GL_EXTENSIONS 0x1F03
+#define GL_NO_ERROR 0
+#define GL_REPLACE 0x1E01
+#define GL_KEEP 0x1E00
+#define GL_CCW 0x0901
+#define GL_TEXTURE_CUBE_MAP_NEGATIVE_X 0x8516
+#define GL_RGB 0x1907
+#define GL_TRIANGLE_STRIP 0x0005
+#define GL_FALSE 0
+#define GL_ZERO 0
+#define GL_CULL_FACE 0x0B44
+#define GL_INVERT 0x150A
+#define GL_INT 0x1404
+#define GL_UNSIGNED_INT 0x1405
+#define GL_UNSIGNED_SHORT 0x1403
+#define GL_NEAREST 0x2600
+#define GL_SCISSOR_TEST 0x0C11
+#define GL_LEQUAL 0x0203
+#define GL_STENCIL_TEST 0x0B90
+#define GL_DITHER 0x0BD0
+#define GL_DEPTH_COMPONENT16 0x81A5
+#define GL_EQUAL 0x0202
+#define GL_FRAMEBUFFER 0x8D40
+#define GL_RGB5 0x8050
+#define GL_LINES 0x0001
+#define GL_DEPTH_BUFFER_BIT 0x00000100
+#define GL_SRC_ALPHA 0x0302
+#define GL_INCR_WRAP 0x8507
+#define GL_LESS 0x0201
+#define GL_MULTISAMPLE 0x809D
+#define GL_FRAMEBUFFER_BINDING 0x8CA6
+#define GL_BACK 0x0405
+#define GL_ALWAYS 0x0207
+#define GL_FUNC_ADD 0x8006
+#define GL_ONE_MINUS_DST_COLOR 0x0307
+#define GL_NOTEQUAL 0x0205
+#define GL_DST_COLOR 0x0306
+#define GL_COMPILE_STATUS 0x8B81
+#define GL_RED 0x1903
+#define GL_COLOR_ATTACHMENT3 0x8CE3
+#define GL_DST_ALPHA 0x0304
+#define GL_RGB5_A1 0x8057
+#define GL_GREATER 0x0204
+#define GL_POLYGON_OFFSET_FILL 0x8037
+#define GL_TRUE 1
+#define GL_NEVER 0x0200
+#define GL_POINTS 0x0000
+#define GL_ONE_MINUS_SRC_COLOR 0x0301
+#define GL_MIRRORED_REPEAT 0x8370
+#define GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS 0x8B4D
+#define GL_R11F_G11F_B10F 0x8C3A
+#define GL_UNSIGNED_INT_10F_11F_11F_REV 0x8C3B
+#define GL_RGBA32UI 0x8D70
+#define GL_RGB32UI 0x8D71
+#define GL_RGBA16UI 0x8D76
+#define GL_RGB16UI 0x8D77
+#define GL_RGBA8UI 0x8D7C
+#define GL_RGB8UI 0x8D7D
+#define GL_RGBA32I 0x8D82
+#define GL_RGB32I 0x8D83
+#define GL_RGBA16I 0x8D88
+#define GL_RGB16I 0x8D89
+#define GL_RGBA8I 0x8D8E
+#define GL_RGB8I 0x8D8F
+#define GL_RED_INTEGER 0x8D94
+#define GL_RG 0x8227
+#define GL_RG_INTEGER 0x8228
+#define GL_R8 0x8229
+#define GL_R16 0x822A
+#define GL_RG8 0x822B
+#define GL_RG16 0x822C
+#define GL_R16F 0x822D
+#define GL_R32F 0x822E
+#define GL_RG16F 0x822F
+#define GL_RG32F 0x8230
+#define GL_R8I 0x8231
+#define GL_R8UI 0x8232
+#define GL_R16I 0x8233
+#define GL_R16UI 0x8234
+#define GL_R32I 0x8235
+#define GL_R32UI 0x8236
+#define GL_RG8I 0x8237
+#define GL_RG8UI 0x8238
+#define GL_RG16I 0x8239
+#define GL_RG16UI 0x823A
+#define GL_RG32I 0x823B
+#define GL_RG32UI 0x823C
+#define GL_RGBA_INTEGER 0x8D99
+#define GL_R8_SNORM 0x8F94
+#define GL_RG8_SNORM 0x8F95
+#define GL_RGB8_SNORM 0x8F96
+#define GL_RGBA8_SNORM 0x8F97
+#define GL_R16_SNORM 0x8F98
+#define GL_RG16_SNORM 0x8F99
+#define GL_RGB16_SNORM 0x8F9A
+#define GL_RGBA16_SNORM 0x8F9B
+#define GL_RGBA16 0x805B
+#define GL_MAX_TEXTURE_SIZE 0x0D33
+#define GL_MAX_CUBE_MAP_TEXTURE_SIZE 0x851C
+#define GL_MAX_3D_TEXTURE_SIZE 0x8073
+#define GL_MAX_ARRAY_TEXTURE_LAYERS 0x88FF
+#define GL_MAX_VERTEX_ATTRIBS 0x8869
+#define GL_CLAMP_TO_BORDER 0x812D
+#define GL_TEXTURE_BORDER_COLOR 0x1004
+#define GL_CURRENT_PROGRAM 0x8B8D
+
+// X Macro list of GL function names and signatures
+#define _SAPP_GL_FUNCS \
+    _SAPP_XMACRO(glBindVertexArray,                 void (GL_APIENTRY *PFN_glBindVertexArray)(GLuint array)) \
+    _SAPP_XMACRO(glFramebufferTextureLayer,         void (GL_APIENTRY *PFN_glFramebufferTextureLayer)(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer)) \
+    _SAPP_XMACRO(glGenFramebuffers,                 void (GL_APIENTRY *PFN_glGenFramebuffers)(GLsizei n, GLuint * framebuffers)) \
+    _SAPP_XMACRO(glBindFramebuffer,                 void (GL_APIENTRY *PFN_glBindFramebuffer)(GLenum target, GLuint framebuffer)) \
+    _SAPP_XMACRO(glBindRenderbuffer,                void (GL_APIENTRY *PFN_glBindRenderbuffer)(GLenum target, GLuint renderbuffer)) \
+    _SAPP_XMACRO(glGetStringi,                      const GLubyte * (GL_APIENTRY *PFN_glGetStringi)(GLenum name, GLuint index)) \
+    _SAPP_XMACRO(glClearBufferfi,                   void (GL_APIENTRY *PFN_glClearBufferfi)(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil)) \
+    _SAPP_XMACRO(glClearBufferfv,                   void (GL_APIENTRY *PFN_glClearBufferfv)(GLenum buffer, GLint drawbuffer, const GLfloat * value)) \
+    _SAPP_XMACRO(glClearBufferuiv,                  void (GL_APIENTRY *PFN_glClearBufferuiv)(GLenum buffer, GLint drawbuffer, const GLuint * value)) \
+    _SAPP_XMACRO(glDeleteRenderbuffers,             void (GL_APIENTRY *PFN_glDeleteRenderbuffers)(GLsizei n, const GLuint * renderbuffers)) \
+    _SAPP_XMACRO(glUniform4fv,                      void (GL_APIENTRY *PFN_glUniform4fv)(GLint location, GLsizei count, const GLfloat * value)) \
+    _SAPP_XMACRO(glUniform2fv,                      void (GL_APIENTRY *PFN_glUniform2fv)(GLint location, GLsizei count, const GLfloat * value)) \
+    _SAPP_XMACRO(glUseProgram,                      void (GL_APIENTRY *PFN_glUseProgram)(GLuint program)) \
+    _SAPP_XMACRO(glShaderSource,                    void (GL_APIENTRY *PFN_glShaderSource)(GLuint shader, GLsizei count, const GLchar *const* string, const GLint * length)) \
+    _SAPP_XMACRO(glLinkProgram,                     void (GL_APIENTRY *PFN_glLinkProgram)(GLuint program)) \
+    _SAPP_XMACRO(glGetUniformLocation,              GLint (GL_APIENTRY *PFN_glGetUniformLocation)(GLuint program, const GLchar * name)) \
+    _SAPP_XMACRO(glGetShaderiv,                     void (GL_APIENTRY *PFN_glGetShaderiv)(GLuint shader, GLenum pname, GLint * params)) \
+    _SAPP_XMACRO(glGetProgramInfoLog,               void (GL_APIENTRY *PFN_glGetProgramInfoLog)(GLuint program, GLsizei bufSize, GLsizei * length, GLchar * infoLog)) \
+    _SAPP_XMACRO(glGetAttribLocation,               GLint(GL_APIENTRY *PFN_glGetAttribLocation)(GLuint program, const GLchar * name)) \
+    _SAPP_XMACRO(glDisableVertexAttribArray,        void (GL_APIENTRY *PFN_glDisableVertexAttribArray)(GLuint index)) \
+    _SAPP_XMACRO(glDeleteShader,                    void (GL_APIENTRY *PFN_glDeleteShader)(GLuint shader)) \
+    _SAPP_XMACRO(glDeleteProgram,                   void (GL_APIENTRY *PFN_glDeleteProgram)(GLuint program)) \
+    _SAPP_XMACRO(glCompileShader,                   void (GL_APIENTRY *PFN_glCompileShader)(GLuint shader)) \
+    _SAPP_XMACRO(glStencilFuncSeparate,             void (GL_APIENTRY *PFN_glStencilFuncSeparate)(GLenum face, GLenum func, GLint ref, GLuint mask)) \
+    _SAPP_XMACRO(glStencilOpSeparate,               void (GL_APIENTRY *PFN_glStencilOpSeparate)(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass)) \
+    _SAPP_XMACRO(glRenderbufferStorageMultisample,  void (GL_APIENTRY *PFN_glRenderbufferStorageMultisample)(GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height)) \
+    _SAPP_XMACRO(glDrawBuffers,                     void (GL_APIENTRY *PFN_glDrawBuffers)(GLsizei n, const GLenum * bufs)) \
+    _SAPP_XMACRO(glVertexAttribDivisor,             void (GL_APIENTRY *PFN_glVertexAttribDivisor)(GLuint index, GLuint divisor)) \
+    _SAPP_XMACRO(glBufferSubData,                   void (GL_APIENTRY *PFN_glBufferSubData)(GLenum target, GLintptr offset, GLsizeiptr size, const void * data)) \
+    _SAPP_XMACRO(glGenBuffers,                      void (GL_APIENTRY *PFN_glGenBuffers)(GLsizei n, GLuint * buffers)) \
+    _SAPP_XMACRO(glCheckFramebufferStatus,          GLenum (GL_APIENTRY *PFN_glCheckFramebufferStatus)(GLenum target)) \
+    _SAPP_XMACRO(glFramebufferRenderbuffer,         void (GL_APIENTRY *PFN_glFramebufferRenderbuffer)(GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer)) \
+    _SAPP_XMACRO(glCompressedTexImage2D,            void (GL_APIENTRY *PFN_glCompressedTexImage2D)(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, const void * data)) \
+    _SAPP_XMACRO(glCompressedTexImage3D,            void (GL_APIENTRY *PFN_glCompressedTexImage3D)(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, const void * data)) \
+    _SAPP_XMACRO(glActiveTexture,                   void (GL_APIENTRY *PFN_glActiveTexture)(GLenum texture)) \
+    _SAPP_XMACRO(glTexSubImage3D,                   void (GL_APIENTRY *PFN_glTexSubImage3D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const void * pixels)) \
+    _SAPP_XMACRO(glUniformMatrix4fv,                void (GL_APIENTRY *PFN_glUniformMatrix4fv)(GLint location, GLsizei count, GLboolean transpose, const GLfloat * value)) \
+    _SAPP_XMACRO(glRenderbufferStorage,             void (GL_APIENTRY *PFN_glRenderbufferStorage)(GLenum target, GLenum internalformat, GLsizei width, GLsizei height)) \
+    _SAPP_XMACRO(glGenTextures,                     void (GL_APIENTRY *PFN_glGenTextures)(GLsizei n, GLuint * textures)) \
+    _SAPP_XMACRO(glPolygonOffset,                   void (GL_APIENTRY *PFN_glPolygonOffset)(GLfloat factor, GLfloat units)) \
+    _SAPP_XMACRO(glDrawElements,                    void (GL_APIENTRY *PFN_glDrawElements)(GLenum mode, GLsizei count, GLenum type, const void * indices)) \
+    _SAPP_XMACRO(glDeleteFramebuffers,              void (GL_APIENTRY *PFN_glDeleteFramebuffers)(GLsizei n, const GLuint * framebuffers)) \
+    _SAPP_XMACRO(glBlendEquationSeparate,           void (GL_APIENTRY *PFN_glBlendEquationSeparate)(GLenum modeRGB, GLenum modeAlpha)) \
+    _SAPP_XMACRO(glDeleteTextures,                  void (GL_APIENTRY *PFN_glDeleteTextures)(GLsizei n, const GLuint * textures)) \
+    _SAPP_XMACRO(glGetProgramiv,                    void (GL_APIENTRY *PFN_glGetProgramiv)(GLuint program, GLenum pname, GLint * params)) \
+    _SAPP_XMACRO(glBindTexture,                     void (GL_APIENTRY *PFN_glBindTexture)(GLenum target, GLuint texture)) \
+    _SAPP_XMACRO(glTexImage3D,                      void (GL_APIENTRY *PFN_glTexImage3D)(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const void * pixels)) \
+    _SAPP_XMACRO(glCreateShader,                    GLuint (GL_APIENTRY *PFN_glCreateShader)(GLenum type)) \
+    _SAPP_XMACRO(glTexSubImage2D,                   void (GL_APIENTRY *PFN_glTexSubImage2D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const void * pixels)) \
+    _SAPP_XMACRO(glClearDepth,                      void (GL_APIENTRY *PFN_glClearDepth)(GLdouble depth)) \
+    _SAPP_XMACRO(glFramebufferTexture2D,            void (GL_APIENTRY *PFN_glFramebufferTexture2D)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level)) \
+    _SAPP_XMACRO(glCreateProgram,                   GLuint (GL_APIENTRY *PFN_glCreateProgram)(void)) \
+    _SAPP_XMACRO(glViewport,                        void (GL_APIENTRY *PFN_glViewport)(GLint x, GLint y, GLsizei width, GLsizei height)) \
+    _SAPP_XMACRO(glDeleteBuffers,                   void (GL_APIENTRY *PFN_glDeleteBuffers)(GLsizei n, const GLuint * buffers)) \
+    _SAPP_XMACRO(glDrawArrays,                      void (GL_APIENTRY *PFN_glDrawArrays)(GLenum mode, GLint first, GLsizei count)) \
+    _SAPP_XMACRO(glDrawElementsInstanced,           void (GL_APIENTRY *PFN_glDrawElementsInstanced)(GLenum mode, GLsizei count, GLenum type, const void * indices, GLsizei instancecount)) \
+    _SAPP_XMACRO(glVertexAttribPointer,             void (GL_APIENTRY *PFN_glVertexAttribPointer)(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void * pointer)) \
+    _SAPP_XMACRO(glUniform1i,                       void (GL_APIENTRY *PFN_glUniform1i)(GLint location, GLint v0)) \
+    _SAPP_XMACRO(glDisable,                         void (GL_APIENTRY *PFN_glDisable)(GLenum cap)) \
+    _SAPP_XMACRO(glColorMask,                       void (GL_APIENTRY *PFN_glColorMask)(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha)) \
+    _SAPP_XMACRO(glBindBuffer,                      void (GL_APIENTRY *PFN_glBindBuffer)(GLenum target, GLuint buffer)) \
+    _SAPP_XMACRO(glDeleteVertexArrays,              void (GL_APIENTRY *PFN_glDeleteVertexArrays)(GLsizei n, const GLuint * arrays)) \
+    _SAPP_XMACRO(glDepthMask,                       void (GL_APIENTRY *PFN_glDepthMask)(GLboolean flag)) \
+    _SAPP_XMACRO(glDrawArraysInstanced,             void (GL_APIENTRY *PFN_glDrawArraysInstanced)(GLenum mode, GLint first, GLsizei count, GLsizei instancecount)) \
+    _SAPP_XMACRO(glClearStencil,                    void (GL_APIENTRY *PFN_glClearStencil)(GLint s)) \
+    _SAPP_XMACRO(glScissor,                         void (GL_APIENTRY *PFN_glScissor)(GLint x, GLint y, GLsizei width, GLsizei height)) \
+    _SAPP_XMACRO(glUniform3fv,                      void (GL_APIENTRY *PFN_glUniform3fv)(GLint location, GLsizei count, const GLfloat * value)) \
+    _SAPP_XMACRO(glGenRenderbuffers,                void (GL_APIENTRY *PFN_glGenRenderbuffers)(GLsizei n, GLuint * renderbuffers)) \
+    _SAPP_XMACRO(glBufferData,                      void (GL_APIENTRY *PFN_glBufferData)(GLenum target, GLsizeiptr size, const void * data, GLenum usage)) \
+    _SAPP_XMACRO(glBlendFuncSeparate,               void (GL_APIENTRY *PFN_glBlendFuncSeparate)(GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha, GLenum dfactorAlpha)) \
+    _SAPP_XMACRO(glTexParameteri,                   void (GL_APIENTRY *PFN_glTexParameteri)(GLenum target, GLenum pname, GLint param)) \
+    _SAPP_XMACRO(glGetIntegerv,                     void (GL_APIENTRY *PFN_glGetIntegerv)(GLenum pname, GLint * data)) \
+    _SAPP_XMACRO(glEnable,                          void (GL_APIENTRY *PFN_glEnable)(GLenum cap)) \
+    _SAPP_XMACRO(glBlitFramebuffer,                 void (GL_APIENTRY *PFN_glBlitFramebuffer)(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter)) \
+    _SAPP_XMACRO(glStencilMask,                     void (GL_APIENTRY *PFN_glStencilMask)(GLuint mask)) \
+    _SAPP_XMACRO(glAttachShader,                    void (GL_APIENTRY *PFN_glAttachShader)(GLuint program, GLuint shader)) \
+    _SAPP_XMACRO(glGetError,                        GLenum (GL_APIENTRY *PFN_glGetError)(void)) \
+    _SAPP_XMACRO(glClearColor,                      void (GL_APIENTRY *PFN_glClearColor)(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)) \
+    _SAPP_XMACRO(glBlendColor,                      void (GL_APIENTRY *PFN_glBlendColor)(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)) \
+    _SAPP_XMACRO(glTexParameterf,                   void (GL_APIENTRY *PFN_glTexParameterf)(GLenum target, GLenum pname, GLfloat param)) \
+    _SAPP_XMACRO(glTexParameterfv,                  void (GL_APIENTRY *PFN_glTexParameterfv)(GLenum target, GLenum pname, GLfloat* params)) \
+    _SAPP_XMACRO(glGetShaderInfoLog,                void (GL_APIENTRY *PFN_glGetShaderInfoLog)(GLuint shader, GLsizei bufSize, GLsizei * length, GLchar * infoLog)) \
+    _SAPP_XMACRO(glDepthFunc,                       void (GL_APIENTRY *PFN_glDepthFunc)(GLenum func)) \
+    _SAPP_XMACRO(glStencilOp ,                      void  (GL_APIENTRY *PFN_glStencilOp)(GLenum fail, GLenum zfail, GLenum zpass)) \
+    _SAPP_XMACRO(glStencilFunc,                     void  (GL_APIENTRY *PFN_glStencilFunc)(GLenum func, GLint ref, GLuint mask)) \
+    _SAPP_XMACRO(glEnableVertexAttribArray,         void  (GL_APIENTRY *PFN_glEnableVertexAttribArray)(GLuint index)) \
+    _SAPP_XMACRO(glBlendFunc,                       void  (GL_APIENTRY *PFN_glBlendFunc)(GLenum sfactor, GLenum dfactor)) \
+    _SAPP_XMACRO(glUniform1fv,                      void  (GL_APIENTRY *PFN_glUniform1fv)(GLint location, GLsizei count, const GLfloat * value)) \
+    _SAPP_XMACRO(glReadBuffer,                      void  (GL_APIENTRY *PFN_glReadBuffer)(GLenum src)) \
+    _SAPP_XMACRO(glClear,                           void  (GL_APIENTRY *PFN_glClear)(GLbitfield mask)) \
+    _SAPP_XMACRO(glTexImage2D,                      void  (GL_APIENTRY *PFN_glTexImage2D)(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void * pixels)) \
+    _SAPP_XMACRO(glGenVertexArrays,                 void  (GL_APIENTRY *PFN_glGenVertexArrays)(GLsizei n, GLuint * arrays)) \
+    _SAPP_XMACRO(glFrontFace,                       void  (GL_APIENTRY *PFN_glFrontFace)(GLenum mode)) \
+    _SAPP_XMACRO(glCullFace,                        void  (GL_APIENTRY *PFN_glCullFace)(GLenum mode))
+
+// generate GL function pointer typedefs
+#define _SAPP_XMACRO(func, proto) typedef proto;
+_SAPP_GL_FUNCS
+#undef _SAPP_XMACRO
+
+// generate GL function pointers
+#define _SAPP_XMACRO(func, proto) static PFN_ ## func func;
+_SAPP_GL_FUNCS
+#undef _SAPP_XMACRO
+
+// helper function to lookup GL functions in GL DLL
+_SOKOL_PRIVATE void* _sapp_win32_glgetprocaddr(const char* name) {
+    void* proc_addr = (void*) _sapp.wgl.GetProcAddress(name);
+    if (0 == proc_addr) {
+        proc_addr = (void*) GetProcAddress(_sapp.wgl.opengl32, name);
+    }
+    SOKOL_ASSERT(proc_addr);
+    return proc_addr;
+}
+
+// populate GL function pointers
+_SOKOL_PRIVATE  void _sapp_win32_gl_loadfuncs(void) {
+    SOKOL_ASSERT(_sapp.wgl.GetProcAddress);
+    SOKOL_ASSERT(_sapp.wgl.opengl32);
+    #define _SAPP_XMACRO(func, proto) func = (PFN_ ## func) _sapp_win32_glgetprocaddr(#func);
+    _SAPP_GL_FUNCS
+    #undef _SAPP_XMACRO
+}
+
+#endif // _SAPP_WIN32 && SOKOL_GLCORE33 && !SOKOL_WIN32_NO_GL_LOADER
+
+/*=== PRIVATE HELPER FUNCTIONS ===============================================*/
 _SOKOL_PRIVATE void _sapp_fail(const char* msg) {
     if (_sapp.desc.fail_cb) {
         _sapp.desc.fail_cb(msg);
@@ -3702,371 +4067,6 @@ _SOKOL_PRIVATE const _sapp_gl_fbconfig* _sapp_gl_choose_fbconfig(const _sapp_gl_
 
 /*== WINDOWS ==================================================================*/
 #if defined(_SAPP_WIN32)
-
-/* NOTE: the optional GL loader only contains the GL constants and functions required for sokol_gfx.h, if you need
-more, you'll need to use you own gl header-generator/loader
-*/
-#if !defined(SOKOL_WIN32_NO_GL_LOADER)
-#if defined(SOKOL_GLCORE33)
-#define __gl_h_ 1
-#define __gl32_h_ 1
-#define __gl31_h_ 1
-#define __GL_H__ 1
-#define __glext_h_ 1
-#define __GLEXT_H_ 1
-#define __gltypes_h_ 1
-#define __glcorearb_h_ 1
-#define __gl_glcorearb_h_ 1
-#define GL_APIENTRY APIENTRY
-
-typedef unsigned int  GLenum;
-typedef unsigned int  GLuint;
-typedef int  GLsizei;
-typedef char  GLchar;
-typedef ptrdiff_t  GLintptr;
-typedef ptrdiff_t  GLsizeiptr;
-typedef double  GLclampd;
-typedef unsigned short  GLushort;
-typedef unsigned char  GLubyte;
-typedef unsigned char  GLboolean;
-typedef uint64_t  GLuint64;
-typedef double  GLdouble;
-typedef unsigned short  GLhalf;
-typedef float  GLclampf;
-typedef unsigned int  GLbitfield;
-typedef signed char  GLbyte;
-typedef short  GLshort;
-typedef void  GLvoid;
-typedef int64_t  GLint64;
-typedef float  GLfloat;
-typedef struct __GLsync * GLsync;
-typedef int  GLint;
-#define GL_INT_2_10_10_10_REV 0x8D9F
-#define GL_R32F 0x822E
-#define GL_PROGRAM_POINT_SIZE 0x8642
-#define GL_STENCIL_ATTACHMENT 0x8D20
-#define GL_DEPTH_ATTACHMENT 0x8D00
-#define GL_COLOR_ATTACHMENT2 0x8CE2
-#define GL_COLOR_ATTACHMENT0 0x8CE0
-#define GL_R16F 0x822D
-#define GL_COLOR_ATTACHMENT22 0x8CF6
-#define GL_DRAW_FRAMEBUFFER 0x8CA9
-#define GL_FRAMEBUFFER_COMPLETE 0x8CD5
-#define GL_NUM_EXTENSIONS 0x821D
-#define GL_INFO_LOG_LENGTH 0x8B84
-#define GL_VERTEX_SHADER 0x8B31
-#define GL_INCR 0x1E02
-#define GL_DYNAMIC_DRAW 0x88E8
-#define GL_STATIC_DRAW 0x88E4
-#define GL_TEXTURE_CUBE_MAP_POSITIVE_Z 0x8519
-#define GL_TEXTURE_CUBE_MAP 0x8513
-#define GL_FUNC_SUBTRACT 0x800A
-#define GL_FUNC_REVERSE_SUBTRACT 0x800B
-#define GL_CONSTANT_COLOR 0x8001
-#define GL_DECR_WRAP 0x8508
-#define GL_R8 0x8229
-#define GL_LINEAR_MIPMAP_LINEAR 0x2703
-#define GL_ELEMENT_ARRAY_BUFFER 0x8893
-#define GL_SHORT 0x1402
-#define GL_DEPTH_TEST 0x0B71
-#define GL_TEXTURE_CUBE_MAP_NEGATIVE_Y 0x8518
-#define GL_LINK_STATUS 0x8B82
-#define GL_TEXTURE_CUBE_MAP_POSITIVE_Y 0x8517
-#define GL_SAMPLE_ALPHA_TO_COVERAGE 0x809E
-#define GL_RGBA16F 0x881A
-#define GL_CONSTANT_ALPHA 0x8003
-#define GL_READ_FRAMEBUFFER 0x8CA8
-#define GL_TEXTURE0 0x84C0
-#define GL_TEXTURE_MIN_LOD 0x813A
-#define GL_CLAMP_TO_EDGE 0x812F
-#define GL_UNSIGNED_SHORT_5_6_5 0x8363
-#define GL_TEXTURE_WRAP_R 0x8072
-#define GL_UNSIGNED_SHORT_5_5_5_1 0x8034
-#define GL_NEAREST_MIPMAP_NEAREST 0x2700
-#define GL_UNSIGNED_SHORT_4_4_4_4 0x8033
-#define GL_SRC_ALPHA_SATURATE 0x0308
-#define GL_STREAM_DRAW 0x88E0
-#define GL_ONE 1
-#define GL_NEAREST_MIPMAP_LINEAR 0x2702
-#define GL_RGB10_A2 0x8059
-#define GL_RGBA8 0x8058
-#define GL_COLOR_ATTACHMENT1 0x8CE1
-#define GL_RGBA4 0x8056
-#define GL_RGB8 0x8051
-#define GL_ARRAY_BUFFER 0x8892
-#define GL_STENCIL 0x1802
-#define GL_TEXTURE_2D 0x0DE1
-#define GL_DEPTH 0x1801
-#define GL_FRONT 0x0404
-#define GL_STENCIL_BUFFER_BIT 0x00000400
-#define GL_REPEAT 0x2901
-#define GL_RGBA 0x1908
-#define GL_TEXTURE_CUBE_MAP_POSITIVE_X 0x8515
-#define GL_DECR 0x1E03
-#define GL_FRAGMENT_SHADER 0x8B30
-#define GL_FLOAT 0x1406
-#define GL_TEXTURE_MAX_LOD 0x813B
-#define GL_DEPTH_COMPONENT 0x1902
-#define GL_ONE_MINUS_DST_ALPHA 0x0305
-#define GL_COLOR 0x1800
-#define GL_TEXTURE_2D_ARRAY 0x8C1A
-#define GL_TRIANGLES 0x0004
-#define GL_UNSIGNED_BYTE 0x1401
-#define GL_TEXTURE_MAG_FILTER 0x2800
-#define GL_ONE_MINUS_CONSTANT_ALPHA 0x8004
-#define GL_NONE 0
-#define GL_SRC_COLOR 0x0300
-#define GL_BYTE 0x1400
-#define GL_TEXTURE_CUBE_MAP_NEGATIVE_Z 0x851A
-#define GL_LINE_STRIP 0x0003
-#define GL_TEXTURE_3D 0x806F
-#define GL_CW 0x0900
-#define GL_LINEAR 0x2601
-#define GL_RENDERBUFFER 0x8D41
-#define GL_GEQUAL 0x0206
-#define GL_COLOR_BUFFER_BIT 0x00004000
-#define GL_RGBA32F 0x8814
-#define GL_BLEND 0x0BE2
-#define GL_ONE_MINUS_SRC_ALPHA 0x0303
-#define GL_ONE_MINUS_CONSTANT_COLOR 0x8002
-#define GL_TEXTURE_WRAP_T 0x2803
-#define GL_TEXTURE_WRAP_S 0x2802
-#define GL_TEXTURE_MIN_FILTER 0x2801
-#define GL_LINEAR_MIPMAP_NEAREST 0x2701
-#define GL_EXTENSIONS 0x1F03
-#define GL_NO_ERROR 0
-#define GL_REPLACE 0x1E01
-#define GL_KEEP 0x1E00
-#define GL_CCW 0x0901
-#define GL_TEXTURE_CUBE_MAP_NEGATIVE_X 0x8516
-#define GL_RGB 0x1907
-#define GL_TRIANGLE_STRIP 0x0005
-#define GL_FALSE 0
-#define GL_ZERO 0
-#define GL_CULL_FACE 0x0B44
-#define GL_INVERT 0x150A
-#define GL_INT 0x1404
-#define GL_UNSIGNED_INT 0x1405
-#define GL_UNSIGNED_SHORT 0x1403
-#define GL_NEAREST 0x2600
-#define GL_SCISSOR_TEST 0x0C11
-#define GL_LEQUAL 0x0203
-#define GL_STENCIL_TEST 0x0B90
-#define GL_DITHER 0x0BD0
-#define GL_DEPTH_COMPONENT16 0x81A5
-#define GL_EQUAL 0x0202
-#define GL_FRAMEBUFFER 0x8D40
-#define GL_RGB5 0x8050
-#define GL_LINES 0x0001
-#define GL_DEPTH_BUFFER_BIT 0x00000100
-#define GL_SRC_ALPHA 0x0302
-#define GL_INCR_WRAP 0x8507
-#define GL_LESS 0x0201
-#define GL_MULTISAMPLE 0x809D
-#define GL_FRAMEBUFFER_BINDING 0x8CA6
-#define GL_BACK 0x0405
-#define GL_ALWAYS 0x0207
-#define GL_FUNC_ADD 0x8006
-#define GL_ONE_MINUS_DST_COLOR 0x0307
-#define GL_NOTEQUAL 0x0205
-#define GL_DST_COLOR 0x0306
-#define GL_COMPILE_STATUS 0x8B81
-#define GL_RED 0x1903
-#define GL_COLOR_ATTACHMENT3 0x8CE3
-#define GL_DST_ALPHA 0x0304
-#define GL_RGB5_A1 0x8057
-#define GL_GREATER 0x0204
-#define GL_POLYGON_OFFSET_FILL 0x8037
-#define GL_TRUE 1
-#define GL_NEVER 0x0200
-#define GL_POINTS 0x0000
-#define GL_ONE_MINUS_SRC_COLOR 0x0301
-#define GL_MIRRORED_REPEAT 0x8370
-#define GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS 0x8B4D
-#define GL_R11F_G11F_B10F 0x8C3A
-#define GL_UNSIGNED_INT_10F_11F_11F_REV 0x8C3B
-#define GL_RGBA32UI 0x8D70
-#define GL_RGB32UI 0x8D71
-#define GL_RGBA16UI 0x8D76
-#define GL_RGB16UI 0x8D77
-#define GL_RGBA8UI 0x8D7C
-#define GL_RGB8UI 0x8D7D
-#define GL_RGBA32I 0x8D82
-#define GL_RGB32I 0x8D83
-#define GL_RGBA16I 0x8D88
-#define GL_RGB16I 0x8D89
-#define GL_RGBA8I 0x8D8E
-#define GL_RGB8I 0x8D8F
-#define GL_RED_INTEGER 0x8D94
-#define GL_RG 0x8227
-#define GL_RG_INTEGER 0x8228
-#define GL_R8 0x8229
-#define GL_R16 0x822A
-#define GL_RG8 0x822B
-#define GL_RG16 0x822C
-#define GL_R16F 0x822D
-#define GL_R32F 0x822E
-#define GL_RG16F 0x822F
-#define GL_RG32F 0x8230
-#define GL_R8I 0x8231
-#define GL_R8UI 0x8232
-#define GL_R16I 0x8233
-#define GL_R16UI 0x8234
-#define GL_R32I 0x8235
-#define GL_R32UI 0x8236
-#define GL_RG8I 0x8237
-#define GL_RG8UI 0x8238
-#define GL_RG16I 0x8239
-#define GL_RG16UI 0x823A
-#define GL_RG32I 0x823B
-#define GL_RG32UI 0x823C
-#define GL_RGBA_INTEGER 0x8D99
-#define GL_R8_SNORM 0x8F94
-#define GL_RG8_SNORM 0x8F95
-#define GL_RGB8_SNORM 0x8F96
-#define GL_RGBA8_SNORM 0x8F97
-#define GL_R16_SNORM 0x8F98
-#define GL_RG16_SNORM 0x8F99
-#define GL_RGB16_SNORM 0x8F9A
-#define GL_RGBA16_SNORM 0x8F9B
-#define GL_RGBA16 0x805B
-#define GL_MAX_TEXTURE_SIZE 0x0D33
-#define GL_MAX_CUBE_MAP_TEXTURE_SIZE 0x851C
-#define GL_MAX_3D_TEXTURE_SIZE 0x8073
-#define GL_MAX_ARRAY_TEXTURE_LAYERS 0x88FF
-#define GL_MAX_VERTEX_ATTRIBS 0x8869
-#define GL_CLAMP_TO_BORDER 0x812D
-#define GL_TEXTURE_BORDER_COLOR 0x1004
-#define GL_CURRENT_PROGRAM 0x8B8D
-
-// X Macro list of GL function names and signatures
-#define _SAPP_GL_FUNCS \
-    _SAPP_XMACRO(glBindVertexArray,                 void (GL_APIENTRY *PFN_glBindVertexArray)(GLuint array)) \
-    _SAPP_XMACRO(glFramebufferTextureLayer,         void (GL_APIENTRY *PFN_glFramebufferTextureLayer)(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer)) \
-    _SAPP_XMACRO(glGenFramebuffers,                 void (GL_APIENTRY *PFN_glGenFramebuffers)(GLsizei n, GLuint * framebuffers)) \
-    _SAPP_XMACRO(glBindFramebuffer,                 void (GL_APIENTRY *PFN_glBindFramebuffer)(GLenum target, GLuint framebuffer)) \
-    _SAPP_XMACRO(glBindRenderbuffer,                void (GL_APIENTRY *PFN_glBindRenderbuffer)(GLenum target, GLuint renderbuffer)) \
-    _SAPP_XMACRO(glGetStringi,                      const GLubyte * (GL_APIENTRY *PFN_glGetStringi)(GLenum name, GLuint index)) \
-    _SAPP_XMACRO(glClearBufferfi,                   void (GL_APIENTRY *PFN_glClearBufferfi)(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil)) \
-    _SAPP_XMACRO(glClearBufferfv,                   void (GL_APIENTRY *PFN_glClearBufferfv)(GLenum buffer, GLint drawbuffer, const GLfloat * value)) \
-    _SAPP_XMACRO(glClearBufferuiv,                  void (GL_APIENTRY *PFN_glClearBufferuiv)(GLenum buffer, GLint drawbuffer, const GLuint * value)) \
-    _SAPP_XMACRO(glDeleteRenderbuffers,             void (GL_APIENTRY *PFN_glDeleteRenderbuffers)(GLsizei n, const GLuint * renderbuffers)) \
-    _SAPP_XMACRO(glUniform4fv,                      void (GL_APIENTRY *PFN_glUniform4fv)(GLint location, GLsizei count, const GLfloat * value)) \
-    _SAPP_XMACRO(glUniform2fv,                      void (GL_APIENTRY *PFN_glUniform2fv)(GLint location, GLsizei count, const GLfloat * value)) \
-    _SAPP_XMACRO(glUseProgram,                      void (GL_APIENTRY *PFN_glUseProgram)(GLuint program)) \
-    _SAPP_XMACRO(glShaderSource,                    void (GL_APIENTRY *PFN_glShaderSource)(GLuint shader, GLsizei count, const GLchar *const* string, const GLint * length)) \
-    _SAPP_XMACRO(glLinkProgram,                     void (GL_APIENTRY *PFN_glLinkProgram)(GLuint program)) \
-    _SAPP_XMACRO(glGetUniformLocation,              GLint (GL_APIENTRY *PFN_glGetUniformLocation)(GLuint program, const GLchar * name)) \
-    _SAPP_XMACRO(glGetShaderiv,                     void (GL_APIENTRY *PFN_glGetShaderiv)(GLuint shader, GLenum pname, GLint * params)) \
-    _SAPP_XMACRO(glGetProgramInfoLog,               void (GL_APIENTRY *PFN_glGetProgramInfoLog)(GLuint program, GLsizei bufSize, GLsizei * length, GLchar * infoLog)) \
-    _SAPP_XMACRO(glGetAttribLocation,               GLint(GL_APIENTRY *PFN_glGetAttribLocation)(GLuint program, const GLchar * name)) \
-    _SAPP_XMACRO(glDisableVertexAttribArray,        void (GL_APIENTRY *PFN_glDisableVertexAttribArray)(GLuint index)) \
-    _SAPP_XMACRO(glDeleteShader,                    void (GL_APIENTRY *PFN_glDeleteShader)(GLuint shader)) \
-    _SAPP_XMACRO(glDeleteProgram,                   void (GL_APIENTRY *PFN_glDeleteProgram)(GLuint program)) \
-    _SAPP_XMACRO(glCompileShader,                   void (GL_APIENTRY *PFN_glCompileShader)(GLuint shader)) \
-    _SAPP_XMACRO(glStencilFuncSeparate,             void (GL_APIENTRY *PFN_glStencilFuncSeparate)(GLenum face, GLenum func, GLint ref, GLuint mask)) \
-    _SAPP_XMACRO(glStencilOpSeparate,               void (GL_APIENTRY *PFN_glStencilOpSeparate)(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass)) \
-    _SAPP_XMACRO(glRenderbufferStorageMultisample,  void (GL_APIENTRY *PFN_glRenderbufferStorageMultisample)(GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height)) \
-    _SAPP_XMACRO(glDrawBuffers,                     void (GL_APIENTRY *PFN_glDrawBuffers)(GLsizei n, const GLenum * bufs)) \
-    _SAPP_XMACRO(glVertexAttribDivisor,             void (GL_APIENTRY *PFN_glVertexAttribDivisor)(GLuint index, GLuint divisor)) \
-    _SAPP_XMACRO(glBufferSubData,                   void (GL_APIENTRY *PFN_glBufferSubData)(GLenum target, GLintptr offset, GLsizeiptr size, const void * data)) \
-    _SAPP_XMACRO(glGenBuffers,                      void (GL_APIENTRY *PFN_glGenBuffers)(GLsizei n, GLuint * buffers)) \
-    _SAPP_XMACRO(glCheckFramebufferStatus,          GLenum (GL_APIENTRY *PFN_glCheckFramebufferStatus)(GLenum target)) \
-    _SAPP_XMACRO(glFramebufferRenderbuffer,         void (GL_APIENTRY *PFN_glFramebufferRenderbuffer)(GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer)) \
-    _SAPP_XMACRO(glCompressedTexImage2D,            void (GL_APIENTRY *PFN_glCompressedTexImage2D)(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, const void * data)) \
-    _SAPP_XMACRO(glCompressedTexImage3D,            void (GL_APIENTRY *PFN_glCompressedTexImage3D)(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, const void * data)) \
-    _SAPP_XMACRO(glActiveTexture,                   void (GL_APIENTRY *PFN_glActiveTexture)(GLenum texture)) \
-    _SAPP_XMACRO(glTexSubImage3D,                   void (GL_APIENTRY *PFN_glTexSubImage3D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const void * pixels)) \
-    _SAPP_XMACRO(glUniformMatrix4fv,                void (GL_APIENTRY *PFN_glUniformMatrix4fv)(GLint location, GLsizei count, GLboolean transpose, const GLfloat * value)) \
-    _SAPP_XMACRO(glRenderbufferStorage,             void (GL_APIENTRY *PFN_glRenderbufferStorage)(GLenum target, GLenum internalformat, GLsizei width, GLsizei height)) \
-    _SAPP_XMACRO(glGenTextures,                     void (GL_APIENTRY *PFN_glGenTextures)(GLsizei n, GLuint * textures)) \
-    _SAPP_XMACRO(glPolygonOffset,                   void (GL_APIENTRY *PFN_glPolygonOffset)(GLfloat factor, GLfloat units)) \
-    _SAPP_XMACRO(glDrawElements,                    void (GL_APIENTRY *PFN_glDrawElements)(GLenum mode, GLsizei count, GLenum type, const void * indices)) \
-    _SAPP_XMACRO(glDeleteFramebuffers,              void (GL_APIENTRY *PFN_glDeleteFramebuffers)(GLsizei n, const GLuint * framebuffers)) \
-    _SAPP_XMACRO(glBlendEquationSeparate,           void (GL_APIENTRY *PFN_glBlendEquationSeparate)(GLenum modeRGB, GLenum modeAlpha)) \
-    _SAPP_XMACRO(glDeleteTextures,                  void (GL_APIENTRY *PFN_glDeleteTextures)(GLsizei n, const GLuint * textures)) \
-    _SAPP_XMACRO(glGetProgramiv,                    void (GL_APIENTRY *PFN_glGetProgramiv)(GLuint program, GLenum pname, GLint * params)) \
-    _SAPP_XMACRO(glBindTexture,                     void (GL_APIENTRY *PFN_glBindTexture)(GLenum target, GLuint texture)) \
-    _SAPP_XMACRO(glTexImage3D,                      void (GL_APIENTRY *PFN_glTexImage3D)(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const void * pixels)) \
-    _SAPP_XMACRO(glCreateShader,                    GLuint (GL_APIENTRY *PFN_glCreateShader)(GLenum type)) \
-    _SAPP_XMACRO(glTexSubImage2D,                   void (GL_APIENTRY *PFN_glTexSubImage2D)(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const void * pixels)) \
-    _SAPP_XMACRO(glClearDepth,                      void (GL_APIENTRY *PFN_glClearDepth)(GLdouble depth)) \
-    _SAPP_XMACRO(glFramebufferTexture2D,            void (GL_APIENTRY *PFN_glFramebufferTexture2D)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level)) \
-    _SAPP_XMACRO(glCreateProgram,                   GLuint (GL_APIENTRY *PFN_glCreateProgram)(void)) \
-    _SAPP_XMACRO(glViewport,                        void (GL_APIENTRY *PFN_glViewport)(GLint x, GLint y, GLsizei width, GLsizei height)) \
-    _SAPP_XMACRO(glDeleteBuffers,                   void (GL_APIENTRY *PFN_glDeleteBuffers)(GLsizei n, const GLuint * buffers)) \
-    _SAPP_XMACRO(glDrawArrays,                      void (GL_APIENTRY *PFN_glDrawArrays)(GLenum mode, GLint first, GLsizei count)) \
-    _SAPP_XMACRO(glDrawElementsInstanced,           void (GL_APIENTRY *PFN_glDrawElementsInstanced)(GLenum mode, GLsizei count, GLenum type, const void * indices, GLsizei instancecount)) \
-    _SAPP_XMACRO(glVertexAttribPointer,             void (GL_APIENTRY *PFN_glVertexAttribPointer)(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void * pointer)) \
-    _SAPP_XMACRO(glUniform1i,                       void (GL_APIENTRY *PFN_glUniform1i)(GLint location, GLint v0)) \
-    _SAPP_XMACRO(glDisable,                         void (GL_APIENTRY *PFN_glDisable)(GLenum cap)) \
-    _SAPP_XMACRO(glColorMask,                       void (GL_APIENTRY *PFN_glColorMask)(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha)) \
-    _SAPP_XMACRO(glBindBuffer,                      void (GL_APIENTRY *PFN_glBindBuffer)(GLenum target, GLuint buffer)) \
-    _SAPP_XMACRO(glDeleteVertexArrays,              void (GL_APIENTRY *PFN_glDeleteVertexArrays)(GLsizei n, const GLuint * arrays)) \
-    _SAPP_XMACRO(glDepthMask,                       void (GL_APIENTRY *PFN_glDepthMask)(GLboolean flag)) \
-    _SAPP_XMACRO(glDrawArraysInstanced,             void (GL_APIENTRY *PFN_glDrawArraysInstanced)(GLenum mode, GLint first, GLsizei count, GLsizei instancecount)) \
-    _SAPP_XMACRO(glClearStencil,                    void (GL_APIENTRY *PFN_glClearStencil)(GLint s)) \
-    _SAPP_XMACRO(glScissor,                         void (GL_APIENTRY *PFN_glScissor)(GLint x, GLint y, GLsizei width, GLsizei height)) \
-    _SAPP_XMACRO(glUniform3fv,                      void (GL_APIENTRY *PFN_glUniform3fv)(GLint location, GLsizei count, const GLfloat * value)) \
-    _SAPP_XMACRO(glGenRenderbuffers,                void (GL_APIENTRY *PFN_glGenRenderbuffers)(GLsizei n, GLuint * renderbuffers)) \
-    _SAPP_XMACRO(glBufferData,                      void (GL_APIENTRY *PFN_glBufferData)(GLenum target, GLsizeiptr size, const void * data, GLenum usage)) \
-    _SAPP_XMACRO(glBlendFuncSeparate,               void (GL_APIENTRY *PFN_glBlendFuncSeparate)(GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha, GLenum dfactorAlpha)) \
-    _SAPP_XMACRO(glTexParameteri,                   void (GL_APIENTRY *PFN_glTexParameteri)(GLenum target, GLenum pname, GLint param)) \
-    _SAPP_XMACRO(glGetIntegerv,                     void (GL_APIENTRY *PFN_glGetIntegerv)(GLenum pname, GLint * data)) \
-    _SAPP_XMACRO(glEnable,                          void (GL_APIENTRY *PFN_glEnable)(GLenum cap)) \
-    _SAPP_XMACRO(glBlitFramebuffer,                 void (GL_APIENTRY *PFN_glBlitFramebuffer)(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter)) \
-    _SAPP_XMACRO(glStencilMask,                     void (GL_APIENTRY *PFN_glStencilMask)(GLuint mask)) \
-    _SAPP_XMACRO(glAttachShader,                    void (GL_APIENTRY *PFN_glAttachShader)(GLuint program, GLuint shader)) \
-    _SAPP_XMACRO(glGetError,                        GLenum (GL_APIENTRY *PFN_glGetError)(void)) \
-    _SAPP_XMACRO(glClearColor,                      void (GL_APIENTRY *PFN_glClearColor)(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)) \
-    _SAPP_XMACRO(glBlendColor,                      void (GL_APIENTRY *PFN_glBlendColor)(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)) \
-    _SAPP_XMACRO(glTexParameterf,                   void (GL_APIENTRY *PFN_glTexParameterf)(GLenum target, GLenum pname, GLfloat param)) \
-    _SAPP_XMACRO(glTexParameterfv,                  void (GL_APIENTRY *PFN_glTexParameterfv)(GLenum target, GLenum pname, GLfloat* params)) \
-    _SAPP_XMACRO(glGetShaderInfoLog,                void (GL_APIENTRY *PFN_glGetShaderInfoLog)(GLuint shader, GLsizei bufSize, GLsizei * length, GLchar * infoLog)) \
-    _SAPP_XMACRO(glDepthFunc,                       void (GL_APIENTRY *PFN_glDepthFunc)(GLenum func)) \
-    _SAPP_XMACRO(glStencilOp ,                      void  (GL_APIENTRY *PFN_glStencilOp)(GLenum fail, GLenum zfail, GLenum zpass)) \
-    _SAPP_XMACRO(glStencilFunc,                     void  (GL_APIENTRY *PFN_glStencilFunc)(GLenum func, GLint ref, GLuint mask)) \
-    _SAPP_XMACRO(glEnableVertexAttribArray,         void  (GL_APIENTRY *PFN_glEnableVertexAttribArray)(GLuint index)) \
-    _SAPP_XMACRO(glBlendFunc,                       void  (GL_APIENTRY *PFN_glBlendFunc)(GLenum sfactor, GLenum dfactor)) \
-    _SAPP_XMACRO(glUniform1fv,                      void  (GL_APIENTRY *PFN_glUniform1fv)(GLint location, GLsizei count, const GLfloat * value)) \
-    _SAPP_XMACRO(glReadBuffer,                      void  (GL_APIENTRY *PFN_glReadBuffer)(GLenum src)) \
-    _SAPP_XMACRO(glClear,                           void  (GL_APIENTRY *PFN_glClear)(GLbitfield mask)) \
-    _SAPP_XMACRO(glTexImage2D,                      void  (GL_APIENTRY *PFN_glTexImage2D)(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void * pixels)) \
-    _SAPP_XMACRO(glGenVertexArrays,                 void  (GL_APIENTRY *PFN_glGenVertexArrays)(GLsizei n, GLuint * arrays)) \
-    _SAPP_XMACRO(glFrontFace,                       void  (GL_APIENTRY *PFN_glFrontFace)(GLenum mode)) \
-    _SAPP_XMACRO(glCullFace,                        void  (GL_APIENTRY *PFN_glCullFace)(GLenum mode))
-
-// generate GL function pointer typedefs
-#define _SAPP_XMACRO(func, proto) typedef proto;
-_SAPP_GL_FUNCS
-#undef _SAPP_XMACRO
-
-// generate GL function pointers
-#define _SAPP_XMACRO(func, proto) static PFN_ ## func func;
-_SAPP_GL_FUNCS
-#undef _SAPP_XMACRO
-
-// helper function to lookup GL functions in GL DLL
-_SOKOL_PRIVATE void* _sapp_win32_glgetprocaddr(const char* name) {
-    void* proc_addr = (void*) _sapp.wgl.GetProcAddress(name);
-    if (0 == proc_addr) {
-        proc_addr = (void*) GetProcAddress(_sapp.wgl.opengl32, name);
-    }
-    SOKOL_ASSERT(proc_addr);
-    return proc_addr;
-}
-
-// populate GL function pointers
-_SOKOL_PRIVATE  void _sapp_win32_gl_loadfuncs(void) {
-    SOKOL_ASSERT(_sapp.wgl.GetProcAddress);
-    SOKOL_ASSERT(_sapp.wgl.opengl32);
-    #define _SAPP_XMACRO(func, proto) func = (PFN_ ## func) _sapp_win32_glgetprocaddr(#func);
-    _SAPP_GL_FUNCS
-    #undef _SAPP_XMACRO
-}
-
-#endif // SOKOL_WIN32_NO_GL_LOADER
-#endif // SOKOL_GLCORE33
 
 #if defined(SOKOL_D3D11)
 #define _SAPP_SAFE_RELEASE(class, obj) if (obj) { class##_Release(obj); obj=0; }

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -250,7 +250,7 @@
             If the Metal backend has been selected, these functions return pointers
             to various Metal API objects required for rendering, otherwise
             they return a null pointer. These void pointers are actually
-            Objective-C ids converted with an ARC __bridge cast so that
+            Objective-C ids converted with a (ARC) __bridge cast so that
             they ids can be tunnel through C code. Also note that the returned
             pointers to the renderpass-descriptor and drawable may change from one
             frame to the next, only the Metal device object is guaranteed to
@@ -259,12 +259,12 @@
         const void* sapp_macos_get_window(void)
             On macOS, get the NSWindow object pointer, otherwise a null pointer.
             Before being used as Objective-C object, the void* must be converted
-            back with an ARC __bridge cast.
+            back with a (ARC) __bridge cast.
 
         const void* sapp_ios_get_window(void)
             On iOS, get the UIWindow object pointer, otherwise a null pointer.
             Before being used as Objective-C object, the void* must be converted
-            back with an ARC __bridge cast.
+            back with a (ARC) __bridge cast.
 
         const void* sapp_win32_get_hwnd(void)
             On Windows, get the window's HWND, otherwise a null pointer. The
@@ -919,15 +919,15 @@ SOKOL_API_DECL bool sapp_gles2(void);
 /* HTML5: enable or disable the hardwired "Leave Site?" dialog box */
 SOKOL_API_DECL void sapp_html5_ask_leave_site(bool ask);
 
-/* Metal: get ARC-bridged pointer to Metal device object */
+/* Metal: get bridged pointer to Metal device object */
 SOKOL_API_DECL const void* sapp_metal_get_device(void);
-/* Metal: get ARC-bridged pointer to this frame's renderpass descriptor */
+/* Metal: get bridged pointer to this frame's renderpass descriptor */
 SOKOL_API_DECL const void* sapp_metal_get_renderpass_descriptor(void);
-/* Metal: get ARC-bridged pointer to current drawable */
+/* Metal: get bridged pointer to current drawable */
 SOKOL_API_DECL const void* sapp_metal_get_drawable(void);
-/* macOS: get ARC-bridged pointer to macOS NSWindow */
+/* macOS: get bridged pointer to macOS NSWindow */
 SOKOL_API_DECL const void* sapp_macos_get_window(void);
-/* iOS: get ARC-bridged pointer to iOS UIWindow */
+/* iOS: get bridged pointer to iOS UIWindow */
 SOKOL_API_DECL const void* sapp_ios_get_window(void);
 
 /* D3D11: get pointer to ID3D11Device object */
@@ -2451,7 +2451,7 @@ _SOKOL_PRIVATE void _sapp_macos_toggle_fullscreen(void) {
         [_sapp.macos.window center];
     }
     [_sapp.macos.window makeKeyAndOrderFront:nil];
-    _sapp_macos_update_dimensions();    
+    _sapp_macos_update_dimensions();
 }
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication*)sender {

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -971,12 +971,9 @@ inline int sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 /* check if the config defines are alright */
 #if defined(__APPLE__)
     // see https://clang.llvm.org/docs/LanguageExtensions.html#automatic-reference-counting
-    #if !__has_feature(objc_arc)
-        #error "sokol_app.h requires ARC (Automatic Reference Counting) on MacOS and iOS"
-    #endif
     #if !defined(__cplusplus)
-        #if !__has_feature(objc_arc_fields)
-            #error "sokol_app.h requires a more recent clang supporting the 'objc_arc_fields' feature!"
+        #if __has_feature(objc_arc) && !__has_feature(objc_arc_fields)
+            #error "sokol_app.h requires __has_feature(objc_arc_field) if ARC is enabled (use a more recent compiler version)"
         #endif
     #endif
     #define _SAPP_APPLE (1)
@@ -2619,7 +2616,7 @@ _SOKOL_PRIVATE void _sapp_macos_app_event(sapp_event_type type) {
 - (void)updateTrackingAreas {
     if (trackingArea != nil) {
         [self removeTrackingArea:trackingArea];
-        trackingArea = nil;
+        _SAPP_OBJC_RELEASE(trackingArea);
     }
     const NSTrackingAreaOptions options = NSTrackingMouseEnteredAndExited |
                                           NSTrackingActiveInKeyWindow |

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1182,43 +1182,6 @@ inline int sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #include <GL/gl.h>
     #include <dlfcn.h> /* dlopen, dlsym, dlclose */
     #include <limits.h> /* LONG_MAX */
-    #define GLX_VENDOR 1
-    #define GLX_RGBA_BIT 0x00000001
-    #define GLX_WINDOW_BIT 0x00000001
-    #define GLX_DRAWABLE_TYPE 0x8010
-    #define GLX_RENDER_TYPE	0x8011
-    #define GLX_RGBA_TYPE 0x8014
-    #define GLX_DOUBLEBUFFER 5
-    #define GLX_STEREO 6
-    #define GLX_AUX_BUFFERS	7
-    #define GLX_RED_SIZE 8
-    #define GLX_GREEN_SIZE 9
-    #define GLX_BLUE_SIZE 10
-    #define GLX_ALPHA_SIZE 11
-    #define GLX_DEPTH_SIZE 12
-    #define GLX_STENCIL_SIZE 13
-    #define GLX_ACCUM_RED_SIZE 14
-    #define GLX_ACCUM_GREEN_SIZE 15
-    #define GLX_ACCUM_BLUE_SIZE	16
-    #define GLX_ACCUM_ALPHA_SIZE 17
-    #define GLX_SAMPLES 0x186a1
-    #define GLX_VISUAL_ID 0x800b
-    #define GLX_FRAMEBUFFER_SRGB_CAPABLE_ARB 0x20b2
-    #define GLX_CONTEXT_DEBUG_BIT_ARB 0x00000001
-    #define GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB 0x00000002
-    #define GLX_CONTEXT_CORE_PROFILE_BIT_ARB 0x00000001
-    #define GLX_CONTEXT_PROFILE_MASK_ARB 0x9126
-    #define GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB 0x00000002
-    #define GLX_CONTEXT_MAJOR_VERSION_ARB 0x2091
-    #define GLX_CONTEXT_MINOR_VERSION_ARB 0x2092
-    #define GLX_CONTEXT_FLAGS_ARB 0x2094
-    #define GLX_CONTEXT_ROBUST_ACCESS_BIT_ARB 0x00000004
-    #define GLX_LOSE_CONTEXT_ON_RESET_ARB 0x8252
-    #define GLX_CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB 0x8256
-    #define GLX_NO_RESET_NOTIFICATION_ARB 0x8261
-    #define GLX_CONTEXT_RELEASE_BEHAVIOR_ARB 0x2097
-    #define GLX_CONTEXT_RELEASE_BEHAVIOR_NONE_ARB 0
-    #define GLX_CONTEXT_RELEASE_BEHAVIOR_FLUSH_ARB 0x2098
 #endif
 
 /*== MACOS DECLARATIONS ======================================================*/
@@ -1460,6 +1423,112 @@ typedef struct {
 
 #endif // _SAPP_ANDROID
 
+/*== LINUX DECLARATIONS ======================================================*/
+#if defined(_SAPP_LINUX)
+
+#define GLX_VENDOR 1
+#define GLX_RGBA_BIT 0x00000001
+#define GLX_WINDOW_BIT 0x00000001
+#define GLX_DRAWABLE_TYPE 0x8010
+#define GLX_RENDER_TYPE	0x8011
+#define GLX_DOUBLEBUFFER 5
+#define GLX_RED_SIZE 8
+#define GLX_GREEN_SIZE 9
+#define GLX_BLUE_SIZE 10
+#define GLX_ALPHA_SIZE 11
+#define GLX_DEPTH_SIZE 12
+#define GLX_STENCIL_SIZE 13
+#define GLX_SAMPLES 0x186a1
+#define GLX_CONTEXT_CORE_PROFILE_BIT_ARB 0x00000001
+#define GLX_CONTEXT_PROFILE_MASK_ARB 0x9126
+#define GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB 0x00000002
+#define GLX_CONTEXT_MAJOR_VERSION_ARB 0x2091
+#define GLX_CONTEXT_MINOR_VERSION_ARB 0x2092
+#define GLX_CONTEXT_FLAGS_ARB 0x2094
+
+typedef XID GLXWindow;
+typedef XID GLXDrawable;
+typedef struct __GLXFBConfig* GLXFBConfig;
+typedef struct __GLXcontext* GLXContext;
+typedef void (*__GLXextproc)(void);
+
+typedef int (*PFNGLXGETFBCONFIGATTRIBPROC)(Display*,GLXFBConfig,int,int*);
+typedef const char* (*PFNGLXGETCLIENTSTRINGPROC)(Display*,int);
+typedef Bool (*PFNGLXQUERYEXTENSIONPROC)(Display*,int*,int*);
+typedef Bool (*PFNGLXQUERYVERSIONPROC)(Display*,int*,int*);
+typedef void (*PFNGLXDESTROYCONTEXTPROC)(Display*,GLXContext);
+typedef Bool (*PFNGLXMAKECURRENTPROC)(Display*,GLXDrawable,GLXContext);
+typedef void (*PFNGLXSWAPBUFFERSPROC)(Display*,GLXDrawable);
+typedef const char* (*PFNGLXQUERYEXTENSIONSSTRINGPROC)(Display*,int);
+typedef GLXFBConfig* (*PFNGLXGETFBCONFIGSPROC)(Display*,int,int*);
+typedef __GLXextproc (* PFNGLXGETPROCADDRESSPROC)(const GLubyte *procName);
+typedef void (*PFNGLXSWAPINTERVALEXTPROC)(Display*,GLXDrawable,int);
+typedef XVisualInfo* (*PFNGLXGETVISUALFROMFBCONFIGPROC)(Display*,GLXFBConfig);
+typedef GLXWindow (*PFNGLXCREATEWINDOWPROC)(Display*,GLXFBConfig,Window,const int*);
+typedef void (*PFNGLXDESTROYWINDOWPROC)(Display*,GLXWindow);
+
+typedef int (*PFNGLXSWAPINTERVALMESAPROC)(int);
+typedef GLXContext (*PFNGLXCREATECONTEXTATTRIBSARBPROC)(Display*,GLXFBConfig,GLXContext,Bool,const int*);
+
+typedef struct {
+    Display* display;
+    int screen;
+    Window root;
+    Colormap colormap;
+    Window window;
+    int window_state;
+    float dpi;
+    unsigned char error_code;
+    Atom UTF8_STRING;
+    Atom WM_PROTOCOLS;
+    Atom WM_DELETE_WINDOW;
+    Atom WM_STATE;
+    Atom NET_WM_NAME;
+    Atom NET_WM_ICON_NAME;
+    Atom NET_WM_STATE;
+    Atom NET_WM_STATE_FULLSCREEN;
+} _sapp_x11_t;
+
+typedef struct {
+    void* libgl;
+    int major;
+    int minor;
+    int eventbase;
+    int errorbase;
+    GLXContext ctx;
+    GLXWindow window;
+
+    // GLX 1.3 functions
+    PFNGLXGETFBCONFIGSPROC GetFBConfigs;
+    PFNGLXGETFBCONFIGATTRIBPROC GetFBConfigAttrib;
+    PFNGLXGETCLIENTSTRINGPROC GetClientString;
+    PFNGLXQUERYEXTENSIONPROC QueryExtension;
+    PFNGLXQUERYVERSIONPROC QueryVersion;
+    PFNGLXDESTROYCONTEXTPROC DestroyContext;
+    PFNGLXMAKECURRENTPROC MakeCurrent;
+    PFNGLXSWAPBUFFERSPROC SwapBuffers;
+    PFNGLXQUERYEXTENSIONSSTRINGPROC QueryExtensionsString;
+    PFNGLXGETVISUALFROMFBCONFIGPROC GetVisualFromFBConfig;
+    PFNGLXCREATEWINDOWPROC CreateWindow;
+    PFNGLXDESTROYWINDOWPROC DestroyWindow;
+
+    // GLX 1.4 and extension functions
+    PFNGLXGETPROCADDRESSPROC GetProcAddress;
+    PFNGLXGETPROCADDRESSPROC GetProcAddressARB;
+    PFNGLXSWAPINTERVALEXTPROC SwapIntervalEXT;
+    PFNGLXSWAPINTERVALMESAPROC SwapIntervalMESA;
+    PFNGLXCREATECONTEXTATTRIBSARBPROC CreateContextAttribsARB;
+
+    // extension availability
+    bool EXT_swap_control;
+    bool MESA_swap_control;
+    bool ARB_multisample;
+    bool ARB_create_context;
+    bool ARB_create_context_profile;
+} _sapp_glx_t;
+
+#endif // _SAPP_LINUX
+
 /*== COMMON DECLARATIONS =====================================================*/
 
 /* helper macros */
@@ -1520,6 +1589,9 @@ static struct {
         #endif
     #elif defined(_SAPP_ANDROID)
         _sapp_android_t android;
+    #elif defined(_SAPP_LINUX)
+        _sapp_x11_t x11;
+        _sapp_glx_t glx;
     #endif
 } _sapp;
 
@@ -5965,82 +6037,6 @@ void ANativeActivity_onCreate(ANativeActivity* activity, void* saved_state, size
 
 /*== LINUX ==================================================================*/
 #if defined(_SAPP_LINUX)
-typedef XID GLXWindow;
-typedef XID GLXDrawable;
-typedef struct __GLXFBConfig* GLXFBConfig;
-typedef struct __GLXcontext* GLXContext;
-typedef void (*__GLXextproc)(void);
-
-typedef int (*PFNGLXGETFBCONFIGATTRIBPROC)(Display*,GLXFBConfig,int,int*);
-typedef const char* (*PFNGLXGETCLIENTSTRINGPROC)(Display*,int);
-typedef Bool (*PFNGLXQUERYEXTENSIONPROC)(Display*,int*,int*);
-typedef Bool (*PFNGLXQUERYVERSIONPROC)(Display*,int*,int*);
-typedef void (*PFNGLXDESTROYCONTEXTPROC)(Display*,GLXContext);
-typedef Bool (*PFNGLXMAKECURRENTPROC)(Display*,GLXDrawable,GLXContext);
-typedef void (*PFNGLXSWAPBUFFERSPROC)(Display*,GLXDrawable);
-typedef const char* (*PFNGLXQUERYEXTENSIONSSTRINGPROC)(Display*,int);
-typedef GLXFBConfig* (*PFNGLXGETFBCONFIGSPROC)(Display*,int,int*);
-typedef GLXContext (*PFNGLXCREATENEWCONTEXTPROC)(Display*,GLXFBConfig,int,GLXContext,Bool);
-typedef __GLXextproc (* PFNGLXGETPROCADDRESSPROC)(const GLubyte *procName);
-typedef void (*PFNGLXSWAPINTERVALEXTPROC)(Display*,GLXDrawable,int);
-typedef XVisualInfo* (*PFNGLXGETVISUALFROMFBCONFIGPROC)(Display*,GLXFBConfig);
-typedef GLXWindow (*PFNGLXCREATEWINDOWPROC)(Display*,GLXFBConfig,Window,const int*);
-typedef void (*PFNGLXDESTROYWINDOWPROC)(Display*,GLXWindow);
-
-typedef int (*PFNGLXSWAPINTERVALMESAPROC)(int);
-typedef GLXContext (*PFNGLXCREATECONTEXTATTRIBSARBPROC)(Display*,GLXFBConfig,GLXContext,Bool,const int*);
-
-static Display* _sapp_x11_display;
-static int _sapp_x11_screen;
-static Window _sapp_x11_root;
-static Colormap _sapp_x11_colormap;
-static Window _sapp_x11_window;
-static float _sapp_x11_dpi;
-static int _sapp_x11_window_state;
-static unsigned char _sapp_x11_error_code;
-static void* _sapp_glx_libgl;
-static int _sapp_glx_major;
-static int _sapp_glx_minor;
-static int _sapp_glx_eventbase;
-static int _sapp_glx_errorbase;
-static GLXContext _sapp_glx_ctx;
-static GLXWindow _sapp_glx_window;
-static Atom _sapp_x11_UTF8_STRING;
-static Atom _sapp_x11_WM_PROTOCOLS;
-static Atom _sapp_x11_WM_DELETE_WINDOW;
-static Atom _sapp_x11_WM_STATE;
-static Atom _sapp_x11_NET_WM_NAME;
-static Atom _sapp_x11_NET_WM_ICON_NAME;
-static Atom _sapp_x11_NET_WM_STATE;
-static Atom _sapp_x11_NET_WM_STATE_FULLSCREEN;
-// GLX 1.3 functions
-static PFNGLXGETFBCONFIGSPROC              _sapp_glx_GetFBConfigs;
-static PFNGLXGETFBCONFIGATTRIBPROC         _sapp_glx_GetFBConfigAttrib;
-static PFNGLXGETCLIENTSTRINGPROC           _sapp_glx_GetClientString;
-static PFNGLXQUERYEXTENSIONPROC            _sapp_glx_QueryExtension;
-static PFNGLXQUERYVERSIONPROC              _sapp_glx_QueryVersion;
-static PFNGLXDESTROYCONTEXTPROC            _sapp_glx_DestroyContext;
-static PFNGLXMAKECURRENTPROC               _sapp_glx_MakeCurrent;
-static PFNGLXSWAPBUFFERSPROC               _sapp_glx_SwapBuffers;
-static PFNGLXQUERYEXTENSIONSSTRINGPROC     _sapp_glx_QueryExtensionsString;
-static PFNGLXCREATENEWCONTEXTPROC          _sapp_glx_CreateNewContext;
-static PFNGLXGETVISUALFROMFBCONFIGPROC     _sapp_glx_GetVisualFromFBConfig;
-static PFNGLXCREATEWINDOWPROC              _sapp_glx_CreateWindow;
-static PFNGLXDESTROYWINDOWPROC             _sapp_glx_DestroyWindow;
-
-// GLX 1.4 and extension functions
-static PFNGLXGETPROCADDRESSPROC            _sapp_glx_GetProcAddress;
-static PFNGLXGETPROCADDRESSPROC            _sapp_glx_GetProcAddressARB;
-static PFNGLXSWAPINTERVALEXTPROC           _sapp_glx_SwapIntervalEXT;
-static PFNGLXSWAPINTERVALMESAPROC          _sapp_glx_SwapIntervalMESA;
-static PFNGLXCREATECONTEXTATTRIBSARBPROC   _sapp_glx_CreateContextAttribsARB;
-static bool _sapp_glx_EXT_swap_control;
-static bool _sapp_glx_MESA_swap_control;
-static bool _sapp_glx_ARB_multisample;
-static bool _sapp_glx_ARB_framebuffer_sRGB;
-static bool _sapp_glx_EXT_framebuffer_sRGB;
-static bool _sapp_glx_ARB_create_context;
-static bool _sapp_glx_ARB_create_context_profile;
 
 /* see GLFW's xkb_unicode.c */
 static const struct _sapp_x11_codepair {
@@ -6879,29 +6875,29 @@ static const struct _sapp_x11_codepair {
 
 _SOKOL_PRIVATE int _sapp_x11_error_handler(Display* display, XErrorEvent* event) {
     _SOKOL_UNUSED(display);
-    _sapp_x11_error_code = event->error_code;
+    _sapp.x11.error_code = event->error_code;
     return 0;
 }
 
 _SOKOL_PRIVATE void _sapp_x11_grab_error_handler(void) {
-    _sapp_x11_error_code = Success;
+    _sapp.x11.error_code = Success;
     XSetErrorHandler(_sapp_x11_error_handler);
 }
 
 _SOKOL_PRIVATE void _sapp_x11_release_error_handler(void) {
-    XSync(_sapp_x11_display, False);
+    XSync(_sapp.x11.display, False);
     XSetErrorHandler(NULL);
 }
 
 _SOKOL_PRIVATE void _sapp_x11_init_extensions(void) {
-    _sapp_x11_UTF8_STRING             = XInternAtom(_sapp_x11_display, "UTF8_STRING", False);
-    _sapp_x11_WM_PROTOCOLS            = XInternAtom(_sapp_x11_display, "WM_PROTOCOLS", False);
-    _sapp_x11_WM_DELETE_WINDOW        = XInternAtom(_sapp_x11_display, "WM_DELETE_WINDOW", False);
-    _sapp_x11_WM_STATE                = XInternAtom(_sapp_x11_display, "WM_STATE", False);
-    _sapp_x11_NET_WM_NAME             = XInternAtom(_sapp_x11_display, "_NET_WM_NAME", False);
-    _sapp_x11_NET_WM_ICON_NAME        = XInternAtom(_sapp_x11_display, "_NET_WM_ICON_NAME", False);
-    _sapp_x11_NET_WM_STATE            = XInternAtom(_sapp_x11_display, "_NET_WM_STATE", False);
-    _sapp_x11_NET_WM_STATE_FULLSCREEN = XInternAtom(_sapp_x11_display, "_NET_WM_STATE_FULLSCREEN", False);
+    _sapp.x11.UTF8_STRING             = XInternAtom(_sapp.x11.display, "UTF8_STRING", False);
+    _sapp.x11.WM_PROTOCOLS            = XInternAtom(_sapp.x11.display, "WM_PROTOCOLS", False);
+    _sapp.x11.WM_DELETE_WINDOW        = XInternAtom(_sapp.x11.display, "WM_DELETE_WINDOW", False);
+    _sapp.x11.WM_STATE                = XInternAtom(_sapp.x11.display, "WM_STATE", False);
+    _sapp.x11.NET_WM_NAME             = XInternAtom(_sapp.x11.display, "_NET_WM_NAME", False);
+    _sapp.x11.NET_WM_ICON_NAME        = XInternAtom(_sapp.x11.display, "_NET_WM_ICON_NAME", False);
+    _sapp.x11.NET_WM_STATE            = XInternAtom(_sapp.x11.display, "_NET_WM_STATE", False);
+    _sapp.x11.NET_WM_STATE_FULLSCREEN = XInternAtom(_sapp.x11.display, "_NET_WM_STATE_FULLSCREEN", False);
 }
 
 _SOKOL_PRIVATE void _sapp_x11_query_system_dpi(void) {
@@ -6909,14 +6905,15 @@ _SOKOL_PRIVATE void _sapp_x11_query_system_dpi(void) {
 
        NOTE: Default to the display-wide DPI as we don't currently have a policy
              for which monitor a window is considered to be on
-    _sapp_x11_dpi = DisplayWidth(_sapp_x11_display, _sapp_x11_screen) *
-        25.4f / DisplayWidthMM(_sapp_x11_display, _sapp_x11_screen);
+
+        _sapp.x11.dpi = DisplayWidth(_sapp.x11.display, _sapp.x11.screen) *
+                        25.4f / DisplayWidthMM(_sapp.x11.display, _sapp.x11.screen);
 
        NOTE: Basing the scale on Xft.dpi where available should provide the most
              consistent user experience (matches Qt, Gtk, etc), although not
              always the most accurate one
     */
-    char* rms = XResourceManagerString(_sapp_x11_display);
+    char* rms = XResourceManagerString(_sapp.x11.display);
     if (rms) {
         XrmDatabase db = XrmGetStringDatabase(rms);
         if (db) {
@@ -6924,7 +6921,7 @@ _SOKOL_PRIVATE void _sapp_x11_query_system_dpi(void) {
             char* type = NULL;
             if (XrmGetResource(db, "Xft.dpi", "Xft.Dpi", &type, &value)) {
                 if (type && strcmp(type, "String") == 0) {
-                    _sapp_x11_dpi = atof(value.addr);
+                    _sapp.x11.dpi = atof(value.addr);
                 }
             }
             XrmDestroyDatabase(db);
@@ -6962,96 +6959,89 @@ _SOKOL_PRIVATE bool _sapp_glx_extsupported(const char* ext, const char* extensio
 
 _SOKOL_PRIVATE void* _sapp_glx_getprocaddr(const char* procname)
 {
-    if (_sapp_glx_GetProcAddress) {
-        return (void*) _sapp_glx_GetProcAddress((const GLubyte*) procname);
+    if (_sapp.glx.GetProcAddress) {
+        return (void*) _sapp.glx.GetProcAddress((const GLubyte*) procname);
     }
-    else if (_sapp_glx_GetProcAddressARB) {
-        return (void*) _sapp_glx_GetProcAddressARB((const GLubyte*) procname);
+    else if (_sapp.glx.GetProcAddressARB) {
+        return (void*) _sapp.glx.GetProcAddressARB((const GLubyte*) procname);
     }
     else {
-        return dlsym(_sapp_glx_libgl, procname);
+        return dlsym(_sapp.glx.libgl, procname);
     }
 }
 
 _SOKOL_PRIVATE void _sapp_glx_init() {
     const char* sonames[] = { "libGL.so.1", "libGL.so", 0 };
     for (int i = 0; sonames[i]; i++) {
-        _sapp_glx_libgl = dlopen(sonames[i], RTLD_LAZY|RTLD_GLOBAL);
-        if (_sapp_glx_libgl) {
+        _sapp.glx.libgl = dlopen(sonames[i], RTLD_LAZY|RTLD_GLOBAL);
+        if (_sapp.glx.libgl) {
             break;
         }
     }
-    if (!_sapp_glx_libgl) {
+    if (!_sapp.glx.libgl) {
         _sapp_fail("GLX: failed to load libGL");
     }
-    _sapp_glx_GetFBConfigs          = (PFNGLXGETFBCONFIGSPROC)          dlsym(_sapp_glx_libgl, "glXGetFBConfigs");
-    _sapp_glx_GetFBConfigAttrib     = (PFNGLXGETFBCONFIGATTRIBPROC)     dlsym(_sapp_glx_libgl, "glXGetFBConfigAttrib");
-    _sapp_glx_GetClientString       = (PFNGLXGETCLIENTSTRINGPROC)       dlsym(_sapp_glx_libgl, "glXGetClientString");
-    _sapp_glx_QueryExtension        = (PFNGLXQUERYEXTENSIONPROC)        dlsym(_sapp_glx_libgl, "glXQueryExtension");
-    _sapp_glx_QueryVersion          = (PFNGLXQUERYVERSIONPROC)          dlsym(_sapp_glx_libgl, "glXQueryVersion");
-    _sapp_glx_DestroyContext        = (PFNGLXDESTROYCONTEXTPROC)        dlsym(_sapp_glx_libgl, "glXDestroyContext");
-    _sapp_glx_MakeCurrent           = (PFNGLXMAKECURRENTPROC)           dlsym(_sapp_glx_libgl, "glXMakeCurrent");
-    _sapp_glx_SwapBuffers           = (PFNGLXSWAPBUFFERSPROC)           dlsym(_sapp_glx_libgl, "glXSwapBuffers");
-    _sapp_glx_QueryExtensionsString = (PFNGLXQUERYEXTENSIONSSTRINGPROC) dlsym(_sapp_glx_libgl, "glXQueryExtensionsString");
-    _sapp_glx_CreateNewContext      = (PFNGLXCREATENEWCONTEXTPROC)      dlsym(_sapp_glx_libgl, "glXCreateNewContext");
-    _sapp_glx_CreateWindow          = (PFNGLXCREATEWINDOWPROC)          dlsym(_sapp_glx_libgl, "glXCreateWindow");
-    _sapp_glx_DestroyWindow         = (PFNGLXDESTROYWINDOWPROC)         dlsym(_sapp_glx_libgl, "glXDestroyWindow");
-    _sapp_glx_GetProcAddress        = (PFNGLXGETPROCADDRESSPROC)        dlsym(_sapp_glx_libgl, "glXGetProcAddress");
-    _sapp_glx_GetProcAddressARB     = (PFNGLXGETPROCADDRESSPROC)        dlsym(_sapp_glx_libgl, "glXGetProcAddressARB");
-    _sapp_glx_GetVisualFromFBConfig = (PFNGLXGETVISUALFROMFBCONFIGPROC) dlsym(_sapp_glx_libgl, "glXGetVisualFromFBConfig");
-    if (!_sapp_glx_GetFBConfigs ||
-        !_sapp_glx_GetFBConfigAttrib ||
-        !_sapp_glx_GetClientString ||
-        !_sapp_glx_QueryExtension ||
-        !_sapp_glx_QueryVersion ||
-        !_sapp_glx_DestroyContext ||
-        !_sapp_glx_MakeCurrent ||
-        !_sapp_glx_SwapBuffers ||
-        !_sapp_glx_QueryExtensionsString ||
-        !_sapp_glx_CreateNewContext ||
-        !_sapp_glx_CreateWindow ||
-        !_sapp_glx_DestroyWindow ||
-        !_sapp_glx_GetProcAddress ||
-        !_sapp_glx_GetProcAddressARB ||
-        !_sapp_glx_GetVisualFromFBConfig)
+    _sapp.glx.GetFBConfigs          = (PFNGLXGETFBCONFIGSPROC)          dlsym(_sapp.glx.libgl, "glXGetFBConfigs");
+    _sapp.glx.GetFBConfigAttrib     = (PFNGLXGETFBCONFIGATTRIBPROC)     dlsym(_sapp.glx.libgl, "glXGetFBConfigAttrib");
+    _sapp.glx.GetClientString       = (PFNGLXGETCLIENTSTRINGPROC)       dlsym(_sapp.glx.libgl, "glXGetClientString");
+    _sapp.glx.QueryExtension        = (PFNGLXQUERYEXTENSIONPROC)        dlsym(_sapp.glx.libgl, "glXQueryExtension");
+    _sapp.glx.QueryVersion          = (PFNGLXQUERYVERSIONPROC)          dlsym(_sapp.glx.libgl, "glXQueryVersion");
+    _sapp.glx.DestroyContext        = (PFNGLXDESTROYCONTEXTPROC)        dlsym(_sapp.glx.libgl, "glXDestroyContext");
+    _sapp.glx.MakeCurrent           = (PFNGLXMAKECURRENTPROC)           dlsym(_sapp.glx.libgl, "glXMakeCurrent");
+    _sapp.glx.SwapBuffers           = (PFNGLXSWAPBUFFERSPROC)           dlsym(_sapp.glx.libgl, "glXSwapBuffers");
+    _sapp.glx.QueryExtensionsString = (PFNGLXQUERYEXTENSIONSSTRINGPROC) dlsym(_sapp.glx.libgl, "glXQueryExtensionsString");
+    _sapp.glx.CreateWindow          = (PFNGLXCREATEWINDOWPROC)          dlsym(_sapp.glx.libgl, "glXCreateWindow");
+    _sapp.glx.DestroyWindow         = (PFNGLXDESTROYWINDOWPROC)         dlsym(_sapp.glx.libgl, "glXDestroyWindow");
+    _sapp.glx.GetProcAddress        = (PFNGLXGETPROCADDRESSPROC)        dlsym(_sapp.glx.libgl, "glXGetProcAddress");
+    _sapp.glx.GetProcAddressARB     = (PFNGLXGETPROCADDRESSPROC)        dlsym(_sapp.glx.libgl, "glXGetProcAddressARB");
+    _sapp.glx.GetVisualFromFBConfig = (PFNGLXGETVISUALFROMFBCONFIGPROC) dlsym(_sapp.glx.libgl, "glXGetVisualFromFBConfig");
+    if (!_sapp.glx.GetFBConfigs ||
+        !_sapp.glx.GetFBConfigAttrib ||
+        !_sapp.glx.GetClientString ||
+        !_sapp.glx.QueryExtension ||
+        !_sapp.glx.QueryVersion ||
+        !_sapp.glx.DestroyContext ||
+        !_sapp.glx.MakeCurrent ||
+        !_sapp.glx.SwapBuffers ||
+        !_sapp.glx.QueryExtensionsString ||
+        !_sapp.glx.CreateWindow ||
+        !_sapp.glx.DestroyWindow ||
+        !_sapp.glx.GetProcAddress ||
+        !_sapp.glx.GetProcAddressARB ||
+        !_sapp.glx.GetVisualFromFBConfig)
     {
         _sapp_fail("GLX: failed to load required entry points");
     }
 
-    if (!_sapp_glx_QueryExtension(_sapp_x11_display,
-                           &_sapp_glx_errorbase,
-                           &_sapp_glx_eventbase))
-    {
+    if (!_sapp.glx.QueryExtension(_sapp.x11.display, &_sapp.glx.errorbase, &_sapp.glx.eventbase)) {
         _sapp_fail("GLX: GLX extension not found");
     }
-    if (!_sapp_glx_QueryVersion(_sapp_x11_display, &_sapp_glx_major, &_sapp_glx_minor)) {
+    if (!_sapp.glx.QueryVersion(_sapp.x11.display, &_sapp.glx.major, &_sapp.glx.minor)) {
         _sapp_fail("GLX: Failed to query GLX version");
     }
-    if (_sapp_glx_major == 1 && _sapp_glx_minor < 3) {
+    if (_sapp.glx.major == 1 && _sapp.glx.minor < 3) {
         _sapp_fail("GLX: GLX version 1.3 is required");
     }
-    const char* exts = _sapp_glx_QueryExtensionsString(_sapp_x11_display, _sapp_x11_screen);
+    const char* exts = _sapp.glx.QueryExtensionsString(_sapp.x11.display, _sapp.x11.screen);
     if (_sapp_glx_extsupported("GLX_EXT_swap_control", exts)) {
-        _sapp_glx_SwapIntervalEXT = (PFNGLXSWAPINTERVALEXTPROC) _sapp_glx_getprocaddr("glXSwapIntervalEXT");
-        _sapp_glx_EXT_swap_control = 0 != _sapp_glx_SwapIntervalEXT;
+        _sapp.glx.SwapIntervalEXT = (PFNGLXSWAPINTERVALEXTPROC) _sapp_glx_getprocaddr("glXSwapIntervalEXT");
+        _sapp.glx.EXT_swap_control = 0 != _sapp.glx.SwapIntervalEXT;
     }
     if (_sapp_glx_extsupported("GLX_MESA_swap_control", exts)) {
-        _sapp_glx_SwapIntervalMESA = (PFNGLXSWAPINTERVALMESAPROC) _sapp_glx_getprocaddr("glXSwapIntervalMESA");
-        _sapp_glx_MESA_swap_control = 0 != _sapp_glx_SwapIntervalMESA;
+        _sapp.glx.SwapIntervalMESA = (PFNGLXSWAPINTERVALMESAPROC) _sapp_glx_getprocaddr("glXSwapIntervalMESA");
+        _sapp.glx.MESA_swap_control = 0 != _sapp.glx.SwapIntervalMESA;
     }
-    _sapp_glx_ARB_multisample = _sapp_glx_extsupported("GLX_ARB_multisample", exts);
-    _sapp_glx_ARB_framebuffer_sRGB = _sapp_glx_extsupported("GLX_ARB_framebuffer_sRGB", exts);
-    _sapp_glx_EXT_framebuffer_sRGB = _sapp_glx_extsupported("GLX_EXT_framebuffer_sRGB", exts);
+    _sapp.glx.ARB_multisample = _sapp_glx_extsupported("GLX_ARB_multisample", exts);
     if (_sapp_glx_extsupported("GLX_ARB_create_context", exts)) {
-        _sapp_glx_CreateContextAttribsARB = (PFNGLXCREATECONTEXTATTRIBSARBPROC) _sapp_glx_getprocaddr("glXCreateContextAttribsARB");
-        _sapp_glx_ARB_create_context = 0 != _sapp_glx_CreateContextAttribsARB;
+        _sapp.glx.CreateContextAttribsARB = (PFNGLXCREATECONTEXTATTRIBSARBPROC) _sapp_glx_getprocaddr("glXCreateContextAttribsARB");
+        _sapp.glx.ARB_create_context = 0 != _sapp.glx.CreateContextAttribsARB;
     }
-    _sapp_glx_ARB_create_context_profile = _sapp_glx_extsupported("GLX_ARB_create_context_profile", exts);
+    _sapp.glx.ARB_create_context_profile = _sapp_glx_extsupported("GLX_ARB_create_context_profile", exts);
 }
 
 _SOKOL_PRIVATE int _sapp_glx_attrib(GLXFBConfig fbconfig, int attrib) {
     int value;
-    _sapp_glx_GetFBConfigAttrib(_sapp_x11_display, fbconfig, attrib, &value);
+    _sapp.glx.GetFBConfigAttrib(_sapp.x11.display, fbconfig, attrib, &value);
     return value;
 }
 
@@ -7066,12 +7056,12 @@ _SOKOL_PRIVATE GLXFBConfig _sapp_glx_choosefbconfig() {
     /* HACK: This is a (hopefully temporary) workaround for Chromium
            (VirtualBox GL) not setting the window bit on any GLXFBConfigs
     */
-    vendor = _sapp_glx_GetClientString(_sapp_x11_display, GLX_VENDOR);
+    vendor = _sapp.glx.GetClientString(_sapp.x11.display, GLX_VENDOR);
     if (vendor && strcmp(vendor, "Chromium") == 0) {
         trust_window_bit = false;
     }
 
-    native_configs = _sapp_glx_GetFBConfigs(_sapp_x11_display, _sapp_x11_screen, &native_count);
+    native_configs = _sapp.glx.GetFBConfigs(_sapp.x11.display, _sapp.x11.screen, &native_count);
     if (!native_configs || !native_count) {
         _sapp_fail("GLX: No GLXFBConfigs returned");
     }
@@ -7102,7 +7092,7 @@ _SOKOL_PRIVATE GLXFBConfig _sapp_glx_choosefbconfig() {
         if (_sapp_glx_attrib(n, GLX_DOUBLEBUFFER)) {
             u->doublebuffer = true;
         }
-        if (_sapp_glx_ARB_multisample) {
+        if (_sapp.glx.ARB_multisample) {
             u->samples = _sapp_glx_attrib(n, GLX_SAMPLES);
         }
         u->handle = (uintptr_t) n;
@@ -7133,7 +7123,7 @@ _SOKOL_PRIVATE void _sapp_glx_choose_visual(Visual** visual, int* depth) {
     if (0 == native) {
         _sapp_fail("GLX: Failed to find a suitable GLXFBConfig");
     }
-    XVisualInfo* result = _sapp_glx_GetVisualFromFBConfig(_sapp_x11_display, native);
+    XVisualInfo* result = _sapp.glx.GetVisualFromFBConfig(_sapp.x11.display, native);
     if (!result) {
         _sapp_fail("GLX: Failed to retrieve Visual for GLXFBConfig");
     }
@@ -7147,7 +7137,7 @@ _SOKOL_PRIVATE void _sapp_glx_create_context(void) {
     if (0 == native){
         _sapp_fail("GLX: Failed to find a suitable GLXFBConfig (2)");
     }
-    if (!(_sapp_glx_ARB_create_context && _sapp_glx_ARB_create_context_profile)) {
+    if (!(_sapp.glx.ARB_create_context && _sapp.glx.ARB_create_context_profile)) {
         _sapp_fail("GLX: ARB_create_context and ARB_create_context_profile required");
     }
     _sapp_x11_grab_error_handler();
@@ -7158,43 +7148,43 @@ _SOKOL_PRIVATE void _sapp_glx_create_context(void) {
         GLX_CONTEXT_FLAGS_ARB, GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB,
         0, 0
     };
-    _sapp_glx_ctx = _sapp_glx_CreateContextAttribsARB(_sapp_x11_display, native, NULL, True, attribs);
-    if (!_sapp_glx_ctx) {
+    _sapp.glx.ctx = _sapp.glx.CreateContextAttribsARB(_sapp.x11.display, native, NULL, True, attribs);
+    if (!_sapp.glx.ctx) {
         _sapp_fail("GLX: failed to create GL context");
     }
     _sapp_x11_release_error_handler();
-    _sapp_glx_window = _sapp_glx_CreateWindow(_sapp_x11_display, native, _sapp_x11_window, NULL);
-    if (!_sapp_glx_window) {
+    _sapp.glx.window = _sapp.glx.CreateWindow(_sapp.x11.display, native, _sapp.x11.window, NULL);
+    if (!_sapp.glx.window) {
         _sapp_fail("GLX: failed to create window");
     }
 }
 
 _SOKOL_PRIVATE void _sapp_glx_destroy_context(void) {
-    if (_sapp_glx_window) {
-        _sapp_glx_DestroyWindow(_sapp_x11_display, _sapp_glx_window);
-        _sapp_glx_window = 0;
+    if (_sapp.glx.window) {
+        _sapp.glx.DestroyWindow(_sapp.x11.display, _sapp.glx.window);
+        _sapp.glx.window = 0;
     }
-    if (_sapp_glx_ctx) {
-        _sapp_glx_DestroyContext(_sapp_x11_display, _sapp_glx_ctx);
-        _sapp_glx_ctx = 0;
+    if (_sapp.glx.ctx) {
+        _sapp.glx.DestroyContext(_sapp.x11.display, _sapp.glx.ctx);
+        _sapp.glx.ctx = 0;
     }
 }
 
 _SOKOL_PRIVATE void _sapp_glx_make_current(void) {
-    _sapp_glx_MakeCurrent(_sapp_x11_display, _sapp_glx_window, _sapp_glx_ctx);
+    _sapp.glx.MakeCurrent(_sapp.x11.display, _sapp.glx.window, _sapp.glx.ctx);
 }
 
 _SOKOL_PRIVATE void _sapp_glx_swap_buffers(void) {
-    _sapp_glx_SwapBuffers(_sapp_x11_display, _sapp_glx_window);
+    _sapp.glx.SwapBuffers(_sapp.x11.display, _sapp.glx.window);
 }
 
 _SOKOL_PRIVATE void _sapp_glx_swapinterval(int interval) {
     _sapp_glx_make_current();
-    if (_sapp_glx_EXT_swap_control) {
-        _sapp_glx_SwapIntervalEXT(_sapp_x11_display, _sapp_glx_window, interval);
+    if (_sapp.glx.EXT_swap_control) {
+        _sapp.glx.SwapIntervalEXT(_sapp.x11.display, _sapp.glx.window, interval);
     }
-    else if (_sapp_glx_MESA_swap_control) {
-        _sapp_glx_SwapIntervalMESA(interval);
+    else if (_sapp.glx.MESA_swap_control) {
+        _sapp.glx.SwapIntervalMESA(interval);
     }
 }
 
@@ -7203,7 +7193,7 @@ _SOKOL_PRIVATE void _sapp_x11_send_event(Atom type, int a, int b, int c, int d, 
     memset(&event, 0, sizeof(event));
 
     event.type = ClientMessage;
-    event.xclient.window = _sapp_x11_window;
+    event.xclient.window = _sapp.x11.window;
     event.xclient.format = 32;
     event.xclient.message_type = type;
     event.xclient.data.l[0] = a;
@@ -7212,7 +7202,7 @@ _SOKOL_PRIVATE void _sapp_x11_send_event(Atom type, int a, int b, int c, int d, 
     event.xclient.data.l[3] = d;
     event.xclient.data.l[4] = e;
 
-    XSendEvent(_sapp_x11_display, _sapp_x11_root,
+    XSendEvent(_sapp.x11.display, _sapp.x11.root,
                False,
                SubstructureNotifyMask | SubstructureRedirectMask,
                &event);
@@ -7220,7 +7210,7 @@ _SOKOL_PRIVATE void _sapp_x11_send_event(Atom type, int a, int b, int c, int d, 
 
 _SOKOL_PRIVATE void _sapp_x11_query_window_size(void) {
     XWindowAttributes attribs;
-    XGetWindowAttributes(_sapp_x11_display, _sapp_x11_window, &attribs);
+    XGetWindowAttributes(_sapp.x11.display, _sapp.x11.window, &attribs);
     _sapp.window_width = attribs.width;
     _sapp.window_height = attribs.height;
     _sapp.framebuffer_width = _sapp.window_width;
@@ -7229,23 +7219,23 @@ _SOKOL_PRIVATE void _sapp_x11_query_window_size(void) {
 
 _SOKOL_PRIVATE void _sapp_x11_set_fullscreen(bool enable) {
     /* NOTE: this function must be called after XMapWindow (which happens in _sapp_x11_show_window()) */
-    if (_sapp_x11_NET_WM_STATE && _sapp_x11_NET_WM_STATE_FULLSCREEN) {
+    if (_sapp.x11.NET_WM_STATE && _sapp.x11.NET_WM_STATE_FULLSCREEN) {
         if (enable) {
             const int _NET_WM_STATE_ADD = 1;
-            _sapp_x11_send_event(_sapp_x11_NET_WM_STATE,
+            _sapp_x11_send_event(_sapp.x11.NET_WM_STATE,
                                 _NET_WM_STATE_ADD,
-                                _sapp_x11_NET_WM_STATE_FULLSCREEN,
+                                _sapp.x11.NET_WM_STATE_FULLSCREEN,
                                 0, 1, 0);
         }
         else {
             const int _NET_WM_STATE_REMOVE = 0;
-            _sapp_x11_send_event(_sapp_x11_NET_WM_STATE,
+            _sapp_x11_send_event(_sapp.x11.NET_WM_STATE,
                                 _NET_WM_STATE_REMOVE,
-                                _sapp_x11_NET_WM_STATE_FULLSCREEN,
+                                _sapp.x11.NET_WM_STATE_FULLSCREEN,
                                 0, 1, 0);
         }
     }
-    XFlush(_sapp_x11_display);
+    XFlush(_sapp.x11.display);
 }
 
 _SOKOL_PRIVATE void _sapp_x11_toggle_fullscreen(void) {
@@ -7255,37 +7245,37 @@ _SOKOL_PRIVATE void _sapp_x11_toggle_fullscreen(void) {
 }
 
 _SOKOL_PRIVATE void _sapp_x11_update_window_title(void) {
-    Xutf8SetWMProperties(_sapp_x11_display,
-        _sapp_x11_window,
+    Xutf8SetWMProperties(_sapp.x11.display,
+        _sapp.x11.window,
         _sapp.window_title, _sapp.window_title,
         NULL, 0, NULL, NULL, NULL);
-    XChangeProperty(_sapp_x11_display, _sapp_x11_window,
-        _sapp_x11_NET_WM_NAME, _sapp_x11_UTF8_STRING, 8,
+    XChangeProperty(_sapp.x11.display, _sapp.x11.window,
+        _sapp.x11.NET_WM_NAME, _sapp.x11.UTF8_STRING, 8,
         PropModeReplace,
         (unsigned char*)_sapp.window_title,
         strlen(_sapp.window_title));
-    XChangeProperty(_sapp_x11_display, _sapp_x11_window,
-        _sapp_x11_NET_WM_ICON_NAME, _sapp_x11_UTF8_STRING, 8,
+    XChangeProperty(_sapp.x11.display, _sapp.x11.window,
+        _sapp.x11.NET_WM_ICON_NAME, _sapp.x11.UTF8_STRING, 8,
         PropModeReplace,
         (unsigned char*)_sapp.window_title,
         strlen(_sapp.window_title));
-    XFlush(_sapp_x11_display);
+    XFlush(_sapp.x11.display);
 }
 
 _SOKOL_PRIVATE void _sapp_x11_create_window(Visual* visual, int depth) {
-    _sapp_x11_colormap = XCreateColormap(_sapp_x11_display, _sapp_x11_root, visual, AllocNone);
+    _sapp.x11.colormap = XCreateColormap(_sapp.x11.display, _sapp.x11.root, visual, AllocNone);
     XSetWindowAttributes wa;
     memset(&wa, 0, sizeof(wa));
     const uint32_t wamask = CWBorderPixel | CWColormap | CWEventMask;
-    wa.colormap = _sapp_x11_colormap;
+    wa.colormap = _sapp.x11.colormap;
     wa.border_pixel = 0;
     wa.event_mask = StructureNotifyMask | KeyPressMask | KeyReleaseMask |
                     PointerMotionMask | ButtonPressMask | ButtonReleaseMask |
                     ExposureMask | FocusChangeMask | VisibilityChangeMask |
                     EnterWindowMask | LeaveWindowMask | PropertyChangeMask;
     _sapp_x11_grab_error_handler();
-    _sapp_x11_window = XCreateWindow(_sapp_x11_display,
-                                     _sapp_x11_root,
+    _sapp.x11.window = XCreateWindow(_sapp.x11.display,
+                                     _sapp.x11.root,
                                      0, 0,
                                      _sapp.window_width,
                                      _sapp.window_height,
@@ -7296,61 +7286,61 @@ _SOKOL_PRIVATE void _sapp_x11_create_window(Visual* visual, int depth) {
                                      wamask,
                                      &wa);
     _sapp_x11_release_error_handler();
-    if (!_sapp_x11_window) {
+    if (!_sapp.x11.window) {
         _sapp_fail("X11: Failed to create window");
     }
     Atom protocols[] = {
-        _sapp_x11_WM_DELETE_WINDOW
+        _sapp.x11.WM_DELETE_WINDOW
     };
-    XSetWMProtocols(_sapp_x11_display, _sapp_x11_window, protocols, 1);
+    XSetWMProtocols(_sapp.x11.display, _sapp.x11.window, protocols, 1);
 
     XSizeHints* hints = XAllocSizeHints();
     hints->flags |= PWinGravity;
     hints->win_gravity = StaticGravity;
-    XSetWMNormalHints(_sapp_x11_display, _sapp_x11_window, hints);
+    XSetWMNormalHints(_sapp.x11.display, _sapp.x11.window, hints);
     XFree(hints);
 
     _sapp_x11_update_window_title();
 }
 
 _SOKOL_PRIVATE void _sapp_x11_destroy_window(void) {
-    if (_sapp_x11_window) {
-        XUnmapWindow(_sapp_x11_display, _sapp_x11_window);
-        XDestroyWindow(_sapp_x11_display, _sapp_x11_window);
-        _sapp_x11_window = 0;
+    if (_sapp.x11.window) {
+        XUnmapWindow(_sapp.x11.display, _sapp.x11.window);
+        XDestroyWindow(_sapp.x11.display, _sapp.x11.window);
+        _sapp.x11.window = 0;
     }
-    if (_sapp_x11_colormap) {
-        XFreeColormap(_sapp_x11_display, _sapp_x11_colormap);
-        _sapp_x11_colormap = 0;
+    if (_sapp.x11.colormap) {
+        XFreeColormap(_sapp.x11.display, _sapp.x11.colormap);
+        _sapp.x11.colormap = 0;
     }
-    XFlush(_sapp_x11_display);
+    XFlush(_sapp.x11.display);
 }
 
 _SOKOL_PRIVATE bool _sapp_x11_window_visible(void) {
     XWindowAttributes wa;
-    XGetWindowAttributes(_sapp_x11_display, _sapp_x11_window, &wa);
+    XGetWindowAttributes(_sapp.x11.display, _sapp.x11.window, &wa);
     return wa.map_state == IsViewable;
 }
 
 _SOKOL_PRIVATE void _sapp_x11_show_window(void) {
     if (!_sapp_x11_window_visible()) {
-        XMapWindow(_sapp_x11_display, _sapp_x11_window);
-        XRaiseWindow(_sapp_x11_display, _sapp_x11_window);
-        XFlush(_sapp_x11_display);
+        XMapWindow(_sapp.x11.display, _sapp.x11.window);
+        XRaiseWindow(_sapp.x11.display, _sapp.x11.window);
+        XFlush(_sapp.x11.display);
     }
 }
 
 _SOKOL_PRIVATE void _sapp_x11_hide_window(void) {
-    XUnmapWindow(_sapp_x11_display, _sapp_x11_window);
-    XFlush(_sapp_x11_display);
+    XUnmapWindow(_sapp.x11.display, _sapp.x11.window);
+    XFlush(_sapp.x11.display);
 }
 
 _SOKOL_PRIVATE unsigned long _sapp_x11_get_window_property(Atom property, Atom type, unsigned char** value) {
     Atom actualType;
     int actualFormat;
     unsigned long itemCount, bytesAfter;
-    XGetWindowProperty(_sapp_x11_display,
-                       _sapp_x11_window,
+    XGetWindowProperty(_sapp.x11.display,
+                       _sapp.x11.window,
                        property,
                        0,
                        LONG_MAX,
@@ -7371,7 +7361,7 @@ _SOKOL_PRIVATE int _sapp_x11_get_window_state(void) {
         Window icon;
     } *state = NULL;
 
-    if (_sapp_x11_get_window_property(_sapp_x11_WM_STATE, _sapp_x11_WM_STATE, (unsigned char**)&state) >= 2) {
+    if (_sapp_x11_get_window_property(_sapp.x11.WM_STATE, _sapp.x11.WM_STATE, (unsigned char**)&state) >= 2) {
         result = state->state;
     }
     if (state) {
@@ -7465,7 +7455,7 @@ _SOKOL_PRIVATE void _sapp_x11_char_event(uint32_t chr, bool repeat, uint32_t mod
 
 _SOKOL_PRIVATE sapp_keycode _sapp_x11_translate_key(int scancode) {
     int dummy;
-    KeySym* keysyms = XGetKeyboardMapping(_sapp_x11_display, scancode, 1, &dummy);
+    KeySym* keysyms = XGetKeyboardMapping(_sapp.x11.display, scancode, 1, &dummy);
     SOKOL_ASSERT(keysyms);
     KeySym keysym = keysyms[0];
     XFree(keysyms);
@@ -7718,10 +7708,10 @@ _SOKOL_PRIVATE void _sapp_x11_process_event(XEvent* event) {
             break;
         case PropertyNotify:
             if (event->xproperty.state == PropertyNewValue) {
-                if (event->xproperty.atom == _sapp_x11_WM_STATE) {
+                if (event->xproperty.atom == _sapp.x11.WM_STATE) {
                     const int state = _sapp_x11_get_window_state();
-                    if (state != _sapp_x11_window_state) {
-                        _sapp_x11_window_state = state;
+                    if (state != _sapp.x11.window_state) {
+                        _sapp.x11.window_state = state;
                         if (state == IconicState) {
                             _sapp_x11_app_event(SAPP_EVENTTYPE_ICONIFIED);
                         }
@@ -7733,9 +7723,9 @@ _SOKOL_PRIVATE void _sapp_x11_process_event(XEvent* event) {
             }
             break;
         case ClientMessage:
-            if (event->xclient.message_type == _sapp_x11_WM_PROTOCOLS) {
+            if (event->xclient.message_type == _sapp.x11.WM_PROTOCOLS) {
                 const Atom protocol = event->xclient.data.l[0];
-                if (protocol == _sapp_x11_WM_DELETE_WINDOW) {
+                if (protocol == _sapp.x11.WM_DELETE_WINDOW) {
                     _sapp.quit_requested = true;
                 }
             }
@@ -7747,19 +7737,19 @@ _SOKOL_PRIVATE void _sapp_x11_process_event(XEvent* event) {
 
 _SOKOL_PRIVATE void _sapp_run(const sapp_desc* desc) {
     _sapp_init_state(desc);
-    _sapp_x11_window_state = NormalState;
+    _sapp.x11.window_state = NormalState;
 
     XInitThreads();
     XrmInitialize();
-    _sapp_x11_display = XOpenDisplay(NULL);
-    if (!_sapp_x11_display) {
+    _sapp.x11.display = XOpenDisplay(NULL);
+    if (!_sapp.x11.display) {
         _sapp_fail("XOpenDisplay() failed!\n");
     }
-    _sapp_x11_screen = DefaultScreen(_sapp_x11_display);
-    _sapp_x11_root = DefaultRootWindow(_sapp_x11_display);
-    XkbSetDetectableAutoRepeat(_sapp_x11_display, true, NULL);
+    _sapp.x11.screen = DefaultScreen(_sapp.x11.display);
+    _sapp.x11.root = DefaultRootWindow(_sapp.x11.display);
+    XkbSetDetectableAutoRepeat(_sapp.x11.display, true, NULL);
     _sapp_x11_query_system_dpi();
-    _sapp.dpi_scale = _sapp_x11_dpi / 96.0f;
+    _sapp.dpi_scale = _sapp.x11.dpi / 96.0f;
     _sapp_x11_init_extensions();
     _sapp_glx_init();
     Visual* visual = 0;
@@ -7774,18 +7764,18 @@ _SOKOL_PRIVATE void _sapp_run(const sapp_desc* desc) {
     }
     _sapp_x11_query_window_size();
     _sapp_glx_swapinterval(_sapp.swap_interval);
-    XFlush(_sapp_x11_display);
+    XFlush(_sapp.x11.display);
     while (!_sapp.quit_ordered) {
         _sapp_glx_make_current();
-        int count = XPending(_sapp_x11_display);
+        int count = XPending(_sapp.x11.display);
         while (count--) {
             XEvent event;
-            XNextEvent(_sapp_x11_display, &event);
+            XNextEvent(_sapp.x11.display, &event);
             _sapp_x11_process_event(&event);
         }
         _sapp_frame();
         _sapp_glx_swap_buffers();
-        XFlush(_sapp_x11_display);
+        XFlush(_sapp.x11.display);
         /* handle quit-requested, either from window or from sapp_request_quit() */
         if (_sapp.quit_requested && !_sapp.quit_ordered) {
             /* give user code a chance to intervene */
@@ -7799,7 +7789,7 @@ _SOKOL_PRIVATE void _sapp_run(const sapp_desc* desc) {
     _sapp_call_cleanup();
     _sapp_glx_destroy_context();
     _sapp_x11_destroy_window();
-    XCloseDisplay(_sapp_x11_display);
+    XCloseDisplay(_sapp.x11.display);
     _sapp_discard_state();
 }
 

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2540,7 +2540,9 @@ _SOKOL_PRIVATE void _sapp_macos_app_event(sapp_event_type type) {
 - (void)windowDidResize:(NSNotification*)notification {
     _SOKOL_UNUSED(notification);
     _sapp_macos_update_dimensions();
-    _sapp_macos_app_event(SAPP_EVENTTYPE_RESIZED);
+    if (!_sapp.first_frame) {
+        _sapp_macos_app_event(SAPP_EVENTTYPE_RESIZED);
+    }
 }
 
 - (void)windowDidMiniaturize:(NSNotification*)notification {

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1247,6 +1247,8 @@ typedef struct {
 
 /*== EMSCRIPTEN DECLARATIONS =================================================*/
 #if defined(_SAPP_EMSCRIPTEN)
+
+#if defined(SOKOL_WGPU)
 typedef struct {
     int state;
     WGPUDevice device;
@@ -1258,6 +1260,7 @@ typedef struct {
     WGPUTextureView msaa_view;
     WGPUTextureView depth_stencil_view;
 } _sapp_wgpu_t;
+#endif
 
 typedef struct {
     bool textfield_created;
@@ -4876,7 +4879,7 @@ _SOKOL_PRIVATE void _sapp_win32_destroy_window(void) {
 }
 
 _SOKOL_PRIVATE void _sapp_win32_init_dpi(void) {
-    
+
     typedef BOOL(WINAPI * SETPROCESSDPIAWARE_T)(void);
     typedef HRESULT(WINAPI * SETPROCESSDPIAWARENESS_T)(PROCESS_DPI_AWARENESS);
     typedef HRESULT(WINAPI * GETDPIFORMONITOR_T)(HMONITOR, MONITOR_DPI_TYPE, UINT*, UINT*);
@@ -7555,7 +7558,7 @@ SOKOL_API_IMPL int sapp_run(const sapp_desc* desc) {
     #elif defined(_SAPP_LINUX)
         _sapp_linux_run(desc);
     #else
-        // calling sapp_run() directly is not supported on Android) 
+        // calling sapp_run() directly is not supported on Android)
         _sapp_fail("sapp_run() not supported on this platform!");
     #endif
     return 0;


### PR DESCRIPTION
Move things around a bit internally to be more consistent with how the implementation block in sokol_gfx.h is structured.

- [x] ~~add an OSX/iOS+Metal-specific doc blurb in sokol-gfx about wrapping the frame function with an autoreleasepool if not using sokol-app.h (this was also required before, just not properly documented)~~ (it seems that this autoreleasepool isn't necessary at all)

- [x] update the sokol-gfx README Updates section
