### PR TITLE
Fix #pragma compilation with tcc on windows

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1455,16 +1455,16 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
         #pragma comment (linker, "/subsystem:windows")
     #endif
 
-    #pragma comment (lib, "kernel32.lib")
-    #pragma comment (lib, "user32.lib")
-    #pragma comment (lib, "shell32.lib")    /* CommandLineToArgvW, DragQueryFileW, DragFinished */
+    #pragma comment (lib, "kernel32")
+    #pragma comment (lib, "user32")
+    #pragma comment (lib, "shell32")    /* CommandLineToArgvW, DragQueryFileW, DragFinished */
     #if defined(SOKOL_D3D11)
-        #pragma comment (lib, "dxgi.lib")
-        #pragma comment (lib, "d3d11.lib")
-        #pragma comment (lib, "dxguid.lib")
+        #pragma comment (lib, "dxgi")
+        #pragma comment (lib, "d3d11")
+        #pragma comment (lib, "dxguid")
     #endif
     #if defined(SOKOL_GLCORE33)
-        #pragma comment (lib, "gdi32.lib")
+        #pragma comment (lib, "gdi32")
     #endif
 
     #if defined(SOKOL_D3D11)
@@ -1508,8 +1508,8 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #include <d3d11_3.h>
     #include <DirectXMath.h>
 
-    #pragma comment (lib, "WindowsApp.lib")
-    #pragma comment (lib, "dxguid.lib")
+    #pragma comment (lib, "WindowsApp")
+    #pragma comment (lib, "dxguid")
 #elif defined(_SAPP_ANDROID)
     #include <pthread.h>
     #include <unistd.h>

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -495,12 +495,12 @@ inline void saudio_setup(const saudio_desc& desc) { return saudio_setup(&desc); 
     #include <synchapi.h>
     #if (defined(WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
         #define SOKOL_WIN32_NO_MMDEVICE
-        #pragma comment (lib, "WindowsApp.lib")
+        #pragma comment (lib, "WindowsApp")
     #else
-        #pragma comment (lib, "kernel32.lib")
-        #pragma comment (lib, "ole32.lib")
+        #pragma comment (lib, "kernel32")
+        #pragma comment (lib, "ole32")
         #if defined(SOKOL_WIN32_NO_MMDEVICE)
-            #pragma comment (lib, "mmdevapi.lib")
+            #pragma comment (lib, "mmdevapi")
         #endif
     #endif
 #endif

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2565,13 +2565,13 @@ inline void sg_init_pass(sg_pass pass_id, const sg_pass_desc& desc) { return sg_
     #include <d3dcompiler.h>
     #ifdef _MSC_VER
     #if (defined(WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
-        #pragma comment (lib, "WindowsApp.lib")
+        #pragma comment (lib, "WindowsApp")
     #else
-        #pragma comment (lib, "kernel32.lib")
-        #pragma comment (lib, "user32.lib")
-        #pragma comment (lib, "dxgi.lib")
-        #pragma comment (lib, "d3d11.lib")
-        #pragma comment (lib, "dxguid.lib")
+        #pragma comment (lib, "kernel32")
+        #pragma comment (lib, "user32")
+        #pragma comment (lib, "dxgi")
+        #pragma comment (lib, "d3d11")
+        #pragma comment (lib, "dxguid")
     #endif
     #endif
 #elif defined(SOKOL_METAL)


### PR DESCRIPTION
The tcc ([Tiny C Compiler](https://bellard.org/tcc/)) linker does not like the `.lib` suffix inside `#pragma comment (lib, "foo.lib")` directives - it fails with `tcc: error: library 'foo.lib' not found` errors. Removing the extension fixes tcc, and all major compilers (msvc/clang/gcc/mingw) compile fine without it, so this change should simply allow the headers to be compiled with a different compiler.

We've needed to, (and have been making) this change over at [vlang/v](https://github.com/vlang/v/tree/master/thirdparty/sokol),  ever since tcc became an officially-supported (and later on, the default for debug builds) C compiler on windows. However, every time we update the headers, we also need to reapply this patch; and we felt that, by PR'ing it upstream, it'd benefit both the V project, and anyone attempting to compile Sokol with tcc :)