### PR TITLE
Fixes for Emscripten SDK 3.1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,22 @@
 ## Updates
 
-- **15-Oct-2022** fixes for Emscripten 3.1.24: the sokol headers now use the new
-  **EM_JS_DEPS()** macro to declare 'indirect dependencies on JS library functions'.
-  This is a (much more robust) follow-up fix to the Emscripten related fixes from 10-Sep-2022.
-  The new Emscripten SDK also displays a couple of Javascript "static analyzer" warnings
-  by the Closure compiler (used in release mode to optimize and minify the generated
-  JS code). I fixed a couple of those warnings, but some warnings persist (all of them
-  false positives). Not sure yet if these can be fixed or need to be supressed, but
-  that's for another time.
-  I also had to undo an older workaround in sokol_app.h on iOS (https://github.com/floooh/sokol/issues/645)
-  because this is now triggering a Metal validation layer error (https://github.com/floooh/sokol/issues/726).
-  The original case is no longer reproducible, so undoing the old workaround seems to
-  be a quick fix. Eventually I want to get rid of MTKView though, and go down to
-  CAMetalLayer.
+- **15-Oct-2022**
+    - fixes for Emscripten 3.1.24: the sokol headers now use the new
+    **EM_JS_DEPS()** macro to declare 'indirect dependencies on JS library functions'.
+    This is a (much more robust) follow-up fix to the Emscripten related fixes from 10-Sep-2022.
+    The new Emscripten SDK also displays a couple of Javascript "static analyzer" warnings
+    by the Closure compiler (used in release mode to optimize and minify the generated
+    JS code). I fixed a couple of those warnings, but some warnings persist (all of them
+    false positives). Not sure yet if these can be fixed or need to be supressed, but
+    that's for another time.
+    - the webkitAudioContext() fallback in sokol_audio.h's Emscripten backend
+    has been removed (only AudioContext is supported now), the fallback also
+    triggered a Closure warning, so it probably never worked as intended anyway.
+    - I also had to undo an older workaround in sokol_app.h on iOS (https://github.com/floooh/sokol/issues/645)
+    because this is now triggering a Metal validation layer error (https://github.com/floooh/sokol/issues/726).
+    The original case is no longer reproducible, so undoing the old workaround seems to
+    be a quick fix. Eventually I want to get rid of MTKView though, and go down to
+    CAMetalLayer.
 
 - **08-Oct-2022** sokol_app.h Android backend: the ```sapp_touchpoint``` struct
   now has a new item ```sapp_android_tooltype android_tooltype;```. This exposes the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Updates
 
+- **15-Oct-2022** fixes for Emscripten 3.1.24: the sokol headers now use the new
+  **EM_JS_DEPS()** macro to declare 'indirect dependencies on JS library functions'.
+  This is a (much more robust) follow-up fix to the Emscripten related fixes from 10-Sep-2022.
+  The new Emscripten SDK also displays a couple of Javascript "static analyzer" warnings
+  by the Closure compiler (used in release mode to optimize and minify the generated
+  JS code). I fixed a couple of those warnings, but some warnings persist (all of them
+  false positives). Not sure yet if these can be fixed or need to be supressed, but
+  that's for another time.
+  I also had to undo an older workaround in sokol_app.h on iOS (https://github.com/floooh/sokol/issues/645)
+  because this is now triggering a Metal validation layer error (https://github.com/floooh/sokol/issues/726).
+  The original case is no longer reproducible, so undoing the old workaround seems to
+  be a quick fix. Eventually I want to get rid of MTKView though, and go down to
+  CAMetalLayer.
+
 - **08-Oct-2022** sokol_app.h Android backend: the ```sapp_touchpoint``` struct
   now has a new item ```sapp_android_tooltype android_tooltype;```. This exposes the
   result of the Android NDK function ```AMotionEvent_getToolType()```.

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4435,6 +4435,10 @@ _SOKOL_PRIVATE void _sapp_ios_show_keyboard(bool shown) {
 /*== EMSCRIPTEN ==============================================================*/
 #if defined(_SAPP_EMSCRIPTEN)
 
+#if defined(EM_JS_DEPS)
+EM_JS_DEPS(sokol_app, "$withStackSave,$allocateUTF8OnStack");
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sokol_args.h
+++ b/sokol_args.h
@@ -692,6 +692,11 @@ _SOKOL_PRIVATE bool _sargs_parse_cargs(int argc, const char** argv) {
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#if defined(EM_JS_DEPS)
+EM_JS_DEPS(sokol_audio, "$withStackSave,$allocateUTF8OnStack");
+#endif
+
 EMSCRIPTEN_KEEPALIVE void _sargs_add_kvp(const char* key, const char* val) {
     SOKOL_ASSERT(_sargs.valid && key && val);
     if (_sargs.num_args >= _sargs.max_args) {

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -1811,12 +1811,6 @@ EM_JS(int, saudio_js_init, (int sample_rate, int num_channels, int buffer_size),
             latencyHint: 'interactive',
         });
     }
-    else if (typeof webkitAudioContext !== 'undefined') {
-        Module._saudio_context = new webkitAudioContext({
-            sampleRate: sample_rate,
-            latencyHint: 'interactive',
-        });
-    }
     else {
         Module._saudio_context = null;
         console.log('sokol_audio.h: no WebAudio support');

--- a/sokol_fetch.h
+++ b/sokol_fetch.h
@@ -119,7 +119,7 @@
     (4) pump the sokol-fetch message queues, and invoke response callbacks
         by calling:
 
-        sfetch_dowork(); 
+        sfetch_dowork();
 
         In an event-driven app this should be called in the event loop. If you
         use sokol-app this would be in your frame_cb function.
@@ -2006,13 +2006,13 @@ EM_JS(void, sfetch_js_send_head_request, (uint32_t slot_id, const char* path_cst
     var req = new XMLHttpRequest();
     req.open('HEAD', path_str);
     req.onreadystatechange = function() {
-        if (this.readyState == this.DONE) {
-            if (this.status == 200) {
-                var content_length = this.getResponseHeader('Content-Length');
+        if (req.readyState == XMLHttpRequest.DONE) {
+            if (req.status == 200) {
+                var content_length = req.getResponseHeader('Content-Length');
                 __sfetch_emsc_head_response(slot_id, content_length);
             }
             else {
-                __sfetch_emsc_failed_http_status(slot_id, this.status);
+                __sfetch_emsc_failed_http_status(slot_id, req.status);
             }
         }
     };
@@ -2030,8 +2030,8 @@ EM_JS(void, sfetch_js_send_get_request, (uint32_t slot_id, const char* path_cstr
         req.setRequestHeader('Range', 'bytes='+offset+'-'+(offset+bytes_to_read-1));
     }
     req.onreadystatechange = function() {
-        if (this.readyState == this.DONE) {
-            if ((this.status == 206) || ((this.status == 200) && !need_range_request)) {
+        if (req.readyState == XMLHttpRequest.DONE) {
+            if ((req.status == 206) || ((req.status == 200) && !need_range_request)) {
                 var u8_array = new Uint8Array(req.response);
                 var content_fetched_size = u8_array.length;
                 if (content_fetched_size <= buf_size) {
@@ -2043,7 +2043,7 @@ EM_JS(void, sfetch_js_send_get_request, (uint32_t slot_id, const char* path_cstr
                 }
             }
             else {
-                __sfetch_emsc_failed_http_status(slot_id, this.status);
+                __sfetch_emsc_failed_http_status(slot_id, req.status);
             }
         }
     };
@@ -2605,4 +2605,3 @@ SOKOL_API_IMPL void sfetch_cancel(sfetch_handle_t h) {
 }
 
 #endif /* SOKOL_FETCH_IMPL */
-


### PR DESCRIPTION
- use the new EM_JS_DEPS() macro to declare 'indirect JS library dependencies'.
- fix a couple of those new Closure compiler warnings
- sokol_audio.h: remove webkitAudioContext fallback
