### PR TITLE
sokol_gfx.h: Fix instancing when running in webgl fallback mode. (SOKOL_GLES2 & SOKOL_GLES3)

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2502,7 +2502,7 @@ inline void sg_init_pass(sg_pass pass_id, const sg_pass_desc& desc) { return sg_
     #define GL_LUMINANCE 0x1909
     #endif
 
-    #ifdef SOKOL_GLES2
+    #if defined(SOKOL_GLES2) && !defined(SOKOL_GLES3)
     #   ifdef GL_ANGLE_instanced_arrays
     #       define SOKOL_INSTANCING_ENABLED
     #       define glDrawArraysInstanced(mode, first, count, instancecount)  glDrawArraysInstancedANGLE(mode, first, count, instancecount)


### PR DESCRIPTION
To be honest I'm not 100% sure why this works. Would think that these defines should still be required when running webgl1.