### PR TITLE
sokol_app.h: add a `tool_type` field to the `sapp_touchpoint` struct (valid on Android)

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1336,6 +1336,7 @@ typedef struct sapp_event {
     float mouse_dy;                     // relative vertical mouse movement since last frame, always valid
     float scroll_x;                     // horizontal mouse wheel scroll distance, valid in MOUSE_SCROLL events
     float scroll_y;                     // vertical mouse wheel scroll distance, valid in MOUSE_SCROLL events
+    int touch_tool_type;                // the type of tool (e.g. finger, pen, mouse) that caused the touch event, valid in TOUCHES_BEGAN, TOUCHES_MOVED, TOUCHES_ENDED
     int num_touches;                    // number of valid items in the touches[] array
     sapp_touchpoint touches[SAPP_MAX_TOUCHPOINTS];  // current touch points, valid in TOUCHES_BEGIN, TOUCHES_MOVED, TOUCHES_ENDED
     int window_width;                   // current window- and framebuffer sizes in pixels, always valid
@@ -8854,6 +8855,7 @@ _SOKOL_PRIVATE bool _sapp_android_touch_event(const AInputEvent* e) {
             dst->changed = true;
         }
     }
+    _sapp.event.touch_tool_type = AMotionEvent_getToolType(e, (size_t)idx);
     _sapp_call_event(&_sapp.event);
     return true;
 }

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1283,6 +1283,7 @@ typedef struct sapp_touchpoint {
     uintptr_t identifier;
     float pos_x;
     float pos_y;
+    int tool_type;
     bool changed;
 } sapp_touchpoint;
 
@@ -1336,7 +1337,6 @@ typedef struct sapp_event {
     float mouse_dy;                     // relative vertical mouse movement since last frame, always valid
     float scroll_x;                     // horizontal mouse wheel scroll distance, valid in MOUSE_SCROLL events
     float scroll_y;                     // vertical mouse wheel scroll distance, valid in MOUSE_SCROLL events
-    int touch_tool_type;                // the type of tool (e.g. finger, pen, mouse) that caused the touch event, valid in TOUCHES_BEGAN, TOUCHES_MOVED, TOUCHES_ENDED
     int num_touches;                    // number of valid items in the touches[] array
     sapp_touchpoint touches[SAPP_MAX_TOUCHPOINTS];  // current touch points, valid in TOUCHES_BEGIN, TOUCHES_MOVED, TOUCHES_ENDED
     int window_width;                   // current window- and framebuffer sizes in pixels, always valid
@@ -8847,6 +8847,7 @@ _SOKOL_PRIVATE bool _sapp_android_touch_event(const AInputEvent* e) {
         dst->identifier = (uintptr_t)AMotionEvent_getPointerId(e, (size_t)i);
         dst->pos_x = (AMotionEvent_getRawX(e, (size_t)i) / _sapp.window_width) * _sapp.framebuffer_width;
         dst->pos_y = (AMotionEvent_getRawY(e, (size_t)i) / _sapp.window_height) * _sapp.framebuffer_height;
+        dst->tool_type = AMotionEvent_getToolType(e, (size_t)i);
 
         if (action == AMOTION_EVENT_ACTION_POINTER_DOWN ||
             action == AMOTION_EVENT_ACTION_POINTER_UP) {
@@ -8855,7 +8856,6 @@ _SOKOL_PRIVATE bool _sapp_android_touch_event(const AInputEvent* e) {
             dst->changed = true;
         }
     }
-    _sapp.event.touch_tool_type = AMotionEvent_getToolType(e, (size_t)idx);
     _sapp_call_event(&_sapp.event);
     return true;
 }


### PR DESCRIPTION
This makes it possible to differentiate between different types of touch input.
See: https://developer.android.com/ndk/reference/group/input#amotionevent_gettooltype for the documentation of this function
I've tested it and it successfully showed 1 for finger input and 2 for S-Pen input.

I'm unsure if adding a new field to the event struct is the way to go; maybe we should provide the user directly with the `AMotionEvent` and the `pointer_index` (`e` and `idx` variables) instead so that they can then use arbitrary NDK functions in their callbacks.