### PR TITLE
sokol_audio: Don't include platform headers if SOKOL_DUMMY_BACKEND is defined

### DIFF
--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -467,7 +467,9 @@ inline void saudio_setup(const saudio_desc& desc) { return saudio_setup(&desc); 
     #define _SOKOL_UNUSED(x) (void)(x)
 #endif
 
-#if (defined(__APPLE__) || defined(__linux__) || defined(__unix__)) && !defined(__EMSCRIPTEN__)
+#if defined(SOKOL_DUMMY_BACKEND)
+    // No threads needed for SOKOL_DUMMY_BACKEND
+#elif (defined(__APPLE__) || defined(__linux__) || defined(__unix__)) && !defined(__EMSCRIPTEN__)
     #include <pthread.h>
 #elif defined(_WIN32)
     #ifndef WIN32_LEAN_AND_MEAN
@@ -482,7 +484,9 @@ inline void saudio_setup(const saudio_desc& desc) { return saudio_setup(&desc); 
     #pragma comment (lib, "ole32.lib")
 #endif
 
-#if defined(__APPLE__)
+#if defined(SOKOL_DUMMY_BACKEND)
+    // No audio API needed for SOKOL_DUMMY_BACKEND
+#elif defined(__APPLE__)
     #include <AudioToolbox/AudioToolbox.h>
 #elif (defined(__linux__) || defined(__unix__)) && !defined(__EMSCRIPTEN__) && !defined(__ANDROID__)
     #define ALSA_PCM_NEW_HW_PARAMS_API
@@ -539,7 +543,11 @@ inline void saudio_setup(const saudio_desc& desc) { return saudio_setup(&desc); 
 #endif
 
 /*=== MUTEX WRAPPER DECLARATIONS =============================================*/
-#if (defined(__APPLE__) || defined(__linux__) || defined(__unix__)) && !defined(__EMSCRIPTEN__)
+#if defined(SOKOL_DUMMY_BACKEND)
+
+typedef struct { int dummy_mutex; } _saudio_mutex_t;
+
+#elif (defined(__APPLE__) || defined(__linux__) || defined(__unix__)) && !defined(__EMSCRIPTEN__)
 
 typedef struct {
     pthread_mutex_t mutex;
@@ -552,11 +560,16 @@ typedef struct {
 } _saudio_mutex_t;
 
 #else
-typedef struct { } _saudio_mutex_t;
+typedef struct { int dummy_mutex; } _saudio_mutex_t;
 #endif
 
+/*=== DUMMY BACKEND DECLARATIONS =============================================*/
+#if defined(SOKOL_DUMMY_BACKEND)
+typedef struct {
+    int dummy_backend;
+} _saudio_backend_t;
 /*=== COREAUDIO BACKEND DECLARATIONS =========================================*/
-#if defined(__APPLE__)
+#elif defined(__APPLE__)
 
 typedef struct {
     AudioQueueRef ca_audio_queue;
@@ -696,7 +709,12 @@ _SOKOL_PRIVATE void _saudio_stream_callback(float* buffer, int num_frames, int n
 }
 
 /*=== MUTEX IMPLEMENTATION ===================================================*/
-#if (defined(__APPLE__) || defined(__linux__) || defined(__unix__)) && !defined(__EMSCRIPTEN__)
+#if defined(SOKOL_DUMMY_BACKEND)
+_SOKOL_PRIVATE void _saudio_mutex_init(_saudio_mutex_t* m) { (void)m; }
+_SOKOL_PRIVATE void _saudio_mutex_destroy(_saudio_mutex_t* m) { (void)m; }
+_SOKOL_PRIVATE void _saudio_mutex_lock(_saudio_mutex_t* m) { (void)m; }
+_SOKOL_PRIVATE void _saudio_mutex_unlock(_saudio_mutex_t* m) { (void)m; }
+#elif (defined(__APPLE__) || defined(__linux__) || defined(__unix__)) && !defined(__EMSCRIPTEN__)
 _SOKOL_PRIVATE void _saudio_mutex_init(_saudio_mutex_t* m) {
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);


### PR DESCRIPTION
Currently using `SOKOL_DUMMY_BACKEND` still includes platform-specific headers. For example I couldn't build the dummy backend on a Linux server without ALSA libraries installed. This PR adds more `#if defined(SOKOL_DUMMY_BACKEND)` checks to skip including headers and defines a dummy mutex as well.

Empty structs have a dummy variable as some MSVC versions can't handle empty structs when compiling in C mode. I also added a dummy variable to the existing empty `_saudio_mutex_t` struct for that reason.