### PR TITLE
sokol_app.h win32: Calculate hidpi framebuffer size more precisely

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1824,6 +1824,7 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #endif
     #include <stdio.h>  /* freopen_s() */
     #include <wchar.h>  /* wcslen() */
+    #include <math.h>   /* roundf() */
 
     #pragma comment (lib, "kernel32")
     #pragma comment (lib, "user32")

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -6440,10 +6440,12 @@ _SOKOL_PRIVATE bool _sapp_win32_wide_to_utf8(const wchar_t* src, char* dst, int 
 _SOKOL_PRIVATE bool _sapp_win32_update_dimensions(void) {
     RECT rect;
     if (GetClientRect(_sapp.win32.hwnd, &rect)) {
-        _sapp.window_width = (int)((float)(rect.right - rect.left) / _sapp.win32.dpi.window_scale);
-        _sapp.window_height = (int)((float)(rect.bottom - rect.top) / _sapp.win32.dpi.window_scale);
-        int fb_width = (int)((float)_sapp.window_width * _sapp.win32.dpi.content_scale);
-        int fb_height = (int)((float)_sapp.window_height * _sapp.win32.dpi.content_scale);
+        float window_width = (float)(rect.right - rect.left) / _sapp.win32.dpi.window_scale;
+        float window_height = (float)(rect.bottom - rect.top) / _sapp.win32.dpi.window_scale;
+        _sapp.window_width = (int)roundf(window_width);
+        _sapp.window_height = (int)roundf(window_height);
+        int fb_width = (int)roundf(window_width * _sapp.win32.dpi.content_scale);
+        int fb_height = (int)roundf(window_height * _sapp.win32.dpi.content_scale);
         /* prevent a framebuffer size of 0 when window is minimized */
         if (0 == fb_width) {
             fb_width = 1;


### PR DESCRIPTION
Minor change, switching from int cast to `roundf` and reusing the float intermediate instead of roundtripping through int.

For a window with 850 logical width and 1.75 dpi scale, client rect is 1487px wide. Dividing it back results in window_width of 849.71.
Current logic truncates it to 849 and sets fb_width to 1485px, making it misaligned with the client rect.
After this change window_width is rounded to 850 and fb_width is back to 1487px.