### PR TITLE
Update docs concerning sg_draw

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -135,6 +135,11 @@
     --- kick off a draw call with:
 
             sg_draw(int base_element, int num_elements, int num_instances)
+   
+               In the case of no instancing: num_instances should be set to 1 and base_element/num_elements are
+               amounts of vertices. In the case of instancing (meaning num_instances > 1), num elements is the
+               number of vertices in one instance, while base_element remains unchanged. base_element is the index
+               of the first vertex to begin drawing from.
 
     --- finish the current rendering pass with:
 

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -135,11 +135,11 @@
     --- kick off a draw call with:
 
             sg_draw(int base_element, int num_elements, int num_instances)
-   
-               In the case of no instancing: num_instances should be set to 1 and base_element/num_elements are
-               amounts of vertices. In the case of instancing (meaning num_instances > 1), num elements is the
-               number of vertices in one instance, while base_element remains unchanged. base_element is the index
-               of the first vertex to begin drawing from.
+
+        In the case of no instancing: num_instances should be set to 1 and base_element/num_elements are
+        amounts of vertices. In the case of instancing (meaning num_instances > 1), num elements is the
+        number of vertices in one instance, while base_element remains unchanged. base_element is the index
+        of the first vertex to begin drawing from.
 
     --- finish the current rendering pass with:
 


### PR DESCRIPTION
I just finished successfully integrating sokol_gfx into my personal code (excellent library you've made here!), and it all went extremely smoothly. Except for one hiccup I was stuck on for about 6 hours today.

There is a small piece of the `sg_buffer` API that was confusing, namely the return value from `sg_append_buffer` and how it needs to be set on `sg_bindings::vertex_buffer_offsets[0]`, along with `sg_bindings::index_buffer`. The imgui-d3d11.cc sample file in the sokol-samples has a nice example of how to do this. I was convinced I had been setting up this offset value incorrectly, however, it was a red herring. The real bug in my integration was that when moving from DirectX 9 to DirectX11 the draw primitive function went from counting the number primitives (in my case triangles) to counting the number of vertices. So I was simply rendering 1/3rd of all my verts each frame. Very confusing.

I tried updating the docs on `sg_draw` to clear this stuff up.

I had also been a bit confused about `base_element`, and thought I might need to be passing the return value from `sg_append_buffer` here... Another red herring.