### PR TITLE
sokol_audio.h: Implement WebAudio worklet backend

### DIFF
--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -275,16 +275,12 @@
 
     THE WEBAUDIO BACKEND
     ====================
-    The WebAudio backend is currently using a ScriptProcessorNode callback to
-    feed the sample data into WebAudio. ScriptProcessorNode has been
-    deprecated for a while because it is running from the main thread, with
-    the default initialization parameters it works 'pretty well' though.
-    Ultimately Sokol Audio will use Audio Worklets, but this requires a few
-    more things to fall into place (Audio Worklets implemented everywhere,
-    SharedArrayBuffers enabled again, and I need to figure out a 'low-cost'
-    solution in terms of implementation effort, since Audio Worklets are
-    a lot more complex than ScriptProcessorNode if the audio data needs to come
-    from the main thread).
+    The WebAudio backend can use either Audio Worklets or a ScriptProcessorNode.
+    If __EMSCRIPTEN_PTHREADS__ is defined and the browser supports them the
+    Audio Worklet backend is used. Using the Worklet backend Sokol Audio will
+    create a background thread to feed the Worklet. If Worklets or threads are
+    not available the ScriptProcessorNode backend will be updated from the
+    main thread.
 
     The WebAudio backend is automatically selected when compiling for
     emscripten (__EMSCRIPTEN__ define exists).
@@ -519,6 +515,10 @@ inline void saudio_setup(const saudio_desc& desc) { return saudio_setup(&desc); 
     #endif
 #elif defined(__EMSCRIPTEN__)
     #include <emscripten/emscripten.h>
+    #if defined(__EMSCRIPTEN_PTHREADS__)
+        #include <emscripten/threading.h>
+        #include <pthread.h>
+    #endif
 #endif
 
 #ifdef _MSC_VER
@@ -632,9 +632,25 @@ typedef struct {
 /*=== WEBAUDIO BACKEND DECLARATIONS ==========================================*/
 #elif defined(__EMSCRIPTEN__)
 
+#if defined(__EMSCRIPTEN_PTHREADS__)
+
+typedef struct {
+    uint8_t* buffer;
+    uint8_t* worklet_memory;
+    pthread_t thread;
+    bool thread_stop;
+} _saudio_backend_t;
+
+typedef struct {
+    int32_t atomic_quantums_queued;
+    int32_t num_quantums;
+} _saudio_worklet_t;
+
+#else
 typedef struct {
     uint8_t* buffer;
 } _saudio_backend_t;
+#endif
 
 /*=== DUMMY BACKEND DECLARATIONS =============================================*/
 #else
@@ -1303,10 +1319,12 @@ EMSCRIPTEN_KEEPALIVE int _saudio_emsc_pull(int num_frames) {
 } /* extern "C" */
 #endif
 
-/* setup the WebAudio context and attach a ScriptProcessorNode */
-EM_JS(int, saudio_js_init, (int sample_rate, int num_channels, int buffer_size), {
+/* setup the WebAudio context */
+EM_JS(int, saudio_js_init_common, (int sample_rate), {
+    Module._saudio_shutdown_worker = false;
     Module._saudio_context = null;
     Module._saudio_node = null;
+    Module._saudio_worklet = null;
     if (typeof AudioContext !== 'undefined') {
         Module._saudio_context = new AudioContext({
             sampleRate: sample_rate,
@@ -1323,23 +1341,9 @@ EM_JS(int, saudio_js_init, (int sample_rate, int num_channels, int buffer_size),
         Module._saudio_context = null;
         console.log('sokol_audio.h: no WebAudio support');
     }
+
     if (Module._saudio_context) {
         console.log('sokol_audio.h: sample rate ', Module._saudio_context.sampleRate);
-        Module._saudio_node = Module._saudio_context.createScriptProcessor(buffer_size, 0, num_channels);
-        Module._saudio_node.onaudioprocess = function pump_audio(event) {
-            var num_frames = event.outputBuffer.length;
-            var ptr = __saudio_emsc_pull(num_frames);
-            if (ptr) {
-                var num_channels = event.outputBuffer.numberOfChannels;
-                for (var chn = 0; chn < num_channels; chn++) {
-                    var chan = event.outputBuffer.getChannelData(chn);
-                    for (var i = 0; i < num_frames; i++) {
-                        chan[i] = HEAPF32[(ptr>>2) + ((num_channels*i)+chn)]
-                    }
-                }
-            }
-        };
-        Module._saudio_node.connect(Module._saudio_context.destination);
 
         // in some browsers, WebAudio needs to be activated on a user action
         var resume_webaudio = function() {
@@ -1352,6 +1356,7 @@ EM_JS(int, saudio_js_init, (int sample_rate, int num_channels, int buffer_size),
         document.addEventListener('click', resume_webaudio, {once:true});
         document.addEventListener('touchstart', resume_webaudio, {once:true});
         document.addEventListener('keydown', resume_webaudio, {once:true});
+
         return 1;
     }
     else {
@@ -1359,15 +1364,41 @@ EM_JS(int, saudio_js_init, (int sample_rate, int num_channels, int buffer_size),
     }
 });
 
+/* setup and attach a ScriptProcessorNode */
+EM_JS(int, saudio_js_init_script_processor, (int num_channels, int buffer_size), {
+    Module._saudio_node = Module._saudio_context.createScriptProcessor(buffer_size, 0, num_channels);
+    Module._saudio_node.onaudioprocess = function pump_audio(event) {
+        var num_frames = event.outputBuffer.length;
+        var ptr = __saudio_emsc_pull(num_frames);
+        if (ptr) {
+            var num_channels = event.outputBuffer.numberOfChannels;
+            for (var chn = 0; chn < num_channels; chn++) {
+                var chan = event.outputBuffer.getChannelData(chn);
+                for (var i = 0; i < num_frames; i++) {
+                    chan[i] = HEAPF32[(ptr>>2) + ((num_channels*i)+chn)]
+                }
+            }
+        }
+    };
+    Module._saudio_node.connect(Module._saudio_context.destination);
+    console.log('sokol_audio.h: Using ScriptProcessorNode');
+    return 1;
+});
+
 /* shutdown the WebAudioContext and ScriptProcessorNode */
 EM_JS(void, saudio_js_shutdown, (void), {
+    Module._saudio_shutdown_worker = true;
     if (Module._saudio_context !== null) {
+        if (Module._saudio_worklet) {
+            Module._saudio_worklet.disconnect();
+        }
         if (Module._saudio_node) {
             Module._saudio_node.disconnect();
         }
         Module._saudio_context.close();
         Module._saudio_context = null;
         Module._saudio_node = null;
+        Module._saudio_worklet = null;
     }
 });
 
@@ -1382,7 +1413,7 @@ EM_JS(int, saudio_js_sample_rate, (void), {
 });
 
 /* get the actual buffer size in number of frames */
-EM_JS(int, saudio_js_buffer_frames, (void), {
+EM_JS(int, saudio_js_buffer_frames_script_processor, (void), {
     if (Module._saudio_node) {
         return Module._saudio_node.bufferSize;
     }
@@ -1391,11 +1422,11 @@ EM_JS(int, saudio_js_buffer_frames, (void), {
     }
 });
 
-_SOKOL_PRIVATE bool _saudio_backend_init(void) {
-    if (saudio_js_init(_saudio.sample_rate, _saudio.num_channels, _saudio.buffer_frames)) {
+_SOKOL_PRIVATE bool _saudio_backend_init_script_processor(void) {
+    if (saudio_js_init_script_processor(_saudio.num_channels, _saudio.buffer_frames)) {
         _saudio.bytes_per_frame = sizeof(float) * _saudio.num_channels;
         _saudio.sample_rate = saudio_js_sample_rate();
-        _saudio.buffer_frames = saudio_js_buffer_frames();
+        _saudio.buffer_frames = saudio_js_buffer_frames_script_processor();
         const int buf_size = _saudio.buffer_frames * _saudio.bytes_per_frame;
         _saudio.backend.buffer = (uint8_t*) SOKOL_MALLOC(buf_size);
         return true;
@@ -1405,8 +1436,227 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
     }
 }
 
+#if defined(__EMSCRIPTEN_PTHREADS__)
+
+/* setup and attach an audio worklet */
+EM_JS(int, saudio_js_init_worklet, (int num_channels, void *worklet_memory, int worklet_slots), {
+    /* pre-check that audio worklets are actually supported */
+    if (!window.SharedArrayBuffer || !Module._saudio_context.audioWorklet || !Module._saudio_context.audioWorklet.addModule) {
+        return 0;
+    }
+
+    var worklet_source = `
+    class SokolAudioWorklet extends AudioWorkletProcessor {
+        constructor() {
+            super();
+            this.ready = false;
+            this.slot = 0;
+            /* the thread initializing sokol_audio will send the worklet a setup message */
+            this.port.onmessage = (e) => {
+                var buffer = e.data.buffer;
+                var offset = e.data.offset;
+                this.num_slots = e.data.num_slots;
+                this.worklet_t = new Int32Array(buffer, offset, 2);
+                this.num_quantums = this.worklet_t[1];
+                /* pre-create the views to the memory to save on GC pressure */
+                this.slots = Array(this.num_slots);
+                for (var i = 0; i < this.num_slots; i++) {
+                    this.slots[i] = new Float32Array(buffer, offset + 8 + i*4*128, 128);
+                }
+                this.ready = true;
+            };
+        }
+
+        process(inputs, outputs, parameters) {
+            var output = outputs[0];
+            /* only write data if ready, outputs are cleared to zero by default */
+            if (this.ready) {
+                /* check if the render thread has written any quantums */
+                var quantums_queued = Atomics.load(this.worklet_t, 0);
+                if (quantums_queued > 0) {
+                    var slot = this.slot;
+                    for (var i = 0; i < output.length; i++) {
+                        output[i].set(this.slots[slot]);
+                        slot = (slot + 1) % this.num_slots;
+                    }
+                    this.slot = slot;
+
+                    /* mark the quantum dequeued and wake up the render thread if there's exactly enough space */
+                    var prev_queued = Atomics.sub(this.worklet_t, 0, 1);
+                    if (prev_queued - 1 == this.num_quantums / 2) {
+                        Atomics.notify(this.worklet_t, 0);
+                    }
+                }
+            }
+            return true;
+        }
+    }
+
+    registerProcessor("sokol-audio-worklet", SokolAudioWorklet)
+    `;
+
+    /* create a Blob-url of inlined JavaScript as the worklet */
+    var blob = new Blob([worklet_source], { type: "text/javascript" });
+    var url = URL.createObjectURL(blob);
+
+    Module._saudio_context.audioWorklet.addModule(url).then(function(e) {
+        /* we might have shut down before this async callback */
+        if (Module._saudio_shutdown_worker) return;
+
+        Module._saudio_worklet = new AudioWorkletNode(Module._saudio_context, "sokol-audio-worklet", {
+            numberOfInputs: 0,
+            numberOfOutputs: 1,
+            outputChannelCount: [num_channels],
+        });
+
+        /* pass the SharedMemoryBuffer to the worklet */
+        var buffer = Module.buffer || Module.wasmMemory.buffer;
+        Module._saudio_worklet.port.postMessage({
+            buffer: buffer,
+            offset: worklet_memory,
+            num_slots: worklet_slots,
+        });
+
+        Module._saudio_worklet.connect(Module._saudio_context.destination);
+        console.log('sokol_audio.h: Using audio worklet');
+    });
+
+    return 1;
+});
+
+EM_JS(int, saudio_js_cancel_worklet, (), {
+    Module._saudio_shutdown_worker = true;
+    if (Module._saudio_worklet) {
+        Module._saudio_worklet.disconnect();
+        Module._saudio_worklet = null;
+    }
+});
+
+#include <stdio.h>
+
+_SOKOL_PRIVATE void *_saudio_emsc_worklet_cb(void *arg) {
+	emscripten_set_thread_name(pthread_self(), "Sokol Audio");
+    /* get the worklet context and quantum slots from the memory pointer */
+    _saudio_worklet_t *worklet = (_saudio_worklet_t*)arg;
+    float *worklet_slots = (float*)((uint8_t*)arg + sizeof(_saudio_worklet_t));
+    const int num_quantums = worklet->num_quantums;
+    const int half_quantums = num_quantums / 2;
+    const int32_t num_slots = (int32_t)(num_quantums * _saudio.num_channels);
+    int32_t slot = 0;
+
+    while (!_saudio.backend.thread_stop) {
+        int32_t queued = (int32_t)emscripten_atomic_load_u32((uint32_t*)&worklet->atomic_quantums_queued);
+
+        /* if we have queued more than half of the buffer wait until we get more space */
+        if (queued > half_quantums) {
+            emscripten_futex_wait(&worklet->atomic_quantums_queued, queued, 1000.0);
+            continue;
+        }
+
+        _saudio_emsc_pull(half_quantums * 128);
+
+        for (int quantum = 0; quantum < half_quantums; quantum++) {
+            /* de-interleave the channels into quantums for the worklet */
+            const int num_channels = _saudio.num_channels;
+            for (int channel = 0; channel < num_channels; channel++) {
+                float *dst = worklet_slots + slot * 128;
+                const float *src = (const float*)_saudio.backend.buffer + quantum * 128 * num_channels + channel;
+                for (int i = 0; i < 128; i++) {
+                    *dst = *src;
+                    dst += 1;
+                    src += num_channels;
+                }
+                slot = (slot + 1) % num_slots;
+            }
+
+            /* publish the quantum to the worker, fixing the atomic count if the worker got ahead */
+            int32_t prev_queued = (int32_t)emscripten_atomic_add_u32((uint32_t*)&worklet->atomic_quantums_queued, 1);
+            if (prev_queued < 0) {
+                emscripten_atomic_store_u32((uint32_t*)&worklet->atomic_quantums_queued, 1);
+            }
+        }
+    }
+
+    return NULL;
+}
+
+_SOKOL_PRIVATE bool _saudio_backend_init_worklet(void) {
+    /* worklet quantums are fixed at 128 so we need the buffer size to be a multiple of that */
+    int worklet_quantums = _saudio.buffer_frames / 128 * 2;
+    if (worklet_quantums < 8) worklet_quantums = 8;
+    /* we need quantum slots for each channel in a quantum */
+    int worklet_slots = worklet_quantums * _saudio.num_channels;
+    int worklet_slot_bytes = worklet_slots * 128 * sizeof(float);
+    /* use half of the quantums for render thread writing */
+    const int buffer_frames = worklet_quantums / 2 * 128;
+    const int bytes_per_frame = sizeof(float) * _saudio.num_channels;
+    const int buf_size = buffer_frames * bytes_per_frame;
+    /* combined allocation of worklet state, worklet quantums, render buffers */
+    void *worklet_memory = SOKOL_MALLOC(sizeof(_saudio_worklet_t) + worklet_slot_bytes + buf_size);
+    _saudio_worklet_t *worklet = (_saudio_worklet_t*)worklet_memory;
+    uint8_t *buffer = (uint8_t*)worklet_memory + sizeof(_saudio_worklet_t) + worklet_slot_bytes;
+
+    if (saudio_js_init_worklet(_saudio.num_channels, worklet_memory, worklet_slots)) {
+        _saudio.sample_rate = saudio_js_sample_rate();
+        _saudio.bytes_per_frame = bytes_per_frame;
+        _saudio.buffer_frames = buffer_frames;
+        _saudio.backend.buffer = buffer;
+
+        worklet->atomic_quantums_queued = 0;
+        worklet->num_quantums = worklet_quantums;
+
+        /* launch the audio render thread */
+        if (0 != pthread_create(&_saudio.backend.thread, 0, _saudio_emsc_worklet_cb, worklet_memory)) {
+            saudio_js_cancel_worklet();
+            SOKOL_FREE(worklet_memory);
+            return false;
+        }
+
+        _saudio.backend.worklet_memory = worklet_memory;
+
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+#endif
+
+_SOKOL_PRIVATE bool _saudio_backend_init(void) {
+
+    /* setup common WebAudio context */
+    if (0 == saudio_js_init_common(_saudio.sample_rate)) {
+        return false;
+    }
+
+    /* try to use worklets if available */
+#if defined(__EMSCRIPTEN_PTHREADS__)
+    if (_saudio_backend_init_worklet()) {
+        return true;
+    }
+#endif
+
+    /* fall back to ScriptProcessorNode */
+    if (_saudio_backend_init_script_processor()) {
+        return true;
+    }
+
+    return false;
+}
+
 _SOKOL_PRIVATE void _saudio_backend_shutdown(void) {
     saudio_js_shutdown();
+
+#if defined(__EMSCRIPTEN_PTHREADS__)
+    _saudio.backend.thread_stop = true;
+    if (_saudio.backend.worklet_memory) {
+        SOKOL_FREE(_saudio.backend.buffer);
+        _saudio.backend.worklet_memory = 0;
+        _saudio.backend.buffer = 0;
+    }
+#endif
+
     if (_saudio.backend.buffer) {
         SOKOL_FREE(_saudio.backend.buffer);
         _saudio.backend.buffer = 0;

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -1549,7 +1549,7 @@ _SOKOL_PRIVATE void *_saudio_emsc_worklet_cb(void *arg) {
 
         /* if we have queued more than half of the buffer wait until we get more space */
         if (queued > half_quantums) {
-            emscripten_futex_wait(&worklet->atomic_quantums_queued, queued, 1000.0);
+            emscripten_futex_wait(&worklet->atomic_quantums_queued, queued, 10.0);
             continue;
         }
 
@@ -1576,6 +1576,9 @@ _SOKOL_PRIVATE void *_saudio_emsc_worklet_cb(void *arg) {
             }
         }
     }
+
+    /* free the worklet memory */
+    SOKOL_FREE(arg);
 
     return NULL;
 }
@@ -1651,7 +1654,7 @@ _SOKOL_PRIVATE void _saudio_backend_shutdown(void) {
 #if defined(__EMSCRIPTEN_PTHREADS__)
     _saudio.backend.thread_stop = true;
     if (_saudio.backend.worklet_memory) {
-        SOKOL_FREE(_saudio.backend.buffer);
+        /* the background thread is responsible for freeing the worklet memory */
         _saudio.backend.worklet_memory = 0;
         _saudio.backend.buffer = 0;
     }


### PR DESCRIPTION
Hi! Turns out my game/engine is doing a lot of nasty blocking stuff on the main thread so I wanted to lift off the audio to a separate thread (especially now that Firefox supports it, albeit with headers). Anyways here's my stab at doing a WebAudio worklet implementation, as always feel free to use any parts of this for your own implementation if you'd prefer!

This PR enables audio worklets if `__EMSCRIPTEN_PTHREADS__` is defined and the browser supports them, otherwise it will fall back to the `ScriptProcessorNode` backend. I tried to test with a minimal repro case that both push/pull API work with worklets and that the fallback works as intended (https://github.com/bqqbarbhg/sokol-audio-worklet-test).

So turns out that the worklets are kind of a pain, getting WASM code to run in the worklet callback is super tricky, maybe even impossible (without a binary WASM blob I guess) in a single header context. I implemented a small JavaScript worker that communicates with a background thread through a single atomic variable and a single producer single consumer queue in lockstep.

#### Things to consider:

The worklets operate on 128 frame "quantum" batches, my first implementation called the user callback at this rate but I didn't like that it differed from the other backends that much so now it rounds the requested buffer size to a suitable value and calls the user callback at that rate. On the other hand operating at the worklet quantum size would make internal code and worklet synchronization a bit simpler.

The internal worklet queue is double the size of the requested buffer size so that it can double buffer with the worklet. You could increase this size independently from the buffer size to have higher latency (safer) without having to grow the user callback buffer size. Not sure if it's worth it though.

The embedded worklet source code is done with ES6 backtick strings which should be supported pretty much everywhere WebAudio is. I don't know if you can catch the syntax error on other browsers for a fallback. The most library-user-friendly approach would be to use `"line1" + "line2"` or a pre-condensed string but that's a lot less nice to edit.