### PR TITLE
gen_zig.py: add compile time branches for self-hosted support

### DIFF
--- a/bindgen/README.md
+++ b/bindgen/README.md
@@ -22,6 +22,7 @@ To update the Zig bindings:
 > cd sokol/bindgen
 > git clone https://github.com/floooh/sokol-zig
 > git clone https://github.com/floooh/sokol-nim
+> git clone https://github.com/floooh/sokol-odin
 > python3 gen_all.py
 ```
 

--- a/bindgen/gen_zig.py
+++ b/bindgen/gen_zig.py
@@ -377,8 +377,7 @@ def gen_struct(decl, prefix):
         elif is_const_prim_ptr(field_type):
             l(f"    {field_name}: ?[*]const {as_zig_prim_type(extract_ptr_type(field_type))} = null,")
         elif is_func_ptr(field_type):
-            sig = f"fn({funcptr_args_c(field_type, prefix)}) callconv(.C) {funcptr_result_c(field_type)}"
-            l(f"    {field_name}: (switch (builtin.zig_backend) {{ .stage1 => ?{sig}, else => ?*const {sig} }}) = null,")
+            l(f"    {field_name}: ?meta.FnPtr(fn({funcptr_args_c(field_type, prefix)}) callconv(.C) {funcptr_result_c(field_type)}) = null,")
         elif is_1d_array_type(field_type):
             array_type = extract_array_type(field_type)
             array_sizes = extract_array_sizes(field_type)
@@ -483,6 +482,7 @@ def pre_parse(inp):
 
 def gen_imports(inp, dep_prefixes):
     l('const builtin = @import("builtin");')
+    l('const meta = @import("std").meta;')
     for dep_prefix in dep_prefixes:
         dep_module_name = module_names[dep_prefix]
         l(f'const {dep_prefix[:-1]} = @import("{dep_module_name}.zig");')


### PR DESCRIPTION
This adds compile-time switches to have the generated code be compatible with both stage1 and self-hosted.

The `asRange` change has to do with [the self-hosted compiler not passing structs/arrays by reference in all cases](https://github.com/ziglang/zig/issues/12638#issuecomment-1228824773). 

In debugging why the triangle example wasn't rendering, the GL state showed that the gpu-side buffer was filled with bad data (ie. not the verts specified in the source). Upon further inspection, even though the buffer data was being read from the text segment, it was being copied into an array on the stack inside `asRange`, and the ptr to that array was then being returned in the `Range`, and then the data on the stack was getting stomped on the way to the call to upload it to the GPU. 

This does seem like a bug in the compiler at the moment. However, it also sounds like the language spec says that the compiler can either pass by value or by reference depending on what is optimal. So, even though it would likely be optimal to always pass by reference to `asRange`, to comply with the spec I think a pointer to the struct/array has to be passed to `asRange`.  https://github.com/ziglang/zig/wiki/Self-Hosted-Compiler-Upgrade-Guide#escaped-pointer-to-parameter seems to say that passing by pointer is the intended way.

This is a breaking change (I've updated the examples: https://github.com/floooh/sokol-zig/pull/26). 