### PR TITLE
set window title on macos

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1032,6 +1032,8 @@ SOKOL_API_DECL const void* sapp_metal_get_renderpass_descriptor(void);
 SOKOL_API_DECL const void* sapp_metal_get_drawable(void);
 /* macOS: get bridged pointer to macOS NSWindow */
 SOKOL_API_DECL const void* sapp_macos_get_window(void);
+/* macOS: set window title */
+SOKOL_API_DECL void sapp_macos_set_title(const char* title);
 /* iOS: get bridged pointer to iOS UIWindow */
 SOKOL_API_DECL const void* sapp_ios_get_window(void);
 
@@ -8342,6 +8344,12 @@ SOKOL_API_IMPL const void* sapp_macos_get_window(void) {
         return obj;
     #else
         return 0;
+    #endif
+}
+
+SOKOL_API_IMPL void sapp_macos_set_title(const char* title) {
+    #if defined(__APPLE__) && !TARGET_OS_IPHONE
+        [_sapp.macos.window setTitle: [NSString stringWithUTF8String:title]];
     #endif
 }
 


### PR DESCRIPTION
This is a very early phase. I don't know want what kind of API you want. Probably one function `sapp_set_title(const char* title)`?

I'll add Windows and Linux a bit later.

Also, does Sokol plan to support multiple windows? Right now all functions seem to be using a global main window.