### PR TITLE
add sapp_input_wait() to fix high cpu usage while idle

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1476,6 +1476,8 @@ SOKOL_APP_API_DECL void sapp_request_quit(void);
 SOKOL_APP_API_DECL void sapp_cancel_quit(void);
 /* initiate a "hard quit" (quit application without sending SAPP_EVENTTYPE_QUIT_REQUSTED) */
 SOKOL_APP_API_DECL void sapp_quit(void);
+/* this causes the app to block until input is received. the flag will be cleared after that, so you will have to call it again if necessary. */
+SOKOL_APP_API_DECL void sapp_input_wait(void);
 /* call from inside event callback to consume the current event (don't forward to platform) */
 SOKOL_APP_API_DECL void sapp_consume_event(void);
 /* get the current frame counter (for comparison with sapp_event.frame_count) */
@@ -2517,6 +2519,7 @@ typedef struct {
     bool event_consumed;
     bool html5_ask_leave_site;
     bool onscreen_keyboard_shown;
+    bool input_wait;
     int window_width;
     int window_height;
     int framebuffer_width;
@@ -11109,11 +11112,13 @@ _SOKOL_PRIVATE void _sapp_linux_run(const sapp_desc* desc) {
         _sapp_timing_measure(&_sapp.timing);
         _sapp_glx_make_current();
         int count = XPending(_sapp.x11.display);
-        while (count--) {
+        if(count) while (count--) {
+jmp:;
             XEvent event;
             XNextEvent(_sapp.x11.display, &event);
             _sapp_x11_process_event(&event);
-        }
+        } else if(_sapp.input_wait) goto jmp;
+        _sapp.input_wait = false;
         _sapp_frame();
         _sapp_glx_swap_buffers();
         XFlush(_sapp.x11.display);
@@ -11334,6 +11339,10 @@ SOKOL_API_IMPL void sapp_cancel_quit(void) {
 
 SOKOL_API_IMPL void sapp_quit(void) {
     _sapp.quit_ordered = true;
+}
+
+SOKOL_API_IMPL void sapp_input_wait(void) {
+    _sapp.input_wait = true;
 }
 
 SOKOL_API_IMPL void sapp_consume_event(void) {


### PR DESCRIPTION
a sokol_app produces constant cpu load because it keeps repainting
the screen whether something has changed or not. we can fix this
easily by simply calling XNextEvent(), which blocks if there are no
pending events. this causes the app to idle until the user interacts
with the program.

a new function sapp_input_wait() was added to control this behaviour,
which causes the sokol app to block until the next input is received.
afterwards, the input_wait flag is cleared and the user has to set
it again if so desired.

this PR currently only addresses linux, and uses a "dirty" goto, which can be avoided by factoring out the XNextEvent block into a separate function.