### PR TITLE
add forward declaration in sokol_glue.h

### DIFF
--- a/sokol_glue.h
+++ b/sokol_glue.h
@@ -86,6 +86,7 @@ extern "C" {
 #endif
 
 #if defined(SOKOL_GFX_INCLUDED) && defined(SOKOL_APP_INCLUDED)
+typedef struct sg_context_desc sg_context_desc;
 SOKOL_API_DECL sg_context_desc sapp_sgcontext(void);
 #endif
 


### PR DESCRIPTION
Then we can generate FFI to `sokol_glue.h` without including other header files!
(If we define `SOKOL_GFX_INCLUDED` and `SOKOL_APP_INCLUDED`)

I mean, I'm doing this:

![rokol](https://user-images.githubusercontent.com/47905926/99234774-4f617a00-2838-11eb-8599-e6c718e9a7d8.png)
