### PR TITLE
Add 'dynamic' allocator functions to sokol headers.

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1358,8 +1358,9 @@ typedef struct sapp_icon_desc {
     sapp_allocator
 
     Used in sapp_desc to provide custom memory-alloc and -free functions
-    to sokol_app.h. If no allocator is provided, malloc() and free()
-    will be called.
+    to sokol_app.h. If memory management should be overridden, both the
+    alloc and free function must be provided (e.g. it's not valid to
+    override one function but not the other).
 */
 typedef void*(*sapp_malloc)(size_t size, void* user_data);
 typedef void(*sapp_free)(void* ptr, void* user_data);

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1579,7 +1579,7 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 #ifdef SOKOL_APP_IMPL
 #define SOKOL_APP_IMPL_INCLUDED (1)
 
-#include <stdlib.h> // malloc/free
+#include <stdlib.h> // malloc, free
 #include <string.h> // memset
 #include <stddef.h> // size_t
 
@@ -2482,7 +2482,7 @@ typedef struct {
         #define _SAPP_CLEAR_ARC_STRUCT(type, item) { item = (type) { 0 }; }
     #endif
 #else
-    #define _SAPP_CLEAR_ARC_STRUCT(type, item) { _sg_clear(&item, sizeof(item)); }
+    #define _SAPP_CLEAR_ARC_STRUCT(type, item) { _sapp_clear(&item, sizeof(item)); }
 #endif
 
 typedef struct {

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2705,17 +2705,17 @@ _SOKOL_PRIVATE bool _sapp_strcpy(const char* src, char* dst, int max_len) {
     }
 }
 
-_SOKOL_PRIVATE sapp_desc _sapp_desc_defaults(const sapp_desc* in_desc) {
-    SOKOL_ASSERT((in_desc->allocator.alloc && in_desc->allocator.free) || (!in_desc->allocator.alloc && !in_desc->allocator.free));
-    sapp_desc desc = *in_desc;
-    desc.sample_count = _sapp_def(desc.sample_count, 1);
-    desc.swap_interval = _sapp_def(desc.swap_interval, 1);
-    desc.html5_canvas_name = _sapp_def(desc.html5_canvas_name, "canvas");
-    desc.clipboard_size = _sapp_def(desc.clipboard_size, 8192);
-    desc.max_dropped_files = _sapp_def(desc.max_dropped_files, 1);
-    desc.max_dropped_file_path_length = _sapp_def(desc.max_dropped_file_path_length, 2048);
-    desc.window_title = _sapp_def(desc.window_title, "sokol_app");
-    return desc;
+_SOKOL_PRIVATE sapp_desc _sapp_desc_defaults(const sapp_desc* desc) {
+    SOKOL_ASSERT((desc->allocator.alloc && desc->allocator.free) || (!desc->allocator.alloc && !desc->allocator.free));
+    sapp_desc res = *desc;
+    res.sample_count = _sapp_def(res.sample_count, 1);
+    res.swap_interval = _sapp_def(res.swap_interval, 1);
+    res.html5_canvas_name = _sapp_def(res.html5_canvas_name, "canvas");
+    res.clipboard_size = _sapp_def(res.clipboard_size, 8192);
+    res.max_dropped_files = _sapp_def(res.max_dropped_files, 1);
+    res.max_dropped_file_path_length = _sapp_def(res.max_dropped_file_path_length, 2048);
+    res.window_title = _sapp_def(res.window_title, "sokol_app");
+    return res;
 }
 
 _SOKOL_PRIVATE void _sapp_init_state(const sapp_desc* desc) {

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -36,8 +36,6 @@
         SOKOL_APP_API_DECL  - public function declaration prefix (default: extern)
         SOKOL_API_DECL      - same as SOKOL_APP_API_DECL
         SOKOL_API_IMPL      - public function implementation prefix (default: -)
-        SOKOL_CALLOC        - your own calloc function (default: calloc(n, s))
-        SOKOL_FREE          - your own free function (default: free(p))
 
     Optionally define the following to force debug checks and validations
     even in release mode:
@@ -1356,6 +1354,20 @@ typedef struct sapp_icon_desc {
     sapp_image_desc images[SAPP_MAX_ICONIMAGES];
 } sapp_icon_desc;
 
+/*
+    sapp_allocator
+
+    Used in sapp_desc to provide custom memory-alloc and -free functions
+    to sokol_app.h. The function prototypes are compatible with
+    malloc/free.
+*/
+typedef void*(*sapp_malloc)(size_t size);
+typedef void(*sapp_free)(void* ptr);
+
+typedef struct sapp_allocator {
+    sapp_malloc alloc;
+    sapp_free free;
+} sapp_allocator;
 
 typedef struct sapp_desc {
     void (*init_cb)(void);                  // these are the user-provided callbacks without user data
@@ -1386,6 +1398,7 @@ typedef struct sapp_desc {
     int max_dropped_files;              // max number of dropped files to process (default: 1)
     int max_dropped_file_path_length;   // max length in bytes of a dropped UTF-8 file path (default: 2048)
     sapp_icon_desc icon;                // the initial window icon to set
+    sapp_allocator allocator;           // optional memory allocation overrides (default: malloc/free)
 
     /* backend-specific options */
     bool gl_force_gles2;                // if true, setup GLES2/WebGL even if GLES3/WebGL2 is available
@@ -1566,6 +1579,7 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 #ifdef SOKOL_APP_IMPL
 #define SOKOL_APP_IMPL_INCLUDED (1)
 
+#include <stdlib.h> // malloc/free
 #include <string.h> // memset
 #include <stddef.h> // size_t
 
@@ -1649,15 +1663,6 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 #ifndef SOKOL_UNREACHABLE
     #define SOKOL_UNREACHABLE SOKOL_ASSERT(false)
 #endif
-#if !defined(SOKOL_CALLOC) || !defined(SOKOL_FREE)
-    #include <stdlib.h>
-#endif
-#if !defined(SOKOL_CALLOC)
-    #define SOKOL_CALLOC(n,s) calloc(n,s)
-#endif
-#if !defined(SOKOL_FREE)
-    #define SOKOL_FREE(p) free(p)
-#endif
 #ifndef SOKOL_LOG
     #ifdef SOKOL_DEBUG
         #if defined(__ANDROID__)
@@ -1672,7 +1677,6 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #endif
 #endif
 #ifndef SOKOL_ABORT
-    #include <stdlib.h>
     #define SOKOL_ABORT() abort()
 #endif
 #ifndef _SOKOL_PRIVATE
@@ -2473,12 +2477,12 @@ typedef struct {
 #if defined(_SAPP_MACOS) || defined(_SAPP_IOS)
     // this is ARC compatible
     #if defined(__cplusplus)
-        #define _SAPP_CLEAR(type, item) { item = { }; }
+        #define _SAPP_CLEAR_ARC_STRUCT(type, item) { item = { }; }
     #else
-        #define _SAPP_CLEAR(type, item) { item = (type) { 0 }; }
+        #define _SAPP_CLEAR_ARC_STRUCT(type, item) { item = (type) { 0 }; }
     #endif
 #else
-    #define _SAPP_CLEAR(type, item) { memset(&item, 0, sizeof(item)); }
+    #define _SAPP_CLEAR_ARC_STRUCT(type, item) { _sg_clear(&item, sizeof(item)); }
 #endif
 
 typedef struct {
@@ -2564,6 +2568,23 @@ typedef struct {
 static _sapp_t _sapp;
 
 /*=== PRIVATE HELPER FUNCTIONS ===============================================*/
+_SOKOL_PRIVATE void _sapp_clear(void* ptr, size_t size) {
+    SOKOL_ASSERT(ptr && (size > 0));
+    memset(ptr, 0, size);
+}
+
+_SOKOL_PRIVATE void* _sapp_malloc_clear(size_t size) {
+    SOKOL_ASSERT(size > 0);
+    void* ptr = _sapp.desc.allocator.alloc(size);
+    SOKOL_ASSERT(ptr);
+    _sapp_clear(ptr, size);
+    return ptr;
+}
+
+_SOKOL_PRIVATE void _sapp_free(void* ptr) {
+    _sapp.desc.allocator.free(ptr);
+}
+
 _SOKOL_PRIVATE void _sapp_fail(const char* msg) {
     if (_sapp.desc.fail_cb) {
         _sapp.desc.fail_cb(msg);
@@ -2675,6 +2696,8 @@ _SOKOL_PRIVATE sapp_desc _sapp_desc_defaults(const sapp_desc* in_desc) {
     desc.max_dropped_files = _sapp_def(desc.max_dropped_files, 1);
     desc.max_dropped_file_path_length = _sapp_def(desc.max_dropped_file_path_length, 2048);
     desc.window_title = _sapp_def(desc.window_title, "sokol_app");
+    desc.allocator.alloc = _sapp_def(desc.allocator.alloc, malloc);
+    desc.allocator.free = _sapp_def(desc.allocator.free, free);
     return desc;
 }
 
@@ -2687,7 +2710,7 @@ _SOKOL_PRIVATE void _sapp_init_state(const sapp_desc* desc) {
     SOKOL_ASSERT(desc->clipboard_size >= 0);
     SOKOL_ASSERT(desc->max_dropped_files >= 0);
     SOKOL_ASSERT(desc->max_dropped_file_path_length >= 0);
-    _SAPP_CLEAR(_sapp_t, _sapp);
+    _SAPP_CLEAR_ARC_STRUCT(_sapp_t, _sapp);
     _sapp.desc = _sapp_desc_defaults(desc);
     _sapp.first_frame = true;
     // NOTE: _sapp.desc.width/height may be 0! Platform backends need to deal with this
@@ -2704,14 +2727,14 @@ _SOKOL_PRIVATE void _sapp_init_state(const sapp_desc* desc) {
     _sapp.clipboard.enabled = _sapp.desc.enable_clipboard;
     if (_sapp.clipboard.enabled) {
         _sapp.clipboard.buf_size = _sapp.desc.clipboard_size;
-        _sapp.clipboard.buffer = (char*) SOKOL_CALLOC(1, (size_t)_sapp.clipboard.buf_size);
+        _sapp.clipboard.buffer = (char*) _sapp_malloc_clear((size_t)_sapp.clipboard.buf_size);
     }
     _sapp.drop.enabled = _sapp.desc.enable_dragndrop;
     if (_sapp.drop.enabled) {
         _sapp.drop.max_files = _sapp.desc.max_dropped_files;
         _sapp.drop.max_path_length = _sapp.desc.max_dropped_file_path_length;
         _sapp.drop.buf_size = _sapp.drop.max_files * _sapp.drop.max_path_length;
-        _sapp.drop.buffer = (char*) SOKOL_CALLOC(1, (size_t)_sapp.drop.buf_size);
+        _sapp.drop.buffer = (char*) _sapp_malloc_clear((size_t)_sapp.drop.buf_size);
     }
     _sapp_strcpy(_sapp.desc.window_title, _sapp.window_title, sizeof(_sapp.window_title));
     _sapp.desc.window_title = _sapp.window_title;
@@ -2724,20 +2747,20 @@ _SOKOL_PRIVATE void _sapp_init_state(const sapp_desc* desc) {
 _SOKOL_PRIVATE void _sapp_discard_state(void) {
     if (_sapp.clipboard.enabled) {
         SOKOL_ASSERT(_sapp.clipboard.buffer);
-        SOKOL_FREE((void*)_sapp.clipboard.buffer);
+        _sapp_free((void*)_sapp.clipboard.buffer);
     }
     if (_sapp.drop.enabled) {
         SOKOL_ASSERT(_sapp.drop.buffer);
-        SOKOL_FREE((void*)_sapp.drop.buffer);
+        _sapp_free((void*)_sapp.drop.buffer);
     }
     if (_sapp.default_icon_pixels) {
-        SOKOL_FREE((void*)_sapp.default_icon_pixels);
+        _sapp_free((void*)_sapp.default_icon_pixels);
     }
-    _SAPP_CLEAR(_sapp_t, _sapp);
+    _SAPP_CLEAR_ARC_STRUCT(_sapp_t, _sapp);
 }
 
 _SOKOL_PRIVATE void _sapp_init_event(sapp_event_type type) {
-    memset(&_sapp.event, 0, sizeof(_sapp.event));
+    _sapp_clear(&_sapp.event, sizeof(_sapp.event));
     _sapp.event.type = type;
     _sapp.event.frame_count = _sapp.frame_count;
     _sapp.event.mouse_button = SAPP_MOUSEBUTTON_INVALID;
@@ -2768,7 +2791,7 @@ _SOKOL_PRIVATE sapp_keycode _sapp_translate_key(int scan_code) {
 _SOKOL_PRIVATE void _sapp_clear_drop_buffer(void) {
     if (_sapp.drop.enabled) {
         SOKOL_ASSERT(_sapp.drop.buffer);
-        memset(_sapp.drop.buffer, 0, (size_t)_sapp.drop.buf_size);
+        _sapp_clear(_sapp.drop.buffer, (size_t)_sapp.drop.buf_size);
     }
 }
 
@@ -2842,7 +2865,7 @@ _SOKOL_PRIVATE void _sapp_setup_default_icon(void) {
     for (int i = 0; i < num_icons; i++) {
         all_num_pixels += icon_sizes[i] * icon_sizes[i];
     }
-    _sapp.default_icon_pixels = (uint32_t*) SOKOL_CALLOC((size_t)all_num_pixels, sizeof(uint32_t));
+    _sapp.default_icon_pixels = (uint32_t*) _sapp_malloc_clear((size_t)all_num_pixels * sizeof(uint32_t));
 
     // initialize default_icon_desc struct
     uint32_t* dst = _sapp.default_icon_pixels;
@@ -4290,7 +4313,7 @@ EMSCRIPTEN_KEEPALIVE void _sapp_emsc_end_drop(int x, int y) {
 
 EMSCRIPTEN_KEEPALIVE void _sapp_emsc_invoke_fetch_cb(int index, int success, int error_code, _sapp_html5_fetch_callback callback, uint32_t fetched_size, void* buf_ptr, uint32_t buf_size, void* user_data) {
     sapp_html5_fetch_response response;
-    memset(&response, 0, sizeof(response));
+    _sapp_clear(&response, sizeof(response));
     response.succeeded = (0 != success);
     response.error_code = (sapp_html5_fetch_error) error_code;
     response.file_index = index;
@@ -5190,7 +5213,7 @@ _SOKOL_PRIVATE void _sapp_emsc_wgpu_surfaces_create(void) {
     SOKOL_ASSERT(0 == _sapp.emsc.wgpu.msaa_view);
 
     WGPUTextureDescriptor ds_desc;
-    memset(&ds_desc, 0, sizeof(ds_desc));
+    _sapp_clear(&ds_desc, sizeof(ds_desc));
     ds_desc.usage = WGPUTextureUsage_OutputAttachment;
     ds_desc.dimension = WGPUTextureDimension_2D;
     ds_desc.size.width = (uint32_t) _sapp.framebuffer_width;
@@ -5205,7 +5228,7 @@ _SOKOL_PRIVATE void _sapp_emsc_wgpu_surfaces_create(void) {
 
     if (_sapp.sample_count > 1) {
         WGPUTextureDescriptor msaa_desc;
-        memset(&msaa_desc, 0, sizeof(msaa_desc));
+        _sapp_clear(&msaa_desc, sizeof(msaa_desc));
         msaa_desc.usage = WGPUTextureUsage_OutputAttachment;
         msaa_desc.dimension = WGPUTextureDimension_2D;
         msaa_desc.size.width = (uint32_t) _sapp.framebuffer_width;
@@ -5417,7 +5440,7 @@ typedef struct {
 } _sapp_gl_fbconfig;
 
 _SOKOL_PRIVATE void _sapp_gl_init_fbconfig(_sapp_gl_fbconfig* fbconfig) {
-    memset(fbconfig, 0, sizeof(_sapp_gl_fbconfig));
+    _sapp_clear(fbconfig, sizeof(_sapp_gl_fbconfig));
     /* -1 means "don't care" */
     fbconfig->red_bits = -1;
     fbconfig->green_bits = -1;
@@ -5515,7 +5538,7 @@ _SOKOL_PRIVATE const _sapp_gl_fbconfig* _sapp_gl_choose_fbconfig(const _sapp_gl_
 #if defined(_SAPP_WIN32) || defined(_SAPP_UWP)
 _SOKOL_PRIVATE bool _sapp_win32_uwp_utf8_to_wide(const char* src, wchar_t* dst, int dst_num_bytes) {
     SOKOL_ASSERT(src && dst && (dst_num_bytes > 1));
-    memset(dst, 0, (size_t)dst_num_bytes);
+    _sapp_clear(dst, (size_t)dst_num_bytes);
     const int dst_chars = dst_num_bytes / (int)sizeof(wchar_t);
     const int dst_needed = MultiByteToWideChar(CP_UTF8, 0, src, -1, 0, 0);
     if ((dst_needed > 0) && (dst_needed < dst_chars)) {
@@ -5877,7 +5900,7 @@ _SOKOL_PRIVATE void _sapp_d3d11_create_default_render_target(void) {
 
     /* common desc for MSAA and depth-stencil texture */
     D3D11_TEXTURE2D_DESC tex_desc;
-    memset(&tex_desc, 0, sizeof(tex_desc));
+    _sapp_clear(&tex_desc, sizeof(tex_desc));
     tex_desc.Width = (UINT)_sapp.framebuffer_width;
     tex_desc.Height = (UINT)_sapp.framebuffer_height;
     tex_desc.MipLevels = 1;
@@ -6033,7 +6056,7 @@ _SOKOL_PRIVATE bool _sapp_wgl_ext_supported(const char* ext) {
 _SOKOL_PRIVATE void _sapp_wgl_load_extensions(void) {
     SOKOL_ASSERT(_sapp.wgl.msg_dc);
     PIXELFORMATDESCRIPTOR pfd;
-    memset(&pfd, 0, sizeof(pfd));
+    _sapp_clear(&pfd, sizeof(pfd));
     pfd.nSize = sizeof(pfd);
     pfd.nVersion = 1;
     pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
@@ -6078,7 +6101,7 @@ _SOKOL_PRIVATE int _sapp_wgl_find_pixel_format(void) {
     const _sapp_gl_fbconfig* closest;
 
     int native_count = _sapp_wgl_attrib(1, WGL_NUMBER_PIXEL_FORMATS_ARB);
-    _sapp_gl_fbconfig* usable_configs = (_sapp_gl_fbconfig*) SOKOL_CALLOC((size_t)native_count, sizeof(_sapp_gl_fbconfig));
+    _sapp_gl_fbconfig* usable_configs = (_sapp_gl_fbconfig*) _sapp_malloc_clear((size_t)native_count * sizeof(_sapp_gl_fbconfig));
     SOKOL_ASSERT(usable_configs);
     int usable_count = 0;
     for (int i = 0; i < native_count; i++) {
@@ -6125,7 +6148,7 @@ _SOKOL_PRIVATE int _sapp_wgl_find_pixel_format(void) {
     if (closest) {
         pixel_format = (int) closest->handle;
     }
-    SOKOL_FREE(usable_configs);
+    _sapp_free(usable_configs);
     return pixel_format;
 }
 
@@ -6192,7 +6215,7 @@ _SOKOL_PRIVATE void _sapp_wgl_swap_buffers(void) {
 
 _SOKOL_PRIVATE bool _sapp_win32_wide_to_utf8(const wchar_t* src, char* dst, int dst_num_bytes) {
     SOKOL_ASSERT(src && dst && (dst_num_bytes > 1));
-    memset(dst, 0, (size_t)dst_num_bytes);
+    _sapp_clear(dst, (size_t)dst_num_bytes);
     const int bytes_needed = WideCharToMultiByte(CP_UTF8, 0, src, -1, NULL, 0, NULL, NULL);
     if (bytes_needed <= dst_num_bytes) {
         WideCharToMultiByte(CP_UTF8, 0, src, -1, dst, dst_num_bytes, NULL, NULL);
@@ -6234,7 +6257,7 @@ _SOKOL_PRIVATE bool _sapp_win32_update_dimensions(void) {
 _SOKOL_PRIVATE void _sapp_win32_set_fullscreen(bool fullscreen, UINT swp_flags) {
     HMONITOR monitor = MonitorFromWindow(_sapp.win32.hwnd, MONITOR_DEFAULTTONEAREST);
     MONITORINFO minfo;
-    memset(&minfo, 0, sizeof(minfo));
+    _sapp_clear(&minfo, sizeof(minfo));
     minfo.cbSize = sizeof(MONITORINFO);
     GetMonitorInfo(monitor, &minfo);
     const RECT mr = minfo.rcMonitor;
@@ -6479,13 +6502,13 @@ _SOKOL_PRIVATE void _sapp_win32_files_dropped(HDROP hdrop) {
     _sapp.drop.num_files = (count > _sapp.drop.max_files) ? _sapp.drop.max_files : count;
     for (UINT i = 0;  i < (UINT)_sapp.drop.num_files;  i++) {
         const UINT num_chars = DragQueryFileW(hdrop, i, NULL, 0) + 1;
-        WCHAR* buffer = (WCHAR*) SOKOL_CALLOC(num_chars, sizeof(WCHAR));
+        WCHAR* buffer = (WCHAR*) _sapp_malloc_clear(num_chars * sizeof(WCHAR));
         DragQueryFileW(hdrop, i, buffer, num_chars);
         if (!_sapp_win32_wide_to_utf8(buffer, _sapp_dropped_file_path_ptr((int)i), _sapp.drop.max_path_length)) {
             SOKOL_LOG("sokol_app.h: dropped file path too long (sapp_desc.max_dropped_file_path_length)\n");
             drop_failed = true;
         }
-        SOKOL_FREE(buffer);
+        _sapp_free(buffer);
     }
     DragFinish(hdrop);
     if (!drop_failed) {
@@ -6505,7 +6528,7 @@ _SOKOL_PRIVATE void _sapp_win32_timing_measure(void) {
         // on D3D11, use the more precise DXGI timestamp
         if (_sapp.d3d11.use_dxgi_frame_stats) {
             DXGI_FRAME_STATISTICS dxgi_stats;
-            _SAPP_CLEAR(DXGI_FRAME_STATISTICS, dxgi_stats);
+            _sapp_clear(DXGI_FRAME_STATISTICS, dxgi_stats);
             HRESULT hr = _sapp_dxgi_GetFrameStatistics(_sapp.d3d11.swap_chain, &dxgi_stats);
             if (SUCCEEDED(hr)) {
                 if (dxgi_stats.SyncRefreshCount != _sapp.d3d11.sync_refresh_count) {
@@ -6643,7 +6666,7 @@ _SOKOL_PRIVATE LRESULT CALLBACK _sapp_win32_wndproc(HWND hWnd, UINT uMsg, WPARAM
                     if (!_sapp.win32.mouse_tracked) {
                         _sapp.win32.mouse_tracked = true;
                         TRACKMOUSEEVENT tme;
-                        memset(&tme, 0, sizeof(tme));
+                        _sapp_clear(&tme, 0, sizeof(tme));
                         tme.cbSize = sizeof(tme);
                         tme.dwFlags = TME_LEAVE;
                         tme.hwndTrack = _sapp.win32.hwnd;
@@ -6767,7 +6790,7 @@ _SOKOL_PRIVATE LRESULT CALLBACK _sapp_win32_wndproc(HWND hWnd, UINT uMsg, WPARAM
 
 _SOKOL_PRIVATE void _sapp_win32_create_window(void) {
     WNDCLASSW wndclassw;
-    memset(&wndclassw, 0, sizeof(wndclassw));
+    _sapp_clear(&wndclassw, sizeof(wndclassw));
     wndclassw.style = CS_HREDRAW | CS_VREDRAW | CS_OWNDC;
     wndclassw.lpfnWndProc = (WNDPROC) _sapp_win32_wndproc;
     wndclassw.hInstance = GetModuleHandleW(NULL);
@@ -7024,7 +7047,7 @@ _SOKOL_PRIVATE void _sapp_win32_update_window_title(void) {
 
 _SOKOL_PRIVATE HICON _sapp_win32_create_icon_from_image(const sapp_image_desc* desc) {
     BITMAPV5HEADER bi;
-    memset(&bi, 0, sizeof(bi));
+    _sapp_clear(&bi, sizeof(bi));
     bi.bV5Size = sizeof(bi);
     bi.bV5Width = desc->width;
     bi.bV5Height = -desc->height;   // NOTE the '-' here to indicate that origin is top-left
@@ -7063,7 +7086,7 @@ _SOKOL_PRIVATE HICON _sapp_win32_create_icon_from_image(const sapp_image_desc* d
     }
 
     ICONINFO icon_info;
-    memset(&icon_info, 0, sizeof(icon_info));
+    _sapp_clear(&icon_info, sizeof(icon_info));
     icon_info.fIcon = true;
     icon_info.xHotspot = 0;
     icon_info.yHotspot = 0;
@@ -7202,7 +7225,7 @@ _SOKOL_PRIVATE char** _sapp_win32_command_line_to_utf8_argv(LPWSTR w_command_lin
         _sapp_fail("Win32: failed to parse command line");
     } else {
         size_t size = wcslen(w_command_line) * 4;
-        argv = (char**) SOKOL_CALLOC(1, ((size_t)argc + 1) * sizeof(char*) + size);
+        argv = (char**) _sapp_malloc_clear(((size_t)argc + 1) * sizeof(char*) + size);
         SOKOL_ASSERT(argv);
         args = (char*) &argv[argc + 1];
         int n;
@@ -7239,7 +7262,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     char** argv_utf8 = _sapp_win32_command_line_to_utf8_argv(GetCommandLineW(), &argc_utf8);
     sapp_desc desc = sokol_main(argc_utf8, argv_utf8);
     _sapp_win32_run(&desc);
-    SOKOL_FREE(argv_utf8);
+    _sapp_free(argv_utf8);
     return 0;
 }
 #endif /* SOKOL_WIN32_FORCE_MAIN */
@@ -9977,7 +10000,7 @@ _SOKOL_PRIVATE GLXFBConfig _sapp_glx_choosefbconfig() {
         _sapp_fail("GLX: No GLXFBConfigs returned");
     }
 
-    usable_configs = (_sapp_gl_fbconfig*) SOKOL_CALLOC((size_t)native_count, sizeof(_sapp_gl_fbconfig));
+    usable_configs = (_sapp_gl_fbconfig*) _sapp_malloc_clear((size_t)native_count * sizeof(_sapp_gl_fbconfig));
     usable_count = 0;
     for (i = 0;  i < native_count;  i++) {
         const GLXFBConfig n = native_configs[i];
@@ -10025,7 +10048,7 @@ _SOKOL_PRIVATE GLXFBConfig _sapp_glx_choosefbconfig() {
         result = (GLXFBConfig) closest->handle;
     }
     XFree(native_configs);
-    SOKOL_FREE(usable_configs);
+    _sapp_free(usable_configs);
     return result;
 }
 
@@ -10101,7 +10124,7 @@ _SOKOL_PRIVATE void _sapp_glx_swapinterval(int interval) {
 
 _SOKOL_PRIVATE void _sapp_x11_send_event(Atom type, int a, int b, int c, int d, int e) {
     XEvent event;
-    memset(&event, 0, sizeof(event));
+    _sapp_clear(&event, sizeof(event));
 
     event.type = ClientMessage;
     event.xclient.window = _sapp.x11.window;
@@ -10158,7 +10181,7 @@ _SOKOL_PRIVATE void _sapp_x11_create_hidden_cursor(void) {
     img->xhot = 0;
     img->yhot = 0;
     const size_t num_bytes = (size_t)(w * h) * sizeof(XcursorPixel);
-    memset(img->pixels, 0, num_bytes);
+    _sapp_clear(img->pixels, num_bytes);
     _sapp.x11.hidden_cursor = XcursorImageLoadCursor(_sapp.x11.display, img);
     XcursorImageDestroy(img);
 }
@@ -10245,7 +10268,7 @@ _SOKOL_PRIVATE void _sapp_x11_set_icon(const sapp_icon_desc* icon_desc, int num_
         const sapp_image_desc* img_desc = &icon_desc->images[i];
         long_count += 2 + (img_desc->width * img_desc->height);
     }
-    long* icon_data = (long*) SOKOL_CALLOC((size_t)long_count, sizeof(long));
+    long* icon_data = (long*) _sapp_malloc_clear((size_t)long_count * sizeof(long));
     SOKOL_ASSERT(icon_data);
     long* dst = icon_data;
     for (int img_index = 0; img_index < num_images; img_index++) {
@@ -10267,14 +10290,14 @@ _SOKOL_PRIVATE void _sapp_x11_set_icon(const sapp_icon_desc* icon_desc, int num_
         PropModeReplace,
         (unsigned char*)icon_data,
         long_count);
-    SOKOL_FREE(icon_data);
+    _sapp_free(icon_data);
     XFlush(_sapp.x11.display);
 }
 
 _SOKOL_PRIVATE void _sapp_x11_create_window(Visual* visual, int depth) {
     _sapp.x11.colormap = XCreateColormap(_sapp.x11.display, _sapp.x11.root, visual, AllocNone);
     XSetWindowAttributes wa;
-    memset(&wa, 0, sizeof(wa));
+    _sapp_clear(&wa, sizeof(wa));
     const uint32_t wamask = CWBorderPixel | CWColormap | CWEventMask;
     wa.colormap = _sapp.x11.colormap;
     wa.border_pixel = 0;
@@ -10995,7 +11018,7 @@ _SOKOL_PRIVATE void _sapp_x11_process_event(XEvent* event) {
                 }
                 else if (_sapp.x11.xdnd.version >= 2) {
                     XEvent reply;
-                    memset(&reply, 0, sizeof(reply));
+                    _sapp_clear(&reply, sizeof(reply));
                     reply.type = ClientMessage;
                     reply.xclient.window = _sapp.x11.window;
                     reply.xclient.message_type = _sapp.x11.xdnd.XdndFinished;
@@ -11016,7 +11039,7 @@ _SOKOL_PRIVATE void _sapp_x11_process_event(XEvent* event) {
                     return;
                 }
                 XEvent reply;
-                memset(&reply, 0, sizeof(reply));
+                _sapp_clear(&reply, sizeof(reply));
                 reply.type = ClientMessage;
                 reply.xclient.window = _sapp.x11.xdnd.source;
                 reply.xclient.message_type = _sapp.x11.xdnd.XdndStatus;
@@ -11050,7 +11073,7 @@ _SOKOL_PRIVATE void _sapp_x11_process_event(XEvent* event) {
                 }
                 if (_sapp.x11.xdnd.version >= 2) {
                     XEvent reply;
-                    memset(&reply, 0, sizeof(reply));
+                    _sapp_clear(&reply, sizeof(reply));
                     reply.type = ClientMessage;
                     reply.xclient.window = _sapp.x11.window;
                     reply.xclient.message_type = _sapp.x11.xdnd.XdndFinished;
@@ -11172,7 +11195,7 @@ sapp_desc sokol_main(int argc, char* argv[]) {
     _SOKOL_UNUSED(argc);
     _SOKOL_UNUSED(argv);
     sapp_desc desc;
-    memset(&desc, 0, sizeof(desc));
+    _sapp_clear(&desc, sizeof(desc));
     return desc;
 }
 #else

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1610,6 +1610,10 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 #ifdef SOKOL_APP_IMPL
 #define SOKOL_APP_IMPL_INCLUDED (1)
 
+#if defined(SOKOL_MALLOC) || defined(SOKOL_CALLOC) || defined(SOKOL_FREE)
+#error "SOKOL_MALLOC/CALLOC/FREE macros are no longer supported, please use sapp_desc.allocator to override memory allocation functions"
+#endif
+
 #include <stdlib.h> // malloc, free
 #include <string.h> // memset
 #include <stddef.h> // size_t

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2706,6 +2706,7 @@ _SOKOL_PRIVATE bool _sapp_strcpy(const char* src, char* dst, int max_len) {
 }
 
 _SOKOL_PRIVATE sapp_desc _sapp_desc_defaults(const sapp_desc* in_desc) {
+    SOKOL_ASSERT((in_desc->allocator.alloc && in_desc->allocator.free) || (!in_desc->allocator.alloc && !in_desc->allocator.free));
     sapp_desc desc = *in_desc;
     desc.sample_count = _sapp_def(desc.sample_count, 1);
     desc.swap_interval = _sapp_def(desc.swap_interval, 1);
@@ -2726,7 +2727,6 @@ _SOKOL_PRIVATE void _sapp_init_state(const sapp_desc* desc) {
     SOKOL_ASSERT(desc->clipboard_size >= 0);
     SOKOL_ASSERT(desc->max_dropped_files >= 0);
     SOKOL_ASSERT(desc->max_dropped_file_path_length >= 0);
-    SOKOL_ASSERT((desc->allocator.alloc && desc->allocator.free) || (!desc->allocator.alloc && !desc->allocator.free));
     _SAPP_CLEAR_ARC_STRUCT(_sapp_t, _sapp);
     _sapp.desc = _sapp_desc_defaults(desc);
     _sapp.first_frame = true;

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -979,6 +979,35 @@
             doesn't matter if the application is started from the command
             line or via double-click.
 
+    MEMORY ALLOCATION OVERRIDE
+    ==========================
+    You can override the memory allocation functions at initialization time
+    like this:
+
+        void* my_alloc(size_t size, void* user_data) {
+            return malloc(size);
+        }
+
+        void my_free(void* ptr, void* user_data) {
+            free(ptr);
+        }
+
+        sapp_desc sokol_main(int argc, char* argv[]) {
+            return (sapp_desc){
+                // ...
+                .allocator = {
+                    .alloc = my_alloc,
+                    .free = my_free,
+                    .user_data = ...;
+                }
+            };
+        }
+
+    If no overrides are provided, malloc and free will be used.
+
+    This only affects memory allocation calls done by sokol_app.h
+    itself though, not any allocations in OS libraries.
+
     TEMP NOTE DUMP
     ==============
     - onscreen keyboard support on Android requires Java :(, should we even bother?

--- a/sokol_args.h
+++ b/sokol_args.h
@@ -361,6 +361,11 @@ inline void sargs_setup(const sargs_desc& desc) { return sargs_setup(&desc); }
 /*--- IMPLEMENTATION ---------------------------------------------------------*/
 #ifdef SOKOL_ARGS_IMPL
 #define SOKOL_ARGS_IMPL_INCLUDED (1)
+
+#if defined(SOKOL_MALLOC) || defined(SOKOL_CALLOC) || defined(SOKOL_FREE)
+#error "SOKOL_MALLOC/CALLOC/FREE macros are no longer supported, please use sargs_desc.allocator to override memory allocation functions"
+#endif
+
 #include <string.h> // memset, strcmp
 #include <stdlib.h> // malloc, free
 

--- a/sokol_args.h
+++ b/sokol_args.h
@@ -17,8 +17,6 @@
 
     SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
     SOKOL_LOG(msg)      - your own logging functions (default: puts(msg))
-    SOKOL_CALLOC(n,s)   - your own calloc() implementation (default: calloc(n,s))
-    SOKOL_FREE(p)       - your own free() implementation (default: free(p))
     SOKOL_ARGS_API_DECL - public function declaration prefix (default: extern)
     SOKOL_API_DECL      - same as SOKOL_ARGS_API_DECL
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
@@ -251,6 +249,7 @@
 #define SOKOL_ARGS_INCLUDED (1)
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h> // size_t
 
 #if defined(SOKOL_API_DECL) && !defined(SOKOL_ARGS_API_DECL)
 #define SOKOL_ARGS_API_DECL SOKOL_API_DECL
@@ -269,11 +268,29 @@
 extern "C" {
 #endif
 
+/*
+    sargs_allocator
+
+    Used in sargs_desc to provide custom memory-alloc and -free functions
+    to sokol_args.h. If memory management should be overridden, both the
+    alloc and free function must be provided (e.g. it's not valid to
+    override one function but not the other).
+*/
+typedef void*(*sargs_malloc)(size_t size, void* user_data);
+typedef void(*sargs_free)(void* ptr, void* user_data);
+
+typedef struct sargs_allocator {
+    sargs_malloc alloc;
+    sargs_free free;
+    void* user_data;
+} sargs_allocator;
+
 typedef struct sargs_desc {
     int argc;
     char** argv;
     int max_args;
     int buf_size;
+    sargs_allocator allocator;
 } sargs_desc;
 
 /* setup sokol-args */
@@ -313,7 +330,8 @@ inline void sargs_setup(const sargs_desc& desc) { return sargs_setup(&desc); }
 /*--- IMPLEMENTATION ---------------------------------------------------------*/
 #ifdef SOKOL_ARGS_IMPL
 #define SOKOL_ARGS_IMPL_INCLUDED (1)
-#include <string.h> /* memset, strcmp */
+#include <string.h> // memset, strcmp
+#include <stdlib.h> // malloc, free
 
 #if defined(__EMSCRIPTEN__)
 #include <emscripten/emscripten.h>
@@ -330,15 +348,6 @@ inline void sargs_setup(const sargs_desc& desc) { return sargs_setup(&desc); }
 #ifndef SOKOL_ASSERT
     #include <assert.h>
     #define SOKOL_ASSERT(c) assert(c)
-#endif
-#if !defined(SOKOL_CALLOC) && !defined(SOKOL_FREE)
-    #include <stdlib.h>
-#endif
-#if !defined(SOKOL_CALLOC)
-    #define SOKOL_CALLOC(n,s) calloc(n,s)
-#endif
-#if !defined(SOKOL_FREE)
-    #define SOKOL_FREE(p) free(p)
 #endif
 #ifndef SOKOL_LOG
     #ifdef SOKOL_DEBUG
@@ -388,10 +397,43 @@ typedef struct {
     uint32_t parse_state;
     char quote;         /* current quote char, 0 if not in a quote */
     bool in_escape;     /* currently in an escape sequence */
+    sargs_allocator allocator;
 } _sargs_state_t;
 static _sargs_state_t _sargs;
 
 /*== PRIVATE IMPLEMENTATION FUNCTIONS ========================================*/
+_SOKOL_PRIVATE void _sargs_clear(void* ptr, size_t size) {
+    SOKOL_ASSERT(ptr && (size > 0));
+    memset(ptr, 0, size);
+}
+
+_SOKOL_PRIVATE void* _sargs_malloc(size_t size) {
+    SOKOL_ASSERT(size > 0);
+    void* ptr;
+    if (_sargs.allocator.alloc) {
+        ptr = _sargs.allocator.alloc(size, _sargs.allocator.user_data);
+    }
+    else {
+        ptr = malloc(size);
+    }
+    SOKOL_ASSERT(ptr);
+    return ptr;
+}
+
+_SOKOL_PRIVATE void* _sargs_malloc_clear(size_t size) {
+    void* ptr = _sargs_malloc(size);
+    _sargs_clear(ptr, size);
+    return ptr;
+}
+
+_SOKOL_PRIVATE void _sargs_free(void* ptr) {
+    if (_sargs.allocator.free) {
+        _sargs.allocator.free(ptr, _sargs.allocator.user_data);
+    }
+    else {
+        free(ptr);
+    }
+}
 
 _SOKOL_PRIVATE void _sargs_putc(char c) {
     if ((_sargs.buf_pos+2) < _sargs.buf_size) {
@@ -661,14 +703,15 @@ EM_JS(void, sargs_js_parse_url, (void), {
 /*== PUBLIC IMPLEMENTATION FUNCTIONS =========================================*/
 SOKOL_API_IMPL void sargs_setup(const sargs_desc* desc) {
     SOKOL_ASSERT(desc);
-    memset(&_sargs, 0, sizeof(_sargs));
+    _sargs_clear(&_sargs, sizeof(_sargs));
     _sargs.max_args = _sargs_def(desc->max_args, _SARGS_MAX_ARGS_DEF);
     _sargs.buf_size = _sargs_def(desc->buf_size, _SARGS_BUF_SIZE_DEF);
     SOKOL_ASSERT(_sargs.buf_size > 8);
-    _sargs.args = (_sargs_kvp_t*) SOKOL_CALLOC((size_t)_sargs.max_args, sizeof(_sargs_kvp_t));
-    _sargs.buf = (char*) SOKOL_CALLOC((size_t)_sargs.buf_size, sizeof(char));
+    _sargs.args = (_sargs_kvp_t*) _sargs_malloc_clear((size_t)_sargs.max_args * sizeof(_sargs_kvp_t));
+    _sargs.buf = (char*) _sargs_malloc_clear((size_t)_sargs.buf_size * sizeof(char));
     /* the first character in buf is reserved and always zero, this is the 'empty string' */
     _sargs.buf_pos = 1;
+    _sargs.allocator = desc->allocator;
     _sargs.valid = true;
 
     /* parse argc/argv */
@@ -683,11 +726,11 @@ SOKOL_API_IMPL void sargs_setup(const sargs_desc* desc) {
 SOKOL_API_IMPL void sargs_shutdown(void) {
     SOKOL_ASSERT(_sargs.valid);
     if (_sargs.args) {
-        SOKOL_FREE(_sargs.args);
+        _sargs_free(_sargs.args);
         _sargs.args = 0;
     }
     if (_sargs.buf) {
-        SOKOL_FREE(_sargs.buf);
+        _sargs_free(_sargs.buf);
         _sargs.buf = 0;
     }
     _sargs.valid = false;

--- a/sokol_args.h
+++ b/sokol_args.h
@@ -216,6 +216,37 @@
         Return the value of argument at index. Returns empty string
         if index is outside range.
 
+
+    MEMORY ALLOCATION OVERRIDE
+    ==========================
+    You can override the memory allocation functions at initialization time
+    like this:
+
+        void* my_alloc(size_t size, void* user_data) {
+            return malloc(size);
+        }
+
+        void my_free(void* ptr, void* user_data) {
+            free(ptr);
+        }
+
+        ...
+            sargs_setup(&(sargs_desc){
+                // ...
+                .allocator = {
+                    .alloc = my_alloc,
+                    .free = my_free,
+                    .user_data = ...;
+                }
+            });
+        ...
+
+    If no overrides are provided, malloc and free will be used.
+
+    This only affects memory allocation calls done by sokol_args.h
+    itself though, not any allocations in OS libraries.
+
+
     TODO
     ====
     - parsing errors?

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -18,8 +18,6 @@
     SOKOL_DUMMY_BACKEND - use a dummy backend
     SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
     SOKOL_LOG(msg)      - your own logging function (default: puts(msg))
-    SOKOL_MALLOC(s)     - your own malloc() implementation (default: malloc(s))
-    SOKOL_FREE(p)       - your own free() implementation (default: free(p))
     SOKOL_AUDIO_API_DECL- public function declaration prefix (default: extern)
     SOKOL_API_DECL      - same as SOKOL_AUDIO_API_DECL
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
@@ -392,6 +390,7 @@
         distribution.
 */
 #define SOKOL_AUDIO_INCLUDED (1)
+#include <stddef.h> // size_t
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -412,15 +411,31 @@
 extern "C" {
 #endif
 
+/*
+    saudio_allocator
+
+    Used in saudio_desc to provide custom memory-alloc and -free functions
+    to sokol_audio.h. The function prototypes are compatible with
+    malloc/free.
+*/
+typedef void*(*saudio_malloc)(size_t size);
+typedef void(*saudio_free)(void* ptr);
+
+typedef struct saudio_allocator {
+    saudio_malloc alloc;
+    saudio_free free;
+} saudio_allocator;
+
 typedef struct saudio_desc {
-    int sample_rate;        /* requested sample rate */
-    int num_channels;       /* number of channels, default: 1 (mono) */
-    int buffer_frames;      /* number of frames in streaming buffer */
-    int packet_frames;      /* number of frames in a packet */
-    int num_packets;        /* number of packets in packet queue */
-    void (*stream_cb)(float* buffer, int num_frames, int num_channels);  /* optional streaming callback (no user data) */
-    void (*stream_userdata_cb)(float* buffer, int num_frames, int num_channels, void* user_data); /*... and with user data */
-    void* user_data;        /* optional user data argument for stream_userdata_cb */
+    int sample_rate;        // requested sample rate
+    int num_channels;       // number of channels, default: 1 (mono)
+    int buffer_frames;      // number of frames in streaming buffer
+    int packet_frames;      // number of frames in a packet
+    int num_packets;        // number of packets in packet queue
+    void (*stream_cb)(float* buffer, int num_frames, int num_channels);  // optional streaming callback (no user data)
+    void (*stream_userdata_cb)(float* buffer, int num_frames, int num_channels, void* user_data); //... and with user data
+    void* user_data;        // optional user data argument for stream_userdata_cb
+    saudio_allocator allocator;     // optional allocation override functions (default: malloc/free)
 } saudio_desc;
 
 /* setup sokol-audio */
@@ -458,6 +473,7 @@ inline void saudio_setup(const saudio_desc& desc) { return saudio_setup(&desc); 
 /*=== IMPLEMENTATION =========================================================*/
 #ifdef SOKOL_AUDIO_IMPL
 #define SOKOL_AUDIO_IMPL_INCLUDED (1)
+#include <stdlib.h> // alloc, free
 #include <string.h> // memset, memcpy
 #include <stddef.h> // size_t
 
@@ -472,11 +488,6 @@ inline void saudio_setup(const saudio_desc& desc) { return saudio_setup(&desc); 
 #ifndef SOKOL_ASSERT
     #include <assert.h>
     #define SOKOL_ASSERT(c) assert(c)
-#endif
-#ifndef SOKOL_MALLOC
-    #include <stdlib.h>
-    #define SOKOL_MALLOC(s) malloc(s)
-    #define SOKOL_FREE(p) free(p)
 #endif
 #ifndef SOKOL_LOG
     #ifdef SOKOL_DEBUG
@@ -893,6 +904,30 @@ _SOKOL_PRIVATE void _saudio_stream_callback(float* buffer, int num_frames, int n
     }
 }
 
+/*=== MEMORY HELPERS ========================================================*/
+_SOKOL_PRIVATE void _saudio_clear(void* ptr, size_t size) {
+    SOKOL_ASSERT(ptr && (size > 0));
+    memset(ptr, 0, size);
+}
+
+_SOKOL_PRIVATE void* _saudio_malloc(size_t size) {
+    SOKOL_ASSERT(size > 0);
+    void* ptr = _saudio.desc.allocator.alloc(size);
+    SOKOL_ASSERT(ptr);
+    return ptr;
+}
+
+_SOKOL_PRIVATE void* _saudio_malloc_clear(size_t size) {
+    SOKOL_ASSERT(size > 0);
+    void* ptr = _saudio_malloc(size);
+    _saudio_clear(ptr, size);
+    return ptr;
+}
+
+_SOKOL_PRIVATE void _saudio_free(void* ptr) {
+    _saudio.desc.allocator.free(ptr);
+}
+
 /*=== MUTEX IMPLEMENTATION ===================================================*/
 #if defined(_SAUDIO_NOTHREADS)
 
@@ -1003,8 +1038,7 @@ _SOKOL_PRIVATE void _saudio_fifo_init(_saudio_fifo_t* fifo, int packet_size, int
     SOKOL_ASSERT((packet_size > 0) && (num_packets > 0));
     fifo->packet_size = packet_size;
     fifo->num_packets = num_packets;
-    fifo->base_ptr = (uint8_t*) SOKOL_MALLOC((size_t)(packet_size * num_packets));
-    SOKOL_ASSERT(fifo->base_ptr);
+    fifo->base_ptr = (uint8_t*) _saudio_malloc((size_t)(packet_size * num_packets));
     fifo->cur_packet = -1;
     fifo->cur_offset = 0;
     _saudio_ring_init(&fifo->read_queue, num_packets);
@@ -1022,7 +1056,7 @@ _SOKOL_PRIVATE void _saudio_fifo_init(_saudio_fifo_t* fifo, int packet_size, int
 
 _SOKOL_PRIVATE void _saudio_fifo_shutdown(_saudio_fifo_t* fifo) {
     SOKOL_ASSERT(fifo->base_ptr);
-    SOKOL_FREE(fifo->base_ptr);
+    _saudio_free(fifo->base_ptr);
     fifo->base_ptr = 0;
     fifo->valid = false;
     _saudio_mutex_destroy(&fifo->mutex);
@@ -1191,7 +1225,7 @@ _SOKOL_PRIVATE void _saudio_coreaudio_callback(void* user_data, _saudio_AudioQue
         int num_bytes = (int) buffer->mAudioDataByteSize;
         if (0 == _saudio_fifo_read(&_saudio.fifo, ptr, num_bytes)) {
             /* not enough read data available, fill the entire buffer with silence */
-            memset(ptr, 0, (size_t)num_bytes);
+            _saudio_clear(ptr, (size_t)num_bytes);
         }
     }
     AudioQueueEnqueueBuffer(queue, buffer, 0, NULL);
@@ -1213,7 +1247,7 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
 
     /* create an audio queue with fp32 samples */
     _saudio_AudioStreamBasicDescription fmt;
-    memset(&fmt, 0, sizeof(fmt));
+    _saudio_clear(&fmt, sizeof(fmt));
     fmt.mSampleRate = (double) _saudio.sample_rate;
     fmt.mFormatID = _saudio_kAudioFormatLinearPCM;
     fmt.mFormatFlags = _saudio_kLinearPCMFormatFlagIsFloat | _saudio_kAudioFormatFlagIsPacked;
@@ -1232,7 +1266,7 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
         res = AudioQueueAllocateBuffer(_saudio.backend.ca_audio_queue, buf_byte_size, &buf);
         SOKOL_ASSERT((res == 0) && buf); (void)res;
         buf->mAudioDataByteSize = buf_byte_size;
-        memset(buf->mAudioData, 0, buf->mAudioDataByteSize);
+        _saudio_clear(buf->mAudioData, buf->mAudioDataByteSize);
         AudioQueueEnqueueBuffer(_saudio.backend.ca_audio_queue, buf, 0, NULL);
     }
 
@@ -1284,7 +1318,7 @@ _SOKOL_PRIVATE void* _saudio_alsa_cb(void* param) {
             else {
                 if (0 == _saudio_fifo_read(&_saudio.fifo, (uint8_t*)_saudio.backend.buffer, _saudio.backend.buffer_byte_size)) {
                     /* not enough read data available, fill the entire buffer with silence */
-                    memset(_saudio.backend.buffer, 0, (size_t)_saudio.backend.buffer_byte_size);
+                    _saudio_clear(_saudio.backend.buffer, (size_t)_saudio.backend.buffer_byte_size);
                 }
             }
         }
@@ -1339,8 +1373,7 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
     /* allocate the streaming buffer */
     _saudio.backend.buffer_byte_size = _saudio.buffer_frames * _saudio.bytes_per_frame;
     _saudio.backend.buffer_frames = _saudio.buffer_frames;
-    _saudio.backend.buffer = (float*) SOKOL_MALLOC((size_t)_saudio.backend.buffer_byte_size);
-    memset(_saudio.backend.buffer, 0, (size_t)_saudio.backend.buffer_byte_size);
+    _saudio.backend.buffer = (float*) _saudio_malloc_clear((size_t)_saudio.backend.buffer_byte_size);
 
     /* create the buffer-streaming start thread */
     if (0 != pthread_create(&_saudio.backend.thread, 0, _saudio_alsa_cb, 0)) {
@@ -1363,7 +1396,7 @@ _SOKOL_PRIVATE void _saudio_backend_shutdown(void) {
     pthread_join(_saudio.backend.thread, 0);
     snd_pcm_drain(_saudio.backend.device);
     snd_pcm_close(_saudio.backend.device);
-    SOKOL_FREE(_saudio.backend.buffer);
+    _saudio_free(_saudio.backend.buffer);
 };
 
 /*=== WASAPI BACKEND IMPLEMENTATION ==========================================*/
@@ -1419,7 +1452,7 @@ _SOKOL_PRIVATE void _saudio_wasapi_fill_buffer(void) {
     else {
         if (0 == _saudio_fifo_read(&_saudio.fifo, (uint8_t*)_saudio.backend.thread.src_buffer, _saudio.backend.thread.src_buffer_byte_size)) {
             /* not enough read data available, fill the entire buffer with silence */
-            memset(_saudio.backend.thread.src_buffer, 0, (size_t)_saudio.backend.thread.src_buffer_byte_size);
+            _saudio_clear(_saudio.backend.thread.src_buffer, (size_t)_saudio.backend.thread.src_buffer_byte_size);
         }
     }
 }
@@ -1487,7 +1520,7 @@ _SOKOL_PRIVATE DWORD WINAPI _saudio_wasapi_thread_fn(LPVOID param) {
 
 _SOKOL_PRIVATE void _saudio_wasapi_release(void) {
     if (_saudio.backend.thread.src_buffer) {
-        SOKOL_FREE(_saudio.backend.thread.src_buffer);
+        _saudio_free(_saudio.backend.thread.src_buffer);
         _saudio.backend.thread.src_buffer = 0;
     }
     if (_saudio.backend.render_client) {
@@ -1602,7 +1635,7 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
     #endif
 
     WAVEFORMATEXTENSIBLE fmtex;
-    memset(&fmtex, 0, sizeof(fmtex));
+    _saudio_clear(&fmtex, sizeof(fmtex));
     fmtex.Format.nChannels = (WORD)_saudio.num_channels;
     fmtex.Format.nSamplesPerSec = (DWORD)_saudio.sample_rate;
     fmtex.Format.wFormatTag = WAVE_FORMAT_EXTENSIBLE;
@@ -1648,8 +1681,7 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
     _saudio.backend.thread.src_buffer_byte_size = _saudio.backend.thread.src_buffer_frames * _saudio.bytes_per_frame;
 
     /* allocate an intermediate buffer for sample format conversion */
-    _saudio.backend.thread.src_buffer = (float*) SOKOL_MALLOC((size_t)_saudio.backend.thread.src_buffer_byte_size);
-    SOKOL_ASSERT(_saudio.backend.thread.src_buffer);
+    _saudio.backend.thread.src_buffer = (float*) _saudio_malloc((size_t)_saudio.backend.thread.src_buffer_byte_size);
 
     /* create streaming thread */
     _saudio.backend.thread.thread_handle = CreateThread(NULL, 0, _saudio_wasapi_thread_fn, 0, 0, 0);
@@ -1698,7 +1730,7 @@ EMSCRIPTEN_KEEPALIVE int _saudio_emsc_pull(int num_frames) {
             const int num_bytes = num_frames * _saudio.bytes_per_frame;
             if (0 == _saudio_fifo_read(&_saudio.fifo, _saudio.backend.buffer, num_bytes)) {
                 /* not enough read data available, fill the entire buffer with silence */
-                memset(_saudio.backend.buffer, 0, (size_t)num_bytes);
+                _saudio_clear(_saudio.backend.buffer, (size_t)num_bytes);
             }
         }
         int res = (int) _saudio.backend.buffer;
@@ -1819,7 +1851,7 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
         _saudio.sample_rate = saudio_js_sample_rate();
         _saudio.buffer_frames = saudio_js_buffer_frames();
         const size_t buf_size = (size_t) (_saudio.buffer_frames * _saudio.bytes_per_frame);
-        _saudio.backend.buffer = (uint8_t*) SOKOL_MALLOC(buf_size);
+        _saudio.backend.buffer = (uint8_t*) _saudio_malloc(buf_size);
         return true;
     }
     else {
@@ -1830,7 +1862,7 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
 _SOKOL_PRIVATE void _saudio_backend_shutdown(void) {
     saudio_js_shutdown();
     if (_saudio.backend.buffer) {
-        SOKOL_FREE(_saudio.backend.buffer);
+        _saudio_free(_saudio.backend.buffer);
         _saudio.backend.buffer = 0;
     }
 }
@@ -1904,7 +1936,7 @@ _SOKOL_PRIVATE void _saudio_opensles_fill_buffer(void) {
         const int src_buffer_byte_size = src_buffer_frames * _saudio.num_channels * (int)sizeof(float);
         if (0 == _saudio_fifo_read(&_saudio.fifo, (uint8_t*)_saudio.backend.src_buffer, src_buffer_byte_size)) {
             /* not enough read data available, fill the entire buffer with silence */
-            memset(_saudio.backend.src_buffer, 0x0, (size_t)src_buffer_byte_size);
+            _saudio_clear(_saudio.backend.src_buffer, (size_t)src_buffer_byte_size);
         }
     }
 }
@@ -1959,9 +1991,9 @@ _SOKOL_PRIVATE void _saudio_backend_shutdown(void) {
     }
 
     for (int i = 0; i < SAUDIO_NUM_BUFFERS; i++) {
-        SOKOL_FREE(_saudio.backend.output_buffers[i]);
+        _saudio_free(_saudio.backend.output_buffers[i]);
     }
-    SOKOL_FREE(_saudio.backend.src_buffer);
+    _saudio_free(_saudio.backend.src_buffer);
 }
 
 _SOKOL_PRIVATE bool _saudio_backend_init(void) {
@@ -1969,16 +2001,12 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
 
     for (int i = 0; i < SAUDIO_NUM_BUFFERS; ++i) {
         const int buffer_size_bytes = (int)sizeof(int16_t) * _saudio.num_channels * _saudio.buffer_frames;
-        _saudio.backend.output_buffers[i] = (int16_t*) SOKOL_MALLOC((size_t)buffer_size_bytes);
-        SOKOL_ASSERT(_saudio.backend.output_buffers[i]);
-        memset(_saudio.backend.output_buffers[i], 0x0, (size_t)buffer_size_bytes);
+        _saudio.backend.output_buffers[i] = (int16_t*) _saudio_malloc_clear((size_t)buffer_size_bytes);
     }
 
     {
         const int buffer_size_bytes = _saudio.bytes_per_frame * _saudio.buffer_frames;
-        _saudio.backend.src_buffer = (float*) SOKOL_MALLOC((size_t)buffer_size_bytes);
-        SOKOL_ASSERT(_saudio.backend.src_buffer);
-        memset(_saudio.backend.src_buffer, 0x0, (size_t)buffer_size_bytes);
+        _saudio.backend.src_buffer = (float*) _saudio_malloc_clear((size_t)buffer_size_bytes);
     }
 
     /* Create engine */
@@ -2091,8 +2119,10 @@ _SOKOL_PRIVATE bool _saudio_backend_init(void) {
 SOKOL_API_IMPL void saudio_setup(const saudio_desc* desc) {
     SOKOL_ASSERT(!_saudio.valid);
     SOKOL_ASSERT(desc);
-    memset(&_saudio, 0, sizeof(_saudio));
+    _saudio_clear(&_saudio, sizeof(_saudio));
     _saudio.desc = *desc;
+    _saudio.desc.allocator.alloc = _saudio_def(_saudio.desc.allocator.alloc, malloc);
+    _saudio.desc.allocator.free = _saudio_def(_saudio.desc.allocator.free, free);
     _saudio.stream_cb = desc->stream_cb;
     _saudio.stream_userdata_cb = desc->stream_userdata_cb;
     _saudio.user_data = desc->user_data;

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -509,6 +509,11 @@ inline void saudio_setup(const saudio_desc& desc) { return saudio_setup(&desc); 
 /*=== IMPLEMENTATION =========================================================*/
 #ifdef SOKOL_AUDIO_IMPL
 #define SOKOL_AUDIO_IMPL_INCLUDED (1)
+
+#if defined(SOKOL_MALLOC) || defined(SOKOL_CALLOC) || defined(SOKOL_FREE)
+#error "SOKOL_MALLOC/CALLOC/FREE macros are no longer supported, please use saudio_desc.allocator to override memory allocation functions"
+#endif
+
 #include <stdlib.h> // alloc, free
 #include <string.h> // memset, memcpy
 #include <stddef.h> // size_t

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -363,6 +363,40 @@
     header must be present (usually both are installed with some sort
     of ALSA development package).
 
+
+    MEMORY ALLOCATION OVERRIDE
+    ==========================
+    You can override the memory allocation functions at initialization time
+    like this:
+
+        void* my_alloc(size_t size, void* user_data) {
+            return malloc(size);
+        }
+
+        void my_free(void* ptr, void* user_data) {
+            free(ptr);
+        }
+
+        ...
+            saudio_setup(&(saudio_desc){
+                // ...
+                .allocator = {
+                    .alloc = my_alloc,
+                    .free = my_free,
+                    .user_data = ...;
+                }
+            });
+        ...
+
+    If no overrides are provided, malloc and free will be used.
+
+    This only affects memory allocation calls done by sokol_audio.h
+    itself though, not any allocations in OS libraries.
+
+    Memory allocation will only happen on the same thread where saudio_setup()
+    was called, so you don't need to worry about thread-safety.
+
+
     LICENSE
     =======
 

--- a/sokol_fetch.h
+++ b/sokol_fetch.h
@@ -1008,6 +1008,11 @@ inline sfetch_handle_t sfetch_send(const sfetch_request_t& request) { return sfe
 /*--- IMPLEMENTATION ---------------------------------------------------------*/
 #ifdef SOKOL_FETCH_IMPL
 #define SOKOL_FETCH_IMPL_INCLUDED (1)
+
+#if defined(SOKOL_MALLOC) || defined(SOKOL_CALLOC) || defined(SOKOL_FREE)
+#error "SOKOL_MALLOC/CALLOC/FREE macros are no longer supported, please use sfetch_desc_t.allocator to override memory allocation functions"
+#endif
+
 #include <stdlib.h> /* malloc, free */
 #include <string.h> /* memset, memcpy */
 

--- a/sokol_fetch.h
+++ b/sokol_fetch.h
@@ -791,6 +791,39 @@
     the blocking traditional file IO functions, not for performance reasons.
 
 
+    MEMORY ALLOCATION OVERRIDE
+    ==========================
+    You can override the memory allocation functions at initialization time
+    like this:
+
+        void* my_alloc(size_t size, void* user_data) {
+            return malloc(size);
+        }
+
+        void my_free(void* ptr, void* user_data) {
+            free(ptr);
+        }
+
+        ...
+            sfetch_setup(&(sfetch_desc_t){
+                // ...
+                .allocator = {
+                    .alloc = my_alloc,
+                    .free = my_free,
+                    .user_data = ...;
+                }
+            });
+        ...
+
+    If no overrides are provided, malloc and free will be used.
+
+    This only affects memory allocation calls done by sokol_fetch.h
+    itself though, not any allocations in OS libraries.
+
+    Memory allocation will only happen on the same thread where sfetch_setup()
+    was called, so you don't need to worry about thread-safety.
+
+
     FUTURE PLANS / V2.0 IDEA DUMP
     =============================
     - An optional polling API (as alternative to callback API)

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -654,6 +654,37 @@
         - SG_VERTEXFORMAT_SHORT4N,
         - SG_VERTEXFORMAT_USHORT4N
 
+
+    MEMORY ALLOCATION OVERRIDE
+    ==========================
+    You can override the memory allocation functions at initialization time
+    like this:
+
+        void* my_alloc(size_t size, void* user_data) {
+            return malloc(size);
+        }
+
+        void my_free(void* ptr, void* user_data) {
+            free(ptr);
+        }
+
+        ...
+            sg_setup(&(sg_desc){
+                // ...
+                .allocator = {
+                    .alloc = my_alloc,
+                    .free = my_free,
+                    .user_data = ...;
+                }
+            });
+        ...
+
+    If no overrides are provided, malloc and free will be used.
+
+    This only affects memory allocation calls done by sokol_gfx.h
+    itself though, not any allocations in OS libraries.
+
+
     TODO:
     ====
     - talk about asynchronous resource creation

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2268,6 +2268,9 @@ typedef struct sg_pass_info {
     .uniform_buffer_size    4 MB (4*1024*1024)
     .staging_buffer_size    8 MB (8*1024*1024)
 
+    .allocator.alloc        malloc (from the C standard library)
+    .allocator.free         free (from the C standard library)
+
     .context.color_format: default value depends on selected backend:
         all GL backends:    SG_PIXELFORMAT_RGBA8
         Metal and D3D11:    SG_PIXELFORMAT_BGRA8
@@ -2417,8 +2420,8 @@ typedef struct sg_desc {
     int uniform_buffer_size;
     int staging_buffer_size;
     int sampler_cache_size;
-    sg_context_desc context;
     sg_allocator allocator;
+    sg_context_desc context;
     uint32_t _end_canary;
 } sg_desc;
 
@@ -15169,7 +15172,7 @@ SOKOL_API_IMPL void sg_shutdown(void) {
     }
     _sg_discard_backend();
     _sg_discard_pools(&_sg.pools);
-    _sg.valid = false;
+    _SG_CLEAR_ARC_STRUCT(_sg_state_t, _sg);
 }
 
 SOKOL_API_IMPL bool sg_isvalid(void) {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2621,6 +2621,10 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
 #if !(defined(SOKOL_GLCORE33)||defined(SOKOL_GLES2)||defined(SOKOL_GLES3)||defined(SOKOL_D3D11)||defined(SOKOL_METAL)||defined(SOKOL_WGPU)||defined(SOKOL_DUMMY_BACKEND))
 #error "Please select a backend with SOKOL_GLCORE33, SOKOL_GLES2, SOKOL_GLES3, SOKOL_D3D11, SOKOL_METAL, SOKOL_WGPU or SOKOL_DUMMY_BACKEND"
 #endif
+#if defined(SOKOL_MALLOC) || defined(SOKOL_CALLOC) || defined(SOKOL_FREE)
+#error "SOKOL_MALLOC/CALLOC/FREE macros are no longer supported, please use sg_desc.allocator to override memory allocation functions"
+#endif
+
 #include <stdlib.h> // malloc, free
 #include <string.h> // memset
 #include <float.h> // FLT_MAX

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -40,8 +40,6 @@
     Optionally provide the following defines with your own implementations:
 
     SOKOL_ASSERT(c)             - your own assert macro (default: assert(c))
-    SOKOL_MALLOC(s)             - your own malloc function (default: malloc(s))
-    SOKOL_FREE(p)               - your own free function (default: free(p))
     SOKOL_LOG(msg)              - your own logging function (default: puts(msg))
     SOKOL_UNREACHABLE()         - a guard macro for unreachable code (default: assert(false))
     SOKOL_GFX_API_DECL          - public function declaration prefix (default: extern)
@@ -2400,6 +2398,14 @@ typedef struct sg_context_desc {
     sg_wgpu_context_desc wgpu;
 } sg_context_desc;
 
+typedef void*(*sg_malloc)(size_t size);
+typedef void(*sg_free)(void* ptr);
+
+typedef struct sg_allocator {
+    sg_malloc alloc;
+    sg_free free;
+} sg_allocator;
+
 typedef struct sg_desc {
     uint32_t _start_canary;
     int buffer_pool_size;
@@ -2412,6 +2418,7 @@ typedef struct sg_desc {
     int staging_buffer_size;
     int sampler_cache_size;
     sg_context_desc context;
+    sg_allocator allocator;
     uint32_t _end_canary;
 } sg_desc;
 
@@ -2570,6 +2577,7 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
 #if !(defined(SOKOL_GLCORE33)||defined(SOKOL_GLES2)||defined(SOKOL_GLES3)||defined(SOKOL_D3D11)||defined(SOKOL_METAL)||defined(SOKOL_WGPU)||defined(SOKOL_DUMMY_BACKEND))
 #error "Please select a backend with SOKOL_GLCORE33, SOKOL_GLES2, SOKOL_GLES3, SOKOL_D3D11, SOKOL_METAL, SOKOL_WGPU or SOKOL_DUMMY_BACKEND"
 #endif
+#include <stdlib.h> /* malloc/free */
 #include <string.h> /* memset */
 #include <float.h> /* FLT_MAX */
 
@@ -2596,11 +2604,6 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
 #endif
 #ifndef SOKOL_UNREACHABLE
     #define SOKOL_UNREACHABLE SOKOL_ASSERT(false)
-#endif
-#ifndef SOKOL_MALLOC
-    #include <stdlib.h>
-    #define SOKOL_MALLOC(s) malloc(s)
-    #define SOKOL_FREE(p) free(p)
 #endif
 #ifndef SOKOL_LOG
     #ifdef SOKOL_DEBUG
@@ -3131,6 +3134,10 @@ typedef struct {
 #define _sg_clamp(v,v0,v1) (((v)<(v0))?(v0):(((v)>(v1))?(v1):(v)))
 #define _sg_fequal(val,cmp,delta) ((((val)-(cmp))> -(delta))&&(((val)-(cmp))<(delta)))
 
+_SOKOL_PRIVATE void* _sg_malloc_clear(size_t size);
+_SOKOL_PRIVATE void _sg_free(void* ptr);
+_SOKOL_PRIVATE void _sg_clear(void* ptr, size_t size);
+
 typedef struct {
     int size;
     int append_pos;
@@ -3341,17 +3348,15 @@ typedef struct {
 
 _SOKOL_PRIVATE void _sg_smpcache_init(_sg_sampler_cache_t* cache, int capacity) {
     SOKOL_ASSERT(cache && (capacity > 0));
-    memset(cache, 0, sizeof(_sg_sampler_cache_t));
+    _sg_clear(cache, sizeof(_sg_sampler_cache_t));
     cache->capacity = capacity;
     const size_t size = (size_t)cache->capacity * sizeof(_sg_sampler_cache_item_t);
-    cache->items = (_sg_sampler_cache_item_t*) SOKOL_MALLOC(size);
-    SOKOL_ASSERT(cache->items);
-    memset(cache->items, 0, size);
+    cache->items = (_sg_sampler_cache_item_t*) _sg_malloc_clear(size);
 }
 
 _SOKOL_PRIVATE void _sg_smpcache_discard(_sg_sampler_cache_t* cache) {
     SOKOL_ASSERT(cache && cache->items);
-    SOKOL_FREE(cache->items);
+    _sg_free(cache->items);
     cache->items = 0;
     cache->num_items = 0;
     cache->capacity = 0;
@@ -4219,6 +4224,40 @@ static _sg_state_t _sg;
 
 /*-- helper functions --------------------------------------------------------*/
 
+// a helper macro to clear a struct with potentially ARC'ed ObjC references
+#if defined(SOKOL_METAL)
+    #if defined(__cplusplus)
+        #define _SG_CLEAR_ARC_STRUCT(type, item) { item = { }; }
+    #else
+        #define _SG_CLEAR_ARC_STRUCT(type, item) { item = (type) { 0 }; }
+    #endif
+#else
+    #define _SG_CLEAR_ARC_STRUCT(type, item) { _sg_clear(&item, sizeof(item)); }
+#endif
+
+_SOKOL_PRIVATE void _sg_clear(void* ptr, size_t size) {
+    SOKOL_ASSERT(ptr && (size > 0));
+    memset(ptr, 0, size);
+}
+
+_SOKOL_PRIVATE void* _sg_malloc(size_t size) {
+    SOKOL_ASSERT(size > 0);
+    void* ptr = _sg.desc.allocator.alloc(size);
+    SOKOL_ASSERT(ptr);
+    return ptr;
+}
+
+_SOKOL_PRIVATE void* _sg_malloc_clear(size_t size) {
+    SOKOL_ASSERT(size > 0);
+    void* ptr = _sg_malloc(size);
+    _sg_clear(ptr, size);
+    return ptr;
+}
+
+_SOKOL_PRIVATE void _sg_free(void* ptr) {
+    _sg.desc.allocator.free(ptr);
+}
+
 _SOKOL_PRIVATE bool _sg_strempty(const _sg_str_t* str) {
     return 0 == str->buf[0];
 }
@@ -4238,7 +4277,7 @@ _SOKOL_PRIVATE void _sg_strcpy(_sg_str_t* dst, const char* src) {
         dst->buf[_SG_STRING_SIZE-1] = 0;
     }
     else {
-        memset(dst->buf, 0, _SG_STRING_SIZE);
+        _sg_clear(dst->buf, _SG_STRING_SIZE);
     }
 }
 
@@ -6250,7 +6289,7 @@ _SOKOL_PRIVATE void _sg_gl_reset_state_cache(void) {
             _SG_GL_CHECK_ERROR();
         }
         #endif
-        memset(&_sg.gl.cache, 0, sizeof(_sg.gl.cache));
+        _sg_clear(&_sg.gl.cache, sizeof(_sg.gl.cache));
         _sg_gl_cache_clear_buffer_bindings(true);
         _SG_GL_CHECK_ERROR();
         _sg_gl_cache_clear_texture_bindings(true);
@@ -6671,10 +6710,10 @@ _SOKOL_PRIVATE GLuint _sg_gl_compile_shader(sg_shader_stage stage, const char* s
         GLint log_len = 0;
         glGetShaderiv(gl_shd, GL_INFO_LOG_LENGTH, &log_len);
         if (log_len > 0) {
-            GLchar* log_buf = (GLchar*) SOKOL_MALLOC((size_t)log_len);
+            GLchar* log_buf = (GLchar*) _sg_malloc((size_t)log_len);
             glGetShaderInfoLog(gl_shd, log_len, &log_len, log_buf);
             SOKOL_LOG(log_buf);
-            SOKOL_FREE(log_buf);
+            _sg_free(log_buf);
         }
         glDeleteShader(gl_shd);
         gl_shd = 0;
@@ -6714,10 +6753,10 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_shader(_sg_shader_t* shd, const s
         GLint log_len = 0;
         glGetProgramiv(gl_prog, GL_INFO_LOG_LENGTH, &log_len);
         if (log_len > 0) {
-            GLchar* log_buf = (GLchar*) SOKOL_MALLOC((size_t)log_len);
+            GLchar* log_buf = (GLchar*) _sg_malloc((size_t)log_len);
             glGetProgramInfoLog(gl_prog, log_len, &log_len, log_buf);
             SOKOL_LOG(log_buf);
-            SOKOL_FREE(log_buf);
+            _sg_free(log_buf);
         }
         glDeleteProgram(gl_prog);
         return SG_RESOURCESTATE_FAILED;
@@ -8511,14 +8550,14 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_buffer(_sg_buffer_t* buf, cons
     }
     else {
         D3D11_BUFFER_DESC d3d11_desc;
-        memset(&d3d11_desc, 0, sizeof(d3d11_desc));
+        _sg_clear(&d3d11_desc, sizeof(d3d11_desc));
         d3d11_desc.ByteWidth = (UINT)buf->cmn.size;
         d3d11_desc.Usage = _sg_d3d11_usage(buf->cmn.usage);
         d3d11_desc.BindFlags = buf->cmn.type == SG_BUFFERTYPE_VERTEXBUFFER ? D3D11_BIND_VERTEX_BUFFER : D3D11_BIND_INDEX_BUFFER;
         d3d11_desc.CPUAccessFlags = _sg_d3d11_cpu_access_flags(buf->cmn.usage);
         D3D11_SUBRESOURCE_DATA* init_data_ptr = 0;
         D3D11_SUBRESOURCE_DATA init_data;
-        memset(&init_data, 0, sizeof(init_data));
+        _sg_clear(&init_data, sizeof(init_data));
         if (buf->cmn.usage == SG_USAGE_IMMUTABLE) {
             SOKOL_ASSERT(desc->data.ptr);
             init_data.pSysMem = desc->data.ptr;
@@ -8589,7 +8628,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
             return SG_RESOURCESTATE_FAILED;
         }
         D3D11_TEXTURE2D_DESC d3d11_desc;
-        memset(&d3d11_desc, 0, sizeof(d3d11_desc));
+        _sg_clear(&d3d11_desc, sizeof(d3d11_desc));
         d3d11_desc.Width = (UINT)img->cmn.width;
         d3d11_desc.Height = (UINT)img->cmn.height;
         d3d11_desc.MipLevels = 1;
@@ -8641,7 +8680,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
             /* if not injected, create texture */
             if (0 == img->d3d11.tex2d) {
                 D3D11_TEXTURE2D_DESC d3d11_tex_desc;
-                memset(&d3d11_tex_desc, 0, sizeof(d3d11_tex_desc));
+                _sg_clear(&d3d11_tex_desc, sizeof(d3d11_tex_desc));
                 d3d11_tex_desc.Width = (UINT)img->cmn.width;
                 d3d11_tex_desc.Height = (UINT)img->cmn.height;
                 d3d11_tex_desc.MipLevels = (UINT)img->cmn.num_mipmaps;
@@ -8682,7 +8721,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
             /* ...and similar, if not injected, create shader-resource-view */
             if (0 == img->d3d11.srv) {
                 D3D11_SHADER_RESOURCE_VIEW_DESC d3d11_srv_desc;
-                memset(&d3d11_srv_desc, 0, sizeof(d3d11_srv_desc));
+                _sg_clear(&d3d11_srv_desc, sizeof(d3d11_srv_desc));
                 d3d11_srv_desc.Format = img->d3d11.format;
                 switch (img->cmn.type) {
                     case SG_IMAGETYPE_2D:
@@ -8728,7 +8767,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
 
             if (0 == img->d3d11.tex3d) {
                 D3D11_TEXTURE3D_DESC d3d11_tex_desc;
-                memset(&d3d11_tex_desc, 0, sizeof(d3d11_tex_desc));
+                _sg_clear(&d3d11_tex_desc, sizeof(d3d11_tex_desc));
                 d3d11_tex_desc.Width = (UINT)img->cmn.width;
                 d3d11_tex_desc.Height = (UINT)img->cmn.height;
                 d3d11_tex_desc.Depth = (UINT)img->cmn.num_slices;
@@ -8760,7 +8799,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
 
             if (0 == img->d3d11.srv) {
                 D3D11_SHADER_RESOURCE_VIEW_DESC d3d11_srv_desc;
-                memset(&d3d11_srv_desc, 0, sizeof(d3d11_srv_desc));
+                _sg_clear(&d3d11_srv_desc, sizeof(d3d11_srv_desc));
                 d3d11_srv_desc.Format = img->d3d11.format;
                 d3d11_srv_desc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE3D;
                 d3d11_srv_desc.Texture3D.MipLevels = (UINT)img->cmn.num_mipmaps;
@@ -8775,7 +8814,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
         /* also need to create a separate MSAA render target texture? */
         if (msaa) {
             D3D11_TEXTURE2D_DESC d3d11_tex_desc;
-            memset(&d3d11_tex_desc, 0, sizeof(d3d11_tex_desc));
+            _sg_clear(&d3d11_tex_desc, sizeof(d3d11_tex_desc));
             d3d11_tex_desc.Width = (UINT)img->cmn.width;
             d3d11_tex_desc.Height = (UINT)img->cmn.height;
             d3d11_tex_desc.MipLevels = 1;
@@ -8795,7 +8834,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
 
         /* sampler state object, note D3D11 implements an internal shared-pool for sampler objects */
         D3D11_SAMPLER_DESC d3d11_smp_desc;
-        memset(&d3d11_smp_desc, 0, sizeof(d3d11_smp_desc));
+        _sg_clear(&d3d11_smp_desc, sizeof(d3d11_smp_desc));
         d3d11_smp_desc.Filter = _sg_d3d11_filter(img->cmn.min_filter, img->cmn.mag_filter, img->cmn.max_anisotropy);
         d3d11_smp_desc.AddressU = _sg_d3d11_address_mode(img->cmn.wrap_u);
         d3d11_smp_desc.AddressV = _sg_d3d11_address_mode(img->cmn.wrap_v);
@@ -8933,7 +8972,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_shader(_sg_shader_t* shd, cons
             /* create a D3D constant buffer for each uniform block */
             SOKOL_ASSERT(0 == d3d11_stage->cbufs[ub_index]);
             D3D11_BUFFER_DESC cb_desc;
-            memset(&cb_desc, 0, sizeof(cb_desc));
+            _sg_clear(&cb_desc, sizeof(cb_desc));
             cb_desc.ByteWidth = (UINT)_sg_roundup((int)ub->size, 16);
             cb_desc.Usage = D3D11_USAGE_DEFAULT;
             cb_desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
@@ -8977,7 +9016,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_shader(_sg_shader_t* shd, cons
         /* need to store the vertex shader byte code, this is needed later in sg_create_pipeline */
         if (vs_succeeded && fs_succeeded) {
             shd->d3d11.vs_blob_length = vs_length;
-            shd->d3d11.vs_blob = SOKOL_MALLOC((size_t)vs_length);
+            shd->d3d11.vs_blob = _sg_malloc((size_t)vs_length);
             SOKOL_ASSERT(shd->d3d11.vs_blob);
             memcpy(shd->d3d11.vs_blob, vs_ptr, vs_length);
             result = SG_RESOURCESTATE_VALID;
@@ -9001,7 +9040,7 @@ _SOKOL_PRIVATE void _sg_d3d11_destroy_shader(_sg_shader_t* shd) {
         _sg_d3d11_Release(shd->d3d11.fs);
     }
     if (shd->d3d11.vs_blob) {
-        SOKOL_FREE(shd->d3d11.vs_blob);
+        _sg_free(shd->d3d11.vs_blob);
     }
     for (int stage_index = 0; stage_index < SG_NUM_SHADER_STAGES; stage_index++) {
         _sg_shader_stage_t* cmn_stage = &shd->cmn.stage[stage_index];
@@ -9030,7 +9069,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_pipeline(_sg_pipeline_t* pip, 
     /* create input layout object */
     HRESULT hr;
     D3D11_INPUT_ELEMENT_DESC d3d11_comps[SG_MAX_VERTEX_ATTRIBUTES];
-    memset(d3d11_comps, 0, sizeof(d3d11_comps));
+    _sg_clear(d3d11_comps, sizeof(d3d11_comps));
     int attr_index = 0;
     for (; attr_index < SG_MAX_VERTEX_ATTRIBUTES; attr_index++) {
         const sg_vertex_attr_desc* a_desc = &desc->layout.attrs[attr_index];
@@ -9077,7 +9116,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_pipeline(_sg_pipeline_t* pip, 
 
     /* create rasterizer state */
     D3D11_RASTERIZER_DESC rs_desc;
-    memset(&rs_desc, 0, sizeof(rs_desc));
+    _sg_clear(&rs_desc, sizeof(rs_desc));
     rs_desc.FillMode = D3D11_FILL_SOLID;
     rs_desc.CullMode = _sg_d3d11_cull_mode(desc->cull_mode);
     rs_desc.FrontCounterClockwise = desc->face_winding == SG_FACEWINDING_CCW;
@@ -9096,7 +9135,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_pipeline(_sg_pipeline_t* pip, 
 
     /* create depth-stencil state */
     D3D11_DEPTH_STENCIL_DESC dss_desc;
-    memset(&dss_desc, 0, sizeof(dss_desc));
+    _sg_clear(&dss_desc, sizeof(dss_desc));
     dss_desc.DepthEnable = TRUE;
     dss_desc.DepthWriteMask = desc->depth.write_enabled ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO;
     dss_desc.DepthFunc = _sg_d3d11_compare_func(desc->depth.compare);
@@ -9121,7 +9160,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_pipeline(_sg_pipeline_t* pip, 
 
     /* create blend state */
     D3D11_BLEND_DESC bs_desc;
-    memset(&bs_desc, 0, sizeof(bs_desc));
+    _sg_clear(&bs_desc, sizeof(bs_desc));
     bs_desc.AlphaToCoverageEnable = desc->alpha_to_coverage_enabled;
     bs_desc.IndependentBlendEnable = TRUE;
     {
@@ -9199,7 +9238,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_pass(_sg_pass_t* pass, _sg_ima
         ID3D11Resource* d3d11_res = 0;
         const bool is_msaa = att_img->cmn.sample_count > 1;
         D3D11_RENDER_TARGET_VIEW_DESC d3d11_rtv_desc;
-        memset(&d3d11_rtv_desc, 0, sizeof(d3d11_rtv_desc));
+        _sg_clear(&d3d11_rtv_desc, sizeof(d3d11_rtv_desc));
         d3d11_rtv_desc.Format = att_img->d3d11.format;
         if ((att_img->cmn.type == SG_IMAGETYPE_2D) || is_msaa) {
             if (is_msaa) {
@@ -9250,7 +9289,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_pass(_sg_pass_t* pass, _sg_ima
 
         /* create D3D11 depth-stencil-view */
         D3D11_DEPTH_STENCIL_VIEW_DESC d3d11_dsv_desc;
-        memset(&d3d11_dsv_desc, 0, sizeof(d3d11_dsv_desc));
+        _sg_clear(&d3d11_dsv_desc, sizeof(d3d11_dsv_desc));
         d3d11_dsv_desc.Format = att_img->d3d11.format;
         const bool is_msaa = att_img->cmn.sample_count > 1;
         if (is_msaa) {
@@ -9342,7 +9381,7 @@ _SOKOL_PRIVATE void _sg_d3d11_begin_pass(_sg_pass_t* pass, const sg_pass_action*
 
     /* set viewport and scissor rect to cover whole screen */
     D3D11_VIEWPORT vp;
-    memset(&vp, 0, sizeof(vp));
+    _sg_clear(&vp, sizeof(vp));
     vp.Width = (FLOAT) w;
     vp.Height = (FLOAT) h;
     vp.MaxDepth = 1.0f;
@@ -9999,7 +10038,7 @@ _SOKOL_PRIVATE void _sg_mtl_init_pool(const sg_desc* desc) {
     SOKOL_ASSERT([_sg.mtl.idpool.pool count] == (NSUInteger)_sg.mtl.idpool.num_slots);
     /* a queue of currently free slot indices */
     _sg.mtl.idpool.free_queue_top = 0;
-    _sg.mtl.idpool.free_queue = (int*)SOKOL_MALLOC((size_t)_sg.mtl.idpool.num_slots * sizeof(int));
+    _sg.mtl.idpool.free_queue = (int*)_sg_malloc_clear((size_t)_sg.mtl.idpool.num_slots * sizeof(int));
     /* pool slot 0 is reserved! */
     for (int i = _sg.mtl.idpool.num_slots-1; i >= 1; i--) {
         _sg.mtl.idpool.free_queue[_sg.mtl.idpool.free_queue_top++] = i;
@@ -10010,7 +10049,7 @@ _SOKOL_PRIVATE void _sg_mtl_init_pool(const sg_desc* desc) {
     */
     _sg.mtl.idpool.release_queue_front = 0;
     _sg.mtl.idpool.release_queue_back = 0;
-    _sg.mtl.idpool.release_queue = (_sg_mtl_release_item_t*)SOKOL_MALLOC((size_t)_sg.mtl.idpool.num_slots * sizeof(_sg_mtl_release_item_t));
+    _sg.mtl.idpool.release_queue = (_sg_mtl_release_item_t*)_sg_malloc_clear((size_t)_sg.mtl.idpool.num_slots * sizeof(_sg_mtl_release_item_t));
     for (int i = 0; i < _sg.mtl.idpool.num_slots; i++) {
         _sg.mtl.idpool.release_queue[i].frame_index = 0;
         _sg.mtl.idpool.release_queue[i].slot_index = _SG_MTL_INVALID_SLOT_INDEX;
@@ -10018,8 +10057,8 @@ _SOKOL_PRIVATE void _sg_mtl_init_pool(const sg_desc* desc) {
 }
 
 _SOKOL_PRIVATE void _sg_mtl_destroy_pool(void) {
-    SOKOL_FREE(_sg.mtl.idpool.release_queue);  _sg.mtl.idpool.release_queue = 0;
-    SOKOL_FREE(_sg.mtl.idpool.free_queue);     _sg.mtl.idpool.free_queue = 0;
+    _sg_free(_sg.mtl.idpool.release_queue);  _sg.mtl.idpool.release_queue = 0;
+    _sg_free(_sg.mtl.idpool.free_queue);     _sg.mtl.idpool.free_queue = 0;
     _SG_OBJC_RELEASE(_sg.mtl.idpool.pool);
 }
 
@@ -10155,7 +10194,7 @@ _SOKOL_PRIVATE int _sg_mtl_create_sampler(id<MTLDevice> mtl_device, const sg_ima
 }
 
 _SOKOL_PRIVATE void _sg_mtl_clear_state_cache(void) {
-    memset(&_sg.mtl.state_cache, 0, sizeof(_sg.mtl.state_cache));
+    _sg_clear(&_sg.mtl.state_cache, sizeof(_sg.mtl.state_cache));
 }
 
 /* https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf */
@@ -11736,14 +11775,14 @@ _SOKOL_PRIVATE void _sg_wgpu_ubpool_init(const sg_desc* desc) {
     _sg.wgpu.ub.num_bytes = desc->uniform_buffer_size + _SG_WGPU_MAX_UNIFORM_UPDATE_SIZE;
 
     WGPUBufferDescriptor ub_desc;
-    memset(&ub_desc, 0, sizeof(ub_desc));
+    _sg_clear(&ub_desc, sizeof(ub_desc));
     ub_desc.size = _sg.wgpu.ub.num_bytes;
     ub_desc.usage = WGPUBufferUsage_Uniform|WGPUBufferUsage_CopyDst;
     _sg.wgpu.ub.buf = wgpuDeviceCreateBuffer(_sg.wgpu.dev, &ub_desc);
     SOKOL_ASSERT(_sg.wgpu.ub.buf);
 
     WGPUBindGroupLayoutBinding ub_bglb_desc[SG_NUM_SHADER_STAGES][SG_MAX_SHADERSTAGE_UBS];
-    memset(ub_bglb_desc, 0, sizeof(ub_bglb_desc));
+    _sg_clear(ub_bglb_desc, sizeof(ub_bglb_desc));
     for (int stage_index = 0; stage_index < SG_NUM_SHADER_STAGES; stage_index++) {
         WGPUShaderStage vis = (stage_index == SG_SHADERSTAGE_VS) ? WGPUShaderStage_Vertex : WGPUShaderStage_Fragment;
         for (int ub_index = 0; ub_index < SG_MAX_SHADERSTAGE_UBS; ub_index++) {
@@ -11756,14 +11795,14 @@ _SOKOL_PRIVATE void _sg_wgpu_ubpool_init(const sg_desc* desc) {
     }
 
     WGPUBindGroupLayoutDescriptor ub_bgl_desc;
-    memset(&ub_bgl_desc, 0, sizeof(ub_bgl_desc));
+    _sg_clear(&ub_bgl_desc, sizeof(ub_bgl_desc));
     ub_bgl_desc.bindingCount = SG_NUM_SHADER_STAGES * SG_MAX_SHADERSTAGE_UBS;
     ub_bgl_desc.bindings = &ub_bglb_desc[0][0];
     _sg.wgpu.ub.bindgroup_layout = wgpuDeviceCreateBindGroupLayout(_sg.wgpu.dev, &ub_bgl_desc);
     SOKOL_ASSERT(_sg.wgpu.ub.bindgroup_layout);
 
     WGPUBindGroupBinding ub_bgb[SG_NUM_SHADER_STAGES][SG_MAX_SHADERSTAGE_UBS];
-    memset(ub_bgb, 0, sizeof(ub_bgb));
+    _sg_clear(ub_bgb, sizeof(ub_bgb));
     for (int stage_index = 0; stage_index < SG_NUM_SHADER_STAGES; stage_index++) {
         for (int ub_index = 0; ub_index < SG_MAX_SHADERSTAGE_UBS; ub_index++) {
             int bind_index = stage_index * SG_MAX_SHADERSTAGE_UBS + ub_index;
@@ -11774,7 +11813,7 @@ _SOKOL_PRIVATE void _sg_wgpu_ubpool_init(const sg_desc* desc) {
         }
     }
     WGPUBindGroupDescriptor bg_desc;
-    memset(&bg_desc, 0, sizeof(bg_desc));
+    _sg_clear(&bg_desc, sizeof(bg_desc));
     bg_desc.layout = _sg.wgpu.ub.bindgroup_layout;
     bg_desc.bindingCount = SG_NUM_SHADER_STAGES * SG_MAX_SHADERSTAGE_UBS;
     bg_desc.bindings = &ub_bgb[0][0];
@@ -11830,7 +11869,7 @@ _SOKOL_PRIVATE void _sg_wgpu_ubpool_next_frame(bool first_frame) {
 
     /* rewind per-frame offsets */
     _sg.wgpu.ub.offset = 0;
-    memset(&_sg.wgpu.ub.bind_offsets, 0, sizeof(_sg.wgpu.ub.bind_offsets));
+    _sg_clear(&_sg.wgpu.ub.bind_offsets, sizeof(_sg.wgpu.ub.bind_offsets));
 
     /* check if a mapped staging buffer is available, otherwise create one */
     for (int i = 0; i < _sg.wgpu.ub.stage.num; i++) {
@@ -11846,7 +11885,7 @@ _SOKOL_PRIVATE void _sg_wgpu_ubpool_next_frame(bool first_frame) {
     const int cur = _sg.wgpu.ub.stage.cur;
 
     WGPUBufferDescriptor desc;
-    memset(&desc, 0, sizeof(desc));
+    _sg_clear(&desc, sizeof(desc));
     desc.size = _sg.wgpu.ub.num_bytes;
     desc.usage = WGPUBufferUsage_CopySrc|WGPUBufferUsage_MapWrite;
     WGPUCreateBufferMappedResult res = wgpuDeviceCreateBufferMapped(_sg.wgpu.dev, &desc);
@@ -11898,13 +11937,13 @@ _SOKOL_PRIVATE uint32_t _sg_wgpu_copy_image_data(WGPUBuffer stg_buf, uint8_t* st
     const uint32_t num_slices = (img->cmn.type == SG_IMAGETYPE_ARRAY) ? img->cmn.num_slices : 1;
     const sg_pixel_format fmt = img->cmn.pixel_format;
     WGPUBufferCopyView src_view;
-    memset(&src_view, 0, sizeof(src_view));
+    _sg_clear(&src_view, sizeof(src_view));
     src_view.buffer = stg_buf;
     WGPUTextureCopyView dst_view;
-    memset(&dst_view, 0, sizeof(dst_view));
+    _sg_clear(&dst_view, sizeof(dst_view));
     dst_view.texture = img->wgpu.tex;
     WGPUExtent3D extent;
-    memset(&extent, 0, sizeof(extent));
+    _sg_clear(&extent, sizeof(extent));
 
     for (uint32_t face_index = 0; face_index < num_faces; face_index++) {
         for (uint32_t mip_index = 0; mip_index < (uint32_t)img->cmn.num_mipmaps; mip_index++) {
@@ -12044,7 +12083,7 @@ _SOKOL_PRIVATE void _sg_wgpu_staging_next_frame(bool first_frame) {
     const int cur = _sg.wgpu.staging.cur;
 
     WGPUBufferDescriptor desc;
-    memset(&desc, 0, sizeof(desc));
+    _sg_clear(&desc, sizeof(desc));
     desc.size = _sg.wgpu.staging.num_bytes;
     desc.usage = WGPUBufferUsage_CopySrc|WGPUBufferUsage_MapWrite;
     WGPUCreateBufferMappedResult res = wgpuDeviceCreateBufferMapped(_sg.wgpu.dev, &desc);
@@ -12137,7 +12176,7 @@ _SOKOL_PRIVATE WGPUSampler _sg_wgpu_create_sampler(const sg_image_desc* img_desc
         /* create a new WGPU sampler and add to sampler cache */
         /* FIXME: anisotropic filtering not supported? */
         WGPUSamplerDescriptor smp_desc;
-        memset(&smp_desc, 0, sizeof(smp_desc));
+        _sg_clear(&smp_desc, sizeof(smp_desc));
         smp_desc.addressModeU = _sg_wgpu_sampler_addrmode(img_desc->wrap_u);
         smp_desc.addressModeV = _sg_wgpu_sampler_addrmode(img_desc->wrap_v);
         smp_desc.addressModeW = _sg_wgpu_sampler_addrmode(img_desc->wrap_w);
@@ -12187,11 +12226,11 @@ _SOKOL_PRIVATE void _sg_wgpu_setup_backend(const sg_desc* desc) {
 
     /* create an empty bind group for shader stages without bound images */
     WGPUBindGroupLayoutDescriptor bgl_desc;
-    memset(&bgl_desc, 0, sizeof(bgl_desc));
+    _sg_clear(&bgl_desc, sizeof(bgl_desc));
     WGPUBindGroupLayout empty_bgl = wgpuDeviceCreateBindGroupLayout(_sg.wgpu.dev, &bgl_desc);
     SOKOL_ASSERT(empty_bgl);
     WGPUBindGroupDescriptor bg_desc;
-    memset(&bg_desc, 0, sizeof(bg_desc));
+    _sg_clear(&bg_desc, sizeof(bg_desc));
     bg_desc.layout = empty_bgl;
     _sg.wgpu.empty_bind_group = wgpuDeviceCreateBindGroup(_sg.wgpu.dev, &bg_desc);
     SOKOL_ASSERT(_sg.wgpu.empty_bind_group);
@@ -12199,7 +12238,7 @@ _SOKOL_PRIVATE void _sg_wgpu_setup_backend(const sg_desc* desc) {
 
     /* create initial per-frame command encoders */
     WGPUCommandEncoderDescriptor cmd_enc_desc;
-    memset(&cmd_enc_desc, 0, sizeof(cmd_enc_desc));
+    _sg_clear(&cmd_enc_desc, sizeof(cmd_enc_desc));
     _sg.wgpu.render_cmd_enc = wgpuDeviceCreateCommandEncoder(_sg.wgpu.dev, &cmd_enc_desc);
     SOKOL_ASSERT(_sg.wgpu.render_cmd_enc);
     _sg.wgpu.staging_cmd_enc = wgpuDeviceCreateCommandEncoder(_sg.wgpu.dev, &cmd_enc_desc);
@@ -12255,7 +12294,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_buffer(_sg_buffer_t* buf, const
     }
     else {
         WGPUBufferDescriptor wgpu_buf_desc;
-        memset(&wgpu_buf_desc, 0, sizeof(wgpu_buf_desc));
+        _sg_clear(&wgpu_buf_desc, sizeof(wgpu_buf_desc));
         wgpu_buf_desc.usage = _sg_wgpu_buffer_usage(buf->cmn.type, buf->cmn.usage);
         wgpu_buf_desc.size = buf->cmn.size;
         if (SG_USAGE_IMMUTABLE == buf->cmn.usage) {
@@ -12313,7 +12352,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_image(_sg_image_t* img, const s
     const bool injected = (0 != desc->wgpu_texture);
     const bool is_msaa = desc->sample_count > 1;
     WGPUTextureDescriptor wgpu_tex_desc;
-    memset(&wgpu_tex_desc, 0, sizeof(wgpu_tex_desc));
+    _sg_clear(&wgpu_tex_desc, sizeof(wgpu_tex_desc));
     _sg_wgpu_init_texdesc_common(&wgpu_tex_desc, desc);
     if (_sg_is_valid_rendertarget_depth_format(img->cmn.pixel_format)) {
         SOKOL_ASSERT(img->cmn.render_target);
@@ -12346,7 +12385,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_image(_sg_image_t* img, const s
             /* copy content into texture via a throw-away staging buffer */
             if (desc->usage == SG_USAGE_IMMUTABLE && !desc->render_target) {
                 WGPUBufferDescriptor wgpu_buf_desc;
-                memset(&wgpu_buf_desc, 0, sizeof(wgpu_buf_desc));
+                _sg_clear(&wgpu_buf_desc, sizeof(wgpu_buf_desc));
                 wgpu_buf_desc.size = _sg_wgpu_image_data_buffer_size(img);
                 wgpu_buf_desc.usage = WGPUBufferUsage_CopySrc|WGPUBufferUsage_CopyDst;
                 WGPUCreateBufferMappedResult map = wgpuDeviceCreateBufferMapped(_sg.wgpu.dev, &wgpu_buf_desc);
@@ -12361,7 +12400,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_image(_sg_image_t* img, const s
 
         /* create texture view object */
         WGPUTextureViewDescriptor wgpu_view_desc;
-        memset(&wgpu_view_desc, 0, sizeof(wgpu_view_desc));
+        _sg_clear(&wgpu_view_desc, sizeof(wgpu_view_desc));
         wgpu_view_desc.dimension = _sg_wgpu_tex_viewdim(desc->type);
         img->wgpu.tex_view = wgpuTextureCreateView(img->wgpu.tex, &wgpu_view_desc);
 
@@ -12447,7 +12486,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_shader(_sg_shader_t* shd, const
 
         _sg_strcpy(&wgpu_stage->entry, stage_desc->entry);
         WGPUShaderModuleDescriptor wgpu_shdmod_desc;
-        memset(&wgpu_shdmod_desc, 0, sizeof(wgpu_shdmod_desc));
+        _sg_clear(&wgpu_shdmod_desc, sizeof(wgpu_shdmod_desc));
         wgpu_shdmod_desc.codeSize = stage_desc->bytecode.size >> 2;
         wgpu_shdmod_desc.code = (const uint32_t*) stage_desc->bytecode.ptr;
         wgpu_stage->module = wgpuDeviceCreateShaderModule(_sg.wgpu.dev, &wgpu_shdmod_desc);
@@ -12462,7 +12501,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_shader(_sg_shader_t* shd, const
             num_imgs = _SG_WGPU_MAX_SHADERSTAGE_IMAGES;
         }
         WGPUBindGroupLayoutBinding bglb_desc[_SG_WGPU_MAX_SHADERSTAGE_IMAGES * 2];
-        memset(bglb_desc, 0, sizeof(bglb_desc));
+        _sg_clear(bglb_desc, sizeof(bglb_desc));
         for (int img_index = 0; img_index < num_imgs; img_index++) {
             /* texture- and sampler-bindings */
             WGPUBindGroupLayoutBinding* tex_desc = &bglb_desc[img_index*2 + 0];
@@ -12479,7 +12518,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_shader(_sg_shader_t* shd, const
             smp_desc->type = WGPUBindingType_Sampler;
         }
         WGPUBindGroupLayoutDescriptor img_bgl_desc;
-        memset(&img_bgl_desc, 0, sizeof(img_bgl_desc));
+        _sg_clear(&img_bgl_desc, sizeof(img_bgl_desc));
         img_bgl_desc.bindingCount = num_imgs * 2;
         img_bgl_desc.bindings = &bglb_desc[0];
         wgpu_stage->bind_group_layout = wgpuDeviceCreateBindGroupLayout(_sg.wgpu.dev, &img_bgl_desc);
@@ -12518,15 +12557,15 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_pipeline(_sg_pipeline_t* pip, _
         shd->wgpu.stage[SG_SHADERSTAGE_FS].bind_group_layout
     };
     WGPUPipelineLayoutDescriptor pl_desc;
-    memset(&pl_desc, 0, sizeof(pl_desc));
+    _sg_clear(&pl_desc, sizeof(pl_desc));
     pl_desc.bindGroupLayoutCount = 3;
     pl_desc.bindGroupLayouts = &pip_bgl[0];
     WGPUPipelineLayout pip_layout = wgpuDeviceCreatePipelineLayout(_sg.wgpu.dev, &pl_desc);
 
     WGPUVertexBufferLayoutDescriptor vb_desc[SG_MAX_SHADERSTAGE_BUFFERS];
-    memset(&vb_desc, 0, sizeof(vb_desc));
+    _sg_clear(&vb_desc, sizeof(vb_desc));
     WGPUVertexAttributeDescriptor va_desc[SG_MAX_SHADERSTAGE_BUFFERS][SG_MAX_VERTEX_ATTRIBUTES];
-    memset(&va_desc, 0, sizeof(va_desc));
+    _sg_clear(&va_desc, sizeof(va_desc));
     int vb_idx = 0;
     for (; vb_idx < SG_MAX_SHADERSTAGE_BUFFERS; vb_idx++) {
         const sg_buffer_layout_desc* src_vb_desc = &desc->layout.buffers[vb_idx];
@@ -12556,13 +12595,13 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_pipeline(_sg_pipeline_t* pip, _
         vb_desc[vb_idx].attributes = &va_desc[vb_idx][0];
     }
     WGPUVertexStateDescriptor vx_state_desc;
-    memset(&vx_state_desc, 0, sizeof(vx_state_desc));
+    _sg_clear(&vx_state_desc, sizeof(vx_state_desc));
     vx_state_desc.indexFormat = _sg_wgpu_indexformat(desc->index_type);
     vx_state_desc.vertexBufferCount = vb_idx;
     vx_state_desc.vertexBuffers = vb_desc;
 
     WGPURasterizationStateDescriptor rs_desc;
-    memset(&rs_desc, 0, sizeof(rs_desc));
+    _sg_clear(&rs_desc, sizeof(rs_desc));
     rs_desc.frontFace = _sg_wgpu_frontface(desc->face_winding);
     rs_desc.cullMode = _sg_wgpu_cullmode(desc->cull_mode);
     rs_desc.depthBias = (int32_t) desc->depth.bias;
@@ -12570,7 +12609,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_pipeline(_sg_pipeline_t* pip, _
     rs_desc.depthBiasSlopeScale = desc->depth.bias_slope_scale;
 
     WGPUDepthStencilStateDescriptor ds_desc;
-    memset(&ds_desc, 0, sizeof(ds_desc));
+    _sg_clear(&ds_desc, sizeof(ds_desc));
     ds_desc.format = _sg_wgpu_textureformat(desc->depth.pixel_format);
     ds_desc.depthWriteEnabled = desc->depth.write_enabled;
     ds_desc.depthCompare = _sg_wgpu_comparefunc(desc->depth.compare);
@@ -12586,12 +12625,12 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_pipeline(_sg_pipeline_t* pip, _
     ds_desc.stencilBack.passOp = _sg_wgpu_stencilop(desc->stencil.back.pass_op);
 
     WGPUProgrammableStageDescriptor fs_desc;
-    memset(&fs_desc, 0, sizeof(fs_desc));
+    _sg_clear(&fs_desc, sizeof(fs_desc));
     fs_desc.module = shd->wgpu.stage[SG_SHADERSTAGE_FS].module;
     fs_desc.entryPoint = shd->wgpu.stage[SG_SHADERSTAGE_VS].entry.buf;
 
     WGPUColorStateDescriptor cs_desc[SG_MAX_COLOR_ATTACHMENTS];
-    memset(cs_desc, 0, sizeof(cs_desc));
+    _sg_clear(cs_desc, sizeof(cs_desc));
     for (uint32_t i = 0; i < desc->color_count; i++) {
         SOKOL_ASSERT(i < SG_MAX_COLOR_ATTACHMENTS);
         cs_desc[i].format = _sg_wgpu_textureformat(desc->colors[i].pixel_format);
@@ -12605,7 +12644,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_pipeline(_sg_pipeline_t* pip, _
     }
 
     WGPURenderPipelineDescriptor pip_desc;
-    memset(&pip_desc, 0, sizeof(pip_desc));
+    _sg_clear(&pip_desc, sizeof(pip_desc));
     pip_desc.layout = pip_layout;
     pip_desc.vertexStage.module = shd->wgpu.stage[SG_SHADERSTAGE_VS].module;
     pip_desc.vertexStage.entryPoint = shd->wgpu.stage[SG_SHADERSTAGE_VS].entry.buf;
@@ -12658,7 +12697,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_pass(_sg_pass_t* pass, _sg_imag
             /* create a render-texture-view to render into the right sub-surface */
             const bool is_msaa = img->cmn.sample_count > 1;
             WGPUTextureViewDescriptor view_desc;
-            memset(&view_desc, 0, sizeof(view_desc));
+            _sg_clear(&view_desc, sizeof(view_desc));
             view_desc.baseMipLevel = is_msaa ? 0 : att_desc->mip_level;
             view_desc.mipLevelCount = 1;
             view_desc.baseArrayLayer = is_msaa ? 0 : att_desc->slice;
@@ -12689,7 +12728,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_pass(_sg_pass_t* pass, _sg_imag
         SOKOL_ASSERT(0 == att_desc->mip_level);
         SOKOL_ASSERT(0 == att_desc->slice);
         WGPUTextureViewDescriptor view_desc;
-        memset(&view_desc, 0, sizeof(view_desc));
+        _sg_clear(&view_desc, sizeof(view_desc));
         WGPUTexture wgpu_tex = ds_img->wgpu.tex;
         SOKOL_ASSERT(wgpu_tex);
         pass->wgpu.ds_att.render_tex_view = wgpuTextureCreateView(wgpu_tex, &view_desc);
@@ -12745,9 +12784,9 @@ _SOKOL_PRIVATE void _sg_wgpu_begin_pass(_sg_pass_t* pass, const sg_pass_action* 
     SOKOL_ASSERT(_sg.wgpu.render_cmd_enc);
     if (pass) {
         WGPURenderPassDescriptor wgpu_pass_desc;
-        memset(&wgpu_pass_desc, 0, sizeof(wgpu_pass_desc));
+        _sg_clear(&wgpu_pass_desc, sizeof(wgpu_pass_desc));
         WGPURenderPassColorAttachmentDescriptor wgpu_color_att_desc[SG_MAX_COLOR_ATTACHMENTS];
-        memset(&wgpu_color_att_desc, 0, sizeof(wgpu_color_att_desc));
+        _sg_clear(&wgpu_color_att_desc, sizeof(wgpu_color_att_desc));
         SOKOL_ASSERT(pass->slot.state == SG_RESOURCESTATE_VALID);
         for (uint32_t i = 0; i < pass->cmn.num_color_atts; i++) {
             const _sg_wgpu_attachment_t* wgpu_att = &pass->wgpu.color_atts[i];
@@ -12766,7 +12805,7 @@ _SOKOL_PRIVATE void _sg_wgpu_begin_pass(_sg_pass_t* pass, const sg_pass_action* 
         wgpu_pass_desc.colorAttachments = &wgpu_color_att_desc[0];
         if (pass->wgpu.ds_att.image) {
             WGPURenderPassDepthStencilAttachmentDescriptor wgpu_ds_att_desc;
-            memset(&wgpu_ds_att_desc, 0, sizeof(wgpu_ds_att_desc));
+            _sg_clear(&wgpu_ds_att_desc, sizeof(wgpu_ds_att_desc));
             wgpu_ds_att_desc.depthLoadOp = _sg_wgpu_load_op(action->depth.action);
             wgpu_ds_att_desc.clearDepth = action->depth.value;
             wgpu_ds_att_desc.stencilLoadOp = _sg_wgpu_load_op(action->stencil.action);
@@ -12783,9 +12822,9 @@ _SOKOL_PRIVATE void _sg_wgpu_begin_pass(_sg_pass_t* pass, const sg_pass_action* 
         WGPUTextureView wgpu_depth_stencil_view = _sg.wgpu.depth_stencil_view_cb ? _sg.wgpu.depth_stencil_view_cb() : _sg.wgpu.depth_stencil_view_userdata_cb(_sg.wgpu.user_data);
 
         WGPURenderPassDescriptor pass_desc;
-        memset(&pass_desc, 0, sizeof(pass_desc));
+        _sg_clear(&pass_desc, sizeof(pass_desc));
         WGPURenderPassColorAttachmentDescriptor color_att_desc;
-        memset(&color_att_desc, 0, sizeof(color_att_desc));
+        _sg_clear(&color_att_desc, sizeof(color_att_desc));
         color_att_desc.loadOp = _sg_wgpu_load_op(action->colors[0].action);
         color_att_desc.clearColor.r = action->colors[0].value.r;
         color_att_desc.clearColor.g = action->colors[0].value.g;
@@ -12796,7 +12835,7 @@ _SOKOL_PRIVATE void _sg_wgpu_begin_pass(_sg_pass_t* pass, const sg_pass_action* 
         pass_desc.colorAttachmentCount = 1;
         pass_desc.colorAttachments = &color_att_desc;
         WGPURenderPassDepthStencilAttachmentDescriptor ds_att_desc;
-        memset(&ds_att_desc, 0, sizeof(ds_att_desc));
+        _sg_clear(&ds_att_desc, sizeof(ds_att_desc));
         ds_att_desc.attachment = wgpu_depth_stencil_view;
         SOKOL_ASSERT(0 != ds_att_desc.attachment);
         ds_att_desc.depthLoadOp = _sg_wgpu_load_op(action->depth.action);
@@ -12838,7 +12877,7 @@ _SOKOL_PRIVATE void _sg_wgpu_commit(void) {
     WGPUCommandBuffer cmd_bufs[2];
 
     WGPUCommandBufferDescriptor cmd_buf_desc;
-    memset(&cmd_buf_desc, 0, sizeof(cmd_buf_desc));
+    _sg_clear(&cmd_buf_desc, sizeof(cmd_buf_desc));
     cmd_bufs[0] = wgpuCommandEncoderFinish(_sg.wgpu.staging_cmd_enc, &cmd_buf_desc);
     SOKOL_ASSERT(cmd_bufs[0]);
     wgpuCommandEncoderRelease(_sg.wgpu.staging_cmd_enc);
@@ -12856,7 +12895,7 @@ _SOKOL_PRIVATE void _sg_wgpu_commit(void) {
 
     /* create a new render- and staging-command-encoders for next frame */
     WGPUCommandEncoderDescriptor cmd_enc_desc;
-    memset(&cmd_enc_desc, 0, sizeof(cmd_enc_desc));
+    _sg_clear(&cmd_enc_desc, sizeof(cmd_enc_desc));
     _sg.wgpu.staging_cmd_enc = wgpuDeviceCreateCommandEncoder(_sg.wgpu.dev, &cmd_enc_desc);
     _sg.wgpu.render_cmd_enc = wgpuDeviceCreateCommandEncoder(_sg.wgpu.dev, &cmd_enc_desc);
 
@@ -12917,7 +12956,7 @@ _SOKOL_PRIVATE WGPUBindGroup _sg_wgpu_create_images_bindgroup(WGPUBindGroupLayou
     SOKOL_ASSERT(_sg.wgpu.dev);
     SOKOL_ASSERT(num_imgs <= _SG_WGPU_MAX_SHADERSTAGE_IMAGES);
     WGPUBindGroupBinding img_bgb[_SG_WGPU_MAX_SHADERSTAGE_IMAGES * 2];
-    memset(&img_bgb, 0, sizeof(img_bgb));
+    _sg_clear(&img_bgb, sizeof(img_bgb));
     for (int img_index = 0; img_index < num_imgs; img_index++) {
         WGPUBindGroupBinding* tex_bdg = &img_bgb[img_index*2 + 0];
         WGPUBindGroupBinding* smp_bdg = &img_bgb[img_index*2 + 1];
@@ -12927,7 +12966,7 @@ _SOKOL_PRIVATE WGPUBindGroup _sg_wgpu_create_images_bindgroup(WGPUBindGroupLayou
         smp_bdg->sampler = imgs[img_index]->wgpu.sampler;
     }
     WGPUBindGroupDescriptor bg_desc;
-    memset(&bg_desc, 0, sizeof(bg_desc));
+    _sg_clear(&bg_desc, sizeof(bg_desc));
     bg_desc.layout = bgl;
     bg_desc.bindingCount = 2 * num_imgs;
     bg_desc.bindings = &img_bgb[0];
@@ -13539,12 +13578,9 @@ _SOKOL_PRIVATE void _sg_init_pool(_sg_pool_t* pool, int num) {
     pool->queue_top = 0;
     /* generation counters indexable by pool slot index, slot 0 is reserved */
     size_t gen_ctrs_size = sizeof(uint32_t) * (size_t)pool->size;
-    pool->gen_ctrs = (uint32_t*) SOKOL_MALLOC(gen_ctrs_size);
-    SOKOL_ASSERT(pool->gen_ctrs);
-    memset(pool->gen_ctrs, 0, gen_ctrs_size);
+    pool->gen_ctrs = (uint32_t*)_sg_malloc_clear(gen_ctrs_size);
     /* it's not a bug to only reserve 'num' here */
-    pool->free_queue = (int*) SOKOL_MALLOC(sizeof(int) * (size_t)num);
-    SOKOL_ASSERT(pool->free_queue);
+    pool->free_queue = (int*) _sg_malloc_clear(sizeof(int) * (size_t)num);
     /* never allocate the zero-th pool item since the invalid id is 0 */
     for (int i = pool->size-1; i >= 1; i--) {
         pool->free_queue[pool->queue_top++] = i;
@@ -13554,10 +13590,10 @@ _SOKOL_PRIVATE void _sg_init_pool(_sg_pool_t* pool, int num) {
 _SOKOL_PRIVATE void _sg_discard_pool(_sg_pool_t* pool) {
     SOKOL_ASSERT(pool);
     SOKOL_ASSERT(pool->free_queue);
-    SOKOL_FREE(pool->free_queue);
+    _sg_free(pool->free_queue);
     pool->free_queue = 0;
     SOKOL_ASSERT(pool->gen_ctrs);
-    SOKOL_FREE(pool->gen_ctrs);
+    _sg_free(pool->gen_ctrs);
     pool->gen_ctrs = 0;
     pool->size = 0;
     pool->queue_top = 0;
@@ -13594,13 +13630,13 @@ _SOKOL_PRIVATE void _sg_pool_free_index(_sg_pool_t* pool, int slot_index) {
 
 _SOKOL_PRIVATE void _sg_reset_slot(_sg_slot_t* slot) {
     SOKOL_ASSERT(slot);
-    memset(slot, 0, sizeof(_sg_slot_t));
+    _sg_clear(slot, sizeof(_sg_slot_t));
 }
 
 _SOKOL_PRIVATE void _sg_reset_buffer(_sg_buffer_t* buf) {
     SOKOL_ASSERT(buf);
     _sg_slot_t slot = buf->slot;
-    memset(buf, 0, sizeof(_sg_buffer_t));
+    _sg_clear(buf, sizeof(_sg_buffer_t));
     buf->slot = slot;
     buf->slot.state = SG_RESOURCESTATE_ALLOC;
 }
@@ -13608,7 +13644,7 @@ _SOKOL_PRIVATE void _sg_reset_buffer(_sg_buffer_t* buf) {
 _SOKOL_PRIVATE void _sg_reset_image(_sg_image_t* img) {
     SOKOL_ASSERT(img);
     _sg_slot_t slot = img->slot;
-    memset(img, 0, sizeof(_sg_image_t));
+    _sg_clear(img, sizeof(_sg_image_t));
     img->slot = slot;
     img->slot.state = SG_RESOURCESTATE_ALLOC;
 }
@@ -13616,7 +13652,7 @@ _SOKOL_PRIVATE void _sg_reset_image(_sg_image_t* img) {
 _SOKOL_PRIVATE void _sg_reset_shader(_sg_shader_t* shd) {
     SOKOL_ASSERT(shd);
     _sg_slot_t slot = shd->slot;
-    memset(shd, 0, sizeof(_sg_shader_t));
+    _sg_clear(shd, sizeof(_sg_shader_t));
     shd->slot = slot;
     shd->slot.state = SG_RESOURCESTATE_ALLOC;
 }
@@ -13624,7 +13660,7 @@ _SOKOL_PRIVATE void _sg_reset_shader(_sg_shader_t* shd) {
 _SOKOL_PRIVATE void _sg_reset_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
     _sg_slot_t slot = pip->slot;
-    memset(pip, 0, sizeof(_sg_pipeline_t));
+    _sg_clear(pip, sizeof(_sg_pipeline_t));
     pip->slot = slot;
     pip->slot.state = SG_RESOURCESTATE_ALLOC;
 }
@@ -13632,7 +13668,7 @@ _SOKOL_PRIVATE void _sg_reset_pipeline(_sg_pipeline_t* pip) {
 _SOKOL_PRIVATE void _sg_reset_pass(_sg_pass_t* pass) {
     SOKOL_ASSERT(pass);
     _sg_slot_t slot = pass->slot;
-    memset(pass, 0, sizeof(_sg_pass_t));
+    _sg_clear(pass, sizeof(_sg_pass_t));
     pass->slot = slot;
     pass->slot.state = SG_RESOURCESTATE_ALLOC;
 }
@@ -13640,7 +13676,7 @@ _SOKOL_PRIVATE void _sg_reset_pass(_sg_pass_t* pass) {
 _SOKOL_PRIVATE void _sg_reset_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     _sg_slot_t slot = ctx->slot;
-    memset(ctx, 0, sizeof(_sg_context_t));
+    _sg_clear(ctx, sizeof(_sg_context_t));
     ctx->slot = slot;
     ctx->slot.state = SG_RESOURCESTATE_ALLOC;
 }
@@ -13652,54 +13688,42 @@ _SOKOL_PRIVATE void _sg_setup_pools(_sg_pools_t* p, const sg_desc* desc) {
     SOKOL_ASSERT((desc->buffer_pool_size > 0) && (desc->buffer_pool_size < _SG_MAX_POOL_SIZE));
     _sg_init_pool(&p->buffer_pool, desc->buffer_pool_size);
     size_t buffer_pool_byte_size = sizeof(_sg_buffer_t) * (size_t)p->buffer_pool.size;
-    p->buffers = (_sg_buffer_t*) SOKOL_MALLOC(buffer_pool_byte_size);
-    SOKOL_ASSERT(p->buffers);
-    memset(p->buffers, 0, buffer_pool_byte_size);
+    p->buffers = (_sg_buffer_t*) _sg_malloc_clear(buffer_pool_byte_size);
 
     SOKOL_ASSERT((desc->image_pool_size > 0) && (desc->image_pool_size < _SG_MAX_POOL_SIZE));
     _sg_init_pool(&p->image_pool, desc->image_pool_size);
     size_t image_pool_byte_size = sizeof(_sg_image_t) * (size_t)p->image_pool.size;
-    p->images = (_sg_image_t*) SOKOL_MALLOC(image_pool_byte_size);
-    SOKOL_ASSERT(p->images);
-    memset(p->images, 0, image_pool_byte_size);
+    p->images = (_sg_image_t*) _sg_malloc_clear(image_pool_byte_size);
 
     SOKOL_ASSERT((desc->shader_pool_size > 0) && (desc->shader_pool_size < _SG_MAX_POOL_SIZE));
     _sg_init_pool(&p->shader_pool, desc->shader_pool_size);
     size_t shader_pool_byte_size = sizeof(_sg_shader_t) * (size_t)p->shader_pool.size;
-    p->shaders = (_sg_shader_t*) SOKOL_MALLOC(shader_pool_byte_size);
-    SOKOL_ASSERT(p->shaders);
-    memset(p->shaders, 0, shader_pool_byte_size);
+    p->shaders = (_sg_shader_t*) _sg_malloc_clear(shader_pool_byte_size);
 
     SOKOL_ASSERT((desc->pipeline_pool_size > 0) && (desc->pipeline_pool_size < _SG_MAX_POOL_SIZE));
     _sg_init_pool(&p->pipeline_pool, desc->pipeline_pool_size);
     size_t pipeline_pool_byte_size = sizeof(_sg_pipeline_t) * (size_t)p->pipeline_pool.size;
-    p->pipelines = (_sg_pipeline_t*) SOKOL_MALLOC(pipeline_pool_byte_size);
-    SOKOL_ASSERT(p->pipelines);
-    memset(p->pipelines, 0, pipeline_pool_byte_size);
+    p->pipelines = (_sg_pipeline_t*) _sg_malloc_clear(pipeline_pool_byte_size);
 
     SOKOL_ASSERT((desc->pass_pool_size > 0) && (desc->pass_pool_size < _SG_MAX_POOL_SIZE));
     _sg_init_pool(&p->pass_pool, desc->pass_pool_size);
     size_t pass_pool_byte_size = sizeof(_sg_pass_t) * (size_t)p->pass_pool.size;
-    p->passes = (_sg_pass_t*) SOKOL_MALLOC(pass_pool_byte_size);
-    SOKOL_ASSERT(p->passes);
-    memset(p->passes, 0, pass_pool_byte_size);
+    p->passes = (_sg_pass_t*) _sg_malloc_clear(pass_pool_byte_size);
 
     SOKOL_ASSERT((desc->context_pool_size > 0) && (desc->context_pool_size < _SG_MAX_POOL_SIZE));
     _sg_init_pool(&p->context_pool, desc->context_pool_size);
     size_t context_pool_byte_size = sizeof(_sg_context_t) * (size_t)p->context_pool.size;
-    p->contexts = (_sg_context_t*) SOKOL_MALLOC(context_pool_byte_size);
-    SOKOL_ASSERT(p->contexts);
-    memset(p->contexts, 0, context_pool_byte_size);
+    p->contexts = (_sg_context_t*) _sg_malloc_clear(context_pool_byte_size);
 }
 
 _SOKOL_PRIVATE void _sg_discard_pools(_sg_pools_t* p) {
     SOKOL_ASSERT(p);
-    SOKOL_FREE(p->contexts);    p->contexts = 0;
-    SOKOL_FREE(p->passes);      p->passes = 0;
-    SOKOL_FREE(p->pipelines);   p->pipelines = 0;
-    SOKOL_FREE(p->shaders);     p->shaders = 0;
-    SOKOL_FREE(p->images);      p->images = 0;
-    SOKOL_FREE(p->buffers);     p->buffers = 0;
+    _sg_free(p->contexts);    p->contexts = 0;
+    _sg_free(p->passes);      p->passes = 0;
+    _sg_free(p->pipelines);   p->pipelines = 0;
+    _sg_free(p->shaders);     p->shaders = 0;
+    _sg_free(p->images);      p->images = 0;
+    _sg_free(p->buffers);     p->buffers = 0;
     _sg_discard_pool(&p->context_pool);
     _sg_discard_pool(&p->pass_pool);
     _sg_discard_pool(&p->pipeline_pool);
@@ -14772,7 +14796,7 @@ _SOKOL_PRIVATE sg_pipeline_desc _sg_pipeline_desc_defaults(const sg_pipeline_des
 
     /* resolve vertex layout strides and offsets */
     int auto_offset[SG_MAX_SHADERSTAGE_BUFFERS];
-    memset(auto_offset, 0, sizeof(auto_offset));
+    _sg_clear(auto_offset, sizeof(auto_offset));
     bool use_auto_offset = true;
     for (int attr_index = 0; attr_index < SG_MAX_VERTEX_ATTRIBUTES; attr_index++) {
         /* to use computed offsets, *all* attr offsets must be 0 */
@@ -15093,21 +15117,10 @@ _SOKOL_PRIVATE bool _sg_uninit_pass(sg_pass pass_id) {
 
 /*== PUBLIC API FUNCTIONS ====================================================*/
 
-#if defined(SOKOL_METAL)
-    // this is ARC compatible
-    #if defined(__cplusplus)
-        #define _SG_CLEAR(type, item) { item = { }; }
-    #else
-        #define _SG_CLEAR(type, item) { item = (type) { 0 }; }
-    #endif
-#else
-    #define _SG_CLEAR(type, item) { memset(&item, 0, sizeof(item)); }
-#endif
-
 SOKOL_API_IMPL void sg_setup(const sg_desc* desc) {
     SOKOL_ASSERT(desc);
     SOKOL_ASSERT((desc->_start_canary == 0) && (desc->_end_canary == 0));
-    _SG_CLEAR(_sg_state_t, _sg);
+    _SG_CLEAR_ARC_STRUCT(_sg_state_t, _sg);
     _sg.desc = *desc;
 
     /* replace zero-init items with their default values
@@ -15132,6 +15145,8 @@ SOKOL_API_IMPL void sg_setup(const sg_desc* desc) {
     _sg.desc.uniform_buffer_size = _sg_def(_sg.desc.uniform_buffer_size, _SG_DEFAULT_UB_SIZE);
     _sg.desc.staging_buffer_size = _sg_def(_sg.desc.staging_buffer_size, _SG_DEFAULT_STAGING_SIZE);
     _sg.desc.sampler_cache_size = _sg_def(_sg.desc.sampler_cache_size, _SG_DEFAULT_SAMPLER_CACHE_CAPACITY);
+    _sg.desc.allocator.alloc = _sg_def(_sg.desc.allocator.alloc, malloc);
+    _sg.desc.allocator.free = _sg_def(_sg.desc.allocator.free, free);
 
     _sg_setup_pools(&_sg.pools, &_sg.desc);
     _sg.frame_index = 1;
@@ -15917,7 +15932,7 @@ SOKOL_API_IMPL void sg_pop_debug_group(void) {
 SOKOL_API_IMPL sg_buffer_info sg_query_buffer_info(sg_buffer buf_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_buffer_info info;
-    memset(&info, 0, sizeof(info));
+    _sg_clear(&info, sizeof(info));
     const _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
     if (buf) {
         info.slot.state = buf->slot.state;
@@ -15941,7 +15956,7 @@ SOKOL_API_IMPL sg_buffer_info sg_query_buffer_info(sg_buffer buf_id) {
 SOKOL_API_IMPL sg_image_info sg_query_image_info(sg_image img_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_image_info info;
-    memset(&info, 0, sizeof(info));
+    _sg_clear(&info, sizeof(info));
     const _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
     if (img) {
         info.slot.state = img->slot.state;
@@ -15964,7 +15979,7 @@ SOKOL_API_IMPL sg_image_info sg_query_image_info(sg_image img_id) {
 SOKOL_API_IMPL sg_shader_info sg_query_shader_info(sg_shader shd_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_shader_info info;
-    memset(&info, 0, sizeof(info));
+    _sg_clear(&info, sizeof(info));
     const _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
     if (shd) {
         info.slot.state = shd->slot.state;
@@ -15977,7 +15992,7 @@ SOKOL_API_IMPL sg_shader_info sg_query_shader_info(sg_shader shd_id) {
 SOKOL_API_IMPL sg_pipeline_info sg_query_pipeline_info(sg_pipeline pip_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_pipeline_info info;
-    memset(&info, 0, sizeof(info));
+    _sg_clear(&info, sizeof(info));
     const _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
     if (pip) {
         info.slot.state = pip->slot.state;
@@ -15990,7 +16005,7 @@ SOKOL_API_IMPL sg_pipeline_info sg_query_pipeline_info(sg_pipeline pip_id) {
 SOKOL_API_IMPL sg_pass_info sg_query_pass_info(sg_pass pass_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_pass_info info;
-    memset(&info, 0, sizeof(info));
+    _sg_clear(&info, sizeof(info));
     const _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
     if (pass) {
         info.slot.state = pass->slot.state;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2580,9 +2580,9 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
 #if !(defined(SOKOL_GLCORE33)||defined(SOKOL_GLES2)||defined(SOKOL_GLES3)||defined(SOKOL_D3D11)||defined(SOKOL_METAL)||defined(SOKOL_WGPU)||defined(SOKOL_DUMMY_BACKEND))
 #error "Please select a backend with SOKOL_GLCORE33, SOKOL_GLES2, SOKOL_GLES3, SOKOL_D3D11, SOKOL_METAL, SOKOL_WGPU or SOKOL_DUMMY_BACKEND"
 #endif
-#include <stdlib.h> /* malloc/free */
-#include <string.h> /* memset */
-#include <float.h> /* FLT_MAX */
+#include <stdlib.h> // malloc, free
+#include <string.h> // memset
+#include <float.h> // FLT_MAX
 
 #ifndef SOKOL_API_IMPL
     #define SOKOL_API_IMPL

--- a/util/sokol_debugtext.h
+++ b/util/sokol_debugtext.h
@@ -3908,21 +3908,21 @@ static inline void _sdtx_put_char(_sdtx_context_t* ctx, char c) {
     }
 }
 
-static sdtx_desc_t _sdtx_desc_defaults(const sdtx_desc_t* in_desc) {
-    SOKOL_ASSERT((in_desc->allocator.alloc && in_desc->allocator.free) || (!in_desc->allocator.alloc && !in_desc->allocator.free));
-    sdtx_desc_t desc = *in_desc;
-    desc.context_pool_size = _sdtx_def(desc.context_pool_size, _SDTX_DEFAULT_CONTEXT_POOL_SIZE);
-    desc.printf_buf_size = _sdtx_def(desc.printf_buf_size, _SDTX_DEFAULT_PRINTF_BUF_SIZE);
+static sdtx_desc_t _sdtx_desc_defaults(const sdtx_desc_t* desc) {
+    SOKOL_ASSERT((desc->allocator.alloc && desc->allocator.free) || (!desc->allocator.alloc && !desc->allocator.free));
+    sdtx_desc_t res = *desc;
+    res.context_pool_size = _sdtx_def(res.context_pool_size, _SDTX_DEFAULT_CONTEXT_POOL_SIZE);
+    res.printf_buf_size = _sdtx_def(res.printf_buf_size, _SDTX_DEFAULT_PRINTF_BUF_SIZE);
     for (int i = 0; i < SDTX_MAX_FONTS; i++) {
-        if (desc.fonts[i].data.ptr) {
-            desc.fonts[i].last_char = _sdtx_def(desc.fonts[i].last_char, 255);
+        if (res.fonts[i].data.ptr) {
+            res.fonts[i].last_char = _sdtx_def(res.fonts[i].last_char, 255);
         }
     }
-    desc.context = _sdtx_context_desc_defaults(&desc.context);
-    SOKOL_ASSERT(desc.context_pool_size > 0);
-    SOKOL_ASSERT(desc.printf_buf_size > 0);
-    SOKOL_ASSERT(desc.context.char_buf_size > 0);
-    return desc;
+    res.context = _sdtx_context_desc_defaults(&res.context);
+    SOKOL_ASSERT(res.context_pool_size > 0);
+    SOKOL_ASSERT(res.printf_buf_size > 0);
+    SOKOL_ASSERT(res.context.char_buf_size > 0);
+    return res;
 }
 
 /*=== PUBLIC API FUNCTIONS ===================================================*/

--- a/util/sokol_debugtext.h
+++ b/util/sokol_debugtext.h
@@ -368,6 +368,34 @@
     Character tiles that haven't been defined in the font will be rendered
     as a solid 8x8 quad.
 
+
+    MEMORY ALLOCATION OVERRIDE
+    ==========================
+    You can override the memory allocation functions at initialization time
+    like this:
+
+        void* my_alloc(size_t size, void* user_data) {
+            return malloc(size);
+        }
+
+        void my_free(void* ptr, void* user_data) {
+            free(ptr);
+        }
+
+        ...
+            sdtx_setup(&(sdtx_desc_t){
+                // ...
+                .allocator = {
+                    .alloc = my_alloc,
+                    .free = my_free,
+                    .user_data = ...;
+                }
+            });
+        ...
+
+    If no overrides are provided, malloc and free will be used.
+
+
     LICENSE
     =======
     zlib/libpng license

--- a/util/sokol_debugtext.h
+++ b/util/sokol_debugtext.h
@@ -637,6 +637,10 @@ inline sdtx_context sdtx_make_context(const sdtx_context_desc_t& desc) { return 
 #ifdef SOKOL_DEBUGTEXT_IMPL
 #define SOKOL_DEBUGTEXT_IMPL_INCLUDED (1)
 
+#if defined(SOKOL_MALLOC) || defined(SOKOL_CALLOC) || defined(SOKOL_FREE)
+#error "SOKOL_MALLOC/CALLOC/FREE macros are no longer supported, please use sdtx_desc_t.allocator to override memory allocation functions"
+#endif
+
 #include <string.h> // memset
 #include <math.h>   // fmodf
 #include <stdarg.h> // for vsnprintf

--- a/util/sokol_fontstash.h
+++ b/util/sokol_fontstash.h
@@ -249,6 +249,11 @@ SOKOL_FONTSTASH_API_DECL uint32_t sfons_rgba(uint8_t r, uint8_t g, uint8_t b, ui
 /*-- IMPLEMENTATION ----------------------------------------------------------*/
 #ifdef SOKOL_FONTSTASH_IMPL
 #define SOKOL_FONTSTASH_IMPL_INCLUDED (1)
+
+#if defined(SOKOL_MALLOC) || defined(SOKOL_CALLOC) || defined(SOKOL_FREE)
+#error "SOKOL_MALLOC/CALLOC/FREE macros are no longer supported, please use sfons_desc_t.allocator to override memory allocation functions"
+#endif
+
 #include <string.h>     // memset, memcpy
 #include <stdlib.h>     // malloc, free
 

--- a/util/sokol_fontstash.h
+++ b/util/sokol_fontstash.h
@@ -1859,6 +1859,16 @@ static sfons_desc_t _sfons_desc_defaults(const sfons_desc_t* desc) {
     return res;
 }
 
+// NOTE clang analyzer will report a potential memory leak for the call
+// to _sfons_malloc_clear in the sfons_create() function, this is a false positive
+// (the freeing happens in sfons_destroy()). The following macro
+// silences the false positive when compilation happens with the analyzer active
+#if __clang_analyzer__
+#define _SFONS_CLANG_ANALYZER_SILENCE_POTENTIAL_LEAK_FALSE_POSITIVE(a,x) _sfons_free(a,x)
+#else
+#define _SFONS_CLANG_ANALYZER_SILENCE_POTENTIAL_LEAK_FALSE_POSITIVE(a,x)
+#endif
+
 SOKOL_API_IMPL FONScontext* sfons_create(const sfons_desc_t* desc) {
     SOKOL_ASSERT(desc);
     SOKOL_ASSERT((desc->allocator.alloc && desc->allocator.free) || (!desc->allocator.alloc && !desc->allocator.free));
@@ -1876,6 +1886,7 @@ SOKOL_API_IMPL FONScontext* sfons_create(const sfons_desc_t* desc) {
     params.renderDelete = _sfons_render_delete;
     params.userPtr = sfons;
     FONScontext* ctx = fonsCreateInternal(&params);
+    _SFONS_CLANG_ANALYZER_SILENCE_POTENTIAL_LEAK_FALSE_POSITIVE(&desc->allocator, sfons);
     return ctx;
 }
 

--- a/util/sokol_fontstash.h
+++ b/util/sokol_fontstash.h
@@ -28,8 +28,6 @@
     ...optionally provide the following macros to override defaults:
 
     SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
-    SOKOL_MALLOC(s)     - your own malloc function (default: malloc(s))
-    SOKOL_FREE(p)       - your own free function (default: free(p))
     SOKOL_FONTSTASH_API_DECL    - public function declaration prefix (default: extern)
     SOKOL_API_DECL      - same as SOKOL_FONTSTASH_API_DECL
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
@@ -55,7 +53,10 @@
     --- Create at least one fontstash context with sfons_create() (this replaces
         glfonsCreate() from fontstash.h's example GL renderer:
 
-            FONScontext* ctx = sfons_create(atlas_width, atlas_height, FONS_ZERO_TOPLEFT);
+            FONScontext* ctx = sfons_create(&(sfons_desc_t){
+                .width = atlas_width,
+                .height = atlas_height,
+            });
 
         Each FONScontext manages one font atlas texture which can hold rasterized
         glyphs for multiple fonts.
@@ -96,7 +97,7 @@
     WHAT HAPPENS UNDER THE HOOD:
     ============================
 
-    FONScontext* sfons_create(int width, int height, int flags):
+    FONScontext* sfons_create(const sfons_desc_t* desc)
         - creates a sokol-gfx shader compatible with sokol-gl
         - creates an sgl_pipeline object with alpha-blending using
           this shader
@@ -130,6 +131,35 @@
     sfons_destroy(FONScontext* ctx):
         - destroy the font atlas texture, sgl_pipeline and sg_shader objects
 
+
+    MEMORY ALLOCATION OVERRIDE
+    ==========================
+    You can override the memory allocation functions at initialization time
+    like this:
+
+        void* my_alloc(size_t size, void* user_data) {
+            return malloc(size);
+        }
+
+        void my_free(void* ptr, void* user_data) {
+            free(ptr);
+        }
+
+        ...
+        FONScontext* fons_context = sfons_create(&(sfons_desc_t){
+            ...
+            .allocator = {
+                .alloc = my_alloc,
+                .free = my_free,
+                .user_data = ...,
+            }
+        });
+        ...
+
+    If no overrides are provided, malloc and free will be used. Please
+    note that this doesn't affect any memory allocation performed
+    in fontstash.h (unfortunately those are hardwired to malloc/free).
+
     LICENSE
     =======
     zlib/libpng license
@@ -158,6 +188,7 @@
 #define SOKOL_FONTSTASH_INCLUDED (1)
 #include <stdint.h>
 #include <stdlib.h>
+#include <stddef.h> // size_t
 
 #if !defined(SOKOL_GFX_INCLUDED)
 #error "Please include sokol_gfx.h before sokol_fontstash.h"
@@ -179,7 +210,33 @@
 extern "C" {
 #endif
 
-SOKOL_FONTSTASH_API_DECL FONScontext* sfons_create(int width, int height, int flags);
+/*
+    sfonst_allocator_t
+
+    Used in sfons_desc_t to provide custom memory-alloc and -free functions
+    to sokol_fontstash.h. If memory management should be overridden, both the
+    alloc and free function must be provided (e.g. it's not valid to
+    override one function but not the other).
+
+    NOTE that this does not affect memory allocation calls inside
+    fontstash.h
+*/
+typedef void*(*sfons_malloc_t)(size_t size, void* user_data);
+typedef void(*sfons_free_t)(void* ptr, void* user_data);
+
+typedef struct sfons_allocator_t {
+    sfons_malloc_t alloc;
+    sfons_free_t free;
+    void* user_data;
+} sfons_allocator_t;
+
+typedef struct sfons_desc_t {
+    int width;    // initial width of font atlas texture (default: 512, must be power of 2)
+    int height;   // initial height of font atlas texture (default: 512, must be power of 2)
+    sfons_allocator_t allocator;    // optional memory allocation overrides
+} sfons_desc_t;
+
+SOKOL_FONTSTASH_API_DECL FONScontext* sfons_create(const sfons_desc_t* desc);
 SOKOL_FONTSTASH_API_DECL void sfons_destroy(FONScontext* ctx);
 SOKOL_FONTSTASH_API_DECL void sfons_flush(FONScontext* ctx);
 SOKOL_FONTSTASH_API_DECL uint32_t sfons_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
@@ -192,7 +249,8 @@ SOKOL_FONTSTASH_API_DECL uint32_t sfons_rgba(uint8_t r, uint8_t g, uint8_t b, ui
 /*-- IMPLEMENTATION ----------------------------------------------------------*/
 #ifdef SOKOL_FONTSTASH_IMPL
 #define SOKOL_FONTSTASH_IMPL_INCLUDED (1)
-#include <string.h>     /* memset, memcpy */
+#include <string.h>     // memset, memcpy
+#include <stdlib.h>     // malloc, free
 
 #if !defined(SOKOL_GL_INCLUDED)
 #error "Please include sokol_gl.h before sokol_fontstash.h"
@@ -212,11 +270,6 @@ SOKOL_FONTSTASH_API_DECL uint32_t sfons_rgba(uint8_t r, uint8_t g, uint8_t b, ui
 #ifndef SOKOL_ASSERT
     #include <assert.h>
     #define SOKOL_ASSERT(c) assert(c)
-#endif
-#ifndef SOKOL_MALLOC
-    #include <stdlib.h>
-    #define SOKOL_MALLOC(s) malloc(s)
-    #define SOKOL_FREE(p) free(p)
 #endif
 #ifndef SOKOL_LOG
     #ifdef SOKOL_DEBUG
@@ -1609,12 +1662,47 @@ static const char* _sfons_fs_source_dummy = "";
 #endif
 
 typedef struct _sfons_t {
+    sfons_desc_t desc;
     sg_shader shd;
     sgl_pipeline pip;
     sg_image img;
-    int width, height;
+    int cur_width, cur_height;
     bool img_dirty;
 } _sfons_t;
+
+static void _sfons_clear(void* ptr, size_t size) {
+    SOKOL_ASSERT(ptr && (size > 0));
+    memset(ptr, 0, size);
+}
+
+static void* _sfons_malloc(const sfons_allocator_t* allocator, size_t size) {
+    SOKOL_ASSERT(allocator && (size > 0));
+    void* ptr;
+    if (allocator->alloc) {
+        ptr = allocator->alloc(size, allocator->user_data);
+    }
+    else {
+        ptr = malloc(size);
+    }
+    SOKOL_ASSERT(ptr);
+    return ptr;
+}
+
+static void* _sfons_malloc_clear(const sfons_allocator_t* allocator, size_t size) {
+    void* ptr = _sfons_malloc(allocator, size);
+    _sfons_clear(ptr, size);
+    return ptr;
+}
+
+static void _sfons_free(const sfons_allocator_t* allocator, void* ptr) {
+    SOKOL_ASSERT(allocator);
+    if (allocator->free) {
+        allocator->free(ptr, allocator->user_data);
+    }
+    else {
+        free(ptr);
+    }
+}
 
 static int _sfons_render_create(void* user_ptr, int width, int height) {
     SOKOL_ASSERT(user_ptr && (width > 8) && (height > 8));
@@ -1623,7 +1711,7 @@ static int _sfons_render_create(void* user_ptr, int width, int height) {
     /* sokol-gl compatible shader which treats RED channel as alpha */
     if (sfons->shd.id == SG_INVALID_ID) {
         sg_shader_desc shd_desc;
-        memset(&shd_desc, 0, sizeof(shd_desc));
+        _sfons_clear(&shd_desc, sizeof(shd_desc));
         shd_desc.attrs[0].name = "position";
         shd_desc.attrs[1].name = "texcoord0";
         shd_desc.attrs[2].name = "color0";
@@ -1687,7 +1775,7 @@ static int _sfons_render_create(void* user_ptr, int width, int height) {
     /* sokol-gl pipeline object */
     if (sfons->pip.id == SG_INVALID_ID) {
         sg_pipeline_desc pip_desc;
-        memset(&pip_desc, 0, sizeof(pip_desc));
+        _sfons_clear(&pip_desc, sizeof(pip_desc));
         pip_desc.shader = sfons->shd;
         pip_desc.colors[0].blend.enabled = true;
         pip_desc.colors[0].blend.src_factor_rgb = SG_BLENDFACTOR_SRC_ALPHA;
@@ -1700,14 +1788,14 @@ static int _sfons_render_create(void* user_ptr, int width, int height) {
         sg_destroy_image(sfons->img);
         sfons->img.id = SG_INVALID_ID;
     }
-    sfons->width = width;
-    sfons->height = height;
+    sfons->cur_width = width;
+    sfons->cur_height = height;
 
     SOKOL_ASSERT(sfons->img.id == SG_INVALID_ID);
     sg_image_desc img_desc;
-    memset(&img_desc, 0, sizeof(img_desc));
-    img_desc.width = sfons->width;
-    img_desc.height = sfons->height;
+    _sfons_clear(&img_desc, sizeof(img_desc));
+    img_desc.width = sfons->cur_width;
+    img_desc.height = sfons->cur_height;
     img_desc.min_filter = SG_FILTER_LINEAR;
     img_desc.mag_filter = SG_FILTER_LINEAR;
     img_desc.usage = SG_USAGE_DYNAMIC;
@@ -1759,28 +1847,28 @@ static void _sfons_render_delete(void* user_ptr) {
         sg_destroy_shader(sfons->shd);
         sfons->shd.id = SG_INVALID_ID;
     }
-    SOKOL_FREE(sfons);
 }
 
-// NOTE clang analyzer will report a potential memory leak for the call
-// to SOKOL_MALLOC in the sfons_create() function, this is a false positive
-// (the freeing happens in _sfons_render_delete()). The following macro
-// silences the false positive when compilation happens with the analyzer active
-#if __clang_analyzer__
-#define _SFONS_CLANG_ANALYZER_SILENCE_POTENTIAL_LEAK_FALSE_POSITIVE(x) SOKOL_FREE(x)
-#else
-#define _SFONS_CLANG_ANALYZER_SILENCE_POTENTIAL_LEAK_FALSE_POSITIVE(x)
-#endif
+#define _sfons_def(val, def) (((val) == 0) ? (def) : (val))
 
-SOKOL_API_IMPL FONScontext* sfons_create(int width, int height, int flags) {
-    SOKOL_ASSERT((width > 0) && (height > 0));
+static sfons_desc_t _sfons_desc_defaults(const sfons_desc_t* desc) {
+    SOKOL_ASSERT(desc);
+    sfons_desc_t res = *desc;
+    res.width = _sfons_def(res.width, 512);
+    res.height = _sfons_def(res.height, 512);
+    return res;
+}
+
+SOKOL_API_IMPL FONScontext* sfons_create(const sfons_desc_t* desc) {
+    SOKOL_ASSERT(desc);
+    SOKOL_ASSERT((desc->allocator.alloc && desc->allocator.free) || (!desc->allocator.alloc && !desc->allocator.free));
+    _sfons_t* sfons = (_sfons_t*) _sfons_malloc_clear(&desc->allocator, sizeof(_sfons_t));
+    sfons->desc = _sfons_desc_defaults(desc);
     FONSparams params;
-    _sfons_t* sfons = (_sfons_t*) SOKOL_MALLOC(sizeof(_sfons_t));
-    memset(sfons, 0, sizeof(_sfons_t));
-    memset(&params, 0, sizeof(params));
-    params.width = width;
-    params.height = height;
-    params.flags = (unsigned char) flags;
+    _sfons_clear(&params, sizeof(params));
+    params.width = sfons->desc.width;
+    params.height = sfons->desc.height;
+    params.flags = FONS_ZERO_TOPLEFT;
     params.renderCreate = _sfons_render_create;
     params.renderResize = _sfons_render_resize;
     params.renderUpdate = _sfons_render_update;
@@ -1788,13 +1876,15 @@ SOKOL_API_IMPL FONScontext* sfons_create(int width, int height, int flags) {
     params.renderDelete = _sfons_render_delete;
     params.userPtr = sfons;
     FONScontext* ctx = fonsCreateInternal(&params);
-    _SFONS_CLANG_ANALYZER_SILENCE_POTENTIAL_LEAK_FALSE_POSITIVE(sfons);
     return ctx;
 }
 
 SOKOL_API_IMPL void sfons_destroy(FONScontext* ctx) {
     SOKOL_ASSERT(ctx);
+    _sfons_t* sfons = (_sfons_t*) ctx->params.userPtr;
     fonsDeleteInternal(ctx);
+    const sfons_allocator_t allocator = sfons->desc.allocator;
+    _sfons_free(&allocator, sfons);
 }
 
 SOKOL_API_IMPL void sfons_flush(FONScontext* ctx) {
@@ -1803,9 +1893,9 @@ SOKOL_API_IMPL void sfons_flush(FONScontext* ctx) {
     if (sfons->img_dirty) {
         sfons->img_dirty = false;
         sg_image_data data;
-        memset(&data, 0, sizeof(data));
+        _sfons_clear(&data, sizeof(data));
         data.subimage[0][0].ptr = ctx->texData;
-        data.subimage[0][0].size = (size_t) (sfons->width * sfons->height);
+        data.subimage[0][0].size = (size_t) (sfons->cur_width * sfons->cur_height);
         sg_update_image(sfons->img, &data);
     }
 }

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -148,6 +148,34 @@
     Finer-grained drawing functions may be moved to the public API
     in the future as needed.
 
+    MEMORY ALLOCATION OVERRIDE
+    ==========================
+    You can override the memory allocation functions at initialization time
+    like this:
+
+        void* my_alloc(size_t size, void* user_data) {
+            return malloc(size);
+        }
+
+        void my_free(void* ptr, void* user_data) {
+            free(ptr);
+        }
+
+        ...
+            sg_imgui_init(&(&ctx, &(sg_imgui_desc_t){
+                // ...
+                .allocator = {
+                    .alloc = my_alloc,
+                    .free = my_free,
+                    .user_data = ...;
+                }
+            });
+        ...
+
+    This only affects memory allocation calls done by sokol_gfx_imgui.h
+    itself though, not any allocations in OS libraries.
+
+
     LICENSE
     =======
     zlib/libpng license

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -45,8 +45,6 @@
         SOKOL_ASSERT(c)     -- your own assert macro, default: assert(c)
         SOKOL_UNREACHABLE   -- your own macro to annotate unreachable code,
                                default: SOKOL_ASSERT(false)
-        SOKOL_MALLOC(s)     -- your own memory allocation function, default: malloc(s)
-        SOKOL_FREE(p)       -- your own memory free function, default: free(p)
         SOKOL_GFX_IMGUI_API_DECL      - public function declaration prefix (default: extern)
         SOKOL_API_DECL      - same as SOKOL_GFX_IMGUI_API_DECL
         SOKOL_API_IMPL      - public function implementation prefix (default: -)
@@ -64,7 +62,21 @@
     --- create an sg_imgui_t struct (which must be preserved between frames)
         and initialize it with:
 
-            sg_imgui_init(&sg_imgui);
+            sg_imgui_init(&sg_imgui, &(sg_imgui_desc_t){ 0 });
+
+        Note that from C++ you can't inline the desc structure initialization:
+
+            const sg_imgui_desc_t desc = { };
+            sg_imgui_init(&sg_imgui, &desc);
+
+        Provide optional memory allocator override functions (compatible with malloc/free) like this:
+
+            sg_imgui_init(&sg_imgui, &(sg_imgui_desc_t){
+                .allocator = {
+                    .alloc = my_malloc,
+                    .free = my_free,
+                }
+            });
 
     --- somewhere in the per-frame code call:
 
@@ -164,6 +176,7 @@
 #define SOKOL_GFX_IMGUI_INCLUDED (1)
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h> // size_t
 
 #if !defined(SOKOL_GFX_INCLUDED)
 #error "Please include sokol_gfx.h before sokol_gfx_imgui.h"
@@ -616,8 +629,33 @@ typedef struct sg_imgui_caps_t {
     bool open;
 } sg_imgui_caps_t;
 
+/*
+    sg_imgui_allocator_t
+
+    Used in sg_imgui_desc_t to provide custom memory alloc and free functions
+    to sokol_gfx_imgui.h. The function prototypes are compatible with
+    malloc/free.
+*/
+typedef void*(*sg_imgui_malloc_t)(size_t size);
+typedef void(*sg_imgui_free_t)(void* ptr);
+
+typedef struct sg_imgui_allocator_t {
+    sg_imgui_malloc_t alloc;
+    sg_imgui_free_t free;
+} sg_imgui_allocator_t;
+
+/*
+    sg_imgui_desc_t
+
+    Initialization options for sg_imgui_init().
+*/
+typedef struct sg_imgui_desc_t {
+    sg_imgui_allocator_t allocator; // optional memory allocation overrides (default: malloc/free)
+} sg_imgui_desc_t;
+
 typedef struct sg_imgui_t {
     uint32_t init_tag;
+    sg_imgui_desc_t desc;
     sg_imgui_buffers_t buffers;
     sg_imgui_images_t images;
     sg_imgui_shaders_t shaders;
@@ -629,7 +667,7 @@ typedef struct sg_imgui_t {
     sg_trace_hooks hooks;
 } sg_imgui_t;
 
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_init(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sg_imgui_init(sg_imgui_t* ctx, const sg_imgui_desc_t* desc);
 SOKOL_GFX_IMGUI_API_DECL void sg_imgui_discard(sg_imgui_t* ctx);
 SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw(sg_imgui_t* ctx);
 
@@ -673,11 +711,6 @@ SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_capabilities_window(sg_imgui_t* ctx)
 #ifndef SOKOL_UNREACHABLE
     #define SOKOL_UNREACHABLE SOKOL_ASSERT(false)
 #endif
-#ifndef SOKOL_MALLOC
-    #include <stdlib.h>
-    #define SOKOL_MALLOC(s) malloc(s)
-    #define SOKOL_FREE(p) free(p)
-#endif
 #ifndef _SOKOL_PRIVATE
     #if defined(__GNUC__) || defined(__clang__)
         #define _SOKOL_PRIVATE __attribute__((unused)) static
@@ -693,7 +726,8 @@ SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_capabilities_window(sg_imgui_t* ctx)
 #endif
 
 #include <string.h>
-#include <stdio.h>      /* snprintf */
+#include <stdio.h>      // snprintf
+#include <stdlib.h>     // malloc, free
 
 #define _SG_IMGUI_SLOT_MASK (0xFFFF)
 #define _SG_IMGUI_LIST_WIDTH (192)
@@ -785,6 +819,44 @@ _SOKOL_PRIVATE void igEnd() {
 #endif
 
 /*--- UTILS ------------------------------------------------------------------*/
+_SOKOL_PRIVATE void _sg_imgui_clear(void* ptr, size_t size) {
+    SOKOL_ASSERT(ptr && (size > 0));
+    memset(ptr, 0, size);
+}
+
+_SOKOL_PRIVATE void* _sg_imgui_malloc(const sg_imgui_allocator_t* allocator, size_t size) {
+    SOKOL_ASSERT(allocator && allocator->alloc && (size > 0));
+    void* ptr = allocator->alloc(size);
+    SOKOL_ASSERT(ptr);
+    return ptr;
+}
+
+_SOKOL_PRIVATE void* _sg_imgui_malloc_clear(const sg_imgui_allocator_t* allocator, size_t size) {
+    SOKOL_ASSERT(allocator && allocator->alloc && (size > 0));
+    void* ptr = _sg_imgui_malloc(allocator, size);
+    _sg_imgui_clear(ptr, size);
+    return ptr;
+}
+
+_SOKOL_PRIVATE void _sg_imgui_free(const sg_imgui_allocator_t* allocator, void* ptr) {
+    SOKOL_ASSERT(allocator && allocator->free);
+    if (ptr) {
+        allocator->free(ptr);
+    }
+}
+
+ _SOKOL_PRIVATE void* _sg_imgui_realloc(const sg_imgui_allocator_t* allocator, void* old_ptr, size_t old_size, size_t new_size) {
+    SOKOL_ASSERT(allocator && (new_size > 0) && (new_size > old_size));
+    void* new_ptr = _sg_imgui_malloc(allocator, new_size);
+    if (old_ptr) {
+        if (old_size > 0) {
+            memcpy(new_ptr, old_ptr, old_size);
+        }
+        _sg_imgui_free(allocator, old_ptr);
+    }
+    return new_ptr;
+}
+
 _SOKOL_PRIVATE int _sg_imgui_slot_index(uint32_t id) {
     int slot_index = (int) (id & _SG_IMGUI_SLOT_MASK);
     SOKOL_ASSERT(0 != slot_index);
@@ -866,30 +938,6 @@ _SOKOL_PRIVATE uint32_t _sg_imgui_std140_uniform_size(sg_uniform_type type, int 
     }
 }
 
-_SOKOL_PRIVATE void* _sg_imgui_alloc(size_t size) {
-    SOKOL_ASSERT(size > 0);
-    return SOKOL_MALLOC(size);
-}
-
-_SOKOL_PRIVATE void _sg_imgui_free(void* ptr) {
-    if (ptr) {
-        SOKOL_FREE(ptr);
-    }
-}
-
-_SOKOL_PRIVATE void* _sg_imgui_realloc(void* old_ptr, size_t old_size, size_t new_size) {
-    SOKOL_ASSERT((new_size > 0) && (new_size > old_size));
-    void* new_ptr = SOKOL_MALLOC(new_size);
-    SOKOL_ASSERT(new_ptr);
-    if (old_ptr) {
-        if (old_size > 0) {
-            memcpy(new_ptr, old_ptr, old_size);
-        }
-        _sg_imgui_free(old_ptr);
-    }
-    return new_ptr;
-}
-
 _SOKOL_PRIVATE void _sg_imgui_strcpy(sg_imgui_str_t* dst, const char* src) {
     SOKOL_ASSERT(dst);
     if (src) {
@@ -901,7 +949,7 @@ _SOKOL_PRIVATE void _sg_imgui_strcpy(sg_imgui_str_t* dst, const char* src) {
         dst->buf[SG_IMGUI_STRBUF_LEN-1] = 0;
     }
     else {
-        memset(dst->buf, 0, SG_IMGUI_STRBUF_LEN);
+        _sg_imgui_clear(dst->buf, SG_IMGUI_STRBUF_LEN);
     }
 }
 
@@ -911,17 +959,17 @@ _SOKOL_PRIVATE sg_imgui_str_t _sg_imgui_make_str(const char* str) {
     return res;
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_str_dup(const char* src) {
-    SOKOL_ASSERT(src);
+_SOKOL_PRIVATE const char* _sg_imgui_str_dup(const sg_imgui_allocator_t* allocator, const char* src) {
+    SOKOL_ASSERT(allocator && src);
     size_t len = strlen(src) + 1;
-    char* dst = (char*) _sg_imgui_alloc(len);
+    char* dst = (char*) _sg_imgui_malloc(allocator, len);
     memcpy(dst, src, len);
     return (const char*) dst;
 }
 
-_SOKOL_PRIVATE const void* _sg_imgui_bin_dup(const void* src, size_t num_bytes) {
-    SOKOL_ASSERT(src && (num_bytes > 0));
-    void* dst = _sg_imgui_alloc(num_bytes);
+_SOKOL_PRIVATE const void* _sg_imgui_bin_dup(const sg_imgui_allocator_t* allocator, const void* src, size_t num_bytes) {
+    SOKOL_ASSERT(allocator && src && (num_bytes > 0));
+    void* dst = _sg_imgui_malloc(allocator, num_bytes);
     memcpy(dst, src, num_bytes);
     return (const void*) dst;
 }
@@ -1423,16 +1471,16 @@ _SOKOL_PRIVATE void _sg_imgui_shader_created(sg_imgui_t* ctx, sg_shader res_id, 
         }
     }
     if (shd->desc.vs.source) {
-        shd->desc.vs.source = _sg_imgui_str_dup(shd->desc.vs.source);
+        shd->desc.vs.source = _sg_imgui_str_dup(&ctx->desc.allocator, shd->desc.vs.source);
     }
     if (shd->desc.vs.bytecode.ptr) {
-        shd->desc.vs.bytecode.ptr = _sg_imgui_bin_dup(shd->desc.vs.bytecode.ptr, shd->desc.vs.bytecode.size);
+        shd->desc.vs.bytecode.ptr = _sg_imgui_bin_dup(&ctx->desc.allocator, shd->desc.vs.bytecode.ptr, shd->desc.vs.bytecode.size);
     }
     if (shd->desc.fs.source) {
-        shd->desc.fs.source = _sg_imgui_str_dup(shd->desc.fs.source);
+        shd->desc.fs.source = _sg_imgui_str_dup(&ctx->desc.allocator, shd->desc.fs.source);
     }
     if (shd->desc.fs.bytecode.ptr) {
-        shd->desc.fs.bytecode.ptr = _sg_imgui_bin_dup(shd->desc.fs.bytecode.ptr, shd->desc.fs.bytecode.size);
+        shd->desc.fs.bytecode.ptr = _sg_imgui_bin_dup(&ctx->desc.allocator, shd->desc.fs.bytecode.ptr, shd->desc.fs.bytecode.size);
     }
     for (int i = 0; i < SG_MAX_VERTEX_ATTRIBUTES; i++) {
         sg_shader_attr_desc* ad = &shd->desc.attrs[i];
@@ -1452,19 +1500,19 @@ _SOKOL_PRIVATE void _sg_imgui_shader_destroyed(sg_imgui_t* ctx, int slot_index) 
     sg_imgui_shader_t* shd = &ctx->shaders.slots[slot_index];
     shd->res_id.id = SG_INVALID_ID;
     if (shd->desc.vs.source) {
-        _sg_imgui_free((void*)shd->desc.vs.source);
+        _sg_imgui_free(&ctx->desc.allocator, (void*)shd->desc.vs.source);
         shd->desc.vs.source = 0;
     }
     if (shd->desc.vs.bytecode.ptr) {
-        _sg_imgui_free((void*)shd->desc.vs.bytecode.ptr);
+        _sg_imgui_free(&ctx->desc.allocator, (void*)shd->desc.vs.bytecode.ptr);
         shd->desc.vs.bytecode.ptr = 0;
     }
     if (shd->desc.fs.source) {
-        _sg_imgui_free((void*)shd->desc.fs.source);
+        _sg_imgui_free(&ctx->desc.allocator, (void*)shd->desc.fs.source);
         shd->desc.fs.source = 0;
     }
     if (shd->desc.fs.bytecode.ptr) {
-        _sg_imgui_free((void*)shd->desc.fs.bytecode.ptr);
+        _sg_imgui_free(&ctx->desc.allocator, (void*)shd->desc.fs.bytecode.ptr);
         shd->desc.fs.bytecode.ptr = 0;
     }
 }
@@ -1508,8 +1556,7 @@ _SOKOL_PRIVATE void _sg_imgui_capture_init(sg_imgui_t* ctx) {
     for (int i = 0; i < 2; i++) {
         sg_imgui_capture_bucket_t* bucket = &ctx->capture.bucket[i];
         bucket->ubuf_size = ubuf_initial_size;
-        bucket->ubuf = (uint8_t*) _sg_imgui_alloc(bucket->ubuf_size);
-        SOKOL_ASSERT(bucket->ubuf);
+        bucket->ubuf = (uint8_t*) _sg_imgui_malloc(&ctx->desc.allocator, bucket->ubuf_size);
     }
 }
 
@@ -1517,7 +1564,7 @@ _SOKOL_PRIVATE void _sg_imgui_capture_discard(sg_imgui_t* ctx) {
     for (int i = 0; i < 2; i++) {
         sg_imgui_capture_bucket_t* bucket = &ctx->capture.bucket[i];
         SOKOL_ASSERT(bucket->ubuf);
-        _sg_imgui_free(bucket->ubuf);
+        _sg_imgui_free(&ctx->desc.allocator, bucket->ubuf);
         bucket->ubuf = 0;
     }
 }
@@ -1543,7 +1590,7 @@ _SOKOL_PRIVATE void _sg_imgui_capture_grow_ubuf(sg_imgui_t* ctx, size_t required
     size_t old_size = bucket->ubuf_size;
     size_t new_size = required_size + (required_size>>1);  /* allocate a bit ahead */
     bucket->ubuf_size = new_size;
-    bucket->ubuf = (uint8_t*) _sg_imgui_realloc(bucket->ubuf, old_size, new_size);
+    bucket->ubuf = (uint8_t*) _sg_imgui_realloc(&ctx->desc.allocator, bucket->ubuf, old_size, new_size);
 }
 
 _SOKOL_PRIVATE sg_imgui_capture_item_t* _sg_imgui_capture_next_write_item(sg_imgui_t* ctx) {
@@ -3836,16 +3883,27 @@ _SOKOL_PRIVATE void _sg_imgui_draw_caps_panel(void) {
     }
 }
 
+#define _sg_imgui_def(val, def) (((val) == 0) ? (def) : (val))
+
+_SOKOL_PRIVATE sg_imgui_desc_t _sg_imgui_desc_defaults(const sg_imgui_desc_t* desc) {
+    sg_imgui_desc_t res;
+    _sg_imgui_clear(&res, sizeof(res));
+    res.allocator.alloc = _sg_imgui_def(desc->allocator.alloc, malloc);
+    res.allocator.free = _sg_imgui_def(desc->allocator.free, free);
+    return res;
+}
+
 /*--- PUBLIC FUNCTIONS -------------------------------------------------------*/
-SOKOL_API_IMPL void sg_imgui_init(sg_imgui_t* ctx) {
-    SOKOL_ASSERT(ctx);
-    memset(ctx, 0, sizeof(sg_imgui_t));
+SOKOL_API_IMPL void sg_imgui_init(sg_imgui_t* ctx, const sg_imgui_desc_t* desc) {
+    SOKOL_ASSERT(ctx && desc);
+    _sg_imgui_clear(ctx, sizeof(sg_imgui_t));
     ctx->init_tag = 0xABCDABCD;
+    ctx->desc = _sg_imgui_desc_defaults(desc);
     _sg_imgui_capture_init(ctx);
 
     /* hook into sokol_gfx functions */
     sg_trace_hooks hooks;
-    memset(&hooks, 0, sizeof(hooks));
+    _sg_imgui_clear(&hooks, sizeof(hooks));
     hooks.user_data = (void*) ctx;
     hooks.reset_state_cache = _sg_imgui_reset_state_cache;
     hooks.make_buffer = _sg_imgui_make_buffer;
@@ -3910,37 +3968,27 @@ SOKOL_API_IMPL void sg_imgui_init(sg_imgui_t* ctx) {
     ctx->hooks = sg_install_trace_hooks(&hooks);
 
     /* allocate resource debug-info slots */
-    sg_desc desc = sg_query_desc();
-    ctx->buffers.num_slots = desc.buffer_pool_size;
-    ctx->images.num_slots = desc.image_pool_size;
-    ctx->shaders.num_slots = desc.shader_pool_size;
-    ctx->pipelines.num_slots = desc.pipeline_pool_size;
-    ctx->passes.num_slots = desc.pass_pool_size;
+    const sg_desc sgdesc = sg_query_desc();
+    ctx->buffers.num_slots = sgdesc.buffer_pool_size;
+    ctx->images.num_slots = sgdesc.image_pool_size;
+    ctx->shaders.num_slots = sgdesc.shader_pool_size;
+    ctx->pipelines.num_slots = sgdesc.pipeline_pool_size;
+    ctx->passes.num_slots = sgdesc.pass_pool_size;
 
     const size_t buffer_pool_size = (size_t)ctx->buffers.num_slots * sizeof(sg_imgui_buffer_t);
-    ctx->buffers.slots = (sg_imgui_buffer_t*) _sg_imgui_alloc(buffer_pool_size);
-    SOKOL_ASSERT(ctx->buffers.slots);
-    memset(ctx->buffers.slots, 0, buffer_pool_size);
+    ctx->buffers.slots = (sg_imgui_buffer_t*) _sg_imgui_malloc_clear(&ctx->desc.allocator, buffer_pool_size);
 
     const size_t image_pool_size = (size_t)ctx->images.num_slots * sizeof(sg_imgui_image_t);
-    ctx->images.slots = (sg_imgui_image_t*) _sg_imgui_alloc(image_pool_size);
-    SOKOL_ASSERT(ctx->images.slots);
-    memset(ctx->images.slots, 0, image_pool_size);
+    ctx->images.slots = (sg_imgui_image_t*) _sg_imgui_malloc_clear(&ctx->desc.allocator, image_pool_size);
 
     const size_t shader_pool_size = (size_t)ctx->shaders.num_slots * sizeof(sg_imgui_shader_t);
-    ctx->shaders.slots = (sg_imgui_shader_t*) _sg_imgui_alloc(shader_pool_size);
-    SOKOL_ASSERT(ctx->shaders.slots);
-    memset(ctx->shaders.slots, 0, shader_pool_size);
+    ctx->shaders.slots = (sg_imgui_shader_t*) _sg_imgui_malloc_clear(&ctx->desc.allocator, shader_pool_size);
 
     const size_t pipeline_pool_size = (size_t)ctx->pipelines.num_slots * sizeof(sg_imgui_pipeline_t);
-    ctx->pipelines.slots = (sg_imgui_pipeline_t*) _sg_imgui_alloc(pipeline_pool_size);
-    SOKOL_ASSERT(ctx->pipelines.slots);
-    memset(ctx->pipelines.slots, 0, pipeline_pool_size);
+    ctx->pipelines.slots = (sg_imgui_pipeline_t*) _sg_imgui_malloc_clear(&ctx->desc.allocator, pipeline_pool_size);
 
     const size_t pass_pool_size = (size_t)ctx->passes.num_slots * sizeof(sg_imgui_pass_t);
-    ctx->passes.slots = (sg_imgui_pass_t*) _sg_imgui_alloc(pass_pool_size);
-    SOKOL_ASSERT(ctx->passes.slots);
-    memset(ctx->passes.slots, 0, pass_pool_size);
+    ctx->passes.slots = (sg_imgui_pass_t*) _sg_imgui_malloc_clear(&ctx->desc.allocator, pass_pool_size);
 }
 
 SOKOL_API_IMPL void sg_imgui_discard(sg_imgui_t* ctx) {
@@ -3955,7 +4003,7 @@ SOKOL_API_IMPL void sg_imgui_discard(sg_imgui_t* ctx) {
                 _sg_imgui_buffer_destroyed(ctx, i);
             }
         }
-        _sg_imgui_free((void*)ctx->buffers.slots);
+        _sg_imgui_free(&ctx->desc.allocator, (void*)ctx->buffers.slots);
         ctx->buffers.slots = 0;
     }
     if (ctx->images.slots) {
@@ -3964,7 +4012,7 @@ SOKOL_API_IMPL void sg_imgui_discard(sg_imgui_t* ctx) {
                 _sg_imgui_image_destroyed(ctx, i);
             }
         }
-        _sg_imgui_free((void*)ctx->images.slots);
+        _sg_imgui_free(&ctx->desc.allocator, (void*)ctx->images.slots);
         ctx->images.slots = 0;
     }
     if (ctx->shaders.slots) {
@@ -3973,7 +4021,7 @@ SOKOL_API_IMPL void sg_imgui_discard(sg_imgui_t* ctx) {
                 _sg_imgui_shader_destroyed(ctx, i);
             }
         }
-        _sg_imgui_free((void*)ctx->shaders.slots);
+        _sg_imgui_free(&ctx->desc.allocator, (void*)ctx->shaders.slots);
         ctx->shaders.slots = 0;
     }
     if (ctx->pipelines.slots) {
@@ -3982,7 +4030,7 @@ SOKOL_API_IMPL void sg_imgui_discard(sg_imgui_t* ctx) {
                 _sg_imgui_pipeline_destroyed(ctx, i);
             }
         }
-        _sg_imgui_free((void*)ctx->pipelines.slots);
+        _sg_imgui_free(&ctx->desc.allocator, (void*)ctx->pipelines.slots);
         ctx->pipelines.slots = 0;
     }
     if (ctx->passes.slots) {
@@ -3991,7 +4039,7 @@ SOKOL_API_IMPL void sg_imgui_discard(sg_imgui_t* ctx) {
                 _sg_imgui_pass_destroyed(ctx, i);
             }
         }
-        _sg_imgui_free((void*)ctx->passes.slots);
+        _sg_imgui_free(&ctx->desc.allocator, (void*)ctx->passes.slots);
         ctx->passes.slots = 0;
     }
 }

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -725,6 +725,11 @@ SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_capabilities_window(sg_imgui_t* ctx)
 /*=== IMPLEMENTATION =========================================================*/
 #ifdef SOKOL_GFX_IMGUI_IMPL
 #define SOKOL_GFX_IMGUI_IMPL_INCLUDED (1)
+
+#if defined(SOKOL_MALLOC) || defined(SOKOL_CALLOC) || defined(SOKOL_FREE)
+#error "SOKOL_MALLOC/CALLOC/FREE macros are no longer supported, please use sg_imgui_desc_t.allocator to override memory allocation functions"
+#endif
+
 #if defined(__cplusplus)
     #if !defined(IMGUI_VERSION)
     #error "Please include imgui.h before the sokol_imgui.h implementation"

--- a/util/sokol_gl.h
+++ b/util/sokol_gl.h
@@ -27,8 +27,6 @@
     ...optionally provide the following macros to override defaults:
 
     SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
-    SOKOL_MALLOC(s)     - your own malloc function (default: malloc(s))
-    SOKOL_FREE(p)       - your own free function (default: free(p))
     SOKOL_GL_API_DECL   - public function declaration prefix (default: extern)
     SOKOL_API_DECL      - same as SOKOL_GL_API_DECL
     SOKOL_API_IMPL      - public function implementation prefix (default: -)
@@ -575,6 +573,7 @@
 #define SOKOL_GL_INCLUDED (1)
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h> // size_t, offsetof
 
 #if !defined(SOKOL_GFX_INCLUDED)
 #error "Please include sokol_gfx.h before sokol_gl.h"
@@ -634,6 +633,21 @@ typedef struct sgl_context_desc_t {
     int sample_count;
 } sgl_context_desc_t;
 
+/*
+    sgl_allocator_t
+
+    Used in sgl_desc_t to provide custom memory alloc and free functions
+    to sokol_gl.h. The function prototypes are compatible with
+    malloc/free.
+*/
+typedef void*(*sgl_malloc_t)(size_t size);
+typedef void(*sgl_free_t)(void* ptr);
+
+typedef struct sgl_allocator_t {
+    sgl_malloc_t alloc;
+    sgl_free_t free;
+} sgl_allocator_t;
+
 typedef struct sgl_desc_t {
     int max_vertices;               // default: 64k
     int max_commands;               // default: 16k
@@ -643,6 +657,7 @@ typedef struct sgl_desc_t {
     sg_pixel_format depth_format;
     int sample_count;
     sg_face_winding face_winding;   // default: SG_FACEWINDING_CCW
+    sgl_allocator_t allocator;      // optional memory allocation overrides (default: malloc/free)
 } sgl_desc_t;
 
 /* the default context handle */
@@ -764,9 +779,9 @@ inline sgl_pipeline sgl_context_make_pipeline(sgl_context ctx, const sg_pipeline
 #ifdef SOKOL_GL_IMPL
 #define SOKOL_GL_IMPL_INCLUDED (1)
 
-#include <stddef.h> /* offsetof */
-#include <string.h> /* memset */
-#include <math.h> /* M_PI, sqrtf, sinf, cosf */
+#include <stdlib.h> // malloc/free
+#include <string.h> // memset
+#include <math.h>   // M_PI, sqrtf, sinf, cosf
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846264338327
@@ -783,11 +798,6 @@ inline sgl_pipeline sgl_context_make_pipeline(sgl_context ctx, const sg_pipeline
 #ifndef SOKOL_ASSERT
     #include <assert.h>
     #define SOKOL_ASSERT(c) assert(c)
-#endif
-#ifndef SOKOL_MALLOC
-    #include <stdlib.h>
-    #define SOKOL_MALLOC(s) malloc(s)
-    #define SOKOL_FREE(p) free(p)
 #endif
 #ifndef SOKOL_LOG
     #ifdef SOKOL_DEBUG
@@ -2266,6 +2276,28 @@ typedef struct {
 static _sgl_t _sgl;
 
 /*== PRIVATE FUNCTIONS =======================================================*/
+static void _sgl_clear(void* ptr, size_t size) {
+    SOKOL_ASSERT(ptr && (size > 0));
+    memset(ptr, 0, size);
+}
+
+static void* _sgl_malloc(size_t size) {
+    SOKOL_ASSERT(size > 0);
+    void* ptr = _sgl.desc.allocator.alloc(size);
+    SOKOL_ASSERT(ptr);
+    return ptr;
+}
+
+static void* _sgl_malloc_clear(size_t size) {
+    SOKOL_ASSERT(size > 0);
+    void* ptr = _sgl_malloc(size);
+    _sgl_clear(ptr, size);
+    return ptr;
+}
+
+static void _sgl_free(void* ptr) {
+    _sgl.desc.allocator.free(ptr);
+}
 
 static void _sgl_init_pool(_sgl_pool_t* pool, int num) {
     SOKOL_ASSERT(pool && (num >= 1));
@@ -2274,12 +2306,9 @@ static void _sgl_init_pool(_sgl_pool_t* pool, int num) {
     pool->queue_top = 0;
     /* generation counters indexable by pool slot index, slot 0 is reserved */
     size_t gen_ctrs_size = sizeof(uint32_t) * (size_t)pool->size;
-    pool->gen_ctrs = (uint32_t*) SOKOL_MALLOC(gen_ctrs_size);
-    SOKOL_ASSERT(pool->gen_ctrs);
-    memset(pool->gen_ctrs, 0, gen_ctrs_size);
+    pool->gen_ctrs = (uint32_t*) _sgl_malloc_clear(gen_ctrs_size);
     /* it's not a bug to only reserve 'num' here */
-    pool->free_queue = (int*) SOKOL_MALLOC(sizeof(int) * (size_t)num);
-    SOKOL_ASSERT(pool->free_queue);
+    pool->free_queue = (int*) _sgl_malloc_clear(sizeof(int) * (size_t)num);
     /* never allocate the zero-th pool item since the invalid id is 0 */
     for (int i = pool->size-1; i >= 1; i--) {
         pool->free_queue[pool->queue_top++] = i;
@@ -2289,10 +2318,10 @@ static void _sgl_init_pool(_sgl_pool_t* pool, int num) {
 static void _sgl_discard_pool(_sgl_pool_t* pool) {
     SOKOL_ASSERT(pool);
     SOKOL_ASSERT(pool->free_queue);
-    SOKOL_FREE(pool->free_queue);
+    _sgl_free(pool->free_queue);
     pool->free_queue = 0;
     SOKOL_ASSERT(pool->gen_ctrs);
-    SOKOL_FREE(pool->gen_ctrs);
+    _sgl_free(pool->gen_ctrs);
     pool->gen_ctrs = 0;
     pool->size = 0;
     pool->queue_top = 0;
@@ -2332,7 +2361,7 @@ static void _sgl_reset_context(_sgl_context_t* ctx) {
     SOKOL_ASSERT(0 == ctx->vertices);
     SOKOL_ASSERT(0 == ctx->uniforms);
     SOKOL_ASSERT(0 == ctx->commands);
-    memset(ctx, 0, sizeof(_sgl_context_t));
+    _sgl_clear(ctx, sizeof(_sgl_context_t));
 }
 
 static void _sgl_setup_context_pool(int pool_size) {
@@ -2340,20 +2369,18 @@ static void _sgl_setup_context_pool(int pool_size) {
     SOKOL_ASSERT((pool_size > 0) && (pool_size < _SGL_MAX_POOL_SIZE));
     _sgl_init_pool(&_sgl.context_pool.pool, pool_size);
     size_t pool_byte_size = sizeof(_sgl_context_t) * (size_t)_sgl.context_pool.pool.size;
-    _sgl.context_pool.contexts = (_sgl_context_t*) SOKOL_MALLOC(pool_byte_size);
-    SOKOL_ASSERT(_sgl.context_pool.contexts);
-    memset(_sgl.context_pool.contexts, 0, pool_byte_size);
+    _sgl.context_pool.contexts = (_sgl_context_t*) _sgl_malloc_clear(pool_byte_size);
 }
 
 static void _sgl_discard_context_pool(void) {
     SOKOL_ASSERT(0 != _sgl.context_pool.contexts);
-    SOKOL_FREE(_sgl.context_pool.contexts); _sgl.context_pool.contexts = 0;
+    _sgl_free(_sgl.context_pool.contexts); _sgl.context_pool.contexts = 0;
     _sgl_discard_pool(&_sgl.context_pool.pool);
 }
 
 static void _sgl_reset_pipeline(_sgl_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
-    memset(pip, 0, sizeof(_sgl_pipeline_t));
+    _sgl_clear(pip, sizeof(_sgl_pipeline_t));
 }
 
 static void _sgl_setup_pipeline_pool(int pool_size) {
@@ -2361,14 +2388,12 @@ static void _sgl_setup_pipeline_pool(int pool_size) {
     SOKOL_ASSERT((pool_size > 0) && (pool_size < _SGL_MAX_POOL_SIZE));
     _sgl_init_pool(&_sgl.pip_pool.pool, pool_size);
     size_t pool_byte_size = sizeof(_sgl_pipeline_t) * (size_t)_sgl.pip_pool.pool.size;
-    _sgl.pip_pool.pips = (_sgl_pipeline_t*) SOKOL_MALLOC(pool_byte_size);
-    SOKOL_ASSERT(_sgl.pip_pool.pips);
-    memset(_sgl.pip_pool.pips, 0, pool_byte_size);
+    _sgl.pip_pool.pips = (_sgl_pipeline_t*) _sgl_malloc_clear(pool_byte_size);
 }
 
 static void _sgl_discard_pipeline_pool(void) {
     SOKOL_ASSERT(0 != _sgl.pip_pool.pips);
-    SOKOL_FREE(_sgl.pip_pool.pips); _sgl.pip_pool.pips = 0;
+    _sgl_free(_sgl.pip_pool.pips); _sgl.pip_pool.pips = 0;
     _sgl_discard_pool(&_sgl.pip_pool.pool);
 }
 
@@ -2612,18 +2637,15 @@ static void _sgl_init_context(sgl_context ctx_id, const sgl_context_desc_t* in_d
     // allocate buffers and pools
     ctx->num_vertices = ctx->desc.max_vertices;
     ctx->num_commands = ctx->num_uniforms = ctx->desc.max_commands;
-    ctx->vertices = (_sgl_vertex_t*) SOKOL_MALLOC((size_t)ctx->num_vertices * sizeof(_sgl_vertex_t));
-    SOKOL_ASSERT(ctx->vertices);
-    ctx->uniforms = (_sgl_uniform_t*) SOKOL_MALLOC((size_t)ctx->num_uniforms * sizeof(_sgl_uniform_t));
-    SOKOL_ASSERT(ctx->uniforms);
-    ctx->commands = (_sgl_command_t*) SOKOL_MALLOC((size_t)ctx->num_commands * sizeof(_sgl_command_t));
-    SOKOL_ASSERT(ctx->commands);
+    ctx->vertices = (_sgl_vertex_t*) _sgl_malloc((size_t)ctx->num_vertices * sizeof(_sgl_vertex_t));
+    ctx->uniforms = (_sgl_uniform_t*) _sgl_malloc((size_t)ctx->num_uniforms * sizeof(_sgl_uniform_t));
+    ctx->commands = (_sgl_command_t*) _sgl_malloc((size_t)ctx->num_commands * sizeof(_sgl_command_t));
 
     // create sokol-gfx resource objects
     sg_push_debug_group("sokol-gl");
 
     sg_buffer_desc vbuf_desc;
-    memset(&vbuf_desc, 0, sizeof(vbuf_desc));
+    _sgl_clear(&vbuf_desc, sizeof(vbuf_desc));
     vbuf_desc.size = (size_t)ctx->num_vertices * sizeof(_sgl_vertex_t);
     vbuf_desc.type = SG_BUFFERTYPE_VERTEXBUFFER;
     vbuf_desc.usage = SG_USAGE_STREAM;
@@ -2632,7 +2654,7 @@ static void _sgl_init_context(sgl_context ctx_id, const sgl_context_desc_t* in_d
     SOKOL_ASSERT(SG_INVALID_ID != ctx->vbuf.id);
 
     sg_pipeline_desc def_pip_desc;
-    memset(&def_pip_desc, 0, sizeof(def_pip_desc));
+    _sgl_clear(&def_pip_desc, sizeof(def_pip_desc));
     def_pip_desc.depth.write_enabled = true;
     ctx->def_pip = _sgl_make_pipeline(&def_pip_desc, &ctx->desc);
     sg_pop_debug_group();
@@ -2666,9 +2688,9 @@ static void _sgl_destroy_context(sgl_context ctx_id) {
         SOKOL_ASSERT(ctx->uniforms);
         SOKOL_ASSERT(ctx->commands);
 
-        SOKOL_FREE(ctx->vertices);
-        SOKOL_FREE(ctx->uniforms);
-        SOKOL_FREE(ctx->commands);
+        _sgl_free(ctx->vertices);
+        _sgl_free(ctx->uniforms);
+        _sgl_free(ctx->commands);
 
         ctx->vertices = 0;
         ctx->uniforms = 0;
@@ -2998,6 +3020,8 @@ static sgl_desc_t _sgl_desc_defaults(const sgl_desc_t* desc) {
     res.context_pool_size = _sgl_def(desc->context_pool_size, _SGL_DEFAULT_CONTEXT_POOL_SIZE);
     res.pipeline_pool_size = _sgl_def(desc->pipeline_pool_size, _SGL_DEFAULT_PIPELINE_POOL_SIZE);
     res.face_winding = _sgl_def(desc->face_winding, SG_FACEWINDING_CCW);
+    res.allocator.alloc = _sgl_def(desc->allocator.alloc, malloc);
+    res.allocator.free = _sgl_def(desc->allocator.free, free);
     return res;
 }
 
@@ -3010,7 +3034,7 @@ static void _sgl_setup_common(void) {
         pixels[i] = 0xFFFFFFFF;
     }
     sg_image_desc img_desc;
-    memset(&img_desc, 0, sizeof(img_desc));
+    _sgl_clear(&img_desc, sizeof(img_desc));
     img_desc.type = SG_IMAGETYPE_2D;
     img_desc.width = 8;
     img_desc.height = 8;
@@ -3025,7 +3049,7 @@ static void _sgl_setup_common(void) {
 
     // one shader for all contexts
     sg_shader_desc shd_desc;
-    memset(&shd_desc, 0, sizeof(shd_desc));
+    _sgl_clear(&shd_desc, sizeof(shd_desc));
     shd_desc.attrs[0].name = "position";
     shd_desc.attrs[1].name = "texcoord0";
     shd_desc.attrs[2].name = "color0";
@@ -3157,7 +3181,7 @@ static void _sgl_draw(_sgl_context_t* ctx) {
 
 static sgl_context_desc_t _sgl_as_context_desc(const sgl_desc_t* desc) {
     sgl_context_desc_t ctx_desc;
-    memset(&ctx_desc, 0, sizeof(ctx_desc));
+    _sgl_clear(&ctx_desc, sizeof(ctx_desc));
     ctx_desc.max_vertices = desc->max_vertices;
     ctx_desc.max_commands = desc->max_commands;
     ctx_desc.color_format = desc->color_format;
@@ -3169,7 +3193,7 @@ static sgl_context_desc_t _sgl_as_context_desc(const sgl_desc_t* desc) {
 /*== PUBLIC FUNCTIONS ========================================================*/
 SOKOL_API_IMPL void sgl_setup(const sgl_desc_t* desc) {
     SOKOL_ASSERT(desc);
-    memset(&_sgl, 0, sizeof(_sgl));
+    _sgl_clear(&_sgl, sizeof(_sgl));
     _sgl.init_cookie = _SGL_INIT_COOKIE;
     _sgl.desc = _sgl_desc_defaults(desc);
     _sgl_setup_pipeline_pool(_sgl.desc.pipeline_pool_size);

--- a/util/sokol_gl.h
+++ b/util/sokol_gl.h
@@ -545,6 +545,34 @@
     to render in the previous draw command will be incremented by the
     number of vertices in the new draw command.
 
+
+    MEMORY ALLOCATION OVERRIDE
+    ==========================
+    You can override the memory allocation functions at initialization time
+    like this:
+
+        void* my_alloc(size_t size, void* user_data) {
+            return malloc(size);
+        }
+
+        void my_free(void* ptr, void* user_data) {
+            free(ptr);
+        }
+
+        ...
+            sgl_setup(&(sgl_desc_t){
+                // ...
+                .allocator = {
+                    .alloc = my_alloc,
+                    .free = my_free,
+                    .user_data = ...;
+                }
+            });
+        ...
+
+    If no overrides are provided, malloc and free will be used.
+
+
     LICENSE
     =======
     zlib/libpng license

--- a/util/sokol_gl.h
+++ b/util/sokol_gl.h
@@ -809,6 +809,10 @@ inline sgl_pipeline sgl_context_make_pipeline(sgl_context ctx, const sg_pipeline
 #ifdef SOKOL_GL_IMPL
 #define SOKOL_GL_IMPL_INCLUDED (1)
 
+#if defined(SOKOL_MALLOC) || defined(SOKOL_CALLOC) || defined(SOKOL_FREE)
+#error "SOKOL_MALLOC/CALLOC/FREE macros are no longer supported, please use sgl_desc_t.allocator to override memory allocation functions"
+#endif
+
 #include <stdlib.h> // malloc/free
 #include <string.h> // memset
 #include <math.h>   // M_PI, sqrtf, sinf, cosf

--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -326,6 +326,10 @@ inline void simgui_new_frame(const simgui_frame_desc_t& desc) { return simgui_ne
 #ifdef SOKOL_IMGUI_IMPL
 #define SOKOL_IMGUI_IMPL_INCLUDED (1)
 
+#if defined(SOKOL_MALLOC) || defined(SOKOL_CALLOC) || defined(SOKOL_FREE)
+#error "SOKOL_MALLOC/CALLOC/FREE macros are no longer supported, please use simgui_desc_t.allocator to override memory allocation functions"
+#endif
+
 #if defined(__cplusplus)
     #if !defined(IMGUI_VERSION)
     #error "Please include imgui.h before the sokol_imgui.h implementation"

--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -183,6 +183,37 @@
 
         simgui_shutdown()
 
+
+    MEMORY ALLOCATION OVERRIDE
+    ==========================
+    You can override the memory allocation functions at initialization time
+    like this:
+
+        void* my_alloc(size_t size, void* user_data) {
+            return malloc(size);
+        }
+
+        void my_free(void* ptr, void* user_data) {
+            free(ptr);
+        }
+
+        ...
+            simgui_setup(&(simgui_desc_t){
+                // ...
+                .allocator = {
+                    .alloc = my_alloc,
+                    .free = my_free,
+                    .user_data = ...;
+                }
+            });
+        ...
+
+    If no overrides are provided, malloc and free will be used.
+
+    This only affects memory allocation calls done by sokol_imgui.h
+    itself though, not any allocations in Dear ImGui.
+
+
     LICENSE
     =======
 


### PR DESCRIPTION
Each header gets a new ```allocator``` struct item in its setup desc struct, with function pointers to ~~malloc/free compatible~~ alloc/free functions which look similar like malloc/free, but have an additional user_data pointer arg.

TODO:

- [x] add a user_data item to the allocator struct and function signatures
- [x] add allocator interface to sokol_args.h
- [x] add preprocessor error if old macros are detected
- [x] ~~change defaults from malloc/free to SOKOL_MALLOC_FUNC and SOKOL_FREE_FUNC~~
- [x] add a standard documentation block about memory management to all headers
- [x] fix sokol_memtrack.h (or discard it? with the dynamic allocator interface it's not that useful anymore)
- [x] fix all samples and tests
- [x] figure out a solution for sokol_fontstash.h
- [x] update changelog with breaking change for sokol_gfx_imgui.h and sokol_fontstash.h

~~Note that sokol_fontstash.h is special, this will only get the new macros, but no dynamic allocator (because of the way sokol_fontstash.h integrates with fontstash.h)~~