### PR TITLE
impl NSTextInputClient

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1781,6 +1781,9 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 
 /*== MACOS DECLARATIONS ======================================================*/
 #if defined(_SAPP_MACOS)
+
+static const NSRange kEmptyRange = { NSNotFound, 0 };
+
 @interface _sapp_macos_app_delegate : NSObject<NSApplicationDelegate>
 @end
 @interface _sapp_macos_window : NSWindow
@@ -1788,10 +1791,17 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 @interface _sapp_macos_window_delegate : NSObject<NSWindowDelegate>
 @end
 #if defined(SOKOL_METAL)
-    @interface _sapp_macos_view : MTKView
+    @interface _sapp_macos_view : MTKView <NSTextInputClient>
+    {
+        NSMutableAttributedString* markedText;
+        NSTrackingArea* trackingArea;
+    }
     @end
 #elif defined(SOKOL_GLCORE33)
-    @interface _sapp_macos_view : NSOpenGLView
+    @interface _sapp_macos_view : NSOpenGLView <NSTextInputClient>{
+        NSMutableAttributedString* markedText;
+        NSTrackingArea* trackingArea;        
+    }
     - (void)timerFired:(id)sender;
     @end
 #endif // SOKOL_GLCORE33
@@ -3510,22 +3520,10 @@ _SOKOL_PRIVATE void _sapp_macos_poll_input_events() {
         if (0 != (mods & SAPP_MODIFIER_SUPER)) {
             _sapp_macos_key_event(SAPP_EVENTTYPE_KEY_UP, key_code, event.isARepeat, mods);
         }
-        const NSString* chars = event.characters;
-        const NSUInteger len = chars.length;
-        if (len > 0) {
-            _sapp_init_event(SAPP_EVENTTYPE_CHAR);
-            _sapp.event.modifiers = mods;
-            for (NSUInteger i = 0; i < len; i++) {
-                const unichar codepoint = [chars characterAtIndex:i];
-                if ((codepoint & 0xFF00) == 0xF700) {
-                    continue;
-                }
-                _sapp.event.char_code = codepoint;
-                _sapp.event.key_repeat = event.isARepeat;
-                _sapp_call_event(&_sapp.event);
-            }
-        }
-        /* if this is a Cmd+V (paste), also send a CLIPBOARD_PASTE event */
+        _sapp.event.modifiers = mods;
+        _sapp.event.key_repeat = event.isARepeat;
+        [[self inputContext] handleEvent:event];
+       /* if this is a Cmd+V (paste), also send a CLIPBOARD_PASTE event */
         if (_sapp.clipboard.enabled && (mods == SAPP_MODIFIER_SUPER) && (key_code == SAPP_KEYCODE_V)) {
             _sapp_init_event(SAPP_EVENTTYPE_CLIPBOARD_PASTED);
             _sapp_call_event(&_sapp.event);
@@ -3538,6 +3536,81 @@ _SOKOL_PRIVATE void _sapp_macos_poll_input_events() {
         event.isARepeat,
         _sapp_macos_mods(event));
 }
+
+- (BOOL)hasMarkedText
+{
+    return [markedText length] > 0;
+}
+
+- (NSRange)markedRange
+{
+    if ([markedText length] > 0)
+        return NSMakeRange(0, [markedText length] - 1);
+    else
+        return kEmptyRange;
+}
+
+- (NSRange)selectedRange
+{
+    return kEmptyRange;
+}
+
+- (void)setMarkedText:(id)string
+        selectedRange:(NSRange)selectedRange
+     replacementRange:(NSRange)replacementRange
+{
+    if ([string isKindOfClass:[NSAttributedString class]])
+        markedText = [[NSMutableAttributedString alloc] initWithAttributedString:string];
+    else
+        markedText = [[NSMutableAttributedString alloc] initWithString:string];
+}
+
+- (void)unmarkText
+{
+    [[markedText mutableString] setString:@""];
+}
+
+- (NSArray*)validAttributesForMarkedText
+{
+    return [NSArray array];
+}
+- (void)doCommandBySelector:(SEL)selector
+{
+}
+
+- (void) insertText:(id)aString replacementRange:(NSRange)replacementRange {
+    const NSString* chars = aString;
+    const NSUInteger len = chars.length;
+    if (len > 0) {
+        _sapp_init_event(SAPP_EVENTTYPE_CHAR);
+        for (NSUInteger i = 0; i < len; i++) {
+            const unichar codepoint = [chars characterAtIndex:i];
+            if ((codepoint & 0xFF00) == 0xF700) {
+                continue;
+            }
+            _sapp.event.char_code = codepoint;
+            _sapp_call_event(&_sapp.event);
+        }
+    }
+}
+
+- (NSAttributedString*)attributedSubstringForProposedRange:(NSRange)range
+                                               actualRange:(NSRangePointer)actualRange
+{
+    return nil;
+}
+
+- (NSUInteger)characterIndexForPoint:(NSPoint)point
+{
+    return 0;
+}
+
+- (NSRect)firstRectForCharacterRange:(NSRange)range
+                         actualRange:(NSRangePointer)actualRange
+{   
+    return NSMakeRect(0.0, 0.0, 0.0, 0.0);
+}
+
 - (void)flagsChanged:(NSEvent*)event {
     const uint32_t old_f = _sapp.macos.flags_changed_store;
     const uint32_t new_f = event.modifierFlags;
@@ -5905,18 +5978,18 @@ _SOKOL_PRIVATE bool _sapp_win32_update_dimensions(void) {
     if (GetClientRect(_sapp.win32.hwnd, &rect)) {
         _sapp.window_width = (int)((float)(rect.right - rect.left) / _sapp.win32.dpi.window_scale);
         _sapp.window_height = (int)((float)(rect.bottom - rect.top) / _sapp.win32.dpi.window_scale);
-        int fb_width = (int)((float)_sapp.window_width * _sapp.win32.dpi.content_scale);
-        int fb_height = (int)((float)_sapp.window_height * _sapp.win32.dpi.content_scale);
-        /* prevent a framebuffer size of 0 when window is minimized */
-        if (0 == fb_width) {
-            fb_width = 1;
-        }
-        if (0 == fb_height) {
-            fb_height = 1;
-        }
+        const int fb_width = (int)((float)_sapp.window_width * _sapp.win32.dpi.content_scale);
+        const int fb_height = (int)((float)_sapp.window_height * _sapp.win32.dpi.content_scale);
         if ((fb_width != _sapp.framebuffer_width) || (fb_height != _sapp.framebuffer_height)) {
             _sapp.framebuffer_width = fb_width;
             _sapp.framebuffer_height = fb_height;
+            /* prevent a framebuffer size of 0 when window is minimized */
+            if (_sapp.framebuffer_width == 0) {
+                _sapp.framebuffer_width = 1;
+            }
+            if (_sapp.framebuffer_height == 0) {
+                _sapp.framebuffer_height = 1;
+            }
             return true;
         }
     }


### PR DESCRIPTION
the PR implements the NSTextInputClient ( #460 ) for `MTKView` and `NSOpenGLView`, this will allow `_sapp_macos_app` to receive key code for characters like `á, é, í, ó, ú` 

a couple of notes: 

1. the `_sapp.event.char_code` is set inside `insertText` method. `_sapp.event.modifiers` and `_sapp.event.key_repeat` are still inside `keyDown` I'm not sure if this is going to break something, but it looks correct. 
2. As suggested in the original feature request ( #460 ) this impl. is similar to the GLFW, the main difference is that `firstRectForCharacterRange` is returning `return NSMakeRect(0.0, 0.0, 0.0, 0.0);`. the original impl uses the window bounds, I'm not sure what is the difference here.. 

This is my first PR here, so feel free to point any corrections, etc.. =)

