### PR TITLE
Improved MRT support. Removed same pixel_format limitation for MRT

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -6255,8 +6255,8 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_pass(_sg_pass_t* pass, _sg_image_
                     return SG_RESOURCESTATE_FAILED;
                 }
                 /* setup color attachments for the framebuffer */
-                #if !defined(SOKOL_GLES2)
-                if (!_sg.gl.gles2) {
+                #if !defined(SOKOL_GLES2) || defined(SOKOL_MRT_ENABLED)
+                if (_sg.features.multiple_render_targets) {
                     const GLenum gl_draw_bufs = GL_COLOR_ATTACHMENT0;
                     glDrawBuffers(1, &gl_draw_bufs);
                 }
@@ -13424,9 +13424,11 @@ _SOKOL_PRIVATE bool _sg_validate_pass_desc(const sg_pass_desc* desc) {
                 sample_count = img->cmn.sample_count;
             }
             else {
-                if (_sg.gl.gles2) {
-                    SOKOL_VALIDATE(img->cmn.pixel_format == color_fmt, _SG_VALIDATE_PASSDESC_COLOR_PIXELFORMATS);
-                }
+                #if defined(_SOKOL_ANY_GL)
+                    if (_sg.gl.gles2) {
+                        SOKOL_VALIDATE(img->cmn.pixel_format == color_fmt, _SG_VALIDATE_PASSDESC_COLOR_PIXELFORMATS);
+                    }
+                #endif
                 SOKOL_VALIDATE(width == img->cmn.width >> att->mip_level, _SG_VALIDATE_PASSDESC_IMAGE_SIZES);
                 SOKOL_VALIDATE(height == img->cmn.height >> att->mip_level, _SG_VALIDATE_PASSDESC_IMAGE_SIZES);
                 SOKOL_VALIDATE(sample_count == img->cmn.sample_count, _SG_VALIDATE_PASSDESC_IMAGE_SAMPLE_COUNTS);


### PR DESCRIPTION
Regarding the issue #450 and #402 , I've created a draft version. I tested on GL and D3d. but haven't tested on other platforms yet. 
I'll wait for your feedback. some notes:

- I think the limitation was for OpenGL-ES2. however, we should check for **EXT_draw_buffers** extension on ES2: https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_draw_buffers.txt . On all other APIs, there should be proper support with different formats for MRT
- question number 5 of the extension text indicates that on ES2, the pixel_format must be the same. so I only put the check for ES2 with MRT support.
- I had to change the API for sg_make_pipeline, so that we get multiple color_formats in `sg_blend_state.color_formats` instead of one.  

EDIT: I just realized that I can put a union around `color_formats` and `color_format` to not break the API, so we would have both fields depending on what user wants to use. what's ur opinion on that ?