### PR TITLE
Fixes for Emscripten 3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Updates
 
+- **10-Sep-2022**: sokol_app.h and sokol_args.h has been fixed for Emscripten 3.21, those headers
+  used the Emscripten Javascript helper function ```ccall()``` which is now part of the
+  'legacy runtime' and causes linker errors. Instead of ```ccall()``` sokol_app.h and sokol_args.h
+  now drop down to a lower level set of Emscripten JS helper functions (which hopefully won't
+  go away anytime soon).
+
 - **05-Aug-2022**: New officially supported and automatically updated language bindings for Odin:
   https://github.com/floooh/sokol-odin (also see [gen_odin.py](https://github.com/floooh/sokol/blob/master/bindgen/gen_odin.py))
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple
 [STB-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt)
 cross-platform libraries for C and C++, written in C.
 
-[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**10-Jul-2022** sokol_app.h can now set the mouse cursor type, and assorted changes)
+[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**10-Sep-2022** an important compatibility fix for Emscripten 3.21 in sokol_app.h and sokol_args.h)
 
 [![Build](/../../actions/workflows/main.yml/badge.svg)](/../../actions/workflows/main.yml) [![Bindings](/../../actions/workflows/gen_bindings.yml/badge.svg)](/../../actions/workflows/gen_bindings.yml) [![build](https://github.com/floooh/sokol-zig/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-zig/actions/workflows/main.yml) [![build](https://github.com/floooh/sokol-nim/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-nim/actions/workflows/main.yml) [![Odin](https://github.com/floooh/sokol-odin/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-odin/actions/workflows/main.yml)
 

--- a/sokol_args.h
+++ b/sokol_args.h
@@ -727,7 +727,11 @@ EM_JS(void, sargs_js_parse_url, (void), {
     for (var p = params.next(); !p.done; p = params.next()) {
         var key = p.value[0];
         var val = p.value[1];
-        var res = ccall('_sargs_add_kvp', 'void', ['string','string'], [key,val]);
+        withStackSave(() => {
+            var key_cstr = allocateUTF8OnStack(key);
+            var val_cstr = allocateUTF8OnStack(val);
+            __sargs_add_kvp(key_cstr, val_cstr)
+        });
     }
 });
 


### PR DESCRIPTION
Emscripten has 'deprecated' the ```ccall()``` Javascript helper function (this is now part of the 'legacy runtime' and causes linker errors. Instead of ccall, sokol_app.h and sokol_args.h now use a lower level set of JS helper functions for string argument marshalling.
