### PR TITLE
fix(imgui): clipboard paste didn't work on Windows

### DIFF
--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -2389,8 +2389,8 @@ SOKOL_API_IMPL bool simgui_handle_event(const sapp_event* ev) {
             if (!_simgui.desc.disable_paste_override) {
                 _simgui_add_imgui_key_event(io, _simgui_copypaste_modifier(), true);
                 _simgui_add_imgui_key_event(io, ImGuiKey_V, true);
-                _simgui_add_imgui_key_event(io, _simgui_copypaste_modifier(), false);
                 _simgui_add_imgui_key_event(io, ImGuiKey_V, false);
+                _simgui_add_imgui_key_event(io, _simgui_copypaste_modifier(), false);
             }
             break;
         default:


### PR DESCRIPTION
**Bug:** clipboard pasting doesn't work on Windows
**Fix:** change order of event simulation by releasing the V key BEFORE releasing the modifier (CTRL/Cmd) key.

Tested on:
1. Windows 10 21H2 Build 19044.1706
2. MacOS 12.4 Monterey