### PR TITLE
Added AAudio support for Android

### DIFF
--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -1736,7 +1736,9 @@ _SOKOL_PRIVATE void _saudio_aaudio_error_callback(AAudioStream* stream, void* us
 }
 
 _SOKOL_PRIVATE void _saudio_backend_shutdown(void) {
+    pthread_mutex_lock(&_saudio.backend.mutex);
     _saudio_aaudio_stop_stream();
+    pthread_mutex_unlock(&_saudio.backend.mutex);
 
     if (_saudio.backend.builder) {
         AAudioStreamBuilder_delete(_saudio.backend.builder);

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -1766,7 +1766,7 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
     AAudioStreamBuilder_setChannelCount(_saudio.backend.builder, _saudio.num_channels);
     AAudioStreamBuilder_setBufferCapacityInFrames(_saudio.backend.builder, _saudio.buffer_frames * 2);
     AAudioStreamBuilder_setDataCallback(_saudio.backend.builder, _saudio_aaudio_data_callback, NULL);
-	AAudioStreamBuilder_setFramesPerDataCallback(_saudio.backend.builder, _saudio.buffer_frames);
+    AAudioStreamBuilder_setFramesPerDataCallback(_saudio.backend.builder, _saudio.buffer_frames);
     AAudioStreamBuilder_setErrorCallback(_saudio.backend.builder, _saudio_aaudio_error_callback, NULL);
 
     if (!_saudio_aaudio_start_stream()) {

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -1710,6 +1710,7 @@ _SOKOL_PRIVATE bool _saudio_aaudio_start_stream(void) {
 
 _SOKOL_PRIVATE void _saudio_aaudio_stop_stream(void) {
     if (_saudio.backend.stream) {
+        AAudioStream_requestStop(_saudio.backend.stream);
         AAudioStream_close(_saudio.backend.stream);
         _saudio.backend.stream = NULL;
     }


### PR DESCRIPTION
This can be selected by compiling with SOKOL_AAUDIO defined.

Requires Android API >= 26.