### PR TITLE
sokol_app.h: fix macos with glcore33 to update dimensions / dpi on startup

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1595,6 +1595,7 @@ _SOKOL_PRIVATE void _sapp_macos_toggle_fullscreen(void) {
             userInfo:nil
             repeats:YES];
         [[NSRunLoop currentRunLoop] addTimer:_sapp_macos_timer_obj forMode:NSDefaultRunLoopMode];
+        _sapp_macos_update_dimensions();
     #endif
     _sapp.valid = true;
     if (_sapp.fullscreen) {
@@ -7215,7 +7216,7 @@ _SOKOL_PRIVATE void _sapp_x11_set_fullscreen(bool enable) {
                                 0, 1, 0);
         }
         else {
-            const int _NET_WM_STATE_REMOVE = 0; 
+            const int _NET_WM_STATE_REMOVE = 0;
             _sapp_x11_send_event(_sapp_x11_NET_WM_STATE,
                                 _NET_WM_STATE_REMOVE,
                                 _sapp_x11_NET_WM_STATE_FULLSCREEN,


### PR DESCRIPTION
macOS with GLCORE33 doesn't call `_sapp_macos_update_dimensions` on startup like with METAL does, which keeps DPI at default value until a resize event comes in.

Not sure if it's the best place to put this function tho I'm not familiar with `sokol_app.h` codebase