### PR TITLE
Sokol multi-window support

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -10671,7 +10671,7 @@ _SOKOL_PRIVATE void _sapp_linux_run(const sapp_desc* desc) {
     for (int i = 1; i < _sapp.window_pool.size; i++) {
         if(_sapp.windows[i].id != SAPP_INVALID_ID){
             // TODO: Is there a better way to handle this instead of creating a tmp object?
-            sapp_destroy_window(_sapp_window(_sapp.windows[i].id) });
+            sapp_destroy_window(_sapp_window(_sapp.windows[i].id));
         }
     }
     

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1306,7 +1306,7 @@ SOKOL_APP_API_DECL const void* sapp_macos_get_window(void);
 /* macOS: get bridged pointer to macOS NSWindow for specified window */
 SOKOL_APP_API_DECL const void* sapp_macos_window_get_window(sapp_window window_id);
 /* iOS: get bridged pointer to iOS UIWindow */
-SOKOL_APP_APP_API_DECL const void* sapp_ios_get_window(void);
+SOKOL_APP_API_DECL const void* sapp_ios_get_window(void);
 
 /* D3D11: get pointer to ID3D11Device object */
 SOKOL_APP_API_DECL const void* sapp_d3d11_get_device(void);
@@ -10735,11 +10735,11 @@ SOKOL_API_IMPL int sapp_run(const sapp_desc* desc) {
 }
 #endif
 
-SOKOL_API_DECL sapp_window sapp_main_window(){
+SOKOL_APP_IMPL sapp_window sapp_main_window(){
     return _sapp_window(_sapp.main_window->id);
 }
 
-SOKOL_API_DECL sapp_window sapp_create_window(const sapp_window_desc* desc){
+SOKOL_API_IMPL sapp_window sapp_create_window(const sapp_window_desc* desc){
     SOKOL_ASSERT(desc);
     sapp_window_desc desc_def = _sapp_window_desc_defaults(desc);
     sapp_window window_id = _sapp_alloc_window();
@@ -10776,7 +10776,7 @@ SOKOL_API_DECL sapp_window sapp_create_window(const sapp_window_desc* desc){
     return window_id;
 }
 
-SOKOL_API_DECL void sapp_destroy_window(sapp_window window_id){
+SOKOL_API_IMPL void sapp_destroy_window(sapp_window window_id){
     SOKOL_ASSERT(window_id.id != SAPP_INVALID_ID);
     _sapp_window_t* window = _sapp_lookup_window(window_id.id);
     SOKOL_ASSERT(window);
@@ -10814,7 +10814,7 @@ SOKOL_API_DECL void sapp_destroy_window(sapp_window window_id){
     _sapp_pool_free_index(&_sapp.window_pool, slot_index);
 }
 
-SOKOL_API_DECL void sapp_gl_make_context_current(sapp_window window_id){
+SOKOL_API_IMPL void sapp_gl_make_context_current(sapp_window window_id){
     #if defined(SOKOL_GLCORE33)
         SOKOL_ASSERT(window_id.id != SAPP_INVALID_ID);
         _sapp_window_t* window = _sapp_lookup_window(window_id.id);
@@ -10836,7 +10836,7 @@ SOKOL_API_IMPL bool sapp_isvalid(void) {
     return _sapp.valid;
 }
 
-SOKOL_API_DECL bool sapp_window_isvalid(sapp_window window) {
+SOKOL_API_IMPL bool sapp_window_isvalid(sapp_window window) {
     bool is_valid = !(window.id == SAPP_INVALID_ID) && _sapp_lookup_window(window.id);
     return is_valid;
 }
@@ -10937,22 +10937,22 @@ SOKOL_API_IMPL bool sapp_keyboard_shown(void) {
     return _sapp.onscreen_keyboard_shown;
 }
 
-SOKOL_APP_API_DECL bool sapp_is_fullscreen() {
+SOKOL_API_IMPL bool sapp_is_fullscreen() {
     return sapp_window_is_fullscreen(_sapp_window(_sapp.main_window->id));
 }
 
-SOKOL_APP_API_DECL bool sapp_window_is_fullscreen(sapp_window window_id) {
+SOKOL_API_IMPL bool sapp_window_is_fullscreen(sapp_window window_id) {
     _sapp_window_t* window = _sapp_lookup_window(window_id.id);
     SOKOL_ASSERT(window);
 
     return window->fullscreen;
 }
 
-SOKOL_APP_API_DECL void sapp_toggle_fullscreen() {
+SOKOL_API_IMPL void sapp_toggle_fullscreen() {
     sapp_window_toggle_fullscreen(_sapp_window(_sapp.main_window->id));
 }
 
-SOKOL_APP_API_DECL void sapp_window_toggle_fullscreen(sapp_window window_id) {
+SOKOL_API_IMPL void sapp_window_toggle_fullscreen(sapp_window window_id) {
     _sapp_window_t* window = _sapp_lookup_window(window_id.id);
     SOKOL_ASSERT(window);
 

--- a/sokol_glue.h
+++ b/sokol_glue.h
@@ -87,6 +87,7 @@ extern "C" {
 
 #if defined(SOKOL_GFX_INCLUDED) && defined(SOKOL_APP_INCLUDED)
 SOKOL_API_DECL sg_context_desc sapp_sgcontext(void);
+SOKOL_API_DECL sg_context_desc sapp_window_sgcontext(sapp_window window_id);
 #endif
 
 #ifdef __cplusplus
@@ -104,26 +105,67 @@ SOKOL_API_DECL sg_context_desc sapp_sgcontext(void);
 #endif
 
 #if defined(SOKOL_GFX_INCLUDED) && defined(SOKOL_APP_INCLUDED)
-SOKOL_API_IMPL sg_context_desc sapp_sgcontext(void) {
+
+// DISCUSS: Not a huge fan of doing the handle->void* casts here
+_SOKOL_PRIVATE void _sapp_gl_make_context_current_cb(void* user_data) {
+    sapp_window window_id;
+    window_id.id = (uint32_t)(uintptr_t)user_data;
+    sapp_gl_make_context_current(window_id);
+}
+
+_SOKOL_PRIVATE const void* _sapp_metal_window_get_renderpass_descriptor_cb(void* user_data) {
+    sapp_window window_id;
+    window_id.id = (uint32_t)(uintptr_t)user_data;
+    return sapp_metal_window_get_renderpass_descriptor(window_id);
+}
+
+_SOKOL_PRIVATE const void* _sapp_metal_window_get_drawable_cb(void* user_data) {
+    sapp_window window_id;
+    window_id.id = (uint32_t)(uintptr_t)user_data;
+    return sapp_metal_window_get_drawable(window_id);
+}
+
+_SOKOL_PRIVATE const void* _sapp_d3d11_window_get_render_target_view_cb(void* user_data) {
+    sapp_window window_id;
+    window_id.id = (uint32_t)(uintptr_t)user_data;
+    return sapp_d3d11_window_get_render_target_view(window_id);
+}
+
+_SOKOL_PRIVATE const void* _sapp_d3d11_window_get_depth_stencil_cb(void* user_data) {
+    sapp_window window_id;
+    window_id.id = (uint32_t)(uintptr_t)user_data;
+    return sapp_d3d11_window_get_depth_stencil_view(window_id);
+}
+
+SOKOL_API_IMPL sg_context_desc sapp_window_sgcontext(sapp_window window_id) {
     sg_context_desc desc;
     memset(&desc, 0, sizeof(desc));
     desc.color_format = (sg_pixel_format) sapp_color_format();
     desc.depth_format = (sg_pixel_format) sapp_depth_format();
-    desc.sample_count = sapp_sample_count();
+    desc.sample_count = sapp_window_sample_count(window_id);
     desc.gl.force_gles2 = sapp_gles2();
+    desc.gl.context_make_current_userdata_cb = _sapp_gl_make_context_current_cb;
+    desc.gl.user_data = (void*) (uintptr_t)window_id.id;
     desc.metal.device = sapp_metal_get_device();
-    desc.metal.renderpass_descriptor_cb = sapp_metal_get_renderpass_descriptor;
-    desc.metal.drawable_cb = sapp_metal_get_drawable;
+    desc.metal.renderpass_descriptor_userdata_cb = _sapp_metal_window_get_renderpass_descriptor_cb;
+    desc.metal.drawable_userdata_cb = _sapp_metal_window_get_drawable_cb;
+    desc.metal.user_data = (void*) (uintptr_t)window_id.id;
     desc.d3d11.device = sapp_d3d11_get_device();
     desc.d3d11.device_context = sapp_d3d11_get_device_context();
-    desc.d3d11.render_target_view_cb = sapp_d3d11_get_render_target_view;
-    desc.d3d11.depth_stencil_view_cb = sapp_d3d11_get_depth_stencil_view;
+    desc.d3d11.render_target_view_userdata_cb = _sapp_d3d11_window_get_render_target_view_cb;
+    desc.d3d11.depth_stencil_view_userdata_cb = _sapp_d3d11_window_get_depth_stencil_cb;
+    desc.d3d11.user_data = (void*) (uintptr_t)window_id.id;
     desc.wgpu.device = sapp_wgpu_get_device();
     desc.wgpu.render_view_cb = sapp_wgpu_get_render_view;
     desc.wgpu.resolve_view_cb = sapp_wgpu_get_resolve_view;
     desc.wgpu.depth_stencil_view_cb = sapp_wgpu_get_depth_stencil_view;
     return desc;
 }
+
+SOKOL_API_IMPL sg_context_desc sapp_sgcontext(void) {
+    return sapp_window_sgcontext(sapp_main_window());
+}
+
 #endif
 
 #endif /* SOKOL_IMPL */


### PR DESCRIPTION
This pull request adds basic multi-window support across sapp/sg/glue. Definitely still in a bit of a rough state and needs testing. Since this would be a pretty substantial change to sapp, I can totally understand if you don't want to merge this. But I wanted to at least present it as an option and open up the discussion around it. I tried to stick to most of your thoughts presented in https://github.com/floooh/sokol/issues/229

### Basic usage
```
sapp_window second_window = sapp_create_window(&(sapp_window_desc){
        .window_title = "Second Window!"
});

sg_context_desc desc = sapp_window_sgcontext(second_window);
sg_context second_context = sg_setup_context(&desc);

sapp_destroy_window(second_window);
```
Events now contain an additional window variable for identifying. I've added a barebones multi-window example here [multi-window-sapp.c](https://github.com/stbachmann/sokol-samples/blob/multi-window-sample/sapp/multi-window-sapp.c)

### Some things to note/discuss
- What's working: win/macos/emsc/linux have all been tested and are working with d3d/gl/mtl. WGPU and android/ios compile, but I haven't tested things properly yet. I currently can't get the wgpu backend to compile (probably just a wrong sdk version).
- What's missing: There are some missing functions we probably want to add to make it properly useful such as show/hide window, etc. I've basically just taken the shortest path to getting multi-window support across all backends for now.
- Backwards compatibility: I've kept the API completely backwards compatible. This means all the samples compile out of the box without any changes required. But, it also means the API is quite a bit more bloated than it needs to be. Most functions that are window related now have a `_window` version. The old functions simply uses the `main_window` to call into the new `_window` variant. So for example `sapp_width()` will essentially call the new function `sapp_window_width(main_window)`. If you're happy to make some breaking changes, we could simplify the API significantly and clean up quite a bit of bloat. For example we could push all the window specific stuff in `sapp_desc` into its own `sapp_window_desc` struct.
- macOS: This ended up being the most involved change. The NSOpenGLView that was previously used does not play nice when using multiple gl contexts. I ended up re-implementing the backend with a custom NSView similar to what glfw does. As a consequence of this, we now have a similar core `while(!_sapp.quit_ordered)` loop like the other backends (rather then doing the update via drawRect). Again, most of this is inspired by the glfw implementation. 
- Pools: the windows use a slightly simplified version of your sg pools (I'm not using resource states). This still feels a little bit bloaty for something that most likely doesn't really happen a lot in an applications life cycle? Happy to adapt this to something simpler (like a linked list) if you'd prefer. Especially on backends that don't permit multi-window, it seems like a wasteful approach.
- I've had forward declare functions in some spots (sokol_gfx.h). If we want to avoid that, it'd mean shuffling around the code order quite a bit in some places. Happy to do so, but felt like the forward declaration was the better path until discussed.

I'm sure there's quite a few things that can be improved and need fixing/discussion. But I think it's a solid starting point for further work. Happy to hear any thoughts/feedback :)