### PR TITLE
MacOS main menu bar activation fix.

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2824,10 +2824,8 @@ _SOKOL_PRIVATE void _sapp_macos_run(const sapp_desc* desc) {
     // set the application dock icon as early as possible, otherwise
     // the dummy icon will be visible for a short time
     sapp_set_icon(&_sapp.desc.icon);
-    NSApp.activationPolicy = NSApplicationActivationPolicyRegular;
     _sapp.macos.app_dlg = [[_sapp_macos_app_delegate alloc] init];
     NSApp.delegate = _sapp.macos.app_dlg;
-    [NSApp activateIgnoringOtherApps:YES];
     [NSApp run];
     // NOTE: [NSApp run] never returns, instead cleanup code
     // must be put into applicationWillTerminate
@@ -3170,6 +3168,8 @@ _SOKOL_PRIVATE void _sapp_macos_frame(void) {
     else {
         [_sapp.macos.window center];
     }
+    NSApp.activationPolicy = NSApplicationActivationPolicyRegular;
+    [NSApp activateIgnoringOtherApps:YES];
     [_sapp.macos.window makeKeyAndOrderFront:nil];
     _sapp_macos_update_dimensions();
     [NSEvent setMouseCoalescingEnabled:NO];


### PR DESCRIPTION
On MacOS 10.14.6, after implementing a quit menu item (seen in pull request #362) and subsequently additional menu items, I found that upon initial App launch the Apple menu and the App's menus in the main menu bar do not respond to mouse clicks. Switching away from the App and then back again resolves the issue.

I found others having the same issue (MacOS 10.15, using Swift) on stack overflow along with a fix: (https://stackoverflow.com/questions/62739862/why-doesnt-activateignoringotherapps-enable-the-menu-bar). Moving the App activation into the function applicationDidFinishLaunching() seems to work great, after this change, the menus are clickable from first launch.