### PR TITLE
Auto-generated distinct macros per lib. Resolves #428

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -29,7 +29,7 @@
         SOKOL_ABORT()       - called after an unrecoverable error (default: abort())
         SOKOL_WIN32_FORCE_MAIN  - define this on Win32 to use a main() entry point instead of WinMain
         SOKOL_NO_ENTRY      - define this if sokol_app.h shouldn't "hijack" the main() function
-        SOKOL_API_DECL      - public function declaration prefix (default: extern)
+        SOKOL_APP_API_DECL  - public function declaration prefix (default: extern)
         SOKOL_API_IMPL      - public function implementation prefix (default: -)
         SOKOL_CALLOC        - your own calloc function (default: calloc(n, s))
         SOKOL_FREE          - your own free function (default: free(p))
@@ -44,7 +44,7 @@
 
         SOKOL_DLL
 
-    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    On Windows, SOKOL_DLL will define SOKOL_APP_API_DECL as __declspec(dllexport)
     or __declspec(dllimport) as needed.
 
     If you use sokol_app.h together with sokol_gfx.h, include both headers
@@ -859,13 +859,17 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifndef SOKOL_API_DECL
+#if defined(SOKOL_API_DECL) && !defined(SOKOL_APP_API_DECL)
+    #define SOKOL_APP_API_DECL SOKOL_API_DECL
+#endif
+
+#ifndef SOKOL_APP_API_DECL
 #if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
-#define SOKOL_API_DECL __declspec(dllexport)
+#define SOKOL_APP_API_DECL __declspec(dllexport)
 #elif defined(_WIN32) && defined(SOKOL_DLL)
-#define SOKOL_API_DECL __declspec(dllimport)
+#define SOKOL_APP_API_DECL __declspec(dllimport)
 #else
-#define SOKOL_API_DECL extern
+#define SOKOL_APP_API_DECL extern
 #endif
 #endif
 
@@ -1146,108 +1150,108 @@ typedef struct sapp_html5_fetch_request {
 extern sapp_desc sokol_main(int argc, char* argv[]);
 
 /* returns true after sokol-app has been initialized */
-SOKOL_API_DECL bool sapp_isvalid(void);
+SOKOL_APP_API_DECL bool sapp_isvalid(void);
 /* returns the current framebuffer width in pixels */
-SOKOL_API_DECL int sapp_width(void);
+SOKOL_APP_API_DECL int sapp_width(void);
 /* returns the current framebuffer height in pixels */
-SOKOL_API_DECL int sapp_height(void);
+SOKOL_APP_API_DECL int sapp_height(void);
 /* get default framebuffer color pixel format */
-SOKOL_API_DECL int sapp_color_format(void);
+SOKOL_APP_API_DECL int sapp_color_format(void);
 /* get default framebuffer depth pixel format */
-SOKOL_API_DECL int sapp_depth_format(void);
+SOKOL_APP_API_DECL int sapp_depth_format(void);
 /* get default framebuffer sample count */
-SOKOL_API_DECL int sapp_sample_count(void);
+SOKOL_APP_API_DECL int sapp_sample_count(void);
 /* returns true when high_dpi was requested and actually running in a high-dpi scenario */
-SOKOL_API_DECL bool sapp_high_dpi(void);
+SOKOL_APP_API_DECL bool sapp_high_dpi(void);
 /* returns the dpi scaling factor (window pixels to framebuffer pixels) */
-SOKOL_API_DECL float sapp_dpi_scale(void);
+SOKOL_APP_API_DECL float sapp_dpi_scale(void);
 /* show or hide the mobile device onscreen keyboard */
-SOKOL_API_DECL void sapp_show_keyboard(bool show);
+SOKOL_APP_API_DECL void sapp_show_keyboard(bool show);
 /* return true if the mobile device onscreen keyboard is currently shown */
-SOKOL_API_DECL bool sapp_keyboard_shown(void);
+SOKOL_APP_API_DECL bool sapp_keyboard_shown(void);
 /* query fullscreen mode */
-SOKOL_API_DECL bool sapp_is_fullscreen(void);
+SOKOL_APP_API_DECL bool sapp_is_fullscreen(void);
 /* toggle fullscreen mode */
-SOKOL_API_DECL void sapp_toggle_fullscreen(void);
+SOKOL_APP_API_DECL void sapp_toggle_fullscreen(void);
 /* show or hide the mouse cursor */
-SOKOL_API_DECL void sapp_show_mouse(bool show);
+SOKOL_APP_API_DECL void sapp_show_mouse(bool show);
 /* show or hide the mouse cursor */
-SOKOL_API_DECL bool sapp_mouse_shown();
+SOKOL_APP_API_DECL bool sapp_mouse_shown();
 /* enable/disable mouse-pointer-lock mode */
-SOKOL_API_DECL void sapp_lock_mouse(bool lock);
+SOKOL_APP_API_DECL void sapp_lock_mouse(bool lock);
 /* return true if in mouse-pointer-lock mode (this may toggle a few frames later) */
-SOKOL_API_DECL bool sapp_mouse_locked(void);
+SOKOL_APP_API_DECL bool sapp_mouse_locked(void);
 /* return the userdata pointer optionally provided in sapp_desc */
-SOKOL_API_DECL void* sapp_userdata(void);
+SOKOL_APP_API_DECL void* sapp_userdata(void);
 /* return a copy of the sapp_desc structure */
-SOKOL_API_DECL sapp_desc sapp_query_desc(void);
+SOKOL_APP_API_DECL sapp_desc sapp_query_desc(void);
 /* initiate a "soft quit" (sends SAPP_EVENTTYPE_QUIT_REQUESTED) */
-SOKOL_API_DECL void sapp_request_quit(void);
+SOKOL_APP_API_DECL void sapp_request_quit(void);
 /* cancel a pending quit (when SAPP_EVENTTYPE_QUIT_REQUESTED has been received) */
-SOKOL_API_DECL void sapp_cancel_quit(void);
+SOKOL_APP_API_DECL void sapp_cancel_quit(void);
 /* initiate a "hard quit" (quit application without sending SAPP_EVENTTYPE_QUIT_REQUSTED) */
-SOKOL_API_DECL void sapp_quit(void);
+SOKOL_APP_API_DECL void sapp_quit(void);
 /* call from inside event callback to consume the current event (don't forward to platform) */
-SOKOL_API_DECL void sapp_consume_event(void);
+SOKOL_APP_API_DECL void sapp_consume_event(void);
 /* get the current frame counter (for comparison with sapp_event.frame_count) */
-SOKOL_API_DECL uint64_t sapp_frame_count(void);
+SOKOL_APP_API_DECL uint64_t sapp_frame_count(void);
 /* write string into clipboard */
-SOKOL_API_DECL void sapp_set_clipboard_string(const char* str);
+SOKOL_APP_API_DECL void sapp_set_clipboard_string(const char* str);
 /* read string from clipboard (usually during SAPP_EVENTTYPE_CLIPBOARD_PASTED) */
-SOKOL_API_DECL const char* sapp_get_clipboard_string(void);
+SOKOL_APP_API_DECL const char* sapp_get_clipboard_string(void);
 /* set the window title (only on desktop platforms) */
-SOKOL_API_DECL void sapp_set_window_title(const char* str);
+SOKOL_APP_API_DECL void sapp_set_window_title(const char* str);
 /* gets the total number of dropped files (after an SAPP_EVENTTYPE_FILES_DROPPED event) */
-SOKOL_API_DECL int sapp_get_num_dropped_files(void);
+SOKOL_APP_API_DECL int sapp_get_num_dropped_files(void);
 /* gets the dropped file paths */
-SOKOL_API_DECL const char* sapp_get_dropped_file_path(int index);
+SOKOL_APP_API_DECL const char* sapp_get_dropped_file_path(int index);
 
 /* special run-function for SOKOL_NO_ENTRY (in standard mode this is an empty stub) */
-SOKOL_API_DECL int sapp_run(const sapp_desc* desc);
+SOKOL_APP_API_DECL int sapp_run(const sapp_desc* desc);
 
 /* GL: return true when GLES2 fallback is active (to detect fallback from GLES3) */
-SOKOL_API_DECL bool sapp_gles2(void);
+SOKOL_APP_API_DECL bool sapp_gles2(void);
 
 /* HTML5: enable or disable the hardwired "Leave Site?" dialog box */
-SOKOL_API_DECL void sapp_html5_ask_leave_site(bool ask);
+SOKOL_APP_API_DECL void sapp_html5_ask_leave_site(bool ask);
 /* HTML5: get byte size of a dropped file */
-SOKOL_API_DECL uint32_t sapp_html5_get_dropped_file_size(int index);
+SOKOL_APP_API_DECL uint32_t sapp_html5_get_dropped_file_size(int index);
 /* HTML5: asynchronously load the content of a dropped file */
-SOKOL_API_DECL void sapp_html5_fetch_dropped_file(const sapp_html5_fetch_request* request);
+SOKOL_APP_API_DECL void sapp_html5_fetch_dropped_file(const sapp_html5_fetch_request* request);
 
 /* Metal: get bridged pointer to Metal device object */
-SOKOL_API_DECL const void* sapp_metal_get_device(void);
+SOKOL_APP_API_DECL const void* sapp_metal_get_device(void);
 /* Metal: get bridged pointer to this frame's renderpass descriptor */
-SOKOL_API_DECL const void* sapp_metal_get_renderpass_descriptor(void);
+SOKOL_APP_API_DECL const void* sapp_metal_get_renderpass_descriptor(void);
 /* Metal: get bridged pointer to current drawable */
-SOKOL_API_DECL const void* sapp_metal_get_drawable(void);
+SOKOL_APP_API_DECL const void* sapp_metal_get_drawable(void);
 /* macOS: get bridged pointer to macOS NSWindow */
-SOKOL_API_DECL const void* sapp_macos_get_window(void);
+SOKOL_APP_API_DECL const void* sapp_macos_get_window(void);
 /* iOS: get bridged pointer to iOS UIWindow */
-SOKOL_API_DECL const void* sapp_ios_get_window(void);
+SOKOL_APP_API_DECL const void* sapp_ios_get_window(void);
 
 /* D3D11: get pointer to ID3D11Device object */
-SOKOL_API_DECL const void* sapp_d3d11_get_device(void);
+SOKOL_APP_API_DECL const void* sapp_d3d11_get_device(void);
 /* D3D11: get pointer to ID3D11DeviceContext object */
-SOKOL_API_DECL const void* sapp_d3d11_get_device_context(void);
+SOKOL_APP_API_DECL const void* sapp_d3d11_get_device_context(void);
 /* D3D11: get pointer to ID3D11RenderTargetView object */
-SOKOL_API_DECL const void* sapp_d3d11_get_render_target_view(void);
+SOKOL_APP_API_DECL const void* sapp_d3d11_get_render_target_view(void);
 /* D3D11: get pointer to ID3D11DepthStencilView */
-SOKOL_API_DECL const void* sapp_d3d11_get_depth_stencil_view(void);
+SOKOL_APP_API_DECL const void* sapp_d3d11_get_depth_stencil_view(void);
 /* Win32: get the HWND window handle */
-SOKOL_API_DECL const void* sapp_win32_get_hwnd(void);
+SOKOL_APP_API_DECL const void* sapp_win32_get_hwnd(void);
 
 /* WebGPU: get WGPUDevice handle */
-SOKOL_API_DECL const void* sapp_wgpu_get_device(void);
+SOKOL_APP_API_DECL const void* sapp_wgpu_get_device(void);
 /* WebGPU: get swapchain's WGPUTextureView handle for rendering */
-SOKOL_API_DECL const void* sapp_wgpu_get_render_view(void);
+SOKOL_APP_API_DECL const void* sapp_wgpu_get_render_view(void);
 /* WebGPU: get swapchain's MSAA-resolve WGPUTextureView (may return null) */
-SOKOL_API_DECL const void* sapp_wgpu_get_resolve_view(void);
+SOKOL_APP_API_DECL const void* sapp_wgpu_get_resolve_view(void);
 /* WebGPU: get swapchain's WGPUTextureView for the depth-stencil surface */
-SOKOL_API_DECL const void* sapp_wgpu_get_depth_stencil_view(void);
+SOKOL_APP_API_DECL const void* sapp_wgpu_get_depth_stencil_view(void);
 
 /* Android: get native activity handle */
-SOKOL_API_DECL const void* sapp_android_get_native_activity(void);
+SOKOL_APP_API_DECL const void* sapp_android_get_native_activity(void);
 
 #ifdef __cplusplus
 } /* extern "C" */
@@ -10207,11 +10211,11 @@ SOKOL_API_IMPL bool sapp_keyboard_shown(void) {
     return _sapp.onscreen_keyboard_shown;
 }
 
-SOKOL_API_DECL bool sapp_is_fullscreen(void) {
+SOKOL_APP_API_DECL bool sapp_is_fullscreen(void) {
     return _sapp.fullscreen;
 }
 
-SOKOL_API_DECL void sapp_toggle_fullscreen(void) {
+SOKOL_APP_API_DECL void sapp_toggle_fullscreen(void) {
     #if defined(_SAPP_MACOS)
     _sapp_macos_toggle_fullscreen();
     #elif defined(_SAPP_WIN32)

--- a/sokol_args.h
+++ b/sokol_args.h
@@ -15,7 +15,7 @@
     SOKOL_LOG(msg)      - your own logging functions (default: puts(msg))
     SOKOL_CALLOC(n,s)   - your own calloc() implementation (default: calloc(n,s))
     SOKOL_FREE(p)       - your own free() implementation (default: free(p))
-    SOKOL_API_DECL      - public function declaration prefix (default: extern)
+    SOKOL_ARGS_API_DECL - public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
 
     If sokol_args.h is compiled as a DLL, define the following before
@@ -23,7 +23,7 @@
 
     SOKOL_DLL
 
-    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    On Windows, SOKOL_DLL will define SOKOL_ARGS_API_DECL as __declspec(dllexport)
     or __declspec(dllimport) as needed.
 
     OVERVIEW
@@ -247,13 +247,17 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifndef SOKOL_API_DECL
+#if defined(SOKOL_API_DECL) && !defined(SOKOL_ARGS_API_DECL)
+    #define SOKOL_ARGS_API_DECL SOKOL_API_DECL
+#endif
+
+#ifndef SOKOL_ARGS_API_DECL
 #if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
-#define SOKOL_API_DECL __declspec(dllexport)
+#define SOKOL_ARGS_API_DECL __declspec(dllexport)
 #elif defined(_WIN32) && defined(SOKOL_DLL)
-#define SOKOL_API_DECL __declspec(dllimport)
+#define SOKOL_ARGS_API_DECL __declspec(dllimport)
 #else
-#define SOKOL_API_DECL extern
+#define SOKOL_ARGS_API_DECL extern
 #endif
 #endif
 
@@ -269,29 +273,29 @@ typedef struct sargs_desc {
 } sargs_desc;
 
 /* setup sokol-args */
-SOKOL_API_DECL void sargs_setup(const sargs_desc* desc);
+SOKOL_ARGS_API_DECL void sargs_setup(const sargs_desc* desc);
 /* shutdown sokol-args */
-SOKOL_API_DECL void sargs_shutdown(void);
+SOKOL_ARGS_API_DECL void sargs_shutdown(void);
 /* true between sargs_setup() and sargs_shutdown() */
-SOKOL_API_DECL bool sargs_isvalid(void);
+SOKOL_ARGS_API_DECL bool sargs_isvalid(void);
 /* test if an argument exists by key name */
-SOKOL_API_DECL bool sargs_exists(const char* key);
+SOKOL_ARGS_API_DECL bool sargs_exists(const char* key);
 /* get value by key name, return empty string if key doesn't exist */
-SOKOL_API_DECL const char* sargs_value(const char* key);
+SOKOL_ARGS_API_DECL const char* sargs_value(const char* key);
 /* get value by key name, return provided default if key doesn't exist */
-SOKOL_API_DECL const char* sargs_value_def(const char* key, const char* def);
+SOKOL_ARGS_API_DECL const char* sargs_value_def(const char* key, const char* def);
 /* return true if val arg matches the value associated with key */
-SOKOL_API_DECL bool sargs_equals(const char* key, const char* val);
+SOKOL_ARGS_API_DECL bool sargs_equals(const char* key, const char* val);
 /* return true if key's value is "true", "yes" or "on" */
-SOKOL_API_DECL bool sargs_boolean(const char* key);
+SOKOL_ARGS_API_DECL bool sargs_boolean(const char* key);
 /* get index of arg by key name, return -1 if not exists */
-SOKOL_API_DECL int sargs_find(const char* key);
+SOKOL_ARGS_API_DECL int sargs_find(const char* key);
 /* get number of parsed arguments */
-SOKOL_API_DECL int sargs_num_args(void);
+SOKOL_ARGS_API_DECL int sargs_num_args(void);
 /* get key name of argument at index, or empty string */
-SOKOL_API_DECL const char* sargs_key_at(int index);
+SOKOL_ARGS_API_DECL const char* sargs_key_at(int index);
 /* get value string of argument at index, or empty string */
-SOKOL_API_DECL const char* sargs_value_at(int index);
+SOKOL_ARGS_API_DECL const char* sargs_value_at(int index);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -16,7 +16,7 @@
     SOKOL_LOG(msg)      - your own logging function (default: puts(msg))
     SOKOL_MALLOC(s)     - your own malloc() implementation (default: malloc(s))
     SOKOL_FREE(p)       - your own free() implementation (default: free(p))
-    SOKOL_API_DECL      - public function declaration prefix (default: extern)
+    SOKOL_AUDIO_API_DECL- public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
 
     SAUDIO_RING_MAX_SLOTS   - max number of slots in the push-audio ring buffer (default 1024)
@@ -26,7 +26,7 @@
 
     SOKOL_DLL
 
-    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    On Windows, SOKOL_DLL will define SOKOL_AUDIO_API_DECL as __declspec(dllexport)
     or __declspec(dllimport) as needed.
 
     FEATURE OVERVIEW
@@ -374,13 +374,17 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifndef SOKOL_API_DECL
+#if defined(SOKOL_API_DECL) && !defined(SOKOL_AUDIO_API_DECL)
+    #define SOKOL_AUDIO_API_DECL SOKOL_API_DECL
+#endif
+
+#ifndef SOKOL_AUDIO_API_DECL
 #if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
-#define SOKOL_API_DECL __declspec(dllexport)
+#define SOKOL_AUDIO_API_DECL __declspec(dllexport)
 #elif defined(_WIN32) && defined(SOKOL_DLL)
-#define SOKOL_API_DECL __declspec(dllimport)
+#define SOKOL_AUDIO_API_DECL __declspec(dllimport)
 #else
-#define SOKOL_API_DECL extern
+#define SOKOL_AUDIO_API_DECL extern
 #endif
 #endif
 
@@ -400,25 +404,25 @@ typedef struct saudio_desc {
 } saudio_desc;
 
 /* setup sokol-audio */
-SOKOL_API_DECL void saudio_setup(const saudio_desc* desc);
+SOKOL_AUDIO_API_DECL void saudio_setup(const saudio_desc* desc);
 /* shutdown sokol-audio */
-SOKOL_API_DECL void saudio_shutdown(void);
+SOKOL_AUDIO_API_DECL void saudio_shutdown(void);
 /* true after setup if audio backend was successfully initialized */
-SOKOL_API_DECL bool saudio_isvalid(void);
+SOKOL_AUDIO_API_DECL bool saudio_isvalid(void);
 /* return the saudio_desc.user_data pointer */
-SOKOL_API_DECL void* saudio_userdata(void);
+SOKOL_AUDIO_API_DECL void* saudio_userdata(void);
 /* return a copy of the original saudio_desc struct */
-SOKOL_API_DECL saudio_desc saudio_query_desc(void);
+SOKOL_AUDIO_API_DECL saudio_desc saudio_query_desc(void);
 /* actual sample rate */
-SOKOL_API_DECL int saudio_sample_rate(void);
+SOKOL_AUDIO_API_DECL int saudio_sample_rate(void);
 /* return actual backend buffer size in number of frames */
-SOKOL_API_DECL int saudio_buffer_frames(void);
+SOKOL_AUDIO_API_DECL int saudio_buffer_frames(void);
 /* actual number of channels */
-SOKOL_API_DECL int saudio_channels(void);
+SOKOL_AUDIO_API_DECL int saudio_channels(void);
 /* get current number of frames to fill packet queue */
-SOKOL_API_DECL int saudio_expect(void);
+SOKOL_AUDIO_API_DECL int saudio_expect(void);
 /* push sample frames from main thread, returns number of frames actually pushed */
-SOKOL_API_DECL int saudio_push(const float* frames, int num_frames);
+SOKOL_AUDIO_API_DECL int saudio_push(const float* frames, int num_frames);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sokol_fetch.h
+++ b/sokol_fetch.h
@@ -16,7 +16,7 @@
     SOKOL_FREE(p)               - your own free function (default: free(p))
     SOKOL_LOG(msg)              - your own logging function (default: puts(msg))
     SOKOL_UNREACHABLE()         - a guard macro for unreachable code (default: assert(false))
-    SOKOL_API_DECL              - public function declaration prefix (default: extern)
+    SOKOL_FETCH_API_DECL        - public function declaration prefix (default: extern)
     SOKOL_API_IMPL              - public function implementation prefix (default: -)
     SFETCH_MAX_PATH             - max length of UTF-8 filesystem path / URL (default: 1024 bytes)
     SFETCH_MAX_USERDATA_UINT64  - max size of embedded userdata in number of uint64_t, userdata
@@ -29,7 +29,7 @@
 
     SOKOL_DLL
 
-    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    On Windows, SOKOL_DLL will define SOKOL_FETCH_API_DECL as __declspec(dllexport)
     or __declspec(dllimport) as needed.
 
     NOTE: The following documentation talks a lot about "IO threads". Actual
@@ -829,13 +829,17 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifndef SOKOL_API_DECL
+#if defined(SOKOL_API_DECL) && !defined(SOKOL_FETCH_API_DECL)
+    #define SOKOL_FETCH_API_DECL SOKOL_API_DECL
+#endif
+
+#ifndef SOKOL_FETCH_API_DECL
 #if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
-#define SOKOL_API_DECL __declspec(dllexport)
+#define SOKOL_FETCH_API_DECL __declspec(dllexport)
 #elif defined(_WIN32) && defined(SOKOL_DLL)
-#define SOKOL_API_DECL __declspec(dllimport)
+#define SOKOL_FETCH_API_DECL __declspec(dllimport)
 #else
-#define SOKOL_API_DECL extern
+#define SOKOL_FETCH_API_DECL extern
 #endif
 #endif
 
@@ -904,35 +908,35 @@ typedef struct sfetch_request_t {
 } sfetch_request_t;
 
 /* setup sokol-fetch (can be called on multiple threads) */
-SOKOL_API_DECL void sfetch_setup(const sfetch_desc_t* desc);
+SOKOL_FETCH_API_DECL void sfetch_setup(const sfetch_desc_t* desc);
 /* discard a sokol-fetch context */
-SOKOL_API_DECL void sfetch_shutdown(void);
+SOKOL_FETCH_API_DECL void sfetch_shutdown(void);
 /* return true if sokol-fetch has been setup */
-SOKOL_API_DECL bool sfetch_valid(void);
+SOKOL_FETCH_API_DECL bool sfetch_valid(void);
 /* get the desc struct that was passed to sfetch_setup() */
-SOKOL_API_DECL sfetch_desc_t sfetch_desc(void);
+SOKOL_FETCH_API_DECL sfetch_desc_t sfetch_desc(void);
 /* return the max userdata size in number of bytes (SFETCH_MAX_USERDATA_UINT64 * sizeof(uint64_t)) */
-SOKOL_API_DECL int sfetch_max_userdata_bytes(void);
+SOKOL_FETCH_API_DECL int sfetch_max_userdata_bytes(void);
 /* return the value of the SFETCH_MAX_PATH implementation config value */
-SOKOL_API_DECL int sfetch_max_path(void);
+SOKOL_FETCH_API_DECL int sfetch_max_path(void);
 
 /* send a fetch-request, get handle to request back */
-SOKOL_API_DECL sfetch_handle_t sfetch_send(const sfetch_request_t* request);
+SOKOL_FETCH_API_DECL sfetch_handle_t sfetch_send(const sfetch_request_t* request);
 /* return true if a handle is valid *and* the request is alive */
-SOKOL_API_DECL bool sfetch_handle_valid(sfetch_handle_t h);
+SOKOL_FETCH_API_DECL bool sfetch_handle_valid(sfetch_handle_t h);
 /* do per-frame work, moves requests into and out of IO threads, and invokes response-callbacks */
-SOKOL_API_DECL void sfetch_dowork(void);
+SOKOL_FETCH_API_DECL void sfetch_dowork(void);
 
 /* bind a data buffer to a request (request must not currently have a buffer bound, must be called from response callback */
-SOKOL_API_DECL void sfetch_bind_buffer(sfetch_handle_t h, void* buffer_ptr, uint32_t buffer_size);
+SOKOL_FETCH_API_DECL void sfetch_bind_buffer(sfetch_handle_t h, void* buffer_ptr, uint32_t buffer_size);
 /* clear the 'buffer binding' of a request, returns previous buffer pointer (can be 0), must be called from response callback */
-SOKOL_API_DECL void* sfetch_unbind_buffer(sfetch_handle_t h);
+SOKOL_FETCH_API_DECL void* sfetch_unbind_buffer(sfetch_handle_t h);
 /* cancel a request that's in flight (will call response callback with .cancelled + .finished) */
-SOKOL_API_DECL void sfetch_cancel(sfetch_handle_t h);
+SOKOL_FETCH_API_DECL void sfetch_cancel(sfetch_handle_t h);
 /* pause a request (will call response callback each frame with .paused) */
-SOKOL_API_DECL void sfetch_pause(sfetch_handle_t h);
+SOKOL_FETCH_API_DECL void sfetch_pause(sfetch_handle_t h);
 /* continue a paused request */
-SOKOL_API_DECL void sfetch_continue(sfetch_handle_t h);
+SOKOL_FETCH_API_DECL void sfetch_continue(sfetch_handle_t h);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -38,7 +38,7 @@
     SOKOL_FREE(p)       - your own free function (default: free(p))
     SOKOL_LOG(msg)      - your own logging function (default: puts(msg))
     SOKOL_UNREACHABLE() - a guard macro for unreachable code (default: assert(false))
-    SOKOL_API_DECL      - public function declaration prefix (default: extern)
+    SOKOL_GFX_API_DECL  - public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
     SOKOL_TRACE_HOOKS   - enable trace hook callbacks (search below for TRACE HOOKS)
 
@@ -47,7 +47,7 @@
 
     SOKOL_DLL
 
-    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    On Windows, SOKOL_DLL will define SOKOL_GFX_API_DECL as __declspec(dllexport)
     or __declspec(dllimport) as needed.
 
     If you want to compile without deprecated structs and functions,
@@ -573,13 +573,17 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifndef SOKOL_API_DECL
+#if defined(SOKOL_API_DECL) && !defined(SOKOL_GFX_API_DECL)
+    #define SOKOL_GFX_API_DECL SOKOL_API_DECL
+#endif
+
+#ifndef SOKOL_GFX_API_DECL
 #if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
-#define SOKOL_API_DECL __declspec(dllexport)
+#define SOKOL_GFX_API_DECL __declspec(dllexport)
 #elif defined(_WIN32) && defined(SOKOL_DLL)
-#define SOKOL_API_DECL __declspec(dllimport)
+#define SOKOL_GFX_API_DECL __declspec(dllimport)
 #else
-#define SOKOL_API_DECL extern
+#define SOKOL_GFX_API_DECL extern
 #endif
 #endif
 
@@ -2205,88 +2209,88 @@ typedef struct sg_desc {
 } sg_desc;
 
 /* setup and misc functions */
-SOKOL_API_DECL void sg_setup(const sg_desc* desc);
-SOKOL_API_DECL void sg_shutdown(void);
-SOKOL_API_DECL bool sg_isvalid(void);
-SOKOL_API_DECL void sg_reset_state_cache(void);
-SOKOL_API_DECL sg_trace_hooks sg_install_trace_hooks(const sg_trace_hooks* trace_hooks);
-SOKOL_API_DECL void sg_push_debug_group(const char* name);
-SOKOL_API_DECL void sg_pop_debug_group(void);
+SOKOL_GFX_API_DECL void sg_setup(const sg_desc* desc);
+SOKOL_GFX_API_DECL void sg_shutdown(void);
+SOKOL_GFX_API_DECL bool sg_isvalid(void);
+SOKOL_GFX_API_DECL void sg_reset_state_cache(void);
+SOKOL_GFX_API_DECL sg_trace_hooks sg_install_trace_hooks(const sg_trace_hooks* trace_hooks);
+SOKOL_GFX_API_DECL void sg_push_debug_group(const char* name);
+SOKOL_GFX_API_DECL void sg_pop_debug_group(void);
 
 /* resource creation, destruction and updating */
-SOKOL_API_DECL sg_buffer sg_make_buffer(const sg_buffer_desc* desc);
-SOKOL_API_DECL sg_image sg_make_image(const sg_image_desc* desc);
-SOKOL_API_DECL sg_shader sg_make_shader(const sg_shader_desc* desc);
-SOKOL_API_DECL sg_pipeline sg_make_pipeline(const sg_pipeline_desc* desc);
-SOKOL_API_DECL sg_pass sg_make_pass(const sg_pass_desc* desc);
-SOKOL_API_DECL void sg_destroy_buffer(sg_buffer buf);
-SOKOL_API_DECL void sg_destroy_image(sg_image img);
-SOKOL_API_DECL void sg_destroy_shader(sg_shader shd);
-SOKOL_API_DECL void sg_destroy_pipeline(sg_pipeline pip);
-SOKOL_API_DECL void sg_destroy_pass(sg_pass pass);
-SOKOL_API_DECL void sg_update_buffer(sg_buffer buf, const void* data_ptr, int data_size);
-SOKOL_API_DECL void sg_update_image(sg_image img, const sg_image_content* data);
-SOKOL_API_DECL int sg_append_buffer(sg_buffer buf, const void* data_ptr, int data_size);
-SOKOL_API_DECL bool sg_query_buffer_overflow(sg_buffer buf);
+SOKOL_GFX_API_DECL sg_buffer sg_make_buffer(const sg_buffer_desc* desc);
+SOKOL_GFX_API_DECL sg_image sg_make_image(const sg_image_desc* desc);
+SOKOL_GFX_API_DECL sg_shader sg_make_shader(const sg_shader_desc* desc);
+SOKOL_GFX_API_DECL sg_pipeline sg_make_pipeline(const sg_pipeline_desc* desc);
+SOKOL_GFX_API_DECL sg_pass sg_make_pass(const sg_pass_desc* desc);
+SOKOL_GFX_API_DECL void sg_destroy_buffer(sg_buffer buf);
+SOKOL_GFX_API_DECL void sg_destroy_image(sg_image img);
+SOKOL_GFX_API_DECL void sg_destroy_shader(sg_shader shd);
+SOKOL_GFX_API_DECL void sg_destroy_pipeline(sg_pipeline pip);
+SOKOL_GFX_API_DECL void sg_destroy_pass(sg_pass pass);
+SOKOL_GFX_API_DECL void sg_update_buffer(sg_buffer buf, const void* data_ptr, int data_size);
+SOKOL_GFX_API_DECL void sg_update_image(sg_image img, const sg_image_content* data);
+SOKOL_GFX_API_DECL int sg_append_buffer(sg_buffer buf, const void* data_ptr, int data_size);
+SOKOL_GFX_API_DECL bool sg_query_buffer_overflow(sg_buffer buf);
 
 /* rendering functions */
-SOKOL_API_DECL void sg_begin_default_pass(const sg_pass_action* pass_action, int width, int height);
-SOKOL_API_DECL void sg_begin_pass(sg_pass pass, const sg_pass_action* pass_action);
-SOKOL_API_DECL void sg_apply_viewport(int x, int y, int width, int height, bool origin_top_left);
-SOKOL_API_DECL void sg_apply_scissor_rect(int x, int y, int width, int height, bool origin_top_left);
-SOKOL_API_DECL void sg_apply_pipeline(sg_pipeline pip);
-SOKOL_API_DECL void sg_apply_bindings(const sg_bindings* bindings);
-SOKOL_API_DECL void sg_apply_uniforms(sg_shader_stage stage, int ub_index, const void* data, int num_bytes);
-SOKOL_API_DECL void sg_draw(int base_element, int num_elements, int num_instances);
-SOKOL_API_DECL void sg_end_pass(void);
-SOKOL_API_DECL void sg_commit(void);
+SOKOL_GFX_API_DECL void sg_begin_default_pass(const sg_pass_action* pass_action, int width, int height);
+SOKOL_GFX_API_DECL void sg_begin_pass(sg_pass pass, const sg_pass_action* pass_action);
+SOKOL_GFX_API_DECL void sg_apply_viewport(int x, int y, int width, int height, bool origin_top_left);
+SOKOL_GFX_API_DECL void sg_apply_scissor_rect(int x, int y, int width, int height, bool origin_top_left);
+SOKOL_GFX_API_DECL void sg_apply_pipeline(sg_pipeline pip);
+SOKOL_GFX_API_DECL void sg_apply_bindings(const sg_bindings* bindings);
+SOKOL_GFX_API_DECL void sg_apply_uniforms(sg_shader_stage stage, int ub_index, const void* data, int num_bytes);
+SOKOL_GFX_API_DECL void sg_draw(int base_element, int num_elements, int num_instances);
+SOKOL_GFX_API_DECL void sg_end_pass(void);
+SOKOL_GFX_API_DECL void sg_commit(void);
 
 /* getting information */
-SOKOL_API_DECL sg_desc sg_query_desc(void);
-SOKOL_API_DECL sg_backend sg_query_backend(void);
-SOKOL_API_DECL sg_features sg_query_features(void);
-SOKOL_API_DECL sg_limits sg_query_limits(void);
-SOKOL_API_DECL sg_pixelformat_info sg_query_pixelformat(sg_pixel_format fmt);
+SOKOL_GFX_API_DECL sg_desc sg_query_desc(void);
+SOKOL_GFX_API_DECL sg_backend sg_query_backend(void);
+SOKOL_GFX_API_DECL sg_features sg_query_features(void);
+SOKOL_GFX_API_DECL sg_limits sg_query_limits(void);
+SOKOL_GFX_API_DECL sg_pixelformat_info sg_query_pixelformat(sg_pixel_format fmt);
 /* get current state of a resource (INITIAL, ALLOC, VALID, FAILED, INVALID) */
-SOKOL_API_DECL sg_resource_state sg_query_buffer_state(sg_buffer buf);
-SOKOL_API_DECL sg_resource_state sg_query_image_state(sg_image img);
-SOKOL_API_DECL sg_resource_state sg_query_shader_state(sg_shader shd);
-SOKOL_API_DECL sg_resource_state sg_query_pipeline_state(sg_pipeline pip);
-SOKOL_API_DECL sg_resource_state sg_query_pass_state(sg_pass pass);
+SOKOL_GFX_API_DECL sg_resource_state sg_query_buffer_state(sg_buffer buf);
+SOKOL_GFX_API_DECL sg_resource_state sg_query_image_state(sg_image img);
+SOKOL_GFX_API_DECL sg_resource_state sg_query_shader_state(sg_shader shd);
+SOKOL_GFX_API_DECL sg_resource_state sg_query_pipeline_state(sg_pipeline pip);
+SOKOL_GFX_API_DECL sg_resource_state sg_query_pass_state(sg_pass pass);
 /* get runtime information about a resource */
-SOKOL_API_DECL sg_buffer_info sg_query_buffer_info(sg_buffer buf);
-SOKOL_API_DECL sg_image_info sg_query_image_info(sg_image img);
-SOKOL_API_DECL sg_shader_info sg_query_shader_info(sg_shader shd);
-SOKOL_API_DECL sg_pipeline_info sg_query_pipeline_info(sg_pipeline pip);
-SOKOL_API_DECL sg_pass_info sg_query_pass_info(sg_pass pass);
+SOKOL_GFX_API_DECL sg_buffer_info sg_query_buffer_info(sg_buffer buf);
+SOKOL_GFX_API_DECL sg_image_info sg_query_image_info(sg_image img);
+SOKOL_GFX_API_DECL sg_shader_info sg_query_shader_info(sg_shader shd);
+SOKOL_GFX_API_DECL sg_pipeline_info sg_query_pipeline_info(sg_pipeline pip);
+SOKOL_GFX_API_DECL sg_pass_info sg_query_pass_info(sg_pass pass);
 /* get resource creation desc struct with their default values replaced */
-SOKOL_API_DECL sg_buffer_desc sg_query_buffer_defaults(const sg_buffer_desc* desc);
-SOKOL_API_DECL sg_image_desc sg_query_image_defaults(const sg_image_desc* desc);
-SOKOL_API_DECL sg_shader_desc sg_query_shader_defaults(const sg_shader_desc* desc);
-SOKOL_API_DECL sg_pipeline_desc sg_query_pipeline_defaults(const sg_pipeline_desc* desc);
-SOKOL_API_DECL sg_pass_desc sg_query_pass_defaults(const sg_pass_desc* desc);
+SOKOL_GFX_API_DECL sg_buffer_desc sg_query_buffer_defaults(const sg_buffer_desc* desc);
+SOKOL_GFX_API_DECL sg_image_desc sg_query_image_defaults(const sg_image_desc* desc);
+SOKOL_GFX_API_DECL sg_shader_desc sg_query_shader_defaults(const sg_shader_desc* desc);
+SOKOL_GFX_API_DECL sg_pipeline_desc sg_query_pipeline_defaults(const sg_pipeline_desc* desc);
+SOKOL_GFX_API_DECL sg_pass_desc sg_query_pass_defaults(const sg_pass_desc* desc);
 
 /* separate resource allocation and initialization (for async setup) */
-SOKOL_API_DECL sg_buffer sg_alloc_buffer(void);
-SOKOL_API_DECL sg_image sg_alloc_image(void);
-SOKOL_API_DECL sg_shader sg_alloc_shader(void);
-SOKOL_API_DECL sg_pipeline sg_alloc_pipeline(void);
-SOKOL_API_DECL sg_pass sg_alloc_pass(void);
-SOKOL_API_DECL void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc);
-SOKOL_API_DECL void sg_init_image(sg_image img_id, const sg_image_desc* desc);
-SOKOL_API_DECL void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc);
-SOKOL_API_DECL void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc);
-SOKOL_API_DECL void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc);
-SOKOL_API_DECL void sg_fail_buffer(sg_buffer buf_id);
-SOKOL_API_DECL void sg_fail_image(sg_image img_id);
-SOKOL_API_DECL void sg_fail_shader(sg_shader shd_id);
-SOKOL_API_DECL void sg_fail_pipeline(sg_pipeline pip_id);
-SOKOL_API_DECL void sg_fail_pass(sg_pass pass_id);
+SOKOL_GFX_API_DECL sg_buffer sg_alloc_buffer(void);
+SOKOL_GFX_API_DECL sg_image sg_alloc_image(void);
+SOKOL_GFX_API_DECL sg_shader sg_alloc_shader(void);
+SOKOL_GFX_API_DECL sg_pipeline sg_alloc_pipeline(void);
+SOKOL_GFX_API_DECL sg_pass sg_alloc_pass(void);
+SOKOL_GFX_API_DECL void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc);
+SOKOL_GFX_API_DECL void sg_init_image(sg_image img_id, const sg_image_desc* desc);
+SOKOL_GFX_API_DECL void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc);
+SOKOL_GFX_API_DECL void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc);
+SOKOL_GFX_API_DECL void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc);
+SOKOL_GFX_API_DECL void sg_fail_buffer(sg_buffer buf_id);
+SOKOL_GFX_API_DECL void sg_fail_image(sg_image img_id);
+SOKOL_GFX_API_DECL void sg_fail_shader(sg_shader shd_id);
+SOKOL_GFX_API_DECL void sg_fail_pipeline(sg_pipeline pip_id);
+SOKOL_GFX_API_DECL void sg_fail_pass(sg_pass pass_id);
 
 /* rendering contexts (optional) */
-SOKOL_API_DECL sg_context sg_setup_context(void);
-SOKOL_API_DECL void sg_activate_context(sg_context ctx_id);
-SOKOL_API_DECL void sg_discard_context(sg_context ctx_id);
+SOKOL_GFX_API_DECL sg_context sg_setup_context(void);
+SOKOL_GFX_API_DECL void sg_activate_context(sg_context ctx_id);
+SOKOL_GFX_API_DECL void sg_discard_context(sg_context ctx_id);
 
 /* Backend-specific helper functions, these may come in handy for mixing
    sokol-gfx rendering with 'native backend' rendering functions.
@@ -2295,13 +2299,13 @@ SOKOL_API_DECL void sg_discard_context(sg_context ctx_id);
 */
 
 /* D3D11: return ID3D11Device */
-SOKOL_API_DECL const void* sg_d3d11_device(void);
+SOKOL_GFX_API_DECL const void* sg_d3d11_device(void);
 
 /* Metal: return __bridge-casted MTLDevice */
-SOKOL_API_DECL const void* sg_mtl_device(void);
+SOKOL_GFX_API_DECL const void* sg_mtl_device(void);
 
 /* Metal: return __bridge-casted MTLRenderCommandEncoder in current pass (or zero if outside pass) */
-SOKOL_API_DECL const void* sg_mtl_render_command_encoder(void);
+SOKOL_GFX_API_DECL const void* sg_mtl_render_command_encoder(void);
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/sokol_glue.h
+++ b/sokol_glue.h
@@ -12,7 +12,7 @@
     ...optionally provide the following macros to override defaults:
 
     SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
-    SOKOL_API_DECL      - public function declaration prefix (default: extern)
+    SOKOL_GLUE_API_DECL - public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
 
     If sokol_glue.h is compiled as a DLL, define the following before
@@ -20,7 +20,7 @@
 
     SOKOL_DLL
 
-    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    On Windows, SOKOL_DLL will define SOKOL_GLUE_API_DECL as __declspec(dllexport)
     or __declspec(dllimport) as needed.
 
     OVERVIEW
@@ -71,13 +71,17 @@
 */
 #define SOKOL_GLUE_INCLUDED
 
-#ifndef SOKOL_API_DECL
+#if defined(SOKOL_API_DECL) && !defined(SOKOL_GLUE_API_DECL)
+    #define SOKOL_GLUE_API_DECL SOKOL_API_DECL
+#endif
+
+#ifndef SOKOL_GLUE_API_DECL
 #if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
-#define SOKOL_API_DECL __declspec(dllexport)
+#define SOKOL_GLUE_API_DECL __declspec(dllexport)
 #elif defined(_WIN32) && defined(SOKOL_DLL)
-#define SOKOL_API_DECL __declspec(dllimport)
+#define SOKOL_GLUE_API_DECL __declspec(dllimport)
 #else
-#define SOKOL_API_DECL extern
+#define SOKOL_GLUE_API_DECL extern
 #endif
 #endif
 
@@ -86,7 +90,7 @@ extern "C" {
 #endif
 
 #if defined(SOKOL_GFX_INCLUDED) && defined(SOKOL_APP_INCLUDED)
-SOKOL_API_DECL sg_context_desc sapp_sgcontext(void);
+SOKOL_GLUE_API_DECL sg_context_desc sapp_sgcontext(void);
 #endif
 
 #ifdef __cplusplus

--- a/sokol_time.h
+++ b/sokol_time.h
@@ -11,7 +11,7 @@
 
     Optionally provide the following defines with your own implementations:
     SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
-    SOKOL_API_DECL      - public function declaration prefix (default: extern)
+    SOKOL_TIME_API_DECL - public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
 
     If sokol_time.h is compiled as a DLL, define the following before
@@ -19,7 +19,7 @@
 
     SOKOL_DLL
 
-    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    On Windows, SOKOL_DLL will define SOKOL_TIME_API_DECL as __declspec(dllexport)
     or __declspec(dllimport) as needed.
 
     void stm_setup();
@@ -101,13 +101,17 @@
 #define SOKOL_TIME_INCLUDED (1)
 #include <stdint.h>
 
-#ifndef SOKOL_API_DECL
+#if defined(SOKOL_API_DECL) && !defined(SOKOL_TIME_API_DECL)
+    #define SOKOL_TIME_API_DECL SOKOL_API_DECL
+#endif
+
+#ifndef SOKOL_TIME_API_DECL
 #if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
-#define SOKOL_API_DECL __declspec(dllexport)
+#define SOKOL_TIME_API_DECL __declspec(dllexport)
 #elif defined(_WIN32) && defined(SOKOL_DLL)
-#define SOKOL_API_DECL __declspec(dllimport)
+#define SOKOL_TIME_API_DECL __declspec(dllimport)
 #else
-#define SOKOL_API_DECL extern
+#define SOKOL_TIME_API_DECL extern
 #endif
 #endif
 
@@ -115,16 +119,16 @@
 extern "C" {
 #endif
 
-SOKOL_API_DECL void stm_setup(void);
-SOKOL_API_DECL uint64_t stm_now(void);
-SOKOL_API_DECL uint64_t stm_diff(uint64_t new_ticks, uint64_t old_ticks);
-SOKOL_API_DECL uint64_t stm_since(uint64_t start_ticks);
-SOKOL_API_DECL uint64_t stm_laptime(uint64_t* last_time);
-SOKOL_API_DECL uint64_t stm_round_to_common_refresh_rate(uint64_t frame_ticks);
-SOKOL_API_DECL double stm_sec(uint64_t ticks);
-SOKOL_API_DECL double stm_ms(uint64_t ticks);
-SOKOL_API_DECL double stm_us(uint64_t ticks);
-SOKOL_API_DECL double stm_ns(uint64_t ticks);
+SOKOL_TIME_API_DECL void stm_setup(void);
+SOKOL_TIME_API_DECL uint64_t stm_now(void);
+SOKOL_TIME_API_DECL uint64_t stm_diff(uint64_t new_ticks, uint64_t old_ticks);
+SOKOL_TIME_API_DECL uint64_t stm_since(uint64_t start_ticks);
+SOKOL_TIME_API_DECL uint64_t stm_laptime(uint64_t* last_time);
+SOKOL_TIME_API_DECL uint64_t stm_round_to_common_refresh_rate(uint64_t frame_ticks);
+SOKOL_TIME_API_DECL double stm_sec(uint64_t ticks);
+SOKOL_TIME_API_DECL double stm_ms(uint64_t ticks);
+SOKOL_TIME_API_DECL double stm_us(uint64_t ticks);
+SOKOL_TIME_API_DECL double stm_ns(uint64_t ticks);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/util/sokol_debugtext.h
+++ b/util/sokol_debugtext.h
@@ -26,7 +26,7 @@
     SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
     SOKOL_MALLOC(s)     - your own malloc function (default: malloc(s))
     SOKOL_FREE(p)       - your own free function (default: free(p))
-    SOKOL_API_DECL      - public function declaration prefix (default: extern)
+    SOKOL_DEBUGTEXT_API_DECL      - public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
     SOKOL_LOG(msg)      - your own logging function (default: puts(msg))
     SOKOL_UNREACHABLE() - a guard macro for unreachable code (default: assert(false))
@@ -36,7 +36,7 @@
 
     SOKOL_DLL
 
-    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    On Windows, SOKOL_DLL will define SOKOL_DEBUGTEXT_API_DECL as __declspec(dllexport)
     or __declspec(dllimport) as needed.
 
     Include the following headers before including sokol_debugtext.h:
@@ -392,13 +392,17 @@
 #error "Please include sokol_gfx.h before sokol_debugtext.h"
 #endif
 
-#ifndef SOKOL_API_DECL
+#if defined(SOKOL_API_DECL) && !defined(SOKOL_DEBUGTEXT_API_DECL)
+    #define SOKOL_DEBUGTEXT_API_DECL SOKOL_API_DECL
+#endif
+
+#ifndef SOKOL_DEBUGTEXT_API_DECL
 #if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
-#define SOKOL_API_DECL __declspec(dllexport)
+#define SOKOL_DEBUGTEXT_API_DECL __declspec(dllexport)
 #elif defined(_WIN32) && defined(SOKOL_DLL)
-#define SOKOL_API_DECL __declspec(dllimport)
+#define SOKOL_DEBUGTEXT_API_DECL __declspec(dllimport)
 #else
-#define SOKOL_API_DECL extern
+#define SOKOL_DEBUGTEXT_API_DECL extern
 #endif
 #endif
 
@@ -490,58 +494,58 @@ typedef struct sdtx_desc_t {
 } sdtx_desc_t;
 
 /* initialization/shutdown */
-SOKOL_API_DECL void sdtx_setup(const sdtx_desc_t* desc);
-SOKOL_API_DECL void sdtx_shutdown(void);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_setup(const sdtx_desc_t* desc);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_shutdown(void);
 
 /* builtin font data (use to populate sdtx_desc.font[]) */
-SOKOL_API_DECL sdtx_font_desc_t sdtx_font_kc853(void);
-SOKOL_API_DECL sdtx_font_desc_t sdtx_font_kc854(void);
-SOKOL_API_DECL sdtx_font_desc_t sdtx_font_z1013(void);
-SOKOL_API_DECL sdtx_font_desc_t sdtx_font_cpc(void);
-SOKOL_API_DECL sdtx_font_desc_t sdtx_font_c64(void);
-SOKOL_API_DECL sdtx_font_desc_t sdtx_font_oric(void);
+SOKOL_DEBUGTEXT_API_DECL sdtx_font_desc_t sdtx_font_kc853(void);
+SOKOL_DEBUGTEXT_API_DECL sdtx_font_desc_t sdtx_font_kc854(void);
+SOKOL_DEBUGTEXT_API_DECL sdtx_font_desc_t sdtx_font_z1013(void);
+SOKOL_DEBUGTEXT_API_DECL sdtx_font_desc_t sdtx_font_cpc(void);
+SOKOL_DEBUGTEXT_API_DECL sdtx_font_desc_t sdtx_font_c64(void);
+SOKOL_DEBUGTEXT_API_DECL sdtx_font_desc_t sdtx_font_oric(void);
 
 /* context functions */
-SOKOL_API_DECL sdtx_context sdtx_make_context(const sdtx_context_desc_t* desc);
-SOKOL_API_DECL void sdtx_destroy_context(sdtx_context ctx);
-SOKOL_API_DECL void sdtx_set_context(sdtx_context ctx);
-SOKOL_API_DECL sdtx_context sdtx_get_context(void);
+SOKOL_DEBUGTEXT_API_DECL sdtx_context sdtx_make_context(const sdtx_context_desc_t* desc);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_destroy_context(sdtx_context ctx);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_set_context(sdtx_context ctx);
+SOKOL_DEBUGTEXT_API_DECL sdtx_context sdtx_get_context(void);
 
 /* draw and rewind the current context */
-SOKOL_API_DECL void sdtx_draw(void);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_draw(void);
 
 /* switch to a different font */
-SOKOL_API_DECL void sdtx_font(int font_index);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_font(int font_index);
 
 /* set a new virtual canvas size in screen pixels */
-SOKOL_API_DECL void sdtx_canvas(float w, float h);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_canvas(float w, float h);
 
 /* set a new origin in character grid coordinates */
-SOKOL_API_DECL void sdtx_origin(float x, float y);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_origin(float x, float y);
 
 /* cursor movement functions (relative to origin in character grid coordinates) */
-SOKOL_API_DECL void sdtx_home(void);
-SOKOL_API_DECL void sdtx_pos(float x, float y);
-SOKOL_API_DECL void sdtx_pos_x(float x);
-SOKOL_API_DECL void sdtx_pos_y(float y);
-SOKOL_API_DECL void sdtx_move(float dx, float dy);
-SOKOL_API_DECL void sdtx_move_x(float dx);
-SOKOL_API_DECL void sdtx_move_y(float dy);
-SOKOL_API_DECL void sdtx_crlf(void);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_home(void);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_pos(float x, float y);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_pos_x(float x);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_pos_y(float y);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_move(float dx, float dy);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_move_x(float dx);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_move_y(float dy);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_crlf(void);
 
 /* set the current text color */
-SOKOL_API_DECL void sdtx_color3b(uint8_t r, uint8_t g, uint8_t b);              // RGB 0..255, A=255
-SOKOL_API_DECL void sdtx_color3f(float r, float g, float b);                    // RGB 0.0f..1.0f, A=1.0f
-SOKOL_API_DECL void sdtx_color4b(uint8_t r, uint8_t g, uint8_t b, uint8_t a);   // RGBA 0..255
-SOKOL_API_DECL void sdtx_color4f(float r, float g, float b, float a);           // RGBA 0.0f..1.0f
-SOKOL_API_DECL void sdtx_color1i(uint32_t rgba);                                // ABGR 0xAABBGGRR
+SOKOL_DEBUGTEXT_API_DECL void sdtx_color3b(uint8_t r, uint8_t g, uint8_t b);              // RGB 0..255, A=255
+SOKOL_DEBUGTEXT_API_DECL void sdtx_color3f(float r, float g, float b);                    // RGB 0.0f..1.0f, A=1.0f
+SOKOL_DEBUGTEXT_API_DECL void sdtx_color4b(uint8_t r, uint8_t g, uint8_t b, uint8_t a);   // RGBA 0..255
+SOKOL_DEBUGTEXT_API_DECL void sdtx_color4f(float r, float g, float b, float a);           // RGBA 0.0f..1.0f
+SOKOL_DEBUGTEXT_API_DECL void sdtx_color1i(uint32_t rgba);                                // ABGR 0xAABBGGRR
 
 /* text rendering */
-SOKOL_API_DECL void sdtx_putc(char c);
-SOKOL_API_DECL void sdtx_puts(const char* str);             // does NOT append newline!
-SOKOL_API_DECL void sdtx_putr(const char* str, int len);    // 'put range', also stops at zero-char
-SOKOL_API_DECL int sdtx_printf(const char* fmt, ...) SOKOL_DEBUGTEXT_PRINTF_ATTR;
-SOKOL_API_DECL int sdtx_vprintf(const char* fmt, va_list args);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_putc(char c);
+SOKOL_DEBUGTEXT_API_DECL void sdtx_puts(const char* str);             // does NOT append newline!
+SOKOL_DEBUGTEXT_API_DECL void sdtx_putr(const char* str, int len);    // 'put range', also stops at zero-char
+SOKOL_DEBUGTEXT_API_DECL int sdtx_printf(const char* fmt, ...) SOKOL_DEBUGTEXT_PRINTF_ATTR;
+SOKOL_DEBUGTEXT_API_DECL int sdtx_vprintf(const char* fmt, va_list args);
 
 #ifdef __cplusplus
 } /* extern "C" */
@@ -4089,7 +4093,7 @@ SOKOL_API_IMPL void sdtx_color1i(uint32_t rgba) {
     }
 }
 
-SOKOL_API_DECL void sdtx_putc(char chr) {
+SOKOL_DEBUGTEXT_API_DECL void sdtx_putc(char chr) {
     SOKOL_ASSERT(_SDTX_INIT_COOKIE == _sdtx.init_cookie);
     _sdtx_context_t* ctx = _sdtx.cur_ctx;
     if (ctx) {
@@ -4097,7 +4101,7 @@ SOKOL_API_DECL void sdtx_putc(char chr) {
     }
 }
 
-SOKOL_API_DECL void sdtx_puts(const char* str) {
+SOKOL_DEBUGTEXT_API_DECL void sdtx_puts(const char* str) {
     SOKOL_ASSERT(_SDTX_INIT_COOKIE == _sdtx.init_cookie);
     _sdtx_context_t* ctx = _sdtx.cur_ctx;
     if (ctx) {
@@ -4108,7 +4112,7 @@ SOKOL_API_DECL void sdtx_puts(const char* str) {
     }
 }
 
-SOKOL_API_DECL void sdtx_putr(const char* str, int len) {
+SOKOL_DEBUGTEXT_API_DECL void sdtx_putr(const char* str, int len) {
     SOKOL_ASSERT(_SDTX_INIT_COOKIE == _sdtx.init_cookie);
     _sdtx_context_t* ctx = _sdtx.cur_ctx;
     if (ctx) {
@@ -4122,7 +4126,7 @@ SOKOL_API_DECL void sdtx_putr(const char* str, int len) {
     }
 }
 
-SOKOL_API_DECL int sdtx_vprintf(const char* fmt, va_list args) {
+SOKOL_DEBUGTEXT_API_DECL int sdtx_vprintf(const char* fmt, va_list args) {
     SOKOL_ASSERT(_SDTX_INIT_COOKIE == _sdtx.init_cookie);
     SOKOL_ASSERT(_sdtx.fmt_buf && (_sdtx.fmt_buf_size >= 2));
     int res = SOKOL_VSNPRINTF(_sdtx.fmt_buf, _sdtx.fmt_buf_size, fmt, args);
@@ -4132,7 +4136,7 @@ SOKOL_API_DECL int sdtx_vprintf(const char* fmt, va_list args) {
     return res;
 }
 
-SOKOL_API_DECL int sdtx_printf(const char* fmt, ...) {
+SOKOL_DEBUGTEXT_API_DECL int sdtx_printf(const char* fmt, ...) {
     SOKOL_ASSERT(_SDTX_INIT_COOKIE == _sdtx.init_cookie);
     SOKOL_ASSERT(_sdtx.fmt_buf && (_sdtx.fmt_buf_size >= 2));
     va_list args;

--- a/util/sokol_fontstash.h
+++ b/util/sokol_fontstash.h
@@ -27,7 +27,7 @@
     SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
     SOKOL_MALLOC(s)     - your own malloc function (default: malloc(s))
     SOKOL_FREE(p)       - your own free function (default: free(p))
-    SOKOL_API_DECL      - public function declaration prefix (default: extern)
+    SOKOL_FONTSTASH_API_DECL      - public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
     SOKOL_LOG(msg)      - your own logging function (default: puts(msg))
     SOKOL_UNREACHABLE() - a guard macro for unreachable code (default: assert(false))
@@ -159,23 +159,27 @@
 #error "Please include sokol_gfx.h before sokol_fontstash.h"
 #endif
 
-#ifndef SOKOL_API_DECL
+#if defined(SOKOL_API_DECL) && !defined(SOKOL_FONTSTASH_API_DECL)
+    #define SOKOL_FONTSTASH_API_DECL SOKOL_API_DECL
+#endif
+
+#ifndef SOKOL_FONTSTASH_API_DECL
 #if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
-#define SOKOL_API_DECL __declspec(dllexport)
+#define SOKOL_FONTSTASH_API_DECL __declspec(dllexport)
 #elif defined(_WIN32) && defined(SOKOL_DLL)
-#define SOKOL_API_DECL __declspec(dllimport)
+#define SOKOL_FONTSTASH_API_DECL __declspec(dllimport)
 #else
-#define SOKOL_API_DECL extern
+#define SOKOL_FONTSTASH_API_DECL extern
 #endif
 #endif
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-SOKOL_API_DECL FONScontext* sfons_create(int width, int height, int flags);
-SOKOL_API_DECL void sfons_destroy(FONScontext* ctx);
-SOKOL_API_DECL void sfons_flush(FONScontext* ctx);
-SOKOL_API_DECL uint32_t sfons_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+SOKOL_FONTSTASH_API_DECL FONScontext* sfons_create(int width, int height, int flags);
+SOKOL_FONTSTASH_API_DECL void sfons_destroy(FONScontext* ctx);
+SOKOL_FONTSTASH_API_DECL void sfons_flush(FONScontext* ctx);
+SOKOL_FONTSTASH_API_DECL uint32_t sfons_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -44,7 +44,7 @@
                                default: SOKOL_ASSERT(false)
         SOKOL_MALLOC(s)     -- your own memory allocation function, default: malloc(s)
         SOKOL_FREE(p)       -- your own memory free function, default: free(p)
-        SOKOL_API_DECL      - public function declaration prefix (default: extern)
+        SOKOL_GFX_IMGUI_API_DECL      - public function declaration prefix (default: extern)
         SOKOL_API_IMPL      - public function implementation prefix (default: -)
 
     If sokol_gfx_imgui.h is compiled as a DLL, define the following before
@@ -52,7 +52,7 @@
 
     SOKOL_DLL
 
-    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    On Windows, SOKOL_DLL will define SOKOL_GFX_IMGUI_API_DECL as __declspec(dllexport)
     or __declspec(dllimport) as needed.
 
     STEP BY STEP:
@@ -165,13 +165,17 @@
 #error "Please include sokol_gfx.h before sokol_gfx_imgui.h"
 #endif
 
-#ifndef SOKOL_API_DECL
+#if defined(SOKOL_API_DECL) && !defined(SOKOL_GFX_IMGUI_API_DECL)
+    #define SOKOL_GFX_IMGUI_API_DECL SOKOL_API_DECL
+#endif
+
+#ifndef SOKOL_GFX_IMGUI_API_DECL
 #if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
-#define SOKOL_API_DECL __declspec(dllexport)
+#define SOKOL_GFX_IMGUI_API_DECL __declspec(dllexport)
 #elif defined(_WIN32) && defined(SOKOL_DLL)
-#define SOKOL_API_DECL __declspec(dllimport)
+#define SOKOL_GFX_IMGUI_API_DECL __declspec(dllimport)
 #else
-#define SOKOL_API_DECL extern
+#define SOKOL_GFX_IMGUI_API_DECL extern
 #endif
 #endif
 
@@ -563,25 +567,25 @@ typedef struct {
     sg_trace_hooks hooks;
 } sg_imgui_t;
 
-SOKOL_API_DECL void sg_imgui_init(sg_imgui_t* ctx);
-SOKOL_API_DECL void sg_imgui_discard(sg_imgui_t* ctx);
-SOKOL_API_DECL void sg_imgui_draw(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_init(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_discard(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw(sg_imgui_t* ctx);
 
-SOKOL_API_DECL void sg_imgui_draw_buffers_content(sg_imgui_t* ctx);
-SOKOL_API_DECL void sg_imgui_draw_images_content(sg_imgui_t* ctx);
-SOKOL_API_DECL void sg_imgui_draw_shaders_content(sg_imgui_t* ctx);
-SOKOL_API_DECL void sg_imgui_draw_pipelines_content(sg_imgui_t* ctx);
-SOKOL_API_DECL void sg_imgui_draw_passes_content(sg_imgui_t* ctx);
-SOKOL_API_DECL void sg_imgui_draw_capture_content(sg_imgui_t* ctx);
-SOKOL_API_DECL void sg_imgui_draw_capabilities_content(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_buffers_content(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_images_content(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_shaders_content(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_pipelines_content(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_passes_content(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_capture_content(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_capabilities_content(sg_imgui_t* ctx);
 
-SOKOL_API_DECL void sg_imgui_draw_buffers_window(sg_imgui_t* ctx);
-SOKOL_API_DECL void sg_imgui_draw_images_window(sg_imgui_t* ctx);
-SOKOL_API_DECL void sg_imgui_draw_shaders_window(sg_imgui_t* ctx);
-SOKOL_API_DECL void sg_imgui_draw_pipelines_window(sg_imgui_t* ctx);
-SOKOL_API_DECL void sg_imgui_draw_passes_window(sg_imgui_t* ctx);
-SOKOL_API_DECL void sg_imgui_draw_capture_window(sg_imgui_t* ctx);
-SOKOL_API_DECL void sg_imgui_draw_capabilities_window(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_buffers_window(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_images_window(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_shaders_window(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_pipelines_window(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_passes_window(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_capture_window(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_capabilities_window(sg_imgui_t* ctx);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/util/sokol_gl.h
+++ b/util/sokol_gl.h
@@ -25,7 +25,7 @@
     SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
     SOKOL_MALLOC(s)     - your own malloc function (default: malloc(s))
     SOKOL_FREE(p)       - your own free function (default: free(p))
-    SOKOL_API_DECL      - public function declaration prefix (default: extern)
+    SOKOL_GL_API_DECL   - public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
     SOKOL_LOG(msg)      - your own logging function (default: puts(msg))
     SOKOL_UNREACHABLE() - a guard macro for unreachable code (default: assert(false))
@@ -35,7 +35,7 @@
 
     SOKOL_DLL
 
-    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    On Windows, SOKOL_DLL will define SOKOL_GL_API_DECL as __declspec(dllexport)
     or __declspec(dllimport) as needed.
 
     Include the following headers before including sokol_gl.h:
@@ -445,13 +445,17 @@
 #error "Please include sokol_gfx.h before sokol_gl.h"
 #endif
 
-#ifndef SOKOL_API_DECL
+#if defined(SOKOL_API_DECL) && !defined(SOKOL_GL_API_DECL)
+    #define SOKOL_GL_API_DECL SOKOL_API_DECL
+#endif
+
+#ifndef SOKOL_GL_API_DECL
 #if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
-#define SOKOL_API_DECL __declspec(dllexport)
+#define SOKOL_GL_API_DECL __declspec(dllexport)
 #elif defined(_WIN32) && defined(SOKOL_DLL)
-#define SOKOL_API_DECL __declspec(dllimport)
+#define SOKOL_GL_API_DECL __declspec(dllimport)
 #else
-#define SOKOL_API_DECL extern
+#define SOKOL_GL_API_DECL extern
 #endif
 #endif
 
@@ -488,92 +492,92 @@ typedef struct sgl_desc_t {
 } sgl_desc_t;
 
 /* setup/shutdown/misc */
-SOKOL_API_DECL void sgl_setup(const sgl_desc_t* desc);
-SOKOL_API_DECL void sgl_shutdown(void);
-SOKOL_API_DECL sgl_error_t sgl_error(void);
-SOKOL_API_DECL void sgl_defaults(void);
-SOKOL_API_DECL float sgl_rad(float deg);
-SOKOL_API_DECL float sgl_deg(float rad);
+SOKOL_GL_API_DECL void sgl_setup(const sgl_desc_t* desc);
+SOKOL_GL_API_DECL void sgl_shutdown(void);
+SOKOL_GL_API_DECL sgl_error_t sgl_error(void);
+SOKOL_GL_API_DECL void sgl_defaults(void);
+SOKOL_GL_API_DECL float sgl_rad(float deg);
+SOKOL_GL_API_DECL float sgl_deg(float rad);
 
 /* create and destroy pipeline objects */
-SOKOL_API_DECL sgl_pipeline sgl_make_pipeline(const sg_pipeline_desc* desc);
-SOKOL_API_DECL void sgl_destroy_pipeline(sgl_pipeline pip);
+SOKOL_GL_API_DECL sgl_pipeline sgl_make_pipeline(const sg_pipeline_desc* desc);
+SOKOL_GL_API_DECL void sgl_destroy_pipeline(sgl_pipeline pip);
 
 /* render state functions */
-SOKOL_API_DECL void sgl_viewport(int x, int y, int w, int h, bool origin_top_left);
-SOKOL_API_DECL void sgl_scissor_rect(int x, int y, int w, int h, bool origin_top_left);
-SOKOL_API_DECL void sgl_enable_texture(void);
-SOKOL_API_DECL void sgl_disable_texture(void);
-SOKOL_API_DECL void sgl_texture(sg_image img);
+SOKOL_GL_API_DECL void sgl_viewport(int x, int y, int w, int h, bool origin_top_left);
+SOKOL_GL_API_DECL void sgl_scissor_rect(int x, int y, int w, int h, bool origin_top_left);
+SOKOL_GL_API_DECL void sgl_enable_texture(void);
+SOKOL_GL_API_DECL void sgl_disable_texture(void);
+SOKOL_GL_API_DECL void sgl_texture(sg_image img);
 
 /* pipeline stack functions */
-SOKOL_API_DECL void sgl_default_pipeline(void);
-SOKOL_API_DECL void sgl_load_pipeline(sgl_pipeline pip);
-SOKOL_API_DECL void sgl_push_pipeline(void);
-SOKOL_API_DECL void sgl_pop_pipeline(void);
+SOKOL_GL_API_DECL void sgl_default_pipeline(void);
+SOKOL_GL_API_DECL void sgl_load_pipeline(sgl_pipeline pip);
+SOKOL_GL_API_DECL void sgl_push_pipeline(void);
+SOKOL_GL_API_DECL void sgl_pop_pipeline(void);
 
 /* matrix stack functions */
-SOKOL_API_DECL void sgl_matrix_mode_modelview(void);
-SOKOL_API_DECL void sgl_matrix_mode_projection(void);
-SOKOL_API_DECL void sgl_matrix_mode_texture(void);
-SOKOL_API_DECL void sgl_load_identity(void);
-SOKOL_API_DECL void sgl_load_matrix(const float m[16]);
-SOKOL_API_DECL void sgl_load_transpose_matrix(const float m[16]);
-SOKOL_API_DECL void sgl_mult_matrix(const float m[16]);
-SOKOL_API_DECL void sgl_mult_transpose_matrix(const float m[16]);
-SOKOL_API_DECL void sgl_rotate(float angle_rad, float x, float y, float z);
-SOKOL_API_DECL void sgl_scale(float x, float y, float z);
-SOKOL_API_DECL void sgl_translate(float x, float y, float z);
-SOKOL_API_DECL void sgl_frustum(float l, float r, float b, float t, float n, float f);
-SOKOL_API_DECL void sgl_ortho(float l, float r, float b, float t, float n, float f);
-SOKOL_API_DECL void sgl_perspective(float fov_y, float aspect, float z_near, float z_far);
-SOKOL_API_DECL void sgl_lookat(float eye_x, float eye_y, float eye_z, float center_x, float center_y, float center_z, float up_x, float up_y, float up_z);
-SOKOL_API_DECL void sgl_push_matrix(void);
-SOKOL_API_DECL void sgl_pop_matrix(void);
+SOKOL_GL_API_DECL void sgl_matrix_mode_modelview(void);
+SOKOL_GL_API_DECL void sgl_matrix_mode_projection(void);
+SOKOL_GL_API_DECL void sgl_matrix_mode_texture(void);
+SOKOL_GL_API_DECL void sgl_load_identity(void);
+SOKOL_GL_API_DECL void sgl_load_matrix(const float m[16]);
+SOKOL_GL_API_DECL void sgl_load_transpose_matrix(const float m[16]);
+SOKOL_GL_API_DECL void sgl_mult_matrix(const float m[16]);
+SOKOL_GL_API_DECL void sgl_mult_transpose_matrix(const float m[16]);
+SOKOL_GL_API_DECL void sgl_rotate(float angle_rad, float x, float y, float z);
+SOKOL_GL_API_DECL void sgl_scale(float x, float y, float z);
+SOKOL_GL_API_DECL void sgl_translate(float x, float y, float z);
+SOKOL_GL_API_DECL void sgl_frustum(float l, float r, float b, float t, float n, float f);
+SOKOL_GL_API_DECL void sgl_ortho(float l, float r, float b, float t, float n, float f);
+SOKOL_GL_API_DECL void sgl_perspective(float fov_y, float aspect, float z_near, float z_far);
+SOKOL_GL_API_DECL void sgl_lookat(float eye_x, float eye_y, float eye_z, float center_x, float center_y, float center_z, float up_x, float up_y, float up_z);
+SOKOL_GL_API_DECL void sgl_push_matrix(void);
+SOKOL_GL_API_DECL void sgl_pop_matrix(void);
 
 /* these functions only set the internal 'current texcoord / color' (valid inside or outside begin/end) */
-SOKOL_API_DECL void sgl_t2f(float u, float v);
-SOKOL_API_DECL void sgl_c3f(float r, float g, float b);
-SOKOL_API_DECL void sgl_c4f(float r, float g, float b, float a);
-SOKOL_API_DECL void sgl_c3b(uint8_t r, uint8_t g, uint8_t b);
-SOKOL_API_DECL void sgl_c4b(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-SOKOL_API_DECL void sgl_c1i(uint32_t rgba);
+SOKOL_GL_API_DECL void sgl_t2f(float u, float v);
+SOKOL_GL_API_DECL void sgl_c3f(float r, float g, float b);
+SOKOL_GL_API_DECL void sgl_c4f(float r, float g, float b, float a);
+SOKOL_GL_API_DECL void sgl_c3b(uint8_t r, uint8_t g, uint8_t b);
+SOKOL_GL_API_DECL void sgl_c4b(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+SOKOL_GL_API_DECL void sgl_c1i(uint32_t rgba);
 
 /* define primitives, each begin/end is one draw command */
-SOKOL_API_DECL void sgl_begin_points(void);
-SOKOL_API_DECL void sgl_begin_lines(void);
-SOKOL_API_DECL void sgl_begin_line_strip(void);
-SOKOL_API_DECL void sgl_begin_triangles(void);
-SOKOL_API_DECL void sgl_begin_triangle_strip(void);
-SOKOL_API_DECL void sgl_begin_quads(void);
-SOKOL_API_DECL void sgl_v2f(float x, float y);
-SOKOL_API_DECL void sgl_v3f(float x, float y, float z);
-SOKOL_API_DECL void sgl_v2f_t2f(float x, float y, float u, float v);
-SOKOL_API_DECL void sgl_v3f_t2f(float x, float y, float z, float u, float v);
-SOKOL_API_DECL void sgl_v2f_c3f(float x, float y, float r, float g, float b);
-SOKOL_API_DECL void sgl_v2f_c3b(float x, float y, uint8_t r, uint8_t g, uint8_t b);
-SOKOL_API_DECL void sgl_v2f_c4f(float x, float y, float r, float g, float b, float a);
-SOKOL_API_DECL void sgl_v2f_c4b(float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-SOKOL_API_DECL void sgl_v2f_c1i(float x, float y, uint32_t rgba);
-SOKOL_API_DECL void sgl_v3f_c3f(float x, float y, float z, float r, float g, float b);
-SOKOL_API_DECL void sgl_v3f_c3b(float x, float y, float z, uint8_t r, uint8_t g, uint8_t b);
-SOKOL_API_DECL void sgl_v3f_c4f(float x, float y, float z, float r, float g, float b, float a);
-SOKOL_API_DECL void sgl_v3f_c4b(float x, float y, float z, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-SOKOL_API_DECL void sgl_v3f_c1i(float x, float y, float z, uint32_t rgba);
-SOKOL_API_DECL void sgl_v2f_t2f_c3f(float x, float y, float u, float v, float r, float g, float b);
-SOKOL_API_DECL void sgl_v2f_t2f_c3b(float x, float y, float u, float v, uint8_t r, uint8_t g, uint8_t b);
-SOKOL_API_DECL void sgl_v2f_t2f_c4f(float x, float y, float u, float v, float r, float g, float b, float a);
-SOKOL_API_DECL void sgl_v2f_t2f_c4b(float x, float y, float u, float v, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-SOKOL_API_DECL void sgl_v2f_t2f_c1i(float x, float y, float u, float v, uint32_t rgba);
-SOKOL_API_DECL void sgl_v3f_t2f_c3f(float x, float y, float z, float u, float v, float r, float g, float b);
-SOKOL_API_DECL void sgl_v3f_t2f_c3b(float x, float y, float z, float u, float v, uint8_t r, uint8_t g, uint8_t b);
-SOKOL_API_DECL void sgl_v3f_t2f_c4f(float x, float y, float z, float u, float v, float r, float g, float b, float a);
-SOKOL_API_DECL void sgl_v3f_t2f_c4b(float x, float y, float z, float u, float v, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-SOKOL_API_DECL void sgl_v3f_t2f_c1i(float x, float y, float z, float u, float v, uint32_t rgba);
-SOKOL_API_DECL void sgl_end(void);
+SOKOL_GL_API_DECL void sgl_begin_points(void);
+SOKOL_GL_API_DECL void sgl_begin_lines(void);
+SOKOL_GL_API_DECL void sgl_begin_line_strip(void);
+SOKOL_GL_API_DECL void sgl_begin_triangles(void);
+SOKOL_GL_API_DECL void sgl_begin_triangle_strip(void);
+SOKOL_GL_API_DECL void sgl_begin_quads(void);
+SOKOL_GL_API_DECL void sgl_v2f(float x, float y);
+SOKOL_GL_API_DECL void sgl_v3f(float x, float y, float z);
+SOKOL_GL_API_DECL void sgl_v2f_t2f(float x, float y, float u, float v);
+SOKOL_GL_API_DECL void sgl_v3f_t2f(float x, float y, float z, float u, float v);
+SOKOL_GL_API_DECL void sgl_v2f_c3f(float x, float y, float r, float g, float b);
+SOKOL_GL_API_DECL void sgl_v2f_c3b(float x, float y, uint8_t r, uint8_t g, uint8_t b);
+SOKOL_GL_API_DECL void sgl_v2f_c4f(float x, float y, float r, float g, float b, float a);
+SOKOL_GL_API_DECL void sgl_v2f_c4b(float x, float y, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+SOKOL_GL_API_DECL void sgl_v2f_c1i(float x, float y, uint32_t rgba);
+SOKOL_GL_API_DECL void sgl_v3f_c3f(float x, float y, float z, float r, float g, float b);
+SOKOL_GL_API_DECL void sgl_v3f_c3b(float x, float y, float z, uint8_t r, uint8_t g, uint8_t b);
+SOKOL_GL_API_DECL void sgl_v3f_c4f(float x, float y, float z, float r, float g, float b, float a);
+SOKOL_GL_API_DECL void sgl_v3f_c4b(float x, float y, float z, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+SOKOL_GL_API_DECL void sgl_v3f_c1i(float x, float y, float z, uint32_t rgba);
+SOKOL_GL_API_DECL void sgl_v2f_t2f_c3f(float x, float y, float u, float v, float r, float g, float b);
+SOKOL_GL_API_DECL void sgl_v2f_t2f_c3b(float x, float y, float u, float v, uint8_t r, uint8_t g, uint8_t b);
+SOKOL_GL_API_DECL void sgl_v2f_t2f_c4f(float x, float y, float u, float v, float r, float g, float b, float a);
+SOKOL_GL_API_DECL void sgl_v2f_t2f_c4b(float x, float y, float u, float v, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+SOKOL_GL_API_DECL void sgl_v2f_t2f_c1i(float x, float y, float u, float v, uint32_t rgba);
+SOKOL_GL_API_DECL void sgl_v3f_t2f_c3f(float x, float y, float z, float u, float v, float r, float g, float b);
+SOKOL_GL_API_DECL void sgl_v3f_t2f_c3b(float x, float y, float z, float u, float v, uint8_t r, uint8_t g, uint8_t b);
+SOKOL_GL_API_DECL void sgl_v3f_t2f_c4f(float x, float y, float z, float u, float v, float r, float g, float b, float a);
+SOKOL_GL_API_DECL void sgl_v3f_t2f_c4b(float x, float y, float z, float u, float v, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+SOKOL_GL_API_DECL void sgl_v3f_t2f_c1i(float x, float y, float z, float u, float v, uint32_t rgba);
+SOKOL_GL_API_DECL void sgl_end(void);
 
 /* render everything */
-SOKOL_API_DECL void sgl_draw(void);
+SOKOL_GL_API_DECL void sgl_draw(void);
 
 #ifdef __cplusplus
 } /* extern "C" */
@@ -3193,7 +3197,7 @@ SOKOL_API_IMPL void sgl_lookat(float eye_x, float eye_y, float eye_z, float cent
     _sgl_lookat(_sgl_matrix(), eye_x, eye_y, eye_z, center_x, center_y, center_z, up_x, up_y, up_z);
 }
 
-SOKOL_API_DECL void sgl_push_matrix(void) {
+SOKOL_GL_API_DECL void sgl_push_matrix(void) {
     SOKOL_ASSERT(_SGL_INIT_COOKIE == _sgl.init_cookie);
     SOKOL_ASSERT((_sgl.cur_matrix_mode >= 0) && (_sgl.cur_matrix_mode < SGL_NUM_MATRIXMODES));
     _sgl.matrix_dirty = true;
@@ -3208,7 +3212,7 @@ SOKOL_API_DECL void sgl_push_matrix(void) {
     }
 }
 
-SOKOL_API_DECL void sgl_pop_matrix(void) {
+SOKOL_GL_API_DECL void sgl_pop_matrix(void) {
     SOKOL_ASSERT(_SGL_INIT_COOKIE == _sgl.init_cookie);
     SOKOL_ASSERT((_sgl.cur_matrix_mode >= 0) && (_sgl.cur_matrix_mode < SGL_NUM_MATRIXMODES));
     _sgl.matrix_dirty = true;

--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -39,7 +39,7 @@
     to override defaults:
 
     SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
-    SOKOL_API_DECL      - public function declaration prefix (default: extern)
+    SOKOL_IMGUI_API_DECL- public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
 
     If sokol_imgui.h is compiled as a DLL, define the following before
@@ -47,7 +47,7 @@
 
     SOKOL_DLL
 
-    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    On Windows, SOKOL_DLL will define SOKOL_IMGUI_API_DECL as __declspec(dllexport)
     or __declspec(dllimport) as needed.
 
     Include the following headers before sokol_imgui.h (both before including
@@ -204,13 +204,17 @@
 #error "Please include sokol_app.h before sokol_imgui.h"
 #endif
 
-#ifndef SOKOL_API_DECL
+#if defined(SOKOL_API_DECL) && !defined(SOKOL_IMGUI_API_DECL)
+    #define SOKOL_IMGUI_API_DECL SOKOL_API_DECL
+#endif
+
+#ifndef SOKOL_IMGUI_API_DECL
 #if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
-#define SOKOL_API_DECL __declspec(dllexport)
+#define SOKOL_IMGUI_API_DECL __declspec(dllexport)
 #elif defined(_WIN32) && defined(SOKOL_DLL)
-#define SOKOL_API_DECL __declspec(dllimport)
+#define SOKOL_IMGUI_API_DECL __declspec(dllimport)
 #else
-#define SOKOL_API_DECL extern
+#define SOKOL_IMGUI_API_DECL extern
 #endif
 #endif
 
@@ -229,13 +233,13 @@ typedef struct simgui_desc_t {
     bool disable_hotkeys;   /* don't let ImGui handle Ctrl-A,C,V,X,Y,Z */
 } simgui_desc_t;
 
-SOKOL_API_DECL void simgui_setup(const simgui_desc_t* desc);
-SOKOL_API_DECL void simgui_new_frame(int width, int height, double delta_time);
-SOKOL_API_DECL void simgui_render(void);
+SOKOL_IMGUI_API_DECL void simgui_setup(const simgui_desc_t* desc);
+SOKOL_IMGUI_API_DECL void simgui_new_frame(int width, int height, double delta_time);
+SOKOL_IMGUI_API_DECL void simgui_render(void);
 #if !defined(SOKOL_IMGUI_NO_SOKOL_APP)
-SOKOL_API_DECL bool simgui_handle_event(const sapp_event* ev);
+SOKOL_IMGUI_API_DECL bool simgui_handle_event(const sapp_event* ev);
 #endif
-SOKOL_API_DECL void simgui_shutdown(void);
+SOKOL_IMGUI_API_DECL void simgui_shutdown(void);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/util/sokol_memtrack.h
+++ b/util/sokol_memtrack.h
@@ -16,7 +16,7 @@
 
     Optionally provide the following defines with your own implementations:
 
-    SOKOL_API_DECL      - public function declaration prefix (default: extern)
+    SOKOL_MEMTRACK_API_DECL      - public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
 
     If sokol_memtrack.h is compiled as a DLL, define the following before
@@ -73,13 +73,17 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#ifndef SOKOL_API_DECL
+#if defined(SOKOL_API_DECL) && !defined(SOKOL_MEMTRACK_API_DECL)
+    #define SOKOL_MEMTRACK_API_DECL SOKOL_API_DECL
+#endif
+
+#ifndef SOKOL_MEMTRACK_API_DECL
 #if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
-#define SOKOL_API_DECL __declspec(dllexport)
+#define SOKOL_MEMTRACK_API_DECL __declspec(dllexport)
 #elif defined(_WIN32) && defined(SOKOL_DLL)
-#define SOKOL_API_DECL __declspec(dllimport)
+#define SOKOL_MEMTRACK_API_DECL __declspec(dllimport)
 #else
-#define SOKOL_API_DECL extern
+#define SOKOL_MEMTRACK_API_DECL extern
 #endif
 #endif
 
@@ -92,7 +96,7 @@ typedef struct smemtrack_info_t {
     int num_bytes;
 } smemtrack_info_t;
 
-SOKOL_API_DECL smemtrack_info_t smemtrack_info(void);
+SOKOL_MEMTRACK_API_DECL smemtrack_info_t smemtrack_info(void);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/util/sokol_shape.h
+++ b/util/sokol_shape.h
@@ -16,7 +16,7 @@
     ...optionally provide the following macros to override defaults:
 
     SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
-    SOKOL_API_DECL      - public function declaration prefix (default: extern)
+    SOKOL_SHAPE_API_DECL- public function declaration prefix (default: extern)
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
 
     If sokol_shape.h is compiled as a DLL, define the following before
@@ -24,7 +24,7 @@
 
     SOKOL_DLL
 
-    On Windows, SOKOL_DLL will define SOKOL_API_DECL as __declspec(dllexport)
+    On Windows, SOKOL_DLL will define SOKOL_SHAPE_API_DECL as __declspec(dllexport)
     or __declspec(dllimport) as needed.
 
     FEATURE OVERVIEW
@@ -364,13 +364,17 @@
 #error "Please include sokol_gfx.h before sokol_shape.h"
 #endif
 
-#ifndef SOKOL_API_DECL
+#if defined(SOKOL_API_DECL) && !defined(SOKOL_SHAPE_API_DECL)
+    #define SOKOL_SHAPE_API_DECL SOKOL_API_DECL
+#endif
+
+#ifndef SOKOL_SHAPE_API_DECL
 #if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_IMPL)
-#define SOKOL_API_DECL __declspec(dllexport)
+#define SOKOL_SHAPE_API_DECL __declspec(dllexport)
 #elif defined(_WIN32) && defined(SOKOL_DLL)
-#define SOKOL_API_DECL __declspec(dllimport)
+#define SOKOL_SHAPE_API_DECL __declspec(dllimport)
 #else
-#define SOKOL_API_DECL extern
+#define SOKOL_SHAPE_API_DECL extern
 #endif
 #endif
 
@@ -472,38 +476,38 @@ typedef struct sshape_torus_t {
 } sshape_torus_t;
 
 /* shape builder functions */
-SOKOL_API_DECL sshape_buffer_t sshape_build_plane(const sshape_buffer_t* buf, const sshape_plane_t* params);
-SOKOL_API_DECL sshape_buffer_t sshape_build_box(const sshape_buffer_t* buf, const sshape_box_t* params);
-SOKOL_API_DECL sshape_buffer_t sshape_build_sphere(const sshape_buffer_t* buf, const sshape_sphere_t* params);
-SOKOL_API_DECL sshape_buffer_t sshape_build_cylinder(const sshape_buffer_t* buf, const sshape_cylinder_t* params);
-SOKOL_API_DECL sshape_buffer_t sshape_build_torus(const sshape_buffer_t* buf, const sshape_torus_t* params);
+SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_plane(const sshape_buffer_t* buf, const sshape_plane_t* params);
+SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_box(const sshape_buffer_t* buf, const sshape_box_t* params);
+SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_sphere(const sshape_buffer_t* buf, const sshape_sphere_t* params);
+SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_cylinder(const sshape_buffer_t* buf, const sshape_cylinder_t* params);
+SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_torus(const sshape_buffer_t* buf, const sshape_torus_t* params);
 
 /* query required vertex- and index-buffer sizes in bytes */
-SOKOL_API_DECL sshape_sizes_t sshape_plane_sizes(uint32_t tiles);
-SOKOL_API_DECL sshape_sizes_t sshape_box_sizes(uint32_t tiles);
-SOKOL_API_DECL sshape_sizes_t sshape_sphere_sizes(uint32_t slices, uint32_t stacks);
-SOKOL_API_DECL sshape_sizes_t sshape_cylinder_sizes(uint32_t slices, uint32_t stacks);
-SOKOL_API_DECL sshape_sizes_t sshape_torus_sizes(uint32_t sides, uint32_t rings);
+SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_plane_sizes(uint32_t tiles);
+SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_box_sizes(uint32_t tiles);
+SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_sphere_sizes(uint32_t slices, uint32_t stacks);
+SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_cylinder_sizes(uint32_t slices, uint32_t stacks);
+SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_torus_sizes(uint32_t sides, uint32_t rings);
 
 /* extract sokol-gfx desc structs and primitive ranges from build state */
-SOKOL_API_DECL sshape_element_range_t sshape_element_range(const sshape_buffer_t* buf);
-SOKOL_API_DECL sg_buffer_desc sshape_vertex_buffer_desc(const sshape_buffer_t* buf);
-SOKOL_API_DECL sg_buffer_desc sshape_index_buffer_desc(const sshape_buffer_t* buf);
-SOKOL_API_DECL sg_buffer_layout_desc sshape_buffer_layout_desc(void);
-SOKOL_API_DECL sg_vertex_attr_desc sshape_position_attr_desc(void);
-SOKOL_API_DECL sg_vertex_attr_desc sshape_normal_attr_desc(void);
-SOKOL_API_DECL sg_vertex_attr_desc sshape_texcoord_attr_desc(void);
-SOKOL_API_DECL sg_vertex_attr_desc sshape_color_attr_desc(void);
+SOKOL_SHAPE_API_DECL sshape_element_range_t sshape_element_range(const sshape_buffer_t* buf);
+SOKOL_SHAPE_API_DECL sg_buffer_desc sshape_vertex_buffer_desc(const sshape_buffer_t* buf);
+SOKOL_SHAPE_API_DECL sg_buffer_desc sshape_index_buffer_desc(const sshape_buffer_t* buf);
+SOKOL_SHAPE_API_DECL sg_buffer_layout_desc sshape_buffer_layout_desc(void);
+SOKOL_SHAPE_API_DECL sg_vertex_attr_desc sshape_position_attr_desc(void);
+SOKOL_SHAPE_API_DECL sg_vertex_attr_desc sshape_normal_attr_desc(void);
+SOKOL_SHAPE_API_DECL sg_vertex_attr_desc sshape_texcoord_attr_desc(void);
+SOKOL_SHAPE_API_DECL sg_vertex_attr_desc sshape_color_attr_desc(void);
 
 /* helper functions to build packed color value from floats or bytes */
-SOKOL_API_DECL uint32_t sshape_color_4f(float r, float g, float b, float a);
-SOKOL_API_DECL uint32_t sshape_color_3f(float r, float g, float b);
-SOKOL_API_DECL uint32_t sshape_color_4b(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-SOKOL_API_DECL uint32_t sshape_color_3b(uint8_t r, uint8_t g, uint8_t b);
+SOKOL_SHAPE_API_DECL uint32_t sshape_color_4f(float r, float g, float b, float a);
+SOKOL_SHAPE_API_DECL uint32_t sshape_color_3f(float r, float g, float b);
+SOKOL_SHAPE_API_DECL uint32_t sshape_color_4b(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+SOKOL_SHAPE_API_DECL uint32_t sshape_color_3b(uint8_t r, uint8_t g, uint8_t b);
 
 /* adapter function for filling matrix struct from generic float[16] array */
-SOKOL_API_DECL sshape_mat4_t sshape_mat4(const float m[16]);
-SOKOL_API_DECL sshape_mat4_t sshape_mat4_transpose(const float m[16]);
+SOKOL_SHAPE_API_DECL sshape_mat4_t sshape_mat4(const float m[16]);
+SOKOL_SHAPE_API_DECL sshape_mat4_t sshape_mat4_transpose(const float m[16]);
 
 #ifdef __cplusplus
 } // extern "C"
@@ -1169,7 +1173,7 @@ static void _sshape_build_cylinder_cap_ring(sshape_buffer_t* buf, const sshape_c
     }
 }
 
-SOKOL_API_DECL sshape_buffer_t sshape_build_cylinder(const sshape_buffer_t* in_buf, const sshape_cylinder_t* in_params) {
+SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_cylinder(const sshape_buffer_t* in_buf, const sshape_cylinder_t* in_params) {
     SOKOL_ASSERT(in_buf && in_params);
     const sshape_cylinder_t params = _sshape_cylinder_defaults(in_params);
     const uint32_t num_vertices = _sshape_cylinder_num_vertices(params.slices, params.stacks);
@@ -1350,7 +1354,7 @@ SOKOL_API_IMPL sg_buffer_desc sshape_index_buffer_desc(const sshape_buffer_t* bu
     return desc;
 }
 
-SOKOL_API_DECL sshape_element_range_t sshape_element_range(const sshape_buffer_t* buf) {
+SOKOL_SHAPE_API_DECL sshape_element_range_t sshape_element_range(const sshape_buffer_t* buf) {
     SOKOL_ASSERT(buf && buf->valid);
     SOKOL_ASSERT(buf->indices.shape_offset < buf->indices.data_size);
     SOKOL_ASSERT(0 == (buf->indices.shape_offset & (sizeof(uint16_t) - 1)));


### PR DESCRIPTION
This was generated by the following ruby script:

```ruby
SDECL = 'SOKOL_API_DECL'

def process_file(fname)
  lines = File.readlines(fname)

  lines.find { |line|
    line =~ /^#if.* SOKOL_([A-Z]_+)_INCLUDED/
  }
  ldecl = "SOKOL_#{$1}_API_DECL"

  decl_line = lines.index { |line|
    line =~ /^#if.* #{SDECL}/
  }

  return if !decl_line

  lines.map! { |line|
    line.
      gsub("#{SDECL}" + ' ' * (ldecl.length - SDECL.length), ldecl).
      gsub(SDECL, ldecl)
  }

  lines[decl_line, 0] = <<~EOF
    #if defined(#{SDECL}) && !defined(#{ldecl})
        #define #{ldecl} #{SDECL}
    #endif

  EOF

  File.write(fname, lines.join)
end

# process_file 'sokol_time.h'

Dir['**/*.h'].each do |f|
  process_file f
end
```