### PR TITLE
sokol_imgui.h: Updated imgui keypad enter constant

### DIFF
--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -1682,7 +1682,7 @@ SOKOL_API_IMPL void simgui_setup(const simgui_desc_t* desc) {
         io->KeyMap[ImGuiKey_Backspace] = SAPP_KEYCODE_BACKSPACE;
         io->KeyMap[ImGuiKey_Space] = SAPP_KEYCODE_SPACE;
         io->KeyMap[ImGuiKey_Enter] = SAPP_KEYCODE_ENTER;
-        io->KeyMap[ImGuiKey_KeyPadEnter] = SAPP_KEYCODE_KP_ENTER;
+        io->KeyMap[ImGuiKey_KeypadEnter] = SAPP_KEYCODE_KP_ENTER;
         io->KeyMap[ImGuiKey_Escape] = SAPP_KEYCODE_ESCAPE;
         if (!_simgui.desc.disable_hotkeys) {
             io->KeyMap[ImGuiKey_A] = SAPP_KEYCODE_A;


### PR DESCRIPTION
The constant in ImGui has been updated in https://github.com/ocornut/imgui/pull/2625

The old one `ImGuiKey_KeyPadEnter` is still present for backwards compatibility but if one uses `IMGUI_DISABLE_OBSOLETE_FUNCTIONS` it is not defined.