### PR TITLE
sokol_app.h: initial mouse-lock implementation

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2426,9 +2426,10 @@ _SOKOL_PRIVATE const char* _sapp_macos_get_clipboard_string(void) {
 }
 
 _SOKOL_PRIVATE void _sapp_macos_center_mouse(void) {
-    const NSRect r = [_sapp.macos.window convertRectToScreen:[_sapp.macos.view frame]];
-    const CGPoint mid_point = CGPointMake(NSMidX(r), NSMidY(r));
-    CGWarpMouseCursorPosition(mid_point);
+    const NSRect r_screen = [_sapp.macos.window convertRectToScreen:[_sapp.macos.view frame]];
+    const CGFloat x = NSMidX(r_screen);
+    const CGFloat y = CGDisplayBounds(kCGDirectMainDisplay).size.height - NSMidY(r_screen);
+    CGWarpMouseCursorPosition(CGPointMake(x, y));
 }
 
 _SOKOL_PRIVATE void _sapp_macos_store_locked_mouse_pos(void) {
@@ -2440,8 +2441,8 @@ _SOKOL_PRIVATE void _sapp_macos_store_locked_mouse_pos(void) {
 _SOKOL_PRIVATE void _sapp_macos_restore_locked_mouse_pos(void) {
     const NSRect r_win = NSMakeRect(_sapp.macos.mouse_locked_x, _sapp.macos.mouse_locked_y, 0, 0);
     const NSRect r_screen = [_sapp.macos.window convertRectToScreen:r_win];
-    CGFloat x = NSMinX(r_screen);
-    CGFloat y = CGDisplayBounds(kCGDirectMainDisplay).size.height - NSMinY(r_screen);
+    const CGFloat x = NSMinX(r_screen);
+    const CGFloat y = CGDisplayBounds(kCGDirectMainDisplay).size.height - NSMinY(r_screen);
     CGWarpMouseCursorPosition(CGPointMake(x, y));
 }
 
@@ -2762,6 +2763,7 @@ _SOKOL_PRIVATE void _sapp_macos_frame(void) {
         _sapp_macos_mouse_event(SAPP_EVENTTYPE_MOUSE_UP, SAPP_MOUSEBUTTON_MIDDLE, _sapp_macos_mod(event.modifierFlags));
     }
 }
+// FIXME: otherMouseDragged?
 - (void)mouseMoved:(NSEvent*)event {
     if (_sapp.mouse.locked) {
         _sapp.mouse.dx = [event deltaX];
@@ -2770,9 +2772,17 @@ _SOKOL_PRIVATE void _sapp_macos_frame(void) {
     _sapp_macos_mouse_event(SAPP_EVENTTYPE_MOUSE_MOVE, SAPP_MOUSEBUTTON_INVALID , _sapp_macos_mod(event.modifierFlags));
 }
 - (void)mouseDragged:(NSEvent*)event {
+    if (_sapp.mouse.locked) {
+        _sapp.mouse.dx = [event deltaX];
+        _sapp.mouse.dy = [event deltaY];
+    }
     _sapp_macos_mouse_event(SAPP_EVENTTYPE_MOUSE_MOVE, SAPP_MOUSEBUTTON_INVALID , _sapp_macos_mod(event.modifierFlags));
 }
 - (void)rightMouseDragged:(NSEvent*)event {
+    if (_sapp.mouse.locked) {
+        _sapp.mouse.dx = [event deltaX];
+        _sapp.mouse.dy = [event deltaY];
+    }
     _sapp_macos_mouse_event(SAPP_EVENTTYPE_MOUSE_MOVE, SAPP_MOUSEBUTTON_INVALID, _sapp_macos_mod(event.modifierFlags));
 }
 - (void)scrollWheel:(NSEvent*)event {

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1119,6 +1119,7 @@ inline int sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #ifdef _MSC_VER
         #pragma warning(push)
         #pragma warning(disable:4201)   /* nonstandard extension used: nameless struct/union */
+        #pragma warning(disable:4204)   /* nonstandard extension used: non-constant aggregate initializer */ 
         #pragma warning(disable:4054)   /* 'type cast': from function pointer */
         #pragma warning(disable:4055)   /* 'type cast': from data pointer */
         #pragma warning(disable:4505)   /* unreferenced local function has been removed */
@@ -4588,15 +4589,15 @@ _SOKOL_PRIVATE void _sapp_win32_lock_mouse(bool lock) {
     _sapp.mouse.dx = _sapp.mouse.dy = 0.0f;
     _sapp.mouse.locked = lock;
     if (_sapp.mouse.locked) {
+        /* store the current mouse position, so it can be restored when unlocked */
         POINT pos;
         BOOL res = GetCursorPos(&pos);
         SOKOL_ASSERT(res); _SOKOL_UNUSED(res);
         _sapp.win32.mouse_locked_x = pos.x;
         _sapp.win32.mouse_locked_y = pos.y;
-        // FIXME FIXME FIXME
     }
     else {
-        // FIXME FIXME FIXME
+        /* restore the 'pre-locked' mouse position */
         BOOL res = SetCursorPos(_sapp.win32.mouse_locked_x, _sapp.win32.mouse_locked_y);
         SOKOL_ASSERT(res); _SOKOL_UNUSED(res);
     }
@@ -5253,6 +5254,11 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 }
 #endif /* SOKOL_WIN32_FORCE_MAIN */
 #endif /* SOKOL_NO_ENTRY */
+
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif
+
 #endif /* _SAPP_WIN32 */
 
 /*== Android ================================================================*/
@@ -8050,9 +8056,5 @@ SOKOL_API_IMPL const void* sapp_android_get_native_activity(void) {
 SOKOL_API_IMPL void sapp_html5_ask_leave_site(bool ask) {
     _sapp.html5_ask_leave_site = ask;
 }
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #endif /* SOKOL_IMPL */

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -249,7 +249,7 @@
             to various Metal API objects required for rendering, otherwise
             they return a null pointer. These void pointers are actually
             Objective-C ids converted with a (ARC) __bridge cast so that
-            they ids can be tunnel through C code. Also note that the returned
+            the ids can be tunnel through C code. Also note that the returned
             pointers to the renderpass-descriptor and drawable may change from one
             frame to the next, only the Metal device object is guaranteed to
             stay the same.
@@ -346,7 +346,7 @@
 
     Enabling the clipboard will dynamically allocate a clipboard buffer
     for UTF-8 encoded text data of the requested size in bytes, the default
-    size if 8 KBytes. Strings that don't fit into the clipboard buffer
+    size is 8 KBytes. Strings that don't fit into the clipboard buffer
     (including the terminating zero) will be silently clipped, so it's
     important that you provide a big enough clipboard size for your
     use case.

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -66,7 +66,7 @@
     taken from GLFW (http://www.glfw.org/)
 
     iOS onscreen keyboard support 'inspired' by libgdx.
-    
+
     Link with the following system libraries:
 
     - on macOS with Metal: Cocoa, QuartzCore, Metal, MetalKit
@@ -1129,7 +1129,7 @@ inline int sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #ifdef _MSC_VER
         #pragma warning(push)
         #pragma warning(disable:4201)   /* nonstandard extension used: nameless struct/union */
-        #pragma warning(disable:4204)   /* nonstandard extension used: non-constant aggregate initializer */ 
+        #pragma warning(disable:4204)   /* nonstandard extension used: non-constant aggregate initializer */
         #pragma warning(disable:4054)   /* 'type cast': from function pointer */
         #pragma warning(disable:4055)   /* 'type cast': from data pointer */
         #pragma warning(disable:4505)   /* unreferenced local function has been removed */
@@ -3423,8 +3423,15 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_size_changed(int event_type, const EmscriptenU
 
 _SOKOL_PRIVATE EM_BOOL _sapp_emsc_mouse_cb(int emsc_type, const EmscriptenMouseEvent* emsc_event, void* user_data) {
     _SOKOL_UNUSED(user_data);
-    _sapp.mouse.x = (emsc_event->targetX * _sapp.dpi_scale);
-    _sapp.mouse.y = (emsc_event->targetY * _sapp.dpi_scale);
+    float new_x = emsc_event->targetX * _sapp.dpi_scale;
+    float new_y = emsc_event->targetY * _sapp.dpi_scale;
+    if (_sapp.mouse.pos_valid) {
+        _sapp.mouse.dx = new_x - _sapp.mouse.x;
+        _sapp.mouse.dy = new_y - _sapp.mouse.y;
+    }
+    _sapp.mouse.x = new_x;
+    _sapp.mouse.y = new_y;
+    _sapp.mouse.pos_valid = true;
     if (_sapp_events_enabled() && (emsc_event->button >= 0) && (emsc_event->button < SAPP_MAX_MOUSEBUTTONS)) {
         sapp_event_type type;
         bool is_button_event = false;

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1313,6 +1313,7 @@ typedef struct {
     HDC dc;
     bool in_create_window;
     bool iconified;
+    bool mouse_tracked;
     _sapp_win32_dpi_t dpi;
 } _sapp_win32_t;
 
@@ -1591,7 +1592,6 @@ typedef struct {
     uint64_t frame_count;
     float mouse_x;
     float mouse_y;
-    bool win32_mouse_tracked;
     bool onscreen_keyboard_shown;
     bool mouse_shown;
     bool mouse_lock_requested;
@@ -4825,8 +4825,8 @@ _SOKOL_PRIVATE LRESULT CALLBACK _sapp_win32_wndproc(HWND hWnd, UINT uMsg, WPARAM
             case WM_MOUSEMOVE:
                 _sapp.mouse_x = (float)GET_X_LPARAM(lParam) * _sapp.win32.dpi.mouse_scale;
                 _sapp.mouse_y = (float)GET_Y_LPARAM(lParam) * _sapp.win32.dpi.mouse_scale;
-                if (!_sapp.win32_mouse_tracked) {
-                    _sapp.win32_mouse_tracked = true;
+                if (!_sapp.win32.mouse_tracked) {
+                    _sapp.win32.mouse_tracked = true;
                     TRACKMOUSEEVENT tme;
                     memset(&tme, 0, sizeof(tme));
                     tme.cbSize = sizeof(tme);
@@ -4838,7 +4838,7 @@ _SOKOL_PRIVATE LRESULT CALLBACK _sapp_win32_wndproc(HWND hWnd, UINT uMsg, WPARAM
                 _sapp_win32_mouse_event(SAPP_EVENTTYPE_MOUSE_MOVE,  SAPP_MOUSEBUTTON_INVALID);
                 break;
             case WM_MOUSELEAVE:
-                _sapp.win32_mouse_tracked = false;
+                _sapp.win32.mouse_tracked = false;
                 _sapp_win32_mouse_event(SAPP_EVENTTYPE_MOUSE_LEAVE, SAPP_MOUSEBUTTON_INVALID);
                 break;
             case WM_MOUSEWHEEL:

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2452,15 +2452,23 @@ _SOKOL_PRIVATE void _sapp_macos_lock_mouse(bool lock) {
     }
     _sapp.mouse.dx = _sapp.mouse.dy = 0.0f;
     _sapp.mouse.locked = lock;
-    /* in locked mode, the mouse position will remain frozen, the system
-       mouse pointer will be centered in the window to prevent it from bumping
-       into the screen edge, and mouseMoved events will only update mouse_dx/dy
+    /*
+        NOTE that this code doesn't warp the mouse cursor to the window
+        center as everybody else does it. This lead to a spike in the
+        *second* mouse-moved event after the warp happened. The
+        mouse centering doesn't seem to be required (mouse-moved events
+        are reported correctly even when the cursor is at an edge of the screen).
+
+        NOTE also that the hide/show of the mouse cursor should properly
+        stack with calls to sapp_show_mouse()
     */
     if (_sapp.mouse.locked) {
         [NSEvent setMouseCoalescingEnabled:NO];
         CGAssociateMouseAndMouseCursorPosition(NO);
+        CGDisplayHideCursor(kCGDirectMainDisplay);
     }
     else {
+        CGDisplayShowCursor(kCGDirectMainDisplay);
         CGAssociateMouseAndMouseCursorPosition(YES);
         [NSEvent setMouseCoalescingEnabled:YES];
     }

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -3574,8 +3574,16 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_wheel_cb(int emsc_type, const EmscriptenWheelE
         if (emsc_event->mouse.metaKey) {
             _sapp.event.modifiers |= SAPP_MODIFIER_SUPER;
         }
-        _sapp.event.scroll_x = -0.1 * (float)emsc_event->deltaX;
-        _sapp.event.scroll_y = -0.1 * (float)emsc_event->deltaY;
+        /* see https://github.com/floooh/sokol/issues/339 */
+        float scale;
+        switch (emsc_event->deltaMode) {
+            case DOM_DELTA_PIXEL: scale = -0.04f; break;
+            case DOM_DELTA_LINE:  scale = -1.33f; break;
+            case DOM_DELTA_PAGE:  scale = -10.0f; break; // FIXME: this is a guess
+            default:              scale = -0.1f; break;  // shouldn't happen
+        }
+        _sapp.event.scroll_x = scale * (float)emsc_event->deltaX;
+        _sapp.event.scroll_y = scale * (float)emsc_event->deltaY;
         _sapp_call_event(&_sapp.event);
     }
     _sapp_emsc_update_keyboard_state();


### PR DESCRIPTION
For getting unrestricted mouse-movement information.

Two new functions:

```c
void sapp_lock_mouse(bool b);
bool sapp_mouse_locked(void);
```

When mouse-lock is active, the mouse pointer is hidden, the mouse position reported in SAPP_EVENTTYPE_MOUSE_MOVE appears frozen, and the new sapp_event items mouse_dx/dy contain relative mouse movement.

It is not guaranteed that mouse movement has the same "trajectory" in lock mode (because on some platforms, the "raw mouse movement" APIs are used). In locked mode, MOUSE_MOVE events will also be generated when the mouse leaves the window area or hits the screen border.

If mouse-lock is inactive, mouse_dx/dy will be computed by subtracting the new mouse position from the previous. 

Implementation status:

- [x] Win32
- [x] macOS
- [x] Linux
- [x] WASM

...this PR also contains the missing sapp_show_mouse() implementation for Linux