### PR TITLE
sokol_imgui.h: use ImDrawCmd::IdxOffset

### DIFF
--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -1993,7 +1993,6 @@ SOKOL_API_IMPL void simgui_render(void) {
         bind.index_buffer_offset = ib_offset;
         sg_apply_bindings(&bind);
 
-        int base_element = 0;
         #if defined(__cplusplus)
             const int num_cmds = cl->CmdBuffer.size();
         #else
@@ -2023,9 +2022,8 @@ SOKOL_API_IMPL void simgui_render(void) {
                 const int scissor_w = (int) ((pcmd->ClipRect.z - pcmd->ClipRect.x) * dpi_scale);
                 const int scissor_h = (int) ((pcmd->ClipRect.w - pcmd->ClipRect.y) * dpi_scale);
                 sg_apply_scissor_rect(scissor_x, scissor_y, scissor_w, scissor_h, true);
-                sg_draw(base_element, (int)pcmd->ElemCount, 1);
+                sg_draw((int)pcmd->IdxOffset, (int)pcmd->ElemCount, 1);
             }
-            base_element += (int)pcmd->ElemCount;
         }
         #if defined(__cplusplus)
             const size_t vtx_size = cl->VtxBuffer.size() * sizeof(ImDrawVert);


### PR DESCRIPTION
sokol_imgui.h wasn't using ```ImDrawCmd::IdxOffset```, causing visual gliches with Dear ImGui v1.86.
Several backends had the same bug. The release notes explain the bug and its fix:
https://github.com/ocornut/imgui/releases/tag/v1.86

I cast the value to ```int``` to be consistent with the rest of the code.