### PR TITLE
Remove wrapper procs for Odin bindings. Use c.int type

### DIFF
--- a/bindgen/gen_odin.py
+++ b/bindgen/gen_odin.py
@@ -209,6 +209,9 @@ def enum_default_item(enum_name):
 def is_prim_type(s):
     return s in prim_types
 
+def is_int_type(s):
+    return s == "int"
+
 def is_struct_type(s):
     return s in struct_types
 
@@ -326,6 +329,8 @@ def funcdecl_args_c(decl, prefix):
         param_type = check_override(f'{func_name}.{param_name}', default=param_decl['type'])
         if is_const_struct_ptr(param_type):
             s += f"#by_ptr {param_name}: {map_type(param_type, prefix, 'odin_arg')}"
+        elif is_int_type(param_type):
+            s += f"#any_int {param_name}: {map_type(param_type, prefix, 'c_arg')}"
         else:
             s += f"{param_name}: {map_type(param_type, prefix, 'c_arg')}"
     return s

--- a/bindgen/gen_odin.py
+++ b/bindgen/gen_odin.py
@@ -92,7 +92,7 @@ overrides = {
 }
 
 prim_types = {
-    'int':          'i32',
+    'int':          'c.int',
     'bool':         'bool',
     'char':         'u8',
     'int8_t':       'i8',
@@ -390,6 +390,7 @@ def gen_c_imports(inp, c_prefix, prefix):
     macos_metal_libs = get_system_libs(prefix, 'macos', 'metal')
     macos_gl_libs = get_system_libs(prefix, 'macos', 'gl')
     linux_gl_libs = get_system_libs(prefix, 'linux', 'gl')
+    l( 'import "core:c"')
     l( 'when ODIN_OS == .Windows {')
     l( '    when #config(SOKOL_USE_GL,false) {')
     l(f'        when ODIN_DEBUG == true {{ foreign import {clib_import} {{ "{clib_prefix}_windows_x64_gl_debug.lib"{windows_gl_libs} }} }}')


### PR DESCRIPTION
With Odin's new support for `#by_ptr` to represent const references for bindings, we can now generate the bindings without wrapper procs by also using `link_prefix` for the foreign block. I also made the changes to use `c.int` where sokol uses `int` in the C headers to be more idiomatic.

A few of the example programs in `sokol-odin` will need to be updated to remove casts to `int` once this is merged.