### PR TITLE
Render layer implementation for sokol_gl.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Updates
 
+- **11-Nov-2022**: sokol_gl.h has 2 new public API functions which enable
+  layered rendering: sgl_layer(), sgl_draw_layer() (technically it's three
+  functions: there's also sgl_context_draw_layer(), but that's just a variant of
+  sgl_draw_layer()). This allows to 'interleave' sokol-gl rendering
+  with other render operations. The [spine-layers-sapp](https://floooh.github.io/sokol-html5/spine-layers-sapp.html)
+  sample has been updated to use multiple sokol-gl layers.
+
 - **09-Nov-2022**: sokol_gfx.h now allows to add 'commit listeners', these
   are callback functions which are called from inside sg_commit(). This is
   mainly useful for libraries which build on top of sokol-gfx to be notified

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple
 [STB-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt)
 cross-platform libraries for C and C++, written in C.
 
-[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**09-Nov-2022** a new minor feature in sokol_gfx.h: commit listener callbacks, and a related minor breaking change in sokol_spine.h)
+[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**11-Nov-2022** sokol_gl.h learned layered rendering)
 
 [![Build](/../../actions/workflows/main.yml/badge.svg)](/../../actions/workflows/main.yml) [![Bindings](/../../actions/workflows/gen_bindings.yml/badge.svg)](/../../actions/workflows/gen_bindings.yml) [![build](https://github.com/floooh/sokol-zig/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-zig/actions/workflows/main.yml) [![build](https://github.com/floooh/sokol-nim/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-nim/actions/workflows/main.yml) [![Odin](https://github.com/floooh/sokol-odin/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-odin/actions/workflows/main.yml)
 

--- a/util/sokol_gl.h
+++ b/util/sokol_gl.h
@@ -3707,7 +3707,7 @@ SOKOL_API_IMPL void sgl_end(void) {
         if (cmd) {
             SOKOL_ASSERT(ctx->cur_uniform > 0);
             cmd->cmd = SGL_COMMAND_DRAW;
-            ctx->layer = ctx->layer;
+            cmd->layer = ctx->layer;
             cmd->args.draw.img = img;
             cmd->args.draw.pip = _sgl_get_pipeline(ctx->pip_stack[ctx->pip_tos], ctx->cur_prim_type);
             cmd->args.draw.base_vertex = ctx->base_vertex;

--- a/util/sokol_gl.h
+++ b/util/sokol_gl.h
@@ -381,7 +381,7 @@
 
     RENDER LAYERS
     =============
-    Render layers allow to split sokol-gl rendering into seperate draw-command
+    Render layers allow to split sokol-gl rendering into separate draw-command
     groups which can then be rendered separately in a sokol-gfx draw pass. This
     allows to mix/interleave sokol-gl rendering with other render operations.
 


### PR DESCRIPTION
Same idea as in sokol_spine.h, sokol-gl commands can be recorded into different layers, and those layers can be rendered separately, this allows to mix chunks of sokol-gl rendering with other drawing operations.

TODO:
- [x] add documentation blurb
- ~~[ ] maybe add a separate sample (I have extended the sokol-spine layers sample to also use sokol-gl layered rendering~~ (once sokol_debugtext.h gets render layers too, I'll add a new sample to interleave this with sokol_gl.h)
- [x] changelog and readme