### PR TITLE
Don't consume keyboard events if mouse is over imgui window

### DIFF
--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -2161,7 +2161,11 @@ SOKOL_API_IMPL bool simgui_handle_event(const sapp_event* ev) {
         default:
             break;
     }
-    return io->WantCaptureKeyboard || io->WantCaptureMouse;
+
+    if (ev->type == SAPP_EVENTTYPE_KEY_DOWN || ev->type == SAPP_EVENTTYPE_KEY_UP) {
+        return io->WantCaptureKeyboard;
+    }
+    return io->WantCaptureMouse;
 }
 #endif
 


### PR DESCRIPTION
Creating an interface with Dear ImGui that only uses the mouse, I found I couldn't dismiss it with my designated toggle key because `simgui_handle_event` was returning `true` if the mouse pointer was positioned inside one of the rendered windows. I figure that if Dear ImGui's `WantCaptureKeyboard` flag is `false`, then `simgui_handle_event` should not return `true` for keyboard events. 

This may be an intentional design thing, though... I'm still getting used to using Dear ImGui and maybe this is expected behavior. It felt like a bug to me, though. Even if it's something to be fixed, this might be a too ham-fisted way of going about it. (It works for my very limited case, though.) 

Anyway, wanted to submit this just in case someone else gets puzzled by it as well. 