### PR TITLE
Fix: sg_uninit_pipeline / sg_init_pipeline pair does not work reliably in OpenGL

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -5972,6 +5972,14 @@ _SOKOL_PRIVATE void _sg_gl_cache_invalidate_program(GLuint prog) {
     }
 }
 
+/* called from _sg_gl_destroy_pipeline() */
+_SOKOL_PRIVATE void _sg_gl_cache_invalidate_pipeline(_sg_pipeline_t* pip) {
+    if (pip == _sg.gl.cache.cur_pipeline) {
+        _sg.gl.cache.cur_pipeline = 0;
+        _sg.gl.cache.cur_pipeline_id.id = SG_INVALID_ID;
+    }
+}
+
 _SOKOL_PRIVATE void _sg_gl_reset_state_cache(void) {
     if (_sg.gl.cur_context) {
         _SG_GL_CHECK_ERROR();
@@ -6594,8 +6602,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_pipeline(_sg_pipeline_t* pip, _sg
 
 _SOKOL_PRIVATE void _sg_gl_destroy_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
-    _SOKOL_UNUSED(pip);
-    /* empty */
+    _sg_gl_cache_invalidate_pipeline(pip);
 }
 
 /*


### PR DESCRIPTION
The following pattern will result in `sokol_gfx` failing to apply its changes to OpenGL state:

```c
sg_uninit_pipeline(pip);

// <... any amount of code, *except* sg_apply_pipeline ...>

sg_init_pipeline(pip, &(sg_pipeline_desc){...});
sg_apply_pipeline(pip); // BUG: actually a no-op, and leaves state unchanged
```

It only happens if *both* of the following conditions hold:
1. The uninited pipeline was the last-applied pipeline.
2. No other call to `sg_apply_pipeline` was made in-between.

## Problem

The problem is that the following branch will be `false` in `_sg_gl_apply_pipeline` (due to pipeline ID reuse), short-circuiting the entirety of the function; thus, the new pipeline will not actually be applied:

```c
if ((_sg.gl.cache.cur_pipeline != pip) || (_sg.gl.cache.cur_pipeline_id.id != pip->slot.id)) {
```

## Fix

The fix is to reset the cached pipeline ID if the pipeline being uninitialized is currently applied. See attached commit.

## Workaround

(included just in case somebody needs a quick & dirty fix)

Add a `sg_reset_state_cache();` call between `sg_uninit_pipeline(...)` and `sg_init_pipeline(...)`. Since this invalidates the entire cache, the next pipeline application will be applied correctly, regardless of ID.