### PR TITLE
Change GH badges to use relative URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sokol
 
-[![Build Status](https://github.com/floooh/sokol/workflows/build_and_test/badge.svg)](https://github.com/floooh/sokol/actions)
+[![Build Status](/../../actions/workflows/build_and_test/badge.svg)](/../../actions)
 
 Simple
 [STB-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sokol
 
-[![Build Status](/../../actions/workflows/build_and_test/badge.svg)](/../../actions)
+[![Build Status](/../../actions/workflows/main.yml/badge.svg)](/../../actions)
 
 Simple
 [STB-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt)


### PR DESCRIPTION
This is a really minor one-liner but it points the status badge and links for branches and forks to the desired place (and not back to the main repo). In the screenshot here you'll see the URL is going to my fork from the relative URL:

![url](https://user-images.githubusercontent.com/8437014/170955855-28ff611b-1573-43a9-94a5-0b647c61ef13.png)

(I'm not sure this is documented anywhere, BTW)