### PR TITLE
sokol_app.h: modernize D3D11 swapchain code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simple
 [STB-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt)
 cross-platform libraries for C and C++, written in C.
 
-[See what's new](#updates) (**07-Oct-2020** sokol_audio.h: ALSA backend initialization fixes)
+[See what's new](#updates) (**10-Oct-2020** sokol_app.h win32/uwp: D3D11/DXGI swapchain code modernization)
 
 [Live Samples](https://floooh.github.io/sokol-html5/index.html) via WASM.
 
@@ -431,6 +431,18 @@ See the sokol_args.h header for a more complete documentation, and the [Tiny
 Emulators](https://floooh.github.io/tiny8bit/) for more interesting usage examples.
 
 # Updates
+
+- **10-Oct-2020**: Improvements to the sokol_app.h Win32+D3D11 and UWP+D3D11 swapchain code:
+  - In the Win32+D3D11 backend and when running on Win10,
+    ```DXGI_SWAP_EFFECT_FLIP_DISCARD``` is now used.  This gets rid of a
+    deprecation warning in the debugger console and also should allow slightly
+    more efficient swaps in some situations. When running on Win7 or Win8, the
+    traditional ```DXGI_SWAP_EFFECT_DISCARD``` is used.
+  - The UWP backend now supports MSAA multisampling (the required fixes for
+    this are the same as in the Win32 backend with the new swap effect: a
+    separate MSAA texture and render-target-view is created where
+    rendering goes into, and this MSAA texture is resolved into the actual
+    swapchain surface before presentation).
 
 - **07-Oct-2020**:
     A fix in the ALSA/Linux backend initialization in sokol_audio.h: Previously,

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simple
 [STB-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt)
 cross-platform libraries for C and C++, written in C.
 
-[See what's new](#updates) (**02-Oct-2020** sokol_app.h win32: draw during resizing and moving the window)
+[See what's new](#updates) (**07-Oct-2020** sokol_audio.h: ALSA backend initialization fixes)
 
 [Live Samples](https://floooh.github.io/sokol-html5/index.html) via WASM.
 
@@ -431,6 +431,15 @@ See the sokol_args.h header for a more complete documentation, and the [Tiny
 Emulators](https://floooh.github.io/tiny8bit/) for more interesting usage examples.
 
 # Updates
+
+- **07-Oct-2020**:
+    A fix in the ALSA/Linux backend initialization in sokol_audio.h: Previously,
+    initialization would fail if ALSA can't allocate the exact requested
+    buffer size. Instead sokol_audio.h let's now pick ALSA a suitable buffer
+    size. Also better log messages in the ALSA initialization code if something
+    goes wrong. Unfortunately I'm not able to reproduce the buffer allocation
+    problem on my Linux machine. Details are in this issue: https://github.com/floooh/sokol/issues/400
+
 
 - **02-Oct-2020**:
     The sokol_app.h Win32 backend can now render while moving and resizing

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1289,6 +1289,8 @@ inline int sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
         #endif
         #include <d3d11.h>
         #include <dxgi.h>
+        // DXGI_SWAP_EFFECT_FLIP_DISCARD is only defined in newer Windows SDKs, so don't depend on it
+        #define _SAPP_DXGI_SWAP_EFFECT_FLIP_DISCARD (4)
     #endif
     #ifndef WM_MOUSEHWHEEL /* see https://github.com/floooh/sokol/issues/138 */
         #define WM_MOUSEHWHEEL (0x020E)
@@ -4740,7 +4742,7 @@ _SOKOL_PRIVATE void _sapp_d3d11_create_device_and_swapchain(void) {
     sc_desc->Windowed = true;
     if (_sapp.win32.is_win10_or_greater) {
         sc_desc->BufferCount = 2;
-        sc_desc->SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+        sc_desc->SwapEffect = (DXGI_SWAP_EFFECT) _SAPP_DXGI_SWAP_EFFECT_FLIP_DISCARD;
     }
     else {
         sc_desc->BufferCount = 1;


### PR DESCRIPTION
- in Win32 backend: use DXGI_SWAP_EFFECT_FLIP_DISCARD if possible (when running on Win10)
- in UWP backend: add MSAA support to swapchain code

In both backends: if MSAA is requested, a separate MSAA texture and render-target-view is created, rendering goes into the MSAA render target, and before presentation the MSAA texture is resolved into the non-MSAA swapchain texture.
