### PR TITLE
bindgen preparations

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1048,17 +1048,17 @@ typedef struct sapp_touchpoint {
 } sapp_touchpoint;
 
 typedef enum sapp_mousebutton {
-    SAPP_MOUSEBUTTON_INVALID = -1,
-    SAPP_MOUSEBUTTON_LEFT = 0,
-    SAPP_MOUSEBUTTON_RIGHT = 1,
-    SAPP_MOUSEBUTTON_MIDDLE = 2,
+    SAPP_MOUSEBUTTON_LEFT = 0x0,
+    SAPP_MOUSEBUTTON_RIGHT = 0x1,
+    SAPP_MOUSEBUTTON_MIDDLE = 0x2,
+    SAPP_MOUSEBUTTON_INVALID = 0x100,
 } sapp_mousebutton;
 
 enum {
-    SAPP_MODIFIER_SHIFT = (1<<0),
-    SAPP_MODIFIER_CTRL = (1<<1),
-    SAPP_MODIFIER_ALT = (1<<2),
-    SAPP_MODIFIER_SUPER = (1<<3)
+    SAPP_MODIFIER_SHIFT = 0x1,
+    SAPP_MODIFIER_CTRL = 0x2,
+    SAPP_MODIFIER_ALT = 0x4,
+    SAPP_MODIFIER_SUPER = 0x8
 };
 
 typedef struct sapp_event {
@@ -1211,7 +1211,7 @@ SOKOL_APP_API_DECL int sapp_get_num_dropped_files(void);
 SOKOL_APP_API_DECL const char* sapp_get_dropped_file_path(int index);
 
 /* special run-function for SOKOL_NO_ENTRY (in standard mode this is an empty stub) */
-SOKOL_APP_API_DECL int sapp_run(const sapp_desc* desc);
+SOKOL_APP_API_DECL void sapp_run(const sapp_desc* desc);
 
 /* GL: return true when GLES2 fallback is active (to detect fallback from GLES3) */
 SOKOL_APP_API_DECL bool sapp_gles2(void);
@@ -1261,7 +1261,7 @@ SOKOL_APP_API_DECL const void* sapp_android_get_native_activity(void);
 } /* extern "C" */
 
 /* reference-based equivalents for C++ */
-inline int sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
+inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 
 #endif
 
@@ -10100,7 +10100,7 @@ int main(int argc, char* argv[]) {
 
 /*== PUBLIC API FUNCTIONS ====================================================*/
 #if defined(SOKOL_NO_ENTRY)
-SOKOL_API_IMPL int sapp_run(const sapp_desc* desc) {
+SOKOL_API_IMPL void sapp_run(const sapp_desc* desc) {
     SOKOL_ASSERT(desc);
     #if defined(_SAPP_MACOS)
         _sapp_macos_run(desc);
@@ -10118,7 +10118,6 @@ SOKOL_API_IMPL int sapp_run(const sapp_desc* desc) {
         // calling sapp_run() directly is not supported on Android)
         _sapp_fail("sapp_run() not supported on this platform!");
     #endif
-    return 0;
 }
 
 /* this is just a stub so the linker doesn't complain */
@@ -10131,9 +10130,8 @@ sapp_desc sokol_main(int argc, char* argv[]) {
 }
 #else
 /* likewise, in normal mode, sapp_run() is just an empty stub */
-SOKOL_API_IMPL int sapp_run(const sapp_desc* desc) {
+SOKOL_API_IMPL void sapp_run(const sapp_desc* desc) {
     _SOKOL_UNUSED(desc);
-    return 0;
 }
 #endif
 

--- a/sokol_fetch.h
+++ b/sokol_fetch.h
@@ -864,7 +864,7 @@ typedef struct sfetch_desc_t {
 typedef struct sfetch_handle_t { uint32_t id; } sfetch_handle_t;
 
 /* error codes */
-typedef enum {
+typedef enum sfetch_error_t {
     SFETCH_ERROR_NO_ERROR,
     SFETCH_ERROR_FILE_NOT_FOUND,
     SFETCH_ERROR_NO_BUFFER,

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -7706,7 +7706,7 @@ _SOKOL_PRIVATE void _sg_d3d11_destroy_buffer(_sg_buffer_t* buf) {
 
 _SOKOL_PRIVATE void _sg_d3d11_fill_subres_data(const _sg_image_t* img, const sg_image_content* content) {
     const int num_faces = (img->cmn.type == SG_IMAGETYPE_CUBE) ? 6:1;
-    const int num_slices = (img->cmn.type == SG_IMAGETYPE_ARRAY) ? img->cmn.depth:1;
+    const int num_slices = (img->cmn.type == SG_IMAGETYPE_ARRAY) ? img->cmn.num_slices:1;
     int subres_index = 0;
     for (int face_index = 0; face_index < num_faces; face_index++) {
         for (int slice_index = 0; slice_index < num_slices; slice_index++) {
@@ -7808,7 +7808,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
                 d3d11_tex_desc.Height = img->cmn.height;
                 d3d11_tex_desc.MipLevels = img->cmn.num_mipmaps;
                 switch (img->cmn.type) {
-                    case SG_IMAGETYPE_ARRAY:    d3d11_tex_desc.ArraySize = img->cmn.depth; break;
+                    case SG_IMAGETYPE_ARRAY:    d3d11_tex_desc.ArraySize = img->cmn.num_slices; break;
                     case SG_IMAGETYPE_CUBE:     d3d11_tex_desc.ArraySize = 6; break;
                     default:                    d3d11_tex_desc.ArraySize = 1; break;
                 }
@@ -7855,7 +7855,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
                     case SG_IMAGETYPE_ARRAY:
                         d3d11_srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
                         d3d11_srv_desc.Texture2DArray.MipLevels = img->cmn.num_mipmaps;
-                        d3d11_srv_desc.Texture2DArray.ArraySize = img->cmn.depth;
+                        d3d11_srv_desc.Texture2DArray.ArraySize = img->cmn.num_slices;
                         break;
                     default:
                         SOKOL_UNREACHABLE; break;
@@ -7887,7 +7887,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
                 memset(&d3d11_tex_desc, 0, sizeof(d3d11_tex_desc));
                 d3d11_tex_desc.Width = img->cmn.width;
                 d3d11_tex_desc.Height = img->cmn.height;
-                d3d11_tex_desc.Depth = img->cmn.depth;
+                d3d11_tex_desc.Depth = img->cmn.num_slices;
                 d3d11_tex_desc.MipLevels = img->cmn.num_mipmaps;
                 d3d11_tex_desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
                 d3d11_tex_desc.Format = img->d3d11.format;
@@ -8705,7 +8705,7 @@ _SOKOL_PRIVATE void _sg_d3d11_update_image(_sg_image_t* img, const sg_image_cont
     }
     SOKOL_ASSERT(d3d11_res);
     const int num_faces = (img->cmn.type == SG_IMAGETYPE_CUBE) ? 6:1;
-    const int num_slices = (img->cmn.type == SG_IMAGETYPE_ARRAY) ? img->cmn.depth:1;
+    const int num_slices = (img->cmn.type == SG_IMAGETYPE_ARRAY) ? img->cmn.num_slices:1;
     int subres_index = 0;
     HRESULT hr;
     _SOKOL_UNUSED(hr);

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -3083,7 +3083,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_image_panel(sg_imgui_t* ctx, sg_image img) {
             igText("Render Target:     %s", desc->render_target ? "YES":"NO");
             igText("Width:             %d", desc->width);
             igText("Height:            %d", desc->height);
-            igText("Depth:             %d", desc->depth);
+            igText("Num Slices:        %d", desc->num_slices);
             igText("Num Mipmaps:       %d", desc->num_mipmaps);
             igText("Pixel Format:      %s", _sg_imgui_pixelformat_string(desc->pixel_format));
             igText("Sample Count:      %d", desc->sample_count);
@@ -3346,7 +3346,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_attachment(sg_imgui_t* ctx, const sg_attachme
         _sg_imgui_show_image(ctx, att->image);
     }
     igText("  Mip Level: %d", att->mip_level);
-    igText("  Face/Layer/Slice: %d", att->layer);
+    igText("  Slice: %d", att->slice);
     _sg_imgui_draw_embedded_image(ctx, att->image, img_scale);
 }
 


### PR DESCRIPTION
API fixes in sokol_gfx.h and sokol_app.h for automatic language bindings generation (removal of nested anonymous unions and expressions in enums).