### PR TITLE
Added sg_dealloc_xxx() and sg_uninit_xxx() suite of functions

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2272,11 +2272,21 @@ SOKOL_API_DECL sg_image sg_alloc_image(void);
 SOKOL_API_DECL sg_shader sg_alloc_shader(void);
 SOKOL_API_DECL sg_pipeline sg_alloc_pipeline(void);
 SOKOL_API_DECL sg_pass sg_alloc_pass(void);
+SOKOL_API_DECL void sg_dealloc_buffer(sg_buffer buf_id);
+SOKOL_API_DECL void sg_dealloc_image(sg_image img_id);
+SOKOL_API_DECL void sg_dealloc_shader(sg_shader shd_id);
+SOKOL_API_DECL void sg_dealloc_pipeline(sg_pipeline pip_id);
+SOKOL_API_DECL void sg_dealloc_pass(sg_pass pass_id);
 SOKOL_API_DECL void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc);
 SOKOL_API_DECL void sg_init_image(sg_image img_id, const sg_image_desc* desc);
 SOKOL_API_DECL void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc);
 SOKOL_API_DECL void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc);
 SOKOL_API_DECL void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc);
+SOKOL_API_DECL bool sg_uninit_buffer(sg_buffer buf_id);
+SOKOL_API_DECL bool sg_uninit_image(sg_image img_id);
+SOKOL_API_DECL bool sg_uninit_shader(sg_shader shd_id);
+SOKOL_API_DECL bool sg_uninit_pipeline(sg_pipeline pip_id);
+SOKOL_API_DECL bool sg_uninit_pass(sg_pass pass_id);
 SOKOL_API_DECL void sg_fail_buffer(sg_buffer buf_id);
 SOKOL_API_DECL void sg_fail_image(sg_image img_id);
 SOKOL_API_DECL void sg_fail_shader(sg_shader shd_id);
@@ -13882,6 +13892,31 @@ _SOKOL_PRIVATE sg_pass _sg_alloc_pass(void) {
     return res;
 }
 
+_SOKOL_PRIVATE void _sg_dealloc_buffer(sg_buffer buf_id) {
+    SOKOL_ASSERT(buf_id.id != SG_INVALID_ID);
+    _sg_pool_free_index(&_sg.pools.buffer_pool, _sg_slot_index(buf_id.id));
+}
+
+_SOKOL_PRIVATE void _sg_dealloc_image(sg_image img_id) {
+    SOKOL_ASSERT(img_id.id != SG_INVALID_ID);
+    _sg_pool_free_index(&_sg.pools.image_pool, _sg_slot_index(img_id.id));
+}
+
+_SOKOL_PRIVATE void _sg_dealloc_shader(sg_shader shd_id) {
+    SOKOL_ASSERT(shd_id.id != SG_INVALID_ID);
+    _sg_pool_free_index(&_sg.pools.shader_pool, _sg_slot_index(shd_id.id));
+}
+
+_SOKOL_PRIVATE void _sg_dealloc_pipeline(sg_pipeline pip_id) {
+    SOKOL_ASSERT(pip_id.id != SG_INVALID_ID);
+    _sg_pool_free_index(&_sg.pools.pipeline_pool, _sg_slot_index(pip_id.id));
+}
+
+_SOKOL_PRIVATE void _sg_dealloc_pass(sg_pass pass_id) {
+    SOKOL_ASSERT(pass_id.id != SG_INVALID_ID);
+    _sg_pool_free_index(&_sg.pools.pass_pool, _sg_slot_index(pass_id.id));
+}
+
 _SOKOL_PRIVATE void _sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc) {
     SOKOL_ASSERT(buf_id.id != SG_INVALID_ID && desc);
     _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
@@ -13977,6 +14012,86 @@ _SOKOL_PRIVATE void _sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc) {
         pass->slot.state = SG_RESOURCESTATE_FAILED;
     }
     SOKOL_ASSERT((pass->slot.state == SG_RESOURCESTATE_VALID)||(pass->slot.state == SG_RESOURCESTATE_FAILED));
+}
+
+_SOKOL_PRIVATE bool _sg_uninit_buffer(sg_buffer buf_id) {
+    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+    if (buf) {
+        if (buf->slot.ctx_id == _sg.active_context.id) {
+            _sg_destroy_buffer(buf);
+            _sg_reset_buffer(buf);
+            return true;
+        }
+        else {
+            SOKOL_LOG("_sg_uninit_buffer: active context mismatch (must be same as for creation)");
+            _SG_TRACE_NOARGS(err_context_mismatch);
+        }
+    }
+    return false;
+}
+
+_SOKOL_PRIVATE bool _sg_uninit_image(sg_image img_id) {
+    _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
+    if (img) {
+        if (img->slot.ctx_id == _sg.active_context.id) {
+            _sg_destroy_image(img);
+            _sg_reset_image(img);
+            return true;
+        }
+        else {
+            SOKOL_LOG("_sg_uninit_image: active context mismatch (must be same as for creation)");
+            _SG_TRACE_NOARGS(err_context_mismatch);
+        }
+    }
+    return false;
+}
+
+_SOKOL_PRIVATE bool _sg_uninit_shader(sg_shader shd_id) {
+    _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
+    if (shd) {
+        if (shd->slot.ctx_id == _sg.active_context.id) {
+            _sg_destroy_shader(shd);
+            _sg_reset_shader(shd);
+            return true;
+        }
+        else {
+            SOKOL_LOG("_sg_uninit_shader: active context mismatch (must be same as for creation)");
+            _SG_TRACE_NOARGS(err_context_mismatch);
+        }
+    }
+    return false;
+}
+
+_SOKOL_PRIVATE bool _sg_uninit_pipeline(sg_pipeline pip_id) {
+    _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
+    if (pip) {
+        if (pip->slot.ctx_id == _sg.active_context.id) {
+            _sg_destroy_pipeline(pip);
+            _sg_reset_pipeline(pip);
+            return true;
+        }
+        else {
+            SOKOL_LOG("_sg_uninit_pipeline: active context mismatch (must be same as for creation)");
+            _SG_TRACE_NOARGS(err_context_mismatch);
+        }
+    }
+    return false;
+}
+
+_SOKOL_PRIVATE bool _sg_uninit_pass(sg_pass pass_id) {
+    _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
+    if (pass) {
+        if (pass->slot.ctx_id == _sg.active_context.id) {
+            _sg_destroy_pass(pass);
+            _sg_reset_pass(pass);
+            return true;
+        }
+        else {
+            SOKOL_LOG("_sg_uninit_pass: active context mismatch (must be same as for creation)");
+            _SG_TRACE_NOARGS(err_context_mismatch);
+        }
+    }
+    return false;
 }
 
 /*== PUBLIC API FUNCTIONS ====================================================*/
@@ -14165,6 +14280,36 @@ SOKOL_API_IMPL sg_pass sg_alloc_pass(void) {
     return res;
 }
 
+SOKOL_API_IMPL void sg_dealloc_buffer(sg_buffer buf_id) {
+    SOKOL_ASSERT(_sg.valid);
+    _sg_dealloc_buffer(buf_id);
+    _SG_TRACE_ARGS(dealloc_buffer, buf_id);
+}
+
+SOKOL_API_IMPL void sg_dealloc_image(sg_image img_id) {
+    SOKOL_ASSERT(_sg.valid);
+    _sg_dealloc_image(img_id);
+    _SG_TRACE_ARGS(dealloc_image, img_id);
+}
+
+SOKOL_API_IMPL void sg_dealloc_shader(sg_shader shd_id) {
+    SOKOL_ASSERT(_sg.valid);
+    _sg_dealloc_shader(shd_id);
+    _SG_TRACE_ARGS(dealloc_shader, shd_id);
+}
+
+SOKOL_API_IMPL void sg_dealloc_pipeline(sg_pipeline pip_id) {
+    SOKOL_ASSERT(_sg.valid);
+    _sg_dealloc_pipeline(pip_id);
+    _SG_TRACE_ARGS(dealloc_pipeline, pip_id);
+}
+
+SOKOL_API_IMPL void sg_dealloc_pass(sg_pass pass_id) {
+    SOKOL_ASSERT(_sg.valid);
+    _sg_dealloc_pass(pass_id);
+    _SG_TRACE_ARGS(dealloc_pass, pass_id);
+}
+
 SOKOL_API_IMPL void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     sg_buffer_desc desc_def = _sg_buffer_desc_defaults(desc);
@@ -14198,6 +14343,41 @@ SOKOL_API_IMPL void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc) {
     sg_pass_desc desc_def = _sg_pass_desc_defaults(desc);
     _sg_init_pass(pass_id, &desc_def);
     _SG_TRACE_ARGS(init_pass, pass_id, &desc_def);
+}
+
+SOKOL_API_IMPL bool sg_uninit_buffer(sg_buffer buf_id) {
+    SOKOL_ASSERT(_sg.valid);
+    bool res = _sg_uninit_buffer(buf_id);
+    _SG_TRACE_ARGS(uninit_buffer, buf_id);
+    return res;
+}
+
+SOKOL_API_IMPL bool sg_uninit_image(sg_image img_id) {
+    SOKOL_ASSERT(_sg.valid);
+    bool res = _sg_uninit_image(img_id);
+    _SG_TRACE_ARGS(uninit_image, img_id);
+    return res;
+}
+
+SOKOL_API_IMPL bool sg_uninit_shader(sg_shader shd_id) {
+    SOKOL_ASSERT(_sg.valid);
+    bool res = _sg_uninit_shader(shd_id);
+    _SG_TRACE_ARGS(uninit_shader, shd_id);
+    return res;
+}
+
+SOKOL_API_IMPL bool sg_uninit_pipeline(sg_pipeline pip_id) {
+    SOKOL_ASSERT(_sg.valid);
+    bool res = _sg_uninit_pipeline(pip_id);
+    _SG_TRACE_ARGS(uninit_pipeline, pip_id);
+    return res;
+}
+
+SOKOL_API_IMPL bool sg_uninit_pass(sg_pass pass_id) {
+    SOKOL_ASSERT(_sg.valid);
+    bool res = _sg_uninit_pass(pass_id);
+    _SG_TRACE_ARGS(uninit_pass, pass_id);
+    return res;
 }
 
 /*-- set allocated resource to failed state ----------------------------------*/
@@ -14372,85 +14552,40 @@ SOKOL_API_IMPL sg_pass sg_make_pass(const sg_pass_desc* desc) {
 SOKOL_API_IMPL void sg_destroy_buffer(sg_buffer buf_id) {
     SOKOL_ASSERT(_sg.valid);
     _SG_TRACE_ARGS(destroy_buffer, buf_id);
-    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
-    if (buf) {
-        if (buf->slot.ctx_id == _sg.active_context.id) {
-            _sg_destroy_buffer(buf);
-            _sg_reset_buffer(buf);
-            _sg_pool_free_index(&_sg.pools.buffer_pool, _sg_slot_index(buf_id.id));
-        }
-        else {
-            SOKOL_LOG("sg_destroy_buffer: active context mismatch (must be same as for creation)");
-            _SG_TRACE_NOARGS(err_context_mismatch);
-        }
+    if (_sg_uninit_buffer(buf_id)) {
+        _sg_dealloc_buffer(buf_id);
     }
 }
 
 SOKOL_API_IMPL void sg_destroy_image(sg_image img_id) {
     SOKOL_ASSERT(_sg.valid);
     _SG_TRACE_ARGS(destroy_image, img_id);
-    _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
-    if (img) {
-        if (img->slot.ctx_id == _sg.active_context.id) {
-            _sg_destroy_image(img);
-            _sg_reset_image(img);
-            _sg_pool_free_index(&_sg.pools.image_pool, _sg_slot_index(img_id.id));
-        }
-        else {
-            SOKOL_LOG("sg_destroy_image: active context mismatch (must be same as for creation)");
-            _SG_TRACE_NOARGS(err_context_mismatch);
-        }
+    if (_sg_uninit_image(img_id)) {
+        _sg_dealloc_image(img_id);
     }
 }
 
 SOKOL_API_IMPL void sg_destroy_shader(sg_shader shd_id) {
     SOKOL_ASSERT(_sg.valid);
     _SG_TRACE_ARGS(destroy_shader, shd_id);
-    _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
-    if (shd) {
-        if (shd->slot.ctx_id == _sg.active_context.id) {
-            _sg_destroy_shader(shd);
-            _sg_reset_shader(shd);
-            _sg_pool_free_index(&_sg.pools.shader_pool, _sg_slot_index(shd_id.id));
-        }
-        else {
-            SOKOL_LOG("sg_destroy_shader: active context mismatch (must be same as for creation)");
-            _SG_TRACE_NOARGS(err_context_mismatch);
-        }
+    if (_sg_uninit_shader(shd_id)) {
+        _sg_dealloc_shader(shd_id);
     }
 }
 
 SOKOL_API_IMPL void sg_destroy_pipeline(sg_pipeline pip_id) {
     SOKOL_ASSERT(_sg.valid);
     _SG_TRACE_ARGS(destroy_pipeline, pip_id);
-    _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
-    if (pip) {
-        if (pip->slot.ctx_id == _sg.active_context.id) {
-            _sg_destroy_pipeline(pip);
-            _sg_reset_pipeline(pip);
-            _sg_pool_free_index(&_sg.pools.pipeline_pool, _sg_slot_index(pip_id.id));
-        }
-        else {
-            SOKOL_LOG("sg_destroy_pipeline: active context mismatch (must be same as for creation)");
-            _SG_TRACE_NOARGS(err_context_mismatch);
-        }
+    if (_sg_uninit_pipeline(pip_id)) {
+        _sg_dealloc_pipeline(pip_id);
     }
 }
 
 SOKOL_API_IMPL void sg_destroy_pass(sg_pass pass_id) {
     SOKOL_ASSERT(_sg.valid);
     _SG_TRACE_ARGS(destroy_pass, pass_id);
-    _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
-    if (pass) {
-        if (pass->slot.ctx_id == _sg.active_context.id) {
-            _sg_destroy_pass(pass);
-            _sg_reset_pass(pass);
-            _sg_pool_free_index(&_sg.pools.pass_pool, _sg_slot_index(pass_id.id));
-        }
-        else {
-            SOKOL_LOG("sg_destroy_pass: active context mismatch (must be same as for creation)");
-            _SG_TRACE_NOARGS(err_context_mismatch);
-        }
+    if (_sg_uninit_pass(pass_id)) {
+        _sg_dealloc_pass(pass_id);
     }
 }
 


### PR DESCRIPTION
These are the equivalent to the sg_alloc/init functions and allow async destruction of resources. This is useful when using sokol in a multithreaded scenario; the render thread does the sg_init/sg_uninit while a separate resource/api/update thread can call the sg_alloc/sg_dealloc.