### PR TITLE
Commit listener callback in sokol-gfx.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## Updates
 
+- **09-Nov-2022**: sokol_gfx.h now allows to add 'commit listeners', these
+  are callback functions which are called from inside sg_commit(). This is
+  mainly useful for libraries which build on top of sokol-gfx to be notified
+  about the start/end point of a frame, which in turn may simplify the public
+  API, or the internal implementation, because the library no longer needs to
+  'guess' when a new frame starts.
+
+  For more details, search for 'COMMIT LISTENERS' in the sokol_gfx.h header.
+
+  This also results in a minor breaking change in sokol_spine.h: The function
+  ```sspine_new_frame()``` has been removed and replaced with an internal commit
+  listener.
+
+  Likewise, sokol_gl.h now uses a commit listener in the implementation, but
+  without changing the public API (the feature will be important for an upcoming
+  sokol-gl feature to support rendering layers, and for this a 'new-frame-function'
+  would have been needed).
+
 - **05-Nov-2022** A breaking change in sokol_fetch.h, and a minor change in
   sokol_app.h which should only break for very users:
   - An ```sfetch_range_t``` ptr/size pair struct has been added to sokol_fetch.h,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple
 [STB-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt)
 cross-platform libraries for C and C++, written in C.
 
-[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**05-Nov-2022** breaking changes in sokol_fetch.h, and for some users in sokol_app.h)
+[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**09-Nov-2022** a new minor feature in sokol_gfx.h: commit listener callbacks, and a related minor breaking change in sokol_spine.h)
 
 [![Build](/../../actions/workflows/main.yml/badge.svg)](/../../actions/workflows/main.yml) [![Bindings](/../../actions/workflows/gen_bindings.yml/badge.svg)](/../../actions/workflows/gen_bindings.yml) [![build](https://github.com/floooh/sokol-zig/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-zig/actions/workflows/main.yml) [![build](https://github.com/floooh/sokol-nim/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-nim/actions/workflows/main.yml) [![Odin](https://github.com/floooh/sokol-odin/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-odin/actions/workflows/main.yml)
 

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -710,6 +710,50 @@
     If no overrides are provided, puts will be used on most platforms.
     On Android, __android_log_write will be used instead.
 
+    COMMIT LISTENERS
+    ================
+    It's possible to hook callback functions into sokol-gfx which are called from
+    inside sg_commit() in unspecified order. This is mainly useful for libraries
+    that build on top of sokol_gfx.h to be notified about the end/start of a frame.
+
+    To add a commit listener, call:
+
+        static void my_commit_listener(void* user_data) {
+            ...
+        }
+
+        bool success = sg_add_commit_listener((sg_commit_listener){
+            .func = my_commit_listener,
+            .user_data = ...,
+        });
+
+    The function returns false if the internal array of commit listeners is full,
+    or the same commit listener had already been added.
+
+    If the function returns true, my_commit_listener() will be called each frame
+    from inside sg_commit().
+
+    By default, 1024 distinct commit listeners can be added, but this number
+    can be tweaked in the sg_setup() call:
+
+        sg_setup(&(sg_desc){
+            .max_commit_listeners = 2048,
+        });
+
+    An sg_commit_listener item is equal to another if both the function
+    pointer and user_data field are equal.
+
+    To remove a commit listener:
+
+        bool success = sg_remove_commit_listener((sg_commit_listener){
+            .func = my_commit_listener,
+            .user_data = ...,
+        });
+
+    ...where the .func and .user_data field are equal to a previous
+    sg_add_commit_listener() call. The function returns true if the commit
+    listener item was found and removed, and false otherwise.
+
     TODO:
     ====
     - talk about asynchronous resource creation

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2461,6 +2461,20 @@ typedef struct sg_context_desc {
 } sg_context_desc;
 
 /*
+    sg_commit_listener
+
+    Used with function sg_add_commit_listener() to add a callback
+    which will be called in sg_commit(). This is useful for libraries
+    building on top of sokol-gfx to be notified about when a frame
+    ends (instead of having to guess, or add a manual 'new-frame'
+    function.
+*/
+typedef struct sg_commit_listener {
+    void (*func)(void* user_data);
+    void* user_data;
+} sg_commit_listener;
+
+/*
     sg_allocator
 
     Used in sg_desc to provide custom memory-alloc and -free functions
@@ -2496,6 +2510,7 @@ typedef struct sg_desc {
     int uniform_buffer_size;
     int staging_buffer_size;
     int sampler_cache_size;
+    int max_commit_listeners;
     sg_allocator allocator;
     sg_logger logger; // optional log function override
     sg_context_desc context;
@@ -2510,6 +2525,8 @@ SOKOL_GFX_API_DECL void sg_reset_state_cache(void);
 SOKOL_GFX_API_DECL sg_trace_hooks sg_install_trace_hooks(const sg_trace_hooks* trace_hooks);
 SOKOL_GFX_API_DECL void sg_push_debug_group(const char* name);
 SOKOL_GFX_API_DECL void sg_pop_debug_group(void);
+SOKOL_GFX_API_DECL bool sg_add_commit_listener(sg_commit_listener listener);
+SOKOL_GFX_API_DECL bool sg_remove_commit_listener(sg_commit_listener listener);
 
 /* resource creation, destruction and updating */
 SOKOL_GFX_API_DECL sg_buffer sg_make_buffer(const sg_buffer_desc* desc);
@@ -3213,6 +3230,7 @@ enum {
     _SG_DEFAULT_SAMPLER_CACHE_CAPACITY = 64,
     _SG_DEFAULT_UB_SIZE = 4 * 1024 * 1024,
     _SG_DEFAULT_STAGING_SIZE = 8 * 1024 * 1024,
+    _SG_DEFAULT_MAX_COMMIT_LISTENERS = 1024,
 };
 
 /* fixed-size string */
@@ -4284,6 +4302,12 @@ typedef enum {
 /*=== GENERIC BACKEND STATE ==================================================*/
 
 typedef struct {
+    int num;        // number of allocated commit listener items
+    int upper;      // the current upper index (no valid items past this point)
+    sg_commit_listener* items;
+} _sg_commit_listeners_t;
+
+typedef struct {
     bool valid;
     sg_desc desc;       /* original desc with default values patched in */
     uint32_t frame_index;
@@ -4313,6 +4337,7 @@ typedef struct {
     #if defined(SOKOL_TRACE_HOOKS)
     sg_trace_hooks hooks;
     #endif
+    _sg_commit_listeners_t commit_listeners;
 } _sg_state_t;
 static _sg_state_t _sg;
 
@@ -15272,6 +15297,73 @@ _SOKOL_PRIVATE bool _sg_uninit_pass(sg_pass pass_id) {
     return false;
 }
 
+_SOKOL_PRIVATE void _sg_setup_commit_listeners(const sg_desc* desc) {
+    SOKOL_ASSERT(desc->max_commit_listeners > 0);
+    SOKOL_ASSERT(0 == _sg.commit_listeners.items);
+    SOKOL_ASSERT(0 == _sg.commit_listeners.num);
+    SOKOL_ASSERT(0 == _sg.commit_listeners.upper);
+    _sg.commit_listeners.num = desc->max_commit_listeners;
+    const size_t size = (size_t)_sg.commit_listeners.num * sizeof(sg_commit_listener);
+    _sg.commit_listeners.items = (sg_commit_listener*)_sg_malloc_clear(size);
+}
+
+_SOKOL_PRIVATE void _sg_discard_commit_listeners(void) {
+    SOKOL_ASSERT(0 != _sg.commit_listeners.items);
+    _sg_free(_sg.commit_listeners.items);
+    _sg.commit_listeners.items = 0;
+}
+
+_SOKOL_PRIVATE void _sg_notify_commit_listeners(void) {
+    SOKOL_ASSERT(_sg.commit_listeners.items);
+    for (int i = 0; i < _sg.commit_listeners.upper; i++) {
+        const sg_commit_listener* listener = &_sg.commit_listeners.items[i];
+        if (listener->func) {
+            listener->func(listener->user_data);
+        }
+    }
+}
+
+_SOKOL_PRIVATE bool _sg_add_commit_listener(const sg_commit_listener* new_listener) {
+    SOKOL_ASSERT(new_listener && new_listener->func);
+    SOKOL_ASSERT(_sg.commit_listeners.items);
+    // first try to plug a hole
+    sg_commit_listener* slot = 0;
+    for (int i = 0; i < _sg.commit_listeners.upper; i++) {
+        slot = &_sg.commit_listeners.items[i];
+        if (slot->func == 0) {
+            break;
+        }
+    }
+    if (!slot) {
+        // append to end
+        if (_sg.commit_listeners.upper < _sg.commit_listeners.num) {
+            slot = &_sg.commit_listeners.items[_sg.commit_listeners.upper++];
+        }
+    }
+    if (!slot) {
+        SG_LOG("commit listener array full\n");
+        return false;
+    }
+    *slot = *new_listener;
+    return true;
+}
+
+_SOKOL_PRIVATE bool _sg_remove_commit_listener(const sg_commit_listener* listener) {
+    SOKOL_ASSERT(listener && listener->func);
+    SOKOL_ASSERT(_sg.commit_listeners.items);
+    for (int i = 0; i < _sg.commit_listeners.upper; i++) {
+        sg_commit_listener* slot = &_sg.commit_listeners.items[i];
+        // both the function pointer and user data must match!
+        if ((slot->func == listener->func) && (slot->user_data == listener->user_data)) {
+            slot->func = 0;
+            slot->user_data = 0;
+            return true;
+        }
+    }
+    // not found
+    return false;
+}
+
 _SOKOL_PRIVATE sg_desc _sg_desc_defaults(const sg_desc* desc) {
     /*
         NOTE: on WebGPU, the default color pixel format MUST be provided,
@@ -15296,6 +15388,7 @@ _SOKOL_PRIVATE sg_desc _sg_desc_defaults(const sg_desc* desc) {
     res.uniform_buffer_size = _sg_def(res.uniform_buffer_size, _SG_DEFAULT_UB_SIZE);
     res.staging_buffer_size = _sg_def(res.staging_buffer_size, _SG_DEFAULT_STAGING_SIZE);
     res.sampler_cache_size = _sg_def(res.sampler_cache_size, _SG_DEFAULT_SAMPLER_CACHE_CAPACITY);
+    res.max_commit_listeners = _sg_def(res.max_commit_listeners, _SG_DEFAULT_MAX_COMMIT_LISTENERS);
     return res;
 }
 
@@ -15308,6 +15401,7 @@ SOKOL_API_IMPL void sg_setup(const sg_desc* desc) {
     _SG_CLEAR_ARC_STRUCT(_sg_state_t, _sg);
     _sg.desc = _sg_desc_defaults(desc);
     _sg_setup_pools(&_sg.pools, &_sg.desc);
+    _sg_setup_commit_listeners(&_sg.desc);
     _sg.frame_index = 1;
     _sg_setup_backend(&_sg.desc);
     _sg.valid = true;
@@ -15327,6 +15421,7 @@ SOKOL_API_IMPL void sg_shutdown(void) {
         }
     }
     _sg_discard_backend();
+    _sg_discard_commit_listeners();
     _sg_discard_pools(&_sg.pools);
     _SG_CLEAR_ARC_STRUCT(_sg_state_t, _sg);
 }
@@ -15992,6 +16087,7 @@ SOKOL_API_IMPL void sg_end_pass(void) {
 SOKOL_API_IMPL void sg_commit(void) {
     SOKOL_ASSERT(_sg.valid);
     _sg_commit();
+    _sg_notify_commit_listeners();
     _SG_TRACE_NOARGS(commit);
     _sg.frame_index++;
 }
@@ -16103,6 +16199,16 @@ SOKOL_API_IMPL void sg_push_debug_group(const char* name) {
 SOKOL_API_IMPL void sg_pop_debug_group(void) {
     SOKOL_ASSERT(_sg.valid);
     _SG_TRACE_NOARGS(pop_debug_group);
+}
+
+SOKOL_API_IMPL bool sg_add_commit_listener(sg_commit_listener listener) {
+    SOKOL_ASSERT(_sg.valid);
+    return _sg_add_commit_listener(&listener);
+}
+
+SOKOL_API_IMPL bool sg_remove_commit_listener(sg_commit_listener listener) {
+    SOKOL_ASSERT(_sg.valid);
+    return _sg_remove_commit_listener(&listener);
 }
 
 SOKOL_API_IMPL sg_buffer_info sg_query_buffer_info(sg_buffer buf_id) {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -15365,10 +15365,6 @@ _SOKOL_PRIVATE bool _sg_remove_commit_listener(const sg_commit_listener* listene
         if ((slot->func == listener->func) && (slot->user_data == listener->user_data)) {
             slot->func = 0;
             slot->user_data = 0;
-            if (i == (_sg.commit_listeners.upper - 1)) {
-                SOKOL_ASSERT(_sg.commit_listeners.upper > 0);
-                _sg.commit_listeners.upper -= 1;
-            }
             // NOTE: since _sg_add_commit_listener() already catches duplicates,
             // we don't need to worry about them here
             return true;

--- a/tests/functional/sokol_gfx_test.c
+++ b/tests/functional/sokol_gfx_test.c
@@ -910,7 +910,7 @@ UTEST(sokol_gfx, commit_listener_add_remove_add) {
     T(sg_add_commit_listener(listener));
     T(_sg.commit_listeners.upper == 1);
     T(sg_remove_commit_listener(listener));
-    T(_sg.commit_listeners.upper == 0);
+    T(_sg.commit_listeners.upper == 1);
     sg_commit();
     T(0 == commit_listener.num_called);
     T(sg_add_commit_listener(listener));
@@ -974,14 +974,14 @@ UTEST(sokol_gfx, commit_listener_multi_add_remove) {
     commit_listener.num_called = 0;
     // removing the second listener will decrement the upper bound
     T(sg_remove_commit_listener(l1));
-    T(_sg.commit_listeners.upper == 1);
+    T(_sg.commit_listeners.upper == 2);
     sg_commit();
     T(commit_listener.num_called == 1);
     T(commit_listener.userdata == 23);
     commit_listener.num_called = 0;
     // and finally remove the first listener too
     T(sg_remove_commit_listener(l0));
-    T(_sg.commit_listeners.upper == 0);
+    T(_sg.commit_listeners.upper == 2);
     sg_commit();
     T(commit_listener.num_called == 0);
     // removing the same listener twice just returns false

--- a/util/sokol_spine.h
+++ b/util/sokol_spine.h
@@ -1024,6 +1024,7 @@ typedef enum sspine_resource_state {
     _SSPINE_XMACRO(VERTEX_BUFFER_OVERFLOW)\
     _SSPINE_XMACRO(INDEX_BUFFER_OVERFLOW)\
     _SSPINE_XMACRO(STRING_TRUNCATED)\
+    _SSPINE_XMACRO(SG_ADD_COMMIT_LISTENER_FAILED)\
 
 #define _SSPINE_XMACRO(code) SSPINE_ERROR_##code,
 typedef enum sspine_error {
@@ -4426,6 +4427,7 @@ static void _sspine_destroy_shared(void) {
     sg_destroy_shader(_sspine.shd);
 }
 
+// called from inside sokol-gfx sg_commit()
 static void _sspine_commit_listener_func(void* userdata) {
     (void)userdata;
     SOKOL_ASSERT(_SSPINE_INIT_COOKIE == _sspine.init_cookie);
@@ -4455,7 +4457,9 @@ SOKOL_API_IMPL void sspine_setup(const sspine_desc* desc) {
     _sspine.def_ctx_id = sspine_make_context(&ctx_desc);
     SOKOL_ASSERT(_sspine_is_default_context(_sspine.def_ctx_id));
     sspine_set_context(_sspine.def_ctx_id);
-    sg_add_commit_listener(_sspine_make_commit_listener());
+    if (!sg_add_commit_listener(_sspine_make_commit_listener())) {
+        _SSPINE_ERROR(SG_ADD_COMMIT_LISTENER_FAILED);
+    }
 }
 
 SOKOL_API_IMPL void sspine_shutdown(void) {


### PR DESCRIPTION
Adds the abillity to hook callback functions into sokol-gfx which are called from inside sg_commit(). This is mostly useful for other libraries on top of sokol-gfx to be notified about the end/start of a new frame.

1 new struct and 2 new functions:

- sg_commit_listener: a function pointer / userdata pair
- sg_add_commit_listener
- sg_remove_commit_listener

Also in other headers:
- in sokol_spine.h, the sspine_new_frame() function has been removed
- sokol_gl.h now internally uses a commit listener (no public API changes)