### PR TITLE
Enable UTF-8 console output for `/subsystem:windows`

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -6349,6 +6349,12 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     _SOKOL_UNUSED(hPrevInstance);
     _SOKOL_UNUSED(lpCmdLine);
     _SOKOL_UNUSED(nCmdShow);
+    if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+        freopen("CON", "r", stdin);
+        freopen("CON", "w", stdout);
+        freopen("CON", "w", stderr);
+    }
+    SetConsoleOutputCP(CP_UTF8);
     int argc_utf8 = 0;
     char** argv_utf8 = _sapp_win32_command_line_to_utf8_argv(GetCommandLineW(), &argc_utf8);
     sapp_desc desc = sokol_main(argc_utf8, argv_utf8);

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -6339,6 +6339,12 @@ _SOKOL_PRIVATE char** _sapp_win32_command_line_to_utf8_argv(LPWSTR w_command_lin
 #if !defined(SOKOL_NO_ENTRY)
 #if defined(SOKOL_WIN32_FORCE_MAIN)
 int main(int argc, char* argv[]) {
+    if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+        freopen("CON", "r", stdin);
+        freopen("CON", "w", stdout);
+        freopen("CON", "w", stderr);
+    }
+    SetConsoleOutputCP(CP_UTF8);
     sapp_desc desc = sokol_main(argc, argv);
     _sapp_win32_run(&desc);
     return 0;


### PR DESCRIPTION
This change attaches stdin/out/err to the console of the parent process so that `/subsystem:windows` applications can still write to the console when executed from a command line.  Additionally, it sets the console output to UTF-8 to enable unicode output at the console.