### PR TITLE
Fix sokol_fetch.h spinning on Windows

### DIFF
--- a/sokol_fetch.h
+++ b/sokol_fetch.h
@@ -1746,7 +1746,7 @@ _SOKOL_PRIVATE uint32_t _sfetch_thread_dequeue_incoming(_sfetch_thread_t* thread
     EnterCriticalSection(&thread->incoming_critsec);
     while (_sfetch_ring_empty(incoming) && !thread->stop_requested) {
         LeaveCriticalSection(&thread->incoming_critsec);
-        WaitForSingleObject(&thread->incoming_event, INFINITE);
+        WaitForSingleObject(thread->incoming_event, INFINITE);
         EnterCriticalSection(&thread->incoming_critsec);
     }
     uint32_t item = 0;


### PR DESCRIPTION
Instead of waiting on the event as it's supposed to `_sfetch_thread_dequeue_incoming()` spins while waiting as the address of the event handle is passed to `WaitForSingleObject()` instead of the handle itself causing the function fail immediately as the handle is invalid.