### PR TITLE
Support integer uniform types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 ## Updates
 
+- **08-Jan-2022**: some enhancements and cleanup to uniform data handling in sokol_gfx.h
+  and the sokol-shdc shader compiler:
+    - The GLSL uniform types ```int```, ```ivec2```, ```ivec3``` and
+      ```ivec4``` can now be used in shader code, those are exposed to the GL
+      backends with the new ```sg_uniform_type``` items
+      ```SG_UNIFORM_TYPE_INT[2,3,4]```.
+    - A new enum ```sg_uniform_layout```, currently with the values ```SG_UNIFORMLAYOUT_NATIVE```
+      and ```SG_UNIFORMLAYOUT_STD140```. The enum is used in ```sg_shader_uniform_block_desc```
+      as a 'packing rule hint', so that the GL backend can properly locate the offset
+      of uniform block members. The default (```SG_UNIFORMLAYOUT_NATIVE``` keeps the same
+      behaviour, so existing backend code shouldn't need to be changed. With the packing
+      rule ```SG_UNIFORMLAYOUT_STD140``` the uniform block interior is expected to be
+      layed out according to the OpenGL std140 packing rule.
+    - Note that with the std140 packing rule, arrays are only allowed for the types
+      ```vec4```, ```int4``` and ```mat4```. This is because the uniform data must
+      still be compatible with ```glUniform()``` calls in the GL backends (which
+      have different 'interior alignment' for arrays).
+    - The sokol-shdc compiler supports the new uniform types and will annotate the 
+      code-generated sg_shader_desc structs with ```SG_UNIFORMLAYOUT_STD140```,
+      and there are new errors to make sure that uniform blocks are compatible
+      with all sokol_gfx.h backends.
+    - Likewise, sokol_gfx.h has tighter validation for the ```sg_shader_uniform_block```
+      desc struct, but only when the GL backend is used (in general, the interior
+      layout of uniform blocks is only relevant for GL backends, on all other backends
+      sokol_gfx.h just passes the uniform data as an opaque block to the shader)
+  For more details see:
+    - [new sections in the sokol_gfx.h documentation](https://github.com/floooh/sokol/blob/ba64add0b67cac16fc86fb6b64d1da5f67e80c0f/sokol_gfx.h#L343-L450)
+    - [documentation of ```sg_uniform_layout```](https://github.com/floooh/sokol/blob/ba64add0b67cac16fc86fb6b64d1da5f67e80c0f/sokol_gfx.h#L1322-L1355)
+    - [enhanced sokol-shdc documentation](https://github.com/floooh/sokol-tools/blob/master/docs/sokol-shdc.md#glsl-uniform-blocks-and-c-structs)
+    - [a new sample 'uniformtypes-sapp'](https://floooh.github.io/sokol-html5/uniformtypes-sapp.html)
+
 - **27-Dec-2021**: sokol_app.h frame timing improvements:
   - A new function ```double sapp_frame_duration(void)``` which returns the frame
     duration in seconds, averaged over the last 256 frames to smooth out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - **08-Jan-2022**: some enhancements and cleanup to uniform data handling in sokol_gfx.h
   and the sokol-shdc shader compiler:
+    - *IMPORTANT*: when updating sokol_gfx.h (and you're using the sokol-shdc shader compiler),
+      don't forget to update the sokol-shdc binaries too!
     - The GLSL uniform types ```int```, ```ivec2```, ```ivec3``` and
       ```ivec4``` can now be used in shader code, those are exposed to the GL
       backends with the new ```sg_uniform_type``` items

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simple
 [STB-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt)
 cross-platform libraries for C and C++, written in C.
 
-[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**27-Dec-2021** sokol_app.h: new sapp_frame_duration() function, and 120Hz support on macOS and iOS)
+[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**07-Jan-2022** sokol_gfx.h: uniform data cleanup and enhancements)
 
 ## Examples and Related Projects
 

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4814,7 +4814,6 @@ _SOKOL_PRIVATE void _sg_dummy_update_image(_sg_image_t* img, const sg_image_data
     _SG_XMACRO(glDrawArraysInstanced,             void, (GLenum mode, GLint first, GLsizei count, GLsizei instancecount)) \
     _SG_XMACRO(glClearStencil,                    void, (GLint s)) \
     _SG_XMACRO(glScissor,                         void, (GLint x, GLint y, GLsizei width, GLsizei height)) \
-    _SG_XMACRO(glUniform3fv,                      void, (GLint location, GLsizei count, const GLfloat * value)) \
     _SG_XMACRO(glGenRenderbuffers,                void, (GLsizei n, GLuint * renderbuffers)) \
     _SG_XMACRO(glBufferData,                      void, (GLenum target, GLsizeiptr size, const void * data, GLenum usage)) \
     _SG_XMACRO(glBlendFuncSeparate,               void, (GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha, GLenum dfactorAlpha)) \
@@ -4835,7 +4834,6 @@ _SOKOL_PRIVATE void _sg_dummy_update_image(_sg_image_t* img, const sg_image_data
     _SG_XMACRO(glStencilFunc,                     void, (GLenum func, GLint ref, GLuint mask)) \
     _SG_XMACRO(glEnableVertexAttribArray,         void, (GLuint index)) \
     _SG_XMACRO(glBlendFunc,                       void, (GLenum sfactor, GLenum dfactor)) \
-    _SG_XMACRO(glUniform1fv,                      void, (GLint location, GLsizei count, const GLfloat * value)) \
     _SG_XMACRO(glReadBuffer,                      void, (GLenum src)) \
     _SG_XMACRO(glReadPixels,                      void, (GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, void * data)) \
     _SG_XMACRO(glClear,                           void, (GLbitfield mask)) \

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4751,8 +4751,15 @@ _SOKOL_PRIVATE void _sg_dummy_update_image(_sg_image_t* img, const sg_image_data
     _SG_XMACRO(glClearBufferuiv,                  void, (GLenum buffer, GLint drawbuffer, const GLuint * value)) \
     _SG_XMACRO(glClearBufferiv,                   void, (GLenum buffer, GLint drawbuffer, const GLint * value)) \
     _SG_XMACRO(glDeleteRenderbuffers,             void, (GLsizei n, const GLuint * renderbuffers)) \
-    _SG_XMACRO(glUniform4fv,                      void, (GLint location, GLsizei count, const GLfloat * value)) \
+    _SG_XMACRO(glUniform1fv,                      void, (GLint location, GLsizei count, const GLfloat * value)) \
     _SG_XMACRO(glUniform2fv,                      void, (GLint location, GLsizei count, const GLfloat * value)) \
+    _SG_XMACRO(glUniform3fv,                      void, (GLint location, GLsizei count, const GLfloat * value)) \
+    _SG_XMACRO(glUniform4fv,                      void, (GLint location, GLsizei count, const GLfloat * value)) \
+    _SG_XMACRO(glUniform1iv,                      void, (GLint location, GLsizei count, const GLint * value)) \
+    _SG_XMACRO(glUniform2iv,                      void, (GLint location, GLsizei count, const GLint * value)) \
+    _SG_XMACRO(glUniform3iv,                      void, (GLint location, GLsizei count, const GLint * value)) \
+    _SG_XMACRO(glUniform4iv,                      void, (GLint location, GLsizei count, const GLint * value)) \
+    _SG_XMACRO(glUniformMatrix4fv,                void, (GLint location, GLsizei count, GLboolean transpose, const GLfloat * value)) \
     _SG_XMACRO(glUseProgram,                      void, (GLuint program)) \
     _SG_XMACRO(glShaderSource,                    void, (GLuint shader, GLsizei count, const GLchar *const* string, const GLint * length)) \
     _SG_XMACRO(glLinkProgram,                     void, (GLuint program)) \
@@ -4777,7 +4784,6 @@ _SOKOL_PRIVATE void _sg_dummy_update_image(_sg_image_t* img, const sg_image_data
     _SG_XMACRO(glCompressedTexImage3D,            void, (GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, const void * data)) \
     _SG_XMACRO(glActiveTexture,                   void, (GLenum texture)) \
     _SG_XMACRO(glTexSubImage3D,                   void, (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const void * pixels)) \
-    _SG_XMACRO(glUniformMatrix4fv,                void, (GLint location, GLsizei count, GLboolean transpose, const GLfloat * value)) \
     _SG_XMACRO(glRenderbufferStorage,             void, (GLenum target, GLenum internalformat, GLsizei width, GLsizei height)) \
     _SG_XMACRO(glGenTextures,                     void, (GLsizei n, GLuint * textures)) \
     _SG_XMACRO(glPolygonOffset,                   void, (GLfloat factor, GLfloat units)) \

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -7362,7 +7362,7 @@ _SOKOL_PRIVATE void _sg_gl_apply_uniforms(sg_shader_stage stage_index, int ub_in
             continue;
         }
         GLfloat* fptr = (GLfloat*) (((uint8_t*)data->ptr) + u->offset);
-        GLint* iptr = (GLint) (((uint8_t*)data->ptr) + u->offset);
+        GLint* iptr = (GLint*) (((uint8_t*)data->ptr) + u->offset);
         switch (u->type) {
             case SG_UNIFORMTYPE_INVALID:
                 break;
@@ -7382,7 +7382,7 @@ _SOKOL_PRIVATE void _sg_gl_apply_uniforms(sg_shader_stage stage_index, int ub_in
                 glUniform4fv(u->gl_loc, u->count, fptr);
                 break;
             case SG_UNIFORMTYPE_INT:
-                SOKOL_ASSERT(count == 1);
+                SOKOL_ASSERT(u->count == 1);
                 glUniform1iv(u->gl_loc, 1, iptr);
                 break;
             case SG_UNIFORMTYPE_INT2:


### PR DESCRIPTION
- new uniform types (only relevant for GL backends):
    - SG_UNIFORMTYPE_INT
    - SG_UNIFORMTYPE_INT2
    - SG_UNIFORMTYPE_INT3
    - SG_UNIFORMTYPE_INT4
 - a new enum sg_uniform_layout (native or std140) used in sg_shader_uniform_block_desc to hint sokol-gfx about the memory layout of uniform blocks (also only relevant for GL backends)
 - tighter validation of uniform block interior (only GL backend)