### PR TITLE
sokol_fetch.h: replace discrete ptr/size pairs with sfetch_range_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## Updates
 
+- **05-Nov-2022** A breaking change in sokol_fetch.h, and a minor change in
+  sokol_app.h which should only break for very users:
+  - An ```sfetch_range_t``` ptr/size pair struct has been added to sokol_fetch.h,
+    and discrete ptr/size pairs have been replaced with sfetch_range_t
+    items. This affects the structs ```sfetch_request_t``` and ```sfetch_response_t```,
+    and the function ```sfetch_bind_buffer()```.
+  - The required changes in ```sfetch_response_t``` might be a bit non-obviois: To
+    access the fetched data, previous ```.buffer_ptr``` and ```.fetched_size```
+    was used. The fetched data is now accessible through an ```sfetch_range_t data```
+    item (```data.ptr``` and ```data.size```). The old ```.fetched_offset``` item
+    has been renamed to ```.data_offset``` to better conform with the new naming.
+  - The last two occurances of discrete ptr/size pairs in sokol_app.h now have also
+    been replaced with ```sapp_range_t``` items, this only affects the structs
+    ```sapp_html5_fetch_request``` and ```sapp_html5_fetch_response```.
+
 - **03-Nov-2022** The language bindings generation has been updated for Zig 0.10.0,
   and clang-14 (there was a minor change in the JSON ast-dump format).
   Many thanks to github user @kcbanner for the Zig PR!

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple
 [STB-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt)
 cross-platform libraries for C and C++, written in C.
 
-[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**02-Oct-2022** new header: sokol_spine.h)
+[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**05-Nov-2022** breaking changes in sokol_fetch.h, and for some users in sokol_app.h)
 
 [![Build](/../../actions/workflows/main.yml/badge.svg)](/../../actions/workflows/main.yml) [![Bindings](/../../actions/workflows/gen_bindings.yml/badge.svg)](/../../actions/workflows/gen_bindings.yml) [![build](https://github.com/floooh/sokol-zig/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-zig/actions/workflows/main.yml) [![build](https://github.com/floooh/sokol-nim/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-nim/actions/workflows/main.yml) [![Odin](https://github.com/floooh/sokol-odin/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-odin/actions/workflows/main.yml)
 

--- a/sokol_fetch.h
+++ b/sokol_fetch.h
@@ -1205,7 +1205,7 @@ typedef struct {
     sfetch_error_t error_code;
     bool finished;
     /* user thread only */
-    uint32_t user_data_size;
+    size_t user_data_size;
     uint64_t user_data[SFETCH_MAX_USERDATA_UINT64];
 } _sfetch_item_user_t;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ else()
     message(FATAL_ERROR "Unrecognized CMAKE_SYSTEM_NAME")
 endif()
 
+message(">> CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}")
 message(">> SOKOL_BACKEND: ${SOKOL_BACKEND}")
 message(">> SOKOL_FORCE_EGL: ${SOKOL_FORCE_EGL}")
 if (OSX_IOS OR OSX_MACOS)
@@ -212,6 +213,9 @@ add_library(spine
 target_include_directories(spine SYSTEM PUBLIC ext/spine-runtimes/spine-c/spine-c/include)
 if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     target_compile_options(spine PRIVATE /wd4267 /wd4244)   # conversion from 'x' to 'y' possible loss of data
+endif()
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(spine PRIVATE -Wno-shorten-64-to-32)
 endif()
 
 


### PR DESCRIPTION
Same as has happend in other sokol headers already, discrete pointer/size pairs are replaced with a sfetch_range_t ptr/size pair struct. This affects:

- sfetch_request_t: .buffer_ptr/.buffer_size have become .buffer, and .user_data_ptr/.user_data_size have become .user_data
- sfetch_response_t: the .buffer_ptr/.fetched_size (no typo) has become .data, the .buffer_ptr/.buffer_size has become .buffer, and for .fetched_offset has been renamed to .data_offset
- in the function sfetch_bind_buffer() the buffer_ptr/buffer_size args have been merged into a single buffer arg

In sokol_app.h, the HTML5 specific structs sapp_html5_fetch_request and sapp_html5_fetch_response has been updated likewise.