### PR TITLE
Fix `sapp_mouse_shown` function signature

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1433,7 +1433,7 @@ SOKOL_APP_API_DECL void sapp_toggle_fullscreen(void);
 /* show or hide the mouse cursor */
 SOKOL_APP_API_DECL void sapp_show_mouse(bool show);
 /* show or hide the mouse cursor */
-SOKOL_APP_API_DECL bool sapp_mouse_shown();
+SOKOL_APP_API_DECL bool sapp_mouse_shown(void);
 /* enable/disable mouse-pointer-lock mode */
 SOKOL_APP_API_DECL void sapp_lock_mouse(bool lock);
 /* return true if in mouse-pointer-lock mode (this may toggle a few frames later) */


### PR DESCRIPTION
I discovered this while experimenting with adding a new language to the bindgen