### PR TITLE
Clean up sokol-gfx resource creation/destruction code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 ## Updates
 
+- **25-Nov-2022**: Some code cleanup around resource creation and destruction in sokol_gfx.h:
+    - It's now safe to call the destroy, uninit and dealloc functions in any
+      resource state, in general, the functions will do the right thing without
+      assertions getting in the way (there are however new log warnings in some
+      cases though, such as attempting to call an ```sg_dealloc_*()``` function on
+      a resource object that's not in ALLOC state)
+    - A related **minor breaking change**: the ```sg_uninit_*()``` functions now return
+      void instead of bool, this is because ```sg_dealloc_*()``` no longer asserts
+      when called in the wrong resource state
+    - Related internal code cleanup in the backend-agnostic resource creation
+      and cleanup code, better or more consistent functions, etc...
+    - The validation layer can now be disabled in debug mode with a runtime
+      flag during setup: ```sg_desc.disable_validation```. This is mainly useful
+      for test code.
+    - Creating a pass object with invalid image objects now no longer asserts,
+      but instead results in a pass object in FAILED state. In debug mode,
+      the validation layer will still stop at this problem though (it's mostly
+      an 'undefined API behaviour' fix in release mode).
+    - Calling ```sg_shutdown()``` with existing resources in ALLOC state will
+      no longer print a log message about an 'active context mismatch'.
+    - A new header documentation blurb about the two-step resource creation
+      and destruction functions (search for RESOURCE CREATION AND DESTRUCTION IN DETAIL)
+
 - **16-Nov-2022**: Render layer support has been added to sokol_debugtext.h,
   same general changes as in sokol_gl.h with two new functions:
   sdtx_layer(layer_id) to select the layer to record text into, and

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple
 [STB-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt)
 cross-platform libraries for C and C++, written in C.
 
-[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**16-Nov-2022** sokol_debugtext.h learned layered rendering)
+[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**25-Nov-2022** sokol_gfx.h: minor breaking change in the ```sg_uninit_*()``` functions)
 
 [![Build](/../../actions/workflows/main.yml/badge.svg)](/../../actions/workflows/main.yml) [![Bindings](/../../actions/workflows/gen_bindings.yml/badge.svg)](/../../actions/workflows/gen_bindings.yml) [![build](https://github.com/floooh/sokol-zig/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-zig/actions/workflows/main.yml) [![build](https://github.com/floooh/sokol-nim/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-nim/actions/workflows/main.yml) [![Odin](https://github.com/floooh/sokol-odin/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-odin/actions/workflows/main.yml)
 

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -912,9 +912,11 @@
     but will generate a warning log message.
 
     NOTE: that two-step resource creation usually only makes sense for buffers
-    and images, but not for shaders, pipelines or passes. Most notably, pipeline
-    creation will fail if the input shader is not in VALID state, and likewise,
-    pass creation will fail if the input images are not in VALID state.
+    and images, but not for shaders, pipelines or passes. Most notably, trying
+    to create a pipeline object with a shader that's not in VALID state will
+    trigger a validation layer error, or if the validation layer is disabled,
+    result in a pipeline object in FAILED state. Same when trying to create
+    a pass object with image invalid image objects.
 
     LICENSE
     =======

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -15125,33 +15125,33 @@ _SOKOL_PRIVATE sg_pass _sg_alloc_pass(void) {
 }
 
 _SOKOL_PRIVATE void _sg_dealloc_buffer(_sg_buffer_t* buf) {
-    SOKOL_ASSERT(buf && buf->slot.state == SG_RESOURCESTATE_ALLOC);
-    _sg_reset_slot(&buf->slot);
+    SOKOL_ASSERT(buf && (buf->slot.state == SG_RESOURCESTATE_ALLOC) && (buf->slot.id != SG_INVALID_ID));
     _sg_pool_free_index(&_sg.pools.buffer_pool, _sg_slot_index(buf->slot.id));
+    _sg_reset_slot(&buf->slot);
 }
 
 _SOKOL_PRIVATE void _sg_dealloc_image(_sg_image_t* img) {
-    SOKOL_ASSERT(img && img->slot.state == SG_RESOURCESTATE_ALLOC);
-    _sg_reset_slot(&img->slot);
+    SOKOL_ASSERT(img && (img->slot.state == SG_RESOURCESTATE_ALLOC) && (img->slot.id != SG_INVALID_ID));
     _sg_pool_free_index(&_sg.pools.image_pool, _sg_slot_index(img->slot.id));
+    _sg_reset_slot(&img->slot);
 }
 
 _SOKOL_PRIVATE void _sg_dealloc_shader(_sg_shader_t* shd) {
-    SOKOL_ASSERT(shd && shd->slot.state == SG_RESOURCESTATE_ALLOC);
-    _sg_reset_slot(&shd->slot);
+    SOKOL_ASSERT(shd && (shd->slot.state == SG_RESOURCESTATE_ALLOC) && (shd->slot.id != SG_INVALID_ID));
     _sg_pool_free_index(&_sg.pools.shader_pool, _sg_slot_index(shd->slot.id));
+    _sg_reset_slot(&shd->slot);
 }
 
 _SOKOL_PRIVATE void _sg_dealloc_pipeline(_sg_pipeline_t* pip) {
-    SOKOL_ASSERT(pip && pip->slot.state == SG_RESOURCESTATE_ALLOC);
-    _sg_reset_slot(&pip->slot);
+    SOKOL_ASSERT(pip && (pip->slot.state == SG_RESOURCESTATE_ALLOC) && (pip->slot.id != SG_INVALID_ID));
     _sg_pool_free_index(&_sg.pools.pipeline_pool, _sg_slot_index(pip->slot.id));
+    _sg_reset_slot(&pip->slot);
 }
 
 _SOKOL_PRIVATE void _sg_dealloc_pass(_sg_pass_t* pass) {
-    SOKOL_ASSERT(pass && pass->slot.state == SG_RESOURCESTATE_ALLOC);
-    _sg_reset_slot(&pass->slot);
+    SOKOL_ASSERT(pass && (pass->slot.state == SG_RESOURCESTATE_ALLOC) && (pass->slot.id != SG_INVALID_ID));
     _sg_pool_free_index(&_sg.pools.pass_pool, _sg_slot_index(pass->slot.id));
+    _sg_reset_slot(&pass->slot);
 }
 
 _SOKOL_PRIVATE void _sg_init_buffer(_sg_buffer_t* buf, const sg_buffer_desc* desc) {
@@ -15569,7 +15569,12 @@ SOKOL_API_IMPL void sg_dealloc_buffer(sg_buffer buf_id) {
     SOKOL_ASSERT(_sg.valid);
     _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
     if (buf) {
-        _sg_dealloc_buffer(buf);
+        if (buf->slot.state == SG_RESOURCESTATE_ALLOC) {
+            _sg_dealloc_buffer(buf);
+        }
+        else {
+            SG_LOG("sg_dealloc_buffer: buffer must be in ALLOC state\n");
+        }
     }
     _SG_TRACE_ARGS(dealloc_buffer, buf_id);
 }
@@ -15578,7 +15583,12 @@ SOKOL_API_IMPL void sg_dealloc_image(sg_image img_id) {
     SOKOL_ASSERT(_sg.valid);
     _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
     if (img) {
-        _sg_dealloc_image(img);
+        if (img->slot.state == SG_RESOURCESTATE_ALLOC) {
+            _sg_dealloc_image(img);
+        }
+        else {
+            SG_LOG("sg_dealloc_image: image must be in ALLOC state\n");
+        }
     }
     _SG_TRACE_ARGS(dealloc_image, img_id);
 }
@@ -15587,7 +15597,12 @@ SOKOL_API_IMPL void sg_dealloc_shader(sg_shader shd_id) {
     SOKOL_ASSERT(_sg.valid);
     _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
     if (shd) {
-        _sg_dealloc_shader(shd);
+        if (shd->slot.state == SG_RESOURCESTATE_ALLOC) {
+            _sg_dealloc_shader(shd);
+        }
+        else {
+            SG_LOG("sg_dealloc_shader: shader must be in ALLOC state\n");
+        }
     }
     _SG_TRACE_ARGS(dealloc_shader, shd_id);
 }
@@ -15596,7 +15611,12 @@ SOKOL_API_IMPL void sg_dealloc_pipeline(sg_pipeline pip_id) {
     SOKOL_ASSERT(_sg.valid);
     _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
     if (pip) {
-        _sg_dealloc_pipeline(pip);
+        if (pip->slot.state == SG_RESOURCESTATE_ALLOC) {
+            _sg_dealloc_pipeline(pip);
+        }
+        else {
+            SG_LOG("sg_dealloc_pipeline: pipeline must be in ALLOC state\n");
+        }
     }
     _SG_TRACE_ARGS(dealloc_pipeline, pip_id);
 }
@@ -15605,7 +15625,12 @@ SOKOL_API_IMPL void sg_dealloc_pass(sg_pass pass_id) {
     SOKOL_ASSERT(_sg.valid);
     _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
     if (pass) {
-        _sg_dealloc_pass(pass);
+        if (pass->slot.state == SG_RESOURCESTATE_ALLOC) {
+            _sg_dealloc_pass(pass);
+        }
+        else {
+            SG_LOG("sg_dealloc_pass: pass must be in ALLOC state\n");
+        }
     }
     _SG_TRACE_ARGS(dealloc_pass, pass_id);
 }
@@ -15613,9 +15638,15 @@ SOKOL_API_IMPL void sg_dealloc_pass(sg_pass pass_id) {
 SOKOL_API_IMPL void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
-    if (buf && (buf->slot.state == SG_RESOURCESTATE_ALLOC)) {
-        sg_buffer_desc desc_def = _sg_buffer_desc_defaults(desc);
-        _sg_init_buffer(buf, &desc_def);
+    if (buf) {
+        if (buf->slot.state == SG_RESOURCESTATE_ALLOC) {
+            sg_buffer_desc desc_def = _sg_buffer_desc_defaults(desc);
+            _sg_init_buffer(buf, &desc_def);
+            SOKOL_ASSERT((buf->slot.state == SG_RESOURCESTATE_VALID) || (buf->slot.state == SG_RESOURCESTATE_FAILED));
+        }
+        else {
+            SG_LOG("sg_init_buffer: buffer must be in alloc state\n");
+        }
     }
     _SG_TRACE_ARGS(init_buffer, buf_id, &desc_def);
 }
@@ -15623,9 +15654,15 @@ SOKOL_API_IMPL void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc)
 SOKOL_API_IMPL void sg_init_image(sg_image img_id, const sg_image_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
-    if (img && (img->slot.state == SG_RESOURCESTATE_ALLOC)) {
-        sg_image_desc desc_def = _sg_image_desc_defaults(desc);
-        _sg_init_image(img, &desc_def);
+    if (img) {
+        if (img->slot.state == SG_RESOURCESTATE_ALLOC) {
+            sg_image_desc desc_def = _sg_image_desc_defaults(desc);
+            _sg_init_image(img, &desc_def);
+            SOKOL_ASSERT((img->slot.state == SG_RESOURCESTATE_VALID) || (img->slot.state == SG_RESOURCESTATE_FAILED));
+        }
+        else {
+            SG_LOG("sg_init_image: image must be in alloc state\n");
+        }
     }
     _SG_TRACE_ARGS(init_image, img_id, &desc_def);
 }
@@ -15633,9 +15670,15 @@ SOKOL_API_IMPL void sg_init_image(sg_image img_id, const sg_image_desc* desc) {
 SOKOL_API_IMPL void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
-    if (shd && (shd->slot.state == SG_RESOURCESTATE_ALLOC)) {
-        sg_shader_desc desc_def = _sg_shader_desc_defaults(desc);
-        _sg_init_shader(shd, &desc_def);
+    if (shd) {
+        if (shd->slot.state == SG_RESOURCESTATE_ALLOC) {
+            sg_shader_desc desc_def = _sg_shader_desc_defaults(desc);
+            _sg_init_shader(shd, &desc_def);
+            SOKOL_ASSERT((shd->slot.state == SG_RESOURCESTATE_VALID) || (shd->slot.state == SG_RESOURCESTATE_FAILED));
+        }
+        else {
+            SG_LOG("sg_init_shader: shader must be in alloc state\n");
+        }
     }
     _SG_TRACE_ARGS(init_shader, shd_id, &desc_def);
 }
@@ -15643,9 +15686,15 @@ SOKOL_API_IMPL void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc)
 SOKOL_API_IMPL void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
-    if (pip && (pip->slot.state == SG_RESOURCESTATE_ALLOC)) {
-        sg_pipeline_desc desc_def = _sg_pipeline_desc_defaults(desc);
-        _sg_init_pipeline(pip, &desc_def);
+    if (pip) {
+        if (pip->slot.state == SG_RESOURCESTATE_ALLOC) {
+            sg_pipeline_desc desc_def = _sg_pipeline_desc_defaults(desc);
+            _sg_init_pipeline(pip, &desc_def);
+            SOKOL_ASSERT((pip->slot.state == SG_RESOURCESTATE_VALID) || (pip->slot.state == SG_RESOURCESTATE_FAILED));
+        }
+        else {
+            SG_LOG("sg_init_pipeline: pipeline must be in alloc state\n");
+        }
     }
     _SG_TRACE_ARGS(init_pipeline, pip_id, &desc_def);
 }
@@ -15653,9 +15702,15 @@ SOKOL_API_IMPL void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc*
 SOKOL_API_IMPL void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
-    if (pass && (pass->slot.state == SG_RESOURCESTATE_ALLOC)) {
-        sg_pass_desc desc_def = _sg_pass_desc_defaults(desc);
-        _sg_init_pass(pass, &desc_def);
+    if (pass) {
+        if (pass->slot.state == SG_RESOURCESTATE_ALLOC) {
+            sg_pass_desc desc_def = _sg_pass_desc_defaults(desc);
+            _sg_init_pass(pass, &desc_def);
+            SOKOL_ASSERT((pass->slot.state == SG_RESOURCESTATE_VALID) || (pass->slot.state == SG_RESOURCESTATE_FAILED));
+        }
+        else {
+            SG_LOG("sg_init_pass: pass must be in alloc state\n");
+        }
     }
     _SG_TRACE_ARGS(init_pass, pass_id, &desc_def);
 }
@@ -15663,8 +15718,14 @@ SOKOL_API_IMPL void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc) {
 SOKOL_API_IMPL void sg_uninit_buffer(sg_buffer buf_id) {
     SOKOL_ASSERT(_sg.valid);
     _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
-    if (buf && ((buf->slot.state == SG_RESOURCESTATE_VALID) || (buf->slot.state == SG_RESOURCESTATE_FAILED))) {
-        _sg_uninit_buffer(buf);
+    if (buf) {
+        if ((buf->slot.state == SG_RESOURCESTATE_VALID) || (buf->slot.state == SG_RESOURCESTATE_FAILED)) {
+            _sg_uninit_buffer(buf);
+            SOKOL_ASSERT(buf->slot.state == SG_RESOURCESTATE_ALLOC);
+        }
+        else {
+            SG_LOG("sg_uninit_buffer: buffer must be in VALID or FAILED state\n");
+        }
     }
     _SG_TRACE_ARGS(uninit_buffer, buf_id);
 }
@@ -15672,8 +15733,14 @@ SOKOL_API_IMPL void sg_uninit_buffer(sg_buffer buf_id) {
 SOKOL_API_IMPL void sg_uninit_image(sg_image img_id) {
     SOKOL_ASSERT(_sg.valid);
     _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
-    if (img && ((img->slot.state == SG_RESOURCESTATE_VALID) || (img->slot.state == SG_RESOURCESTATE_FAILED))) {
-        _sg_uninit_image(img);
+    if (img) {
+        if ((img->slot.state == SG_RESOURCESTATE_VALID) || (img->slot.state == SG_RESOURCESTATE_FAILED)) {
+            _sg_uninit_image(img);
+            SOKOL_ASSERT(img->slot.state == SG_RESOURCESTATE_ALLOC);
+        }
+        else {
+            SG_LOG("sg_uninit_image: image must be in VALID or FAILED state\n");
+        }
     }
     _SG_TRACE_ARGS(uninit_image, img_id);
 }
@@ -15681,8 +15748,14 @@ SOKOL_API_IMPL void sg_uninit_image(sg_image img_id) {
 SOKOL_API_IMPL void sg_uninit_shader(sg_shader shd_id) {
     SOKOL_ASSERT(_sg.valid);
     _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
-    if (shd && ((shd->slot.state == SG_RESOURCESTATE_VALID) || (shd->slot.state == SG_RESOURCESTATE_FAILED))) {
-        _sg_uninit_shader(shd);
+    if (shd) {
+        if ((shd->slot.state == SG_RESOURCESTATE_VALID) || (shd->slot.state == SG_RESOURCESTATE_FAILED)) {
+            _sg_uninit_shader(shd);
+            SOKOL_ASSERT(shd->slot.state == SG_RESOURCESTATE_ALLOC);
+        }
+        else {
+            SG_LOG("sg_uninit_shader: shader must be in VALID or FAILED state\n");
+        }
     }
     _SG_TRACE_ARGS(uninit_shader, shd_id);
 }
@@ -15690,8 +15763,14 @@ SOKOL_API_IMPL void sg_uninit_shader(sg_shader shd_id) {
 SOKOL_API_IMPL void sg_uninit_pipeline(sg_pipeline pip_id) {
     SOKOL_ASSERT(_sg.valid);
     _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
-    if (pip && ((pip->slot.state == SG_RESOURCESTATE_VALID) || (pip->slot.state == SG_RESOURCESTATE_FAILED))) {
-        _sg_uninit_pipeline(pip);
+    if (pip) {
+        if ((pip->slot.state == SG_RESOURCESTATE_VALID) || (pip->slot.state == SG_RESOURCESTATE_FAILED)) {
+            _sg_uninit_pipeline(pip);
+            SOKOL_ASSERT(pip->slot.state == SG_RESOURCESTATE_ALLOC);
+        }
+        else {
+            SG_LOG("sg_uninit_pipeline: pipeline must be in VALID or FAILED state\n");
+        }
     }
     _SG_TRACE_ARGS(uninit_pipeline, pip_id);
 }
@@ -15699,8 +15778,14 @@ SOKOL_API_IMPL void sg_uninit_pipeline(sg_pipeline pip_id) {
 SOKOL_API_IMPL void sg_uninit_pass(sg_pass pass_id) {
     SOKOL_ASSERT(_sg.valid);
     _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
-    if (pass && ((pass->slot.state == SG_RESOURCESTATE_VALID) || (pass->slot.state == SG_RESOURCESTATE_FAILED))) {
-        _sg_uninit_pass(pass);
+    if (pass) {
+        if ((pass->slot.state == SG_RESOURCESTATE_VALID) || (pass->slot.state == SG_RESOURCESTATE_FAILED)) {
+            _sg_uninit_pass(pass);
+            SOKOL_ASSERT(pass->slot.state == SG_RESOURCESTATE_ALLOC);
+        }
+        else {
+            SG_LOG("sg_uninit_pass: pass must be in VALID or FAILED state\n");
+        }
     }
     _SG_TRACE_ARGS(uninit_pass, pass_id);
 }
@@ -15709,9 +15794,14 @@ SOKOL_API_IMPL void sg_uninit_pass(sg_pass pass_id) {
 SOKOL_API_IMPL void sg_fail_buffer(sg_buffer buf_id) {
     SOKOL_ASSERT(_sg.valid);
     _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
-    if (buf && buf->slot.state == SG_RESOURCESTATE_ALLOC) {
-        buf->slot.ctx_id = _sg.active_context.id;
-        buf->slot.state = SG_RESOURCESTATE_FAILED;
+    if (buf) {
+        if (buf->slot.state == SG_RESOURCESTATE_ALLOC) {
+            buf->slot.ctx_id = _sg.active_context.id;
+            buf->slot.state = SG_RESOURCESTATE_FAILED;
+        }
+        else {
+            SG_LOG("sg_fail_buffer: buffer must be in ALLOC state\n");
+        }
     }
     _SG_TRACE_ARGS(fail_buffer, buf_id);
 }
@@ -15719,9 +15809,14 @@ SOKOL_API_IMPL void sg_fail_buffer(sg_buffer buf_id) {
 SOKOL_API_IMPL void sg_fail_image(sg_image img_id) {
     SOKOL_ASSERT(_sg.valid);
     _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
-    if (img && img->slot.state == SG_RESOURCESTATE_ALLOC) {
-        img->slot.ctx_id = _sg.active_context.id;
-        img->slot.state = SG_RESOURCESTATE_FAILED;
+    if (img) {
+        if (img->slot.state == SG_RESOURCESTATE_ALLOC) {
+            img->slot.ctx_id = _sg.active_context.id;
+            img->slot.state = SG_RESOURCESTATE_FAILED;
+        }
+        else {
+            SG_LOG("sg_fail_image: image must be in ALLOC state\n");
+        }
     }
     _SG_TRACE_ARGS(fail_image, img_id);
 }
@@ -15729,9 +15824,14 @@ SOKOL_API_IMPL void sg_fail_image(sg_image img_id) {
 SOKOL_API_IMPL void sg_fail_shader(sg_shader shd_id) {
     SOKOL_ASSERT(_sg.valid);
     _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
-    if (shd && shd->slot.state == SG_RESOURCESTATE_ALLOC) {
-        shd->slot.ctx_id = _sg.active_context.id;
-        shd->slot.state = SG_RESOURCESTATE_FAILED;
+    if (shd) {
+        if (shd->slot.state == SG_RESOURCESTATE_ALLOC) {
+            shd->slot.ctx_id = _sg.active_context.id;
+            shd->slot.state = SG_RESOURCESTATE_FAILED;
+        }
+        else {
+            SG_LOG("sg_fail_shader: shader must be in ALLOC state\n");
+        }
     }
     _SG_TRACE_ARGS(fail_shader, shd_id);
 }
@@ -15739,9 +15839,14 @@ SOKOL_API_IMPL void sg_fail_shader(sg_shader shd_id) {
 SOKOL_API_IMPL void sg_fail_pipeline(sg_pipeline pip_id) {
     SOKOL_ASSERT(_sg.valid);
     _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
-    if (pip && pip->slot.state == SG_RESOURCESTATE_ALLOC) {
-        pip->slot.ctx_id = _sg.active_context.id;
-        pip->slot.state = SG_RESOURCESTATE_FAILED;
+    if (pip) {
+        if (pip->slot.state == SG_RESOURCESTATE_ALLOC) {
+            pip->slot.ctx_id = _sg.active_context.id;
+            pip->slot.state = SG_RESOURCESTATE_FAILED;
+        }
+        else {
+            SG_LOG("sg_fail_pipeline: pipeline must be in ALLOC state\n");
+        }
     }
     _SG_TRACE_ARGS(fail_pipeline, pip_id);
 }
@@ -15749,9 +15854,14 @@ SOKOL_API_IMPL void sg_fail_pipeline(sg_pipeline pip_id) {
 SOKOL_API_IMPL void sg_fail_pass(sg_pass pass_id) {
     SOKOL_ASSERT(_sg.valid);
     _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
-    if (pass && pass->slot.state == SG_RESOURCESTATE_ALLOC) {
-        pass->slot.ctx_id = _sg.active_context.id;
-        pass->slot.state = SG_RESOURCESTATE_FAILED;
+    if (pass) {
+        if (pass->slot.state == SG_RESOURCESTATE_ALLOC) {
+            pass->slot.ctx_id = _sg.active_context.id;
+            pass->slot.state = SG_RESOURCESTATE_FAILED;
+        }
+        else {
+            SG_LOG("sg_fail_pass: pass must be in ALLOC state\n");
+        }
     }
     _SG_TRACE_ARGS(fail_pass, pass_id);
 }
@@ -15798,8 +15908,11 @@ SOKOL_API_IMPL sg_buffer sg_make_buffer(const sg_buffer_desc* desc) {
     SOKOL_ASSERT(desc);
     sg_buffer buf_id = _sg_alloc_buffer();
     if (buf_id.id != SG_INVALID_ID) {
+        _sg_buffer_t* buf = _sg_buffer_at(&_sg.pools, buf_id.id);
+        SOKOL_ASSERT(buf && (buf->slot.state == SG_RESOURCESTATE_ALLOC));
         sg_buffer_desc desc_def = _sg_buffer_desc_defaults(desc);
-        _sg_init_buffer(_sg_buffer_at(&_sg.pools, buf_id.id), &desc_def);
+        _sg_init_buffer(buf, &desc_def);
+        SOKOL_ASSERT((buf->slot.state == SG_RESOURCESTATE_VALID) || (buf->slot.state == SG_RESOURCESTATE_FAILED));
     }
     else {
         SG_LOG("buffer pool exhausted!");
@@ -15812,10 +15925,13 @@ SOKOL_API_IMPL sg_buffer sg_make_buffer(const sg_buffer_desc* desc) {
 SOKOL_API_IMPL sg_image sg_make_image(const sg_image_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     SOKOL_ASSERT(desc);
-    sg_image_desc desc_def = _sg_image_desc_defaults(desc);
     sg_image img_id = _sg_alloc_image();
     if (img_id.id != SG_INVALID_ID) {
-        _sg_init_image(_sg_image_at(&_sg.pools, img_id.id), &desc_def);
+        _sg_image_t* img = _sg_image_at(&_sg.pools, img_id.id);
+        SOKOL_ASSERT(img && (img->slot.state == SG_RESOURCESTATE_ALLOC));
+        sg_image_desc desc_def = _sg_image_desc_defaults(desc);
+        _sg_init_image(img, &desc_def);
+        SOKOL_ASSERT((img->slot.state == SG_RESOURCESTATE_VALID) || (img->slot.state == SG_RESOURCESTATE_FAILED));
     }
     else {
         SG_LOG("image pool exhausted!");
@@ -15828,10 +15944,13 @@ SOKOL_API_IMPL sg_image sg_make_image(const sg_image_desc* desc) {
 SOKOL_API_IMPL sg_shader sg_make_shader(const sg_shader_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     SOKOL_ASSERT(desc);
-    sg_shader_desc desc_def = _sg_shader_desc_defaults(desc);
     sg_shader shd_id = _sg_alloc_shader();
     if (shd_id.id != SG_INVALID_ID) {
-        _sg_init_shader(_sg_shader_at(&_sg.pools, shd_id.id), &desc_def);
+        _sg_shader_t* shd = _sg_shader_at(&_sg.pools, shd_id.id);
+        SOKOL_ASSERT(shd && (shd->slot.state == SG_RESOURCESTATE_ALLOC));
+        sg_shader_desc desc_def = _sg_shader_desc_defaults(desc);
+        _sg_init_shader(shd, &desc_def);
+        SOKOL_ASSERT((shd->slot.state == SG_RESOURCESTATE_VALID) || (shd->slot.state == SG_RESOURCESTATE_FAILED));
     }
     else {
         SG_LOG("shader pool exhausted!");
@@ -15844,10 +15963,13 @@ SOKOL_API_IMPL sg_shader sg_make_shader(const sg_shader_desc* desc) {
 SOKOL_API_IMPL sg_pipeline sg_make_pipeline(const sg_pipeline_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     SOKOL_ASSERT(desc);
-    sg_pipeline_desc desc_def = _sg_pipeline_desc_defaults(desc);
     sg_pipeline pip_id = _sg_alloc_pipeline();
     if (pip_id.id != SG_INVALID_ID) {
-        _sg_init_pipeline(_sg_pipeline_at(&_sg.pools, pip_id.id), &desc_def);
+        _sg_pipeline_t* pip = _sg_pipeline_at(&_sg.pools, pip_id.id);
+        SOKOL_ASSERT(pip && (pip->slot.state == SG_RESOURCESTATE_ALLOC));
+        sg_pipeline_desc desc_def = _sg_pipeline_desc_defaults(desc);
+        _sg_init_pipeline(pip, &desc_def);
+        SOKOL_ASSERT((pip->slot.state == SG_RESOURCESTATE_VALID) || (pip->slot.state == SG_RESOURCESTATE_FAILED));
     }
     else {
         SG_LOG("pipeline pool exhausted!");
@@ -15860,10 +15982,13 @@ SOKOL_API_IMPL sg_pipeline sg_make_pipeline(const sg_pipeline_desc* desc) {
 SOKOL_API_IMPL sg_pass sg_make_pass(const sg_pass_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     SOKOL_ASSERT(desc);
-    sg_pass_desc desc_def = _sg_pass_desc_defaults(desc);
     sg_pass pass_id = _sg_alloc_pass();
     if (pass_id.id != SG_INVALID_ID) {
-        _sg_init_pass(_sg_pass_at(&_sg.pools, pass_id.id), &desc_def);
+        _sg_pass_t* pass = _sg_pass_at(&_sg.pools, pass_id.id);
+        SOKOL_ASSERT(pass && (pass->slot.state == SG_RESOURCESTATE_ALLOC));
+        sg_pass_desc desc_def = _sg_pass_desc_defaults(desc);
+        _sg_init_pass(pass, &desc_def);
+        SOKOL_ASSERT((pass->slot.state == SG_RESOURCESTATE_VALID) || (pass->slot.state == SG_RESOURCESTATE_FAILED));
     }
     else {
         SG_LOG("pass pool exhausted!");
@@ -15881,8 +16006,12 @@ SOKOL_API_IMPL void sg_destroy_buffer(sg_buffer buf_id) {
     if (buf) {
         if ((buf->slot.state == SG_RESOURCESTATE_VALID) || (buf->slot.state == SG_RESOURCESTATE_FAILED)) {
             _sg_uninit_buffer(buf);
+            SOKOL_ASSERT(buf->slot.state == SG_RESOURCESTATE_ALLOC);
         }
-        _sg_dealloc_buffer(buf);
+        if (buf->slot.state == SG_RESOURCESTATE_ALLOC) {
+            _sg_dealloc_buffer(buf);
+            SOKOL_ASSERT(buf->slot.state == SG_RESOURCESTATE_INITIAL);
+        }
     }
 }
 
@@ -15893,8 +16022,12 @@ SOKOL_API_IMPL void sg_destroy_image(sg_image img_id) {
     if (img) {
         if ((img->slot.state == SG_RESOURCESTATE_VALID) || (img->slot.state == SG_RESOURCESTATE_FAILED)) {
             _sg_uninit_image(img);
+            SOKOL_ASSERT(img->slot.state == SG_RESOURCESTATE_ALLOC);
         }
-        _sg_dealloc_image(img);
+        if (img->slot.state == SG_RESOURCESTATE_ALLOC) {
+            _sg_dealloc_image(img);
+            SOKOL_ASSERT(img->slot.state == SG_RESOURCESTATE_INITIAL);
+        }
     }
 }
 
@@ -15905,8 +16038,12 @@ SOKOL_API_IMPL void sg_destroy_shader(sg_shader shd_id) {
     if (shd) {
         if ((shd->slot.state == SG_RESOURCESTATE_VALID) || (shd->slot.state == SG_RESOURCESTATE_FAILED)) {
             _sg_uninit_shader(shd);
+            SOKOL_ASSERT(shd->slot.state == SG_RESOURCESTATE_ALLOC);
         }
-        _sg_dealloc_shader(shd);
+        if (shd->slot.state == SG_RESOURCESTATE_ALLOC) {
+            _sg_dealloc_shader(shd);
+            SOKOL_ASSERT(shd->slot.state == SG_RESOURCESTATE_INITIAL);
+        }
     }
 }
 
@@ -15917,8 +16054,12 @@ SOKOL_API_IMPL void sg_destroy_pipeline(sg_pipeline pip_id) {
     if (pip) {
         if ((pip->slot.state == SG_RESOURCESTATE_VALID) || (pip->slot.state == SG_RESOURCESTATE_FAILED)) {
             _sg_uninit_pipeline(pip);
+            SOKOL_ASSERT(pip->slot.state == SG_RESOURCESTATE_ALLOC);
         }
-        _sg_dealloc_pipeline(pip);
+        if (pip->slot.state == SG_RESOURCESTATE_ALLOC) {
+            _sg_dealloc_pipeline(pip);
+            SOKOL_ASSERT(pip->slot.state == SG_RESOURCESTATE_INITIAL);
+        }
     }
 }
 
@@ -15929,8 +16070,12 @@ SOKOL_API_IMPL void sg_destroy_pass(sg_pass pass_id) {
     if (pass) {
         if ((pass->slot.state == SG_RESOURCESTATE_VALID) || (pass->slot.state == SG_RESOURCESTATE_FAILED)) {
             _sg_uninit_pass(pass);
+            SOKOL_ASSERT(pass->slot.state == SG_RESOURCESTATE_ALLOC);
         }
-        _sg_dealloc_pass(pass);
+        if (pass->slot.state == SG_RESOURCESTATE_ALLOC) {
+            _sg_dealloc_pass(pass);
+            SOKOL_ASSERT(pass->slot.state == SG_RESOURCESTATE_INITIAL);
+        }
     }
 }
 

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2645,11 +2645,11 @@ SOKOL_GFX_API_DECL void sg_init_image(sg_image img_id, const sg_image_desc* desc
 SOKOL_GFX_API_DECL void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc);
 SOKOL_GFX_API_DECL void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc);
 SOKOL_GFX_API_DECL void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc);
-SOKOL_GFX_API_DECL bool sg_uninit_buffer(sg_buffer buf_id);
-SOKOL_GFX_API_DECL bool sg_uninit_image(sg_image img_id);
-SOKOL_GFX_API_DECL bool sg_uninit_shader(sg_shader shd_id);
-SOKOL_GFX_API_DECL bool sg_uninit_pipeline(sg_pipeline pip_id);
-SOKOL_GFX_API_DECL bool sg_uninit_pass(sg_pass pass_id);
+SOKOL_GFX_API_DECL void sg_uninit_buffer(sg_buffer buf_id);
+SOKOL_GFX_API_DECL void sg_uninit_image(sg_image img_id);
+SOKOL_GFX_API_DECL void sg_uninit_shader(sg_shader shd_id);
+SOKOL_GFX_API_DECL void sg_uninit_pipeline(sg_pipeline pip_id);
+SOKOL_GFX_API_DECL void sg_uninit_pass(sg_pass pass_id);
 SOKOL_GFX_API_DECL void sg_fail_buffer(sg_buffer buf_id);
 SOKOL_GFX_API_DECL void sg_fail_image(sg_image img_id);
 SOKOL_GFX_API_DECL void sg_fail_shader(sg_shader shd_id);
@@ -4928,7 +4928,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_dummy_create_context(_sg_context_t* ctx) {
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_dummy_destroy_context(_sg_context_t* ctx) {
+_SOKOL_PRIVATE void _sg_dummy_discard_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     _SOKOL_UNUSED(ctx);
 }
@@ -4944,7 +4944,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_dummy_create_buffer(_sg_buffer_t* buf, cons
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_dummy_destroy_buffer(_sg_buffer_t* buf) {
+_SOKOL_PRIVATE void _sg_dummy_discard_buffer(_sg_buffer_t* buf) {
     SOKOL_ASSERT(buf);
     _SOKOL_UNUSED(buf);
 }
@@ -4955,7 +4955,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_dummy_create_image(_sg_image_t* img, const 
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_dummy_destroy_image(_sg_image_t* img) {
+_SOKOL_PRIVATE void _sg_dummy_discard_image(_sg_image_t* img) {
     SOKOL_ASSERT(img);
     _SOKOL_UNUSED(img);
 }
@@ -4966,7 +4966,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_dummy_create_shader(_sg_shader_t* shd, cons
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_dummy_destroy_shader(_sg_shader_t* shd) {
+_SOKOL_PRIVATE void _sg_dummy_discard_shader(_sg_shader_t* shd) {
     SOKOL_ASSERT(shd);
     _SOKOL_UNUSED(shd);
 }
@@ -4986,7 +4986,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_dummy_create_pipeline(_sg_pipeline_t* pip, 
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_dummy_destroy_pipeline(_sg_pipeline_t* pip) {
+_SOKOL_PRIVATE void _sg_dummy_discard_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
     _SOKOL_UNUSED(pip);
 }
@@ -5018,7 +5018,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_dummy_create_pass(_sg_pass_t* pass, _sg_ima
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_dummy_destroy_pass(_sg_pass_t* pass) {
+_SOKOL_PRIVATE void _sg_dummy_discard_pass(_sg_pass_t* pass) {
     SOKOL_ASSERT(pass);
     _SOKOL_UNUSED(pass);
 }
@@ -6345,7 +6345,7 @@ _SOKOL_PRIVATE void _sg_gl_cache_restore_buffer_binding(GLenum target) {
     }
 }
 
-/* called when from _sg_gl_destroy_buffer() */
+/* called when _sg_gl_deinit_buffer() */
 _SOKOL_PRIVATE void _sg_gl_cache_invalidate_buffer(GLuint buf) {
     if (buf == _sg.gl.cache.vertex_buffer) {
         _sg.gl.cache.vertex_buffer = 0;
@@ -6454,7 +6454,7 @@ _SOKOL_PRIVATE void _sg_gl_cache_invalidate_texture(GLuint tex) {
     }
 }
 
-/* called from _sg_gl_destroy_shader() */
+/* called from _sg_gl_discard_shader() */
 _SOKOL_PRIVATE void _sg_gl_cache_invalidate_program(GLuint prog) {
     if (prog == _sg.gl.cache.prog) {
         _sg.gl.cache.prog = 0;
@@ -6616,7 +6616,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_context(_sg_context_t* ctx) {
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_gl_destroy_context(_sg_context_t* ctx) {
+_SOKOL_PRIVATE void _sg_gl_discard_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     #if !defined(SOKOL_GLES2)
     if (!_sg.gl.gles2) {
@@ -6661,7 +6661,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_buffer(_sg_buffer_t* buf, const s
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_gl_destroy_buffer(_sg_buffer_t* buf) {
+_SOKOL_PRIVATE void _sg_gl_discard_buffer(_sg_buffer_t* buf) {
     SOKOL_ASSERT(buf);
     _SG_GL_CHECK_ERROR();
     for (int slot = 0; slot < buf->cmn.num_slots; slot++) {
@@ -6867,7 +6867,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_image(_sg_image_t* img, const sg_
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_gl_destroy_image(_sg_image_t* img) {
+_SOKOL_PRIVATE void _sg_gl_discard_image(_sg_image_t* img) {
     SOKOL_ASSERT(img);
     _SG_GL_CHECK_ERROR();
     for (int slot = 0; slot < img->cmn.num_slots; slot++) {
@@ -7025,7 +7025,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_shader(_sg_shader_t* shd, const s
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_gl_destroy_shader(_sg_shader_t* shd) {
+_SOKOL_PRIVATE void _sg_gl_discard_shader(_sg_shader_t* shd) {
     SOKOL_ASSERT(shd);
     _SG_GL_CHECK_ERROR();
     if (shd->gl.prog) {
@@ -8724,7 +8724,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_context(_sg_context_t* ctx) {
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_d3d11_destroy_context(_sg_context_t* ctx) {
+_SOKOL_PRIVATE void _sg_d3d11_discard_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     _SOKOL_UNUSED(ctx);
     /* empty */
@@ -8763,7 +8763,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_buffer(_sg_buffer_t* buf, cons
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_d3d11_destroy_buffer(_sg_buffer_t* buf) {
+_SOKOL_PRIVATE void _sg_d3d11_discard_buffer(_sg_buffer_t* buf) {
     SOKOL_ASSERT(buf);
     if (buf->d3d11.buf) {
         _sg_d3d11_Release(buf->d3d11.buf);
@@ -9057,7 +9057,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_d3d11_destroy_image(_sg_image_t* img) {
+_SOKOL_PRIVATE void _sg_d3d11_discard_image(_sg_image_t* img) {
     SOKOL_ASSERT(img);
     if (img->d3d11.tex2d) {
         _sg_d3d11_Release(img->d3d11.tex2d);
@@ -9222,7 +9222,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_shader(_sg_shader_t* shd, cons
     return result;
 }
 
-_SOKOL_PRIVATE void _sg_d3d11_destroy_shader(_sg_shader_t* shd) {
+_SOKOL_PRIVATE void _sg_d3d11_discard_shader(_sg_shader_t* shd) {
     SOKOL_ASSERT(shd);
     if (shd->d3d11.vs) {
         _sg_d3d11_Release(shd->d3d11.vs);
@@ -10622,7 +10622,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_mtl_create_context(_sg_context_t* ctx) {
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_mtl_destroy_context(_sg_context_t* ctx) {
+_SOKOL_PRIVATE void _sg_mtl_discard_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     _SOKOL_UNUSED(ctx);
     /* empty */
@@ -10659,7 +10659,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_mtl_create_buffer(_sg_buffer_t* buf, const 
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_mtl_destroy_buffer(_sg_buffer_t* buf) {
+_SOKOL_PRIVATE void _sg_mtl_discard_buffer(_sg_buffer_t* buf) {
     SOKOL_ASSERT(buf);
     for (int slot = 0; slot < buf->cmn.num_slots; slot++) {
         /* it's valid to call release resource with '0' */
@@ -10880,7 +10880,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_mtl_create_image(_sg_image_t* img, const sg
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_mtl_destroy_image(_sg_image_t* img) {
+_SOKOL_PRIVATE void _sg_mtl_discard_image(_sg_image_t* img) {
     SOKOL_ASSERT(img);
     /* it's valid to call release resource with a 'null resource' */
     for (int slot = 0; slot < img->cmn.num_slots; slot++) {
@@ -10984,7 +10984,7 @@ failed:
     return SG_RESOURCESTATE_FAILED;
 }
 
-_SOKOL_PRIVATE void _sg_mtl_destroy_shader(_sg_shader_t* shd) {
+_SOKOL_PRIVATE void _sg_mtl_discard_shader(_sg_shader_t* shd) {
     SOKOL_ASSERT(shd);
     /* it is valid to call _sg_mtl_release_resource with a 'null resource' */
     _sg_mtl_release_resource(_sg.mtl.frame_index, shd->mtl.stage[SG_SHADERSTAGE_VS].mtl_func);
@@ -12500,7 +12500,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_context(_sg_context_t* ctx) {
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_wgpu_destroy_context(_sg_context_t* ctx) {
+_SOKOL_PRIVATE void _sg_wgpu_discard_context(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     _SOKOL_UNUSED(ctx);
 }
@@ -12538,7 +12538,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_buffer(_sg_buffer_t* buf, const
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_wgpu_destroy_buffer(_sg_buffer_t* buf) {
+_SOKOL_PRIVATE void _sg_wgpu_discard_buffer(_sg_buffer_t* buf) {
     SOKOL_ASSERT(buf);
     WGPUBuffer wgpu_buf = buf->wgpu.buf;
     if (0 != wgpu_buf) {
@@ -12652,7 +12652,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_image(_sg_image_t* img, const s
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_wgpu_destroy_image(_sg_image_t* img) {
+_SOKOL_PRIVATE void _sg_wgpu_discard_image(_sg_image_t* img) {
     SOKOL_ASSERT(img);
     if (img->wgpu.tex) {
         wgpuTextureRelease(img->wgpu.tex);
@@ -12753,7 +12753,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_shader(_sg_shader_t* shd, const
     return success ? SG_RESOURCESTATE_VALID : SG_RESOURCESTATE_FAILED;
 }
 
-_SOKOL_PRIVATE void _sg_wgpu_destroy_shader(_sg_shader_t* shd) {
+_SOKOL_PRIVATE void _sg_wgpu_discard_shader(_sg_shader_t* shd) {
     SOKOL_ASSERT(shd);
     for (int stage_index = 0; stage_index < SG_NUM_SHADER_STAGES; stage_index++) {
         _sg_wgpu_shader_stage_t* wgpu_stage = &shd->wgpu.stage[stage_index];
@@ -13389,17 +13389,17 @@ static inline sg_resource_state _sg_create_context(_sg_context_t* ctx) {
     #endif
 }
 
-static inline void _sg_destroy_context(_sg_context_t* ctx) {
+static inline void _sg_discard_context(_sg_context_t* ctx) {
     #if defined(_SOKOL_ANY_GL)
-    _sg_gl_destroy_context(ctx);
+    _sg_gl_discard_context(ctx);
     #elif defined(SOKOL_METAL)
-    _sg_mtl_destroy_context(ctx);
+    _sg_mtl_discard_context(ctx);
     #elif defined(SOKOL_D3D11)
-    _sg_d3d11_destroy_context(ctx);
+    _sg_d3d11_discard_context(ctx);
     #elif defined(SOKOL_WGPU)
-    _sg_wgpu_destroy_context(ctx);
+    _sg_wgpu_discard_context(ctx);
     #elif defined(SOKOL_DUMMY_BACKEND)
-    _sg_dummy_destroy_context(ctx);
+    _sg_dummy_discard_context(ctx);
     #else
     #error("INVALID BACKEND");
     #endif
@@ -13421,17 +13421,17 @@ static inline sg_resource_state _sg_create_buffer(_sg_buffer_t* buf, const sg_bu
     #endif
 }
 
-static inline void _sg_destroy_buffer(_sg_buffer_t* buf) {
+static inline void _sg_discard_buffer(_sg_buffer_t* buf) {
     #if defined(_SOKOL_ANY_GL)
-    _sg_gl_destroy_buffer(buf);
+    _sg_gl_discard_buffer(buf);
     #elif defined(SOKOL_METAL)
-    _sg_mtl_destroy_buffer(buf);
+    _sg_mtl_discard_buffer(buf);
     #elif defined(SOKOL_D3D11)
-    _sg_d3d11_destroy_buffer(buf);
+    _sg_d3d11_discard_buffer(buf);
     #elif defined(SOKOL_WGPU)
-    _sg_wgpu_destroy_buffer(buf);
+    _sg_wgpu_discard_buffer(buf);
     #elif defined(SOKOL_DUMMY_BACKEND)
-    _sg_dummy_destroy_buffer(buf);
+    _sg_dummy_discard_buffer(buf);
     #else
     #error("INVALID BACKEND");
     #endif
@@ -13453,17 +13453,17 @@ static inline sg_resource_state _sg_create_image(_sg_image_t* img, const sg_imag
     #endif
 }
 
-static inline void _sg_destroy_image(_sg_image_t* img) {
+static inline void _sg_discard_image(_sg_image_t* img) {
     #if defined(_SOKOL_ANY_GL)
-    _sg_gl_destroy_image(img);
+    _sg_gl_discard_image(img);
     #elif defined(SOKOL_METAL)
-    _sg_mtl_destroy_image(img);
+    _sg_mtl_discard_image(img);
     #elif defined(SOKOL_D3D11)
-    _sg_d3d11_destroy_image(img);
+    _sg_d3d11_discard_image(img);
     #elif defined(SOKOL_WGPU)
-    _sg_wgpu_destroy_image(img);
+    _sg_wgpu_discard_image(img);
     #elif defined(SOKOL_DUMMY_BACKEND)
-    _sg_dummy_destroy_image(img);
+    _sg_dummy_discard_image(img);
     #else
     #error("INVALID BACKEND");
     #endif
@@ -13485,17 +13485,17 @@ static inline sg_resource_state _sg_create_shader(_sg_shader_t* shd, const sg_sh
     #endif
 }
 
-static inline void _sg_destroy_shader(_sg_shader_t* shd) {
+static inline void _sg_discard_shader(_sg_shader_t* shd) {
     #if defined(_SOKOL_ANY_GL)
-    _sg_gl_destroy_shader(shd);
+    _sg_gl_discard_shader(shd);
     #elif defined(SOKOL_METAL)
-    _sg_mtl_destroy_shader(shd);
+    _sg_mtl_discard_shader(shd);
     #elif defined(SOKOL_D3D11)
-    _sg_d3d11_destroy_shader(shd);
+    _sg_d3d11_discard_shader(shd);
     #elif defined(SOKOL_WGPU)
-    _sg_wgpu_destroy_shader(shd);
+    _sg_wgpu_discard_shader(shd);
     #elif defined(SOKOL_DUMMY_BACKEND)
-    _sg_dummy_destroy_shader(shd);
+    _sg_dummy_discard_shader(shd);
     #else
     #error("INVALID BACKEND");
     #endif
@@ -13517,17 +13517,17 @@ static inline sg_resource_state _sg_create_pipeline(_sg_pipeline_t* pip, _sg_sha
     #endif
 }
 
-static inline void _sg_destroy_pipeline(_sg_pipeline_t* pip) {
+static inline void _sg_discard_pipeline(_sg_pipeline_t* pip) {
     #if defined(_SOKOL_ANY_GL)
-    _sg_gl_destroy_pipeline(pip);
+    _sg_gl_discard_pipeline(pip);
     #elif defined(SOKOL_METAL)
-    _sg_mtl_destroy_pipeline(pip);
+    _sg_mtl_discard_pipeline(pip);
     #elif defined(SOKOL_D3D11)
-    _sg_d3d11_destroy_pipeline(pip);
+    _sg_d3d11_discard_pipeline(pip);
     #elif defined(SOKOL_WGPU)
-    _sg_wgpu_destroy_pipeline(pip);
+    _sg_wgpu_discard_pipeline(pip);
     #elif defined(SOKOL_DUMMY_BACKEND)
-    _sg_dummy_destroy_pipeline(pip);
+    _sg_dummy_discard_pipeline(pip);
     #else
     #error("INVALID BACKEND");
     #endif
@@ -13549,17 +13549,17 @@ static inline sg_resource_state _sg_create_pass(_sg_pass_t* pass, _sg_image_t** 
     #endif
 }
 
-static inline void _sg_destroy_pass(_sg_pass_t* pass) {
+static inline void _sg_discard_pass(_sg_pass_t* pass) {
     #if defined(_SOKOL_ANY_GL)
-    _sg_gl_destroy_pass(pass);
+    _sg_gl_discard_pass(pass);
     #elif defined(SOKOL_METAL)
-    _sg_mtl_destroy_pass(pass);
+    _sg_mtl_discard_pass(pass);
     #elif defined(SOKOL_D3D11)
-    _sg_d3d11_destroy_pass(pass);
+    _sg_d3d11_discard_pass(pass);
     #elif defined(SOKOL_WGPU)
-    return _sg_wgpu_destroy_pass(pass);
+    return _sg_wgpu_discard_pass(pass);
     #elif defined(SOKOL_DUMMY_BACKEND)
-    _sg_dummy_destroy_pass(pass);
+    _sg_dummy_discard_pass(pass);
     #else
     #error("INVALID BACKEND");
     #endif
@@ -13859,7 +13859,7 @@ _SOKOL_PRIVATE void _sg_reset_slot(_sg_slot_t* slot) {
     _sg_clear(slot, sizeof(_sg_slot_t));
 }
 
-_SOKOL_PRIVATE void _sg_reset_buffer(_sg_buffer_t* buf) {
+_SOKOL_PRIVATE void _sg_reset_buffer_to_alloc_state(_sg_buffer_t* buf) {
     SOKOL_ASSERT(buf);
     _sg_slot_t slot = buf->slot;
     _sg_clear(buf, sizeof(_sg_buffer_t));
@@ -13867,7 +13867,7 @@ _SOKOL_PRIVATE void _sg_reset_buffer(_sg_buffer_t* buf) {
     buf->slot.state = SG_RESOURCESTATE_ALLOC;
 }
 
-_SOKOL_PRIVATE void _sg_reset_image(_sg_image_t* img) {
+_SOKOL_PRIVATE void _sg_reset_image_to_alloc_state(_sg_image_t* img) {
     SOKOL_ASSERT(img);
     _sg_slot_t slot = img->slot;
     _sg_clear(img, sizeof(_sg_image_t));
@@ -13875,7 +13875,7 @@ _SOKOL_PRIVATE void _sg_reset_image(_sg_image_t* img) {
     img->slot.state = SG_RESOURCESTATE_ALLOC;
 }
 
-_SOKOL_PRIVATE void _sg_reset_shader(_sg_shader_t* shd) {
+_SOKOL_PRIVATE void _sg_reset_shader_to_alloc_state(_sg_shader_t* shd) {
     SOKOL_ASSERT(shd);
     _sg_slot_t slot = shd->slot;
     _sg_clear(shd, sizeof(_sg_shader_t));
@@ -13883,7 +13883,7 @@ _SOKOL_PRIVATE void _sg_reset_shader(_sg_shader_t* shd) {
     shd->slot.state = SG_RESOURCESTATE_ALLOC;
 }
 
-_SOKOL_PRIVATE void _sg_reset_pipeline(_sg_pipeline_t* pip) {
+_SOKOL_PRIVATE void _sg_reset_pipeline_to_alloc_state(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
     _sg_slot_t slot = pip->slot;
     _sg_clear(pip, sizeof(_sg_pipeline_t));
@@ -13891,7 +13891,7 @@ _SOKOL_PRIVATE void _sg_reset_pipeline(_sg_pipeline_t* pip) {
     pip->slot.state = SG_RESOURCESTATE_ALLOC;
 }
 
-_SOKOL_PRIVATE void _sg_reset_pass(_sg_pass_t* pass) {
+_SOKOL_PRIVATE void _sg_reset_pass_to_alloc_state(_sg_pass_t* pass) {
     SOKOL_ASSERT(pass);
     _sg_slot_t slot = pass->slot;
     _sg_clear(pass, sizeof(_sg_pass_t));
@@ -13899,7 +13899,7 @@ _SOKOL_PRIVATE void _sg_reset_pass(_sg_pass_t* pass) {
     pass->slot.state = SG_RESOURCESTATE_ALLOC;
 }
 
-_SOKOL_PRIVATE void _sg_reset_context(_sg_context_t* ctx) {
+_SOKOL_PRIVATE void _sg_reset_context_to_alloc_state(_sg_context_t* ctx) {
     SOKOL_ASSERT(ctx);
     _sg_slot_t slot = ctx->slot;
     _sg_clear(ctx, sizeof(_sg_context_t));
@@ -14094,7 +14094,7 @@ _SOKOL_PRIVATE _sg_context_t* _sg_lookup_context(const _sg_pools_t* p, uint32_t 
     return 0;
 }
 
-_SOKOL_PRIVATE void _sg_destroy_all_resources(_sg_pools_t* p, uint32_t ctx_id) {
+_SOKOL_PRIVATE void _sg_discard_all_resources(_sg_pools_t* p, uint32_t ctx_id) {
     /*  this is a bit dumb since it loops over all pool slots to
         find the occupied slots, on the other hand it is only ever
         executed at shutdown
@@ -14106,7 +14106,7 @@ _SOKOL_PRIVATE void _sg_destroy_all_resources(_sg_pools_t* p, uint32_t ctx_id) {
         if (p->buffers[i].slot.ctx_id == ctx_id) {
             sg_resource_state state = p->buffers[i].slot.state;
             if ((state == SG_RESOURCESTATE_VALID) || (state == SG_RESOURCESTATE_FAILED)) {
-                _sg_destroy_buffer(&p->buffers[i]);
+                _sg_discard_buffer(&p->buffers[i]);
             }
         }
     }
@@ -14114,7 +14114,7 @@ _SOKOL_PRIVATE void _sg_destroy_all_resources(_sg_pools_t* p, uint32_t ctx_id) {
         if (p->images[i].slot.ctx_id == ctx_id) {
             sg_resource_state state = p->images[i].slot.state;
             if ((state == SG_RESOURCESTATE_VALID) || (state == SG_RESOURCESTATE_FAILED)) {
-                _sg_destroy_image(&p->images[i]);
+                _sg_discard_image(&p->images[i]);
             }
         }
     }
@@ -14122,7 +14122,7 @@ _SOKOL_PRIVATE void _sg_destroy_all_resources(_sg_pools_t* p, uint32_t ctx_id) {
         if (p->shaders[i].slot.ctx_id == ctx_id) {
             sg_resource_state state = p->shaders[i].slot.state;
             if ((state == SG_RESOURCESTATE_VALID) || (state == SG_RESOURCESTATE_FAILED)) {
-                _sg_destroy_shader(&p->shaders[i]);
+                _sg_discard_shader(&p->shaders[i]);
             }
         }
     }
@@ -14130,7 +14130,7 @@ _SOKOL_PRIVATE void _sg_destroy_all_resources(_sg_pools_t* p, uint32_t ctx_id) {
         if (p->pipelines[i].slot.ctx_id == ctx_id) {
             sg_resource_state state = p->pipelines[i].slot.state;
             if ((state == SG_RESOURCESTATE_VALID) || (state == SG_RESOURCESTATE_FAILED)) {
-                _sg_destroy_pipeline(&p->pipelines[i]);
+                _sg_discard_pipeline(&p->pipelines[i]);
             }
         }
     }
@@ -14138,7 +14138,7 @@ _SOKOL_PRIVATE void _sg_destroy_all_resources(_sg_pools_t* p, uint32_t ctx_id) {
         if (p->passes[i].slot.ctx_id == ctx_id) {
             sg_resource_state state = p->passes[i].slot.state;
             if ((state == SG_RESOURCESTATE_VALID) || (state == SG_RESOURCESTATE_FAILED)) {
-                _sg_destroy_pass(&p->passes[i]);
+                _sg_discard_pass(&p->passes[i]);
             }
         }
     }
@@ -15124,50 +15124,39 @@ _SOKOL_PRIVATE sg_pass _sg_alloc_pass(void) {
     return res;
 }
 
-_SOKOL_PRIVATE void _sg_dealloc_buffer(sg_buffer buf_id) {
-    SOKOL_ASSERT(buf_id.id != SG_INVALID_ID);
-    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+_SOKOL_PRIVATE void _sg_dealloc_buffer(_sg_buffer_t* buf) {
     SOKOL_ASSERT(buf && buf->slot.state == SG_RESOURCESTATE_ALLOC);
     _sg_reset_slot(&buf->slot);
-    _sg_pool_free_index(&_sg.pools.buffer_pool, _sg_slot_index(buf_id.id));
+    _sg_pool_free_index(&_sg.pools.buffer_pool, _sg_slot_index(buf->slot.id));
 }
 
-_SOKOL_PRIVATE void _sg_dealloc_image(sg_image img_id) {
-    SOKOL_ASSERT(img_id.id != SG_INVALID_ID);
-    _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
+_SOKOL_PRIVATE void _sg_dealloc_image(_sg_image_t* img) {
     SOKOL_ASSERT(img && img->slot.state == SG_RESOURCESTATE_ALLOC);
     _sg_reset_slot(&img->slot);
-    _sg_pool_free_index(&_sg.pools.image_pool, _sg_slot_index(img_id.id));
+    _sg_pool_free_index(&_sg.pools.image_pool, _sg_slot_index(img->slot.id));
 }
 
-_SOKOL_PRIVATE void _sg_dealloc_shader(sg_shader shd_id) {
-    SOKOL_ASSERT(shd_id.id != SG_INVALID_ID);
-    _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
+_SOKOL_PRIVATE void _sg_dealloc_shader(_sg_shader_t* shd) {
     SOKOL_ASSERT(shd && shd->slot.state == SG_RESOURCESTATE_ALLOC);
     _sg_reset_slot(&shd->slot);
-    _sg_pool_free_index(&_sg.pools.shader_pool, _sg_slot_index(shd_id.id));
+    _sg_pool_free_index(&_sg.pools.shader_pool, _sg_slot_index(shd->slot.id));
 }
 
-_SOKOL_PRIVATE void _sg_dealloc_pipeline(sg_pipeline pip_id) {
-    SOKOL_ASSERT(pip_id.id != SG_INVALID_ID);
-    _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
+_SOKOL_PRIVATE void _sg_dealloc_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip && pip->slot.state == SG_RESOURCESTATE_ALLOC);
     _sg_reset_slot(&pip->slot);
-    _sg_pool_free_index(&_sg.pools.pipeline_pool, _sg_slot_index(pip_id.id));
+    _sg_pool_free_index(&_sg.pools.pipeline_pool, _sg_slot_index(pip->slot.id));
 }
 
-_SOKOL_PRIVATE void _sg_dealloc_pass(sg_pass pass_id) {
-    SOKOL_ASSERT(pass_id.id != SG_INVALID_ID);
-    _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
+_SOKOL_PRIVATE void _sg_dealloc_pass(_sg_pass_t* pass) {
     SOKOL_ASSERT(pass && pass->slot.state == SG_RESOURCESTATE_ALLOC);
     _sg_reset_slot(&pass->slot);
-    _sg_pool_free_index(&_sg.pools.pass_pool, _sg_slot_index(pass_id.id));
+    _sg_pool_free_index(&_sg.pools.pass_pool, _sg_slot_index(pass->slot.id));
 }
 
-_SOKOL_PRIVATE void _sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc) {
-    SOKOL_ASSERT(buf_id.id != SG_INVALID_ID && desc);
-    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
-    SOKOL_ASSERT(buf && buf->slot.state == SG_RESOURCESTATE_ALLOC);
+_SOKOL_PRIVATE void _sg_init_buffer(_sg_buffer_t* buf, const sg_buffer_desc* desc) {
+    SOKOL_ASSERT(buf && (buf->slot.state == SG_RESOURCESTATE_ALLOC));
+    SOKOL_ASSERT(desc);
     buf->slot.ctx_id = _sg.active_context.id;
     if (_sg_validate_buffer_desc(desc)) {
         buf->slot.state = _sg_create_buffer(buf, desc);
@@ -15178,10 +15167,9 @@ _SOKOL_PRIVATE void _sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc
     SOKOL_ASSERT((buf->slot.state == SG_RESOURCESTATE_VALID)||(buf->slot.state == SG_RESOURCESTATE_FAILED));
 }
 
-_SOKOL_PRIVATE void _sg_init_image(sg_image img_id, const sg_image_desc* desc) {
-    SOKOL_ASSERT(img_id.id != SG_INVALID_ID && desc);
-    _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
-    SOKOL_ASSERT(img && img->slot.state == SG_RESOURCESTATE_ALLOC);
+_SOKOL_PRIVATE void _sg_init_image(_sg_image_t* img, const sg_image_desc* desc) {
+    SOKOL_ASSERT(img && (img->slot.state == SG_RESOURCESTATE_ALLOC));
+    SOKOL_ASSERT(desc);
     img->slot.ctx_id = _sg.active_context.id;
     if (_sg_validate_image_desc(desc)) {
         img->slot.state = _sg_create_image(img, desc);
@@ -15192,10 +15180,9 @@ _SOKOL_PRIVATE void _sg_init_image(sg_image img_id, const sg_image_desc* desc) {
     SOKOL_ASSERT((img->slot.state == SG_RESOURCESTATE_VALID)||(img->slot.state == SG_RESOURCESTATE_FAILED));
 }
 
-_SOKOL_PRIVATE void _sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc) {
-    SOKOL_ASSERT(shd_id.id != SG_INVALID_ID && desc);
-    _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
-    SOKOL_ASSERT(shd && shd->slot.state == SG_RESOURCESTATE_ALLOC);
+_SOKOL_PRIVATE void _sg_init_shader(_sg_shader_t* shd, const sg_shader_desc* desc) {
+    SOKOL_ASSERT(shd && (shd->slot.state == SG_RESOURCESTATE_ALLOC));
+    SOKOL_ASSERT(desc);
     shd->slot.ctx_id = _sg.active_context.id;
     if (_sg_validate_shader_desc(desc)) {
         shd->slot.state = _sg_create_shader(shd, desc);
@@ -15206,10 +15193,9 @@ _SOKOL_PRIVATE void _sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc
     SOKOL_ASSERT((shd->slot.state == SG_RESOURCESTATE_VALID)||(shd->slot.state == SG_RESOURCESTATE_FAILED));
 }
 
-_SOKOL_PRIVATE void _sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc) {
-    SOKOL_ASSERT(pip_id.id != SG_INVALID_ID && desc);
-    _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
-    SOKOL_ASSERT(pip && pip->slot.state == SG_RESOURCESTATE_ALLOC);
+_SOKOL_PRIVATE void _sg_init_pipeline(_sg_pipeline_t* pip, const sg_pipeline_desc* desc) {
+    SOKOL_ASSERT(pip && (pip->slot.state == SG_RESOURCESTATE_ALLOC));
+    SOKOL_ASSERT(desc);
     pip->slot.ctx_id = _sg.active_context.id;
     if (_sg_validate_pipeline_desc(desc)) {
         _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, desc->shader.id);
@@ -15226,10 +15212,9 @@ _SOKOL_PRIVATE void _sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc
     SOKOL_ASSERT((pip->slot.state == SG_RESOURCESTATE_VALID)||(pip->slot.state == SG_RESOURCESTATE_FAILED));
 }
 
-_SOKOL_PRIVATE void _sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc) {
-    SOKOL_ASSERT(pass_id.id != SG_INVALID_ID && desc);
-    _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
+_SOKOL_PRIVATE void _sg_init_pass(_sg_pass_t* pass, const sg_pass_desc* desc) {
     SOKOL_ASSERT(pass && pass->slot.state == SG_RESOURCESTATE_ALLOC);
+    SOKOL_ASSERT(desc);
     pass->slot.ctx_id = _sg.active_context.id;
     if (_sg_validate_pass_desc(desc)) {
         /* lookup pass attachment image pointers */
@@ -15261,84 +15246,64 @@ _SOKOL_PRIVATE void _sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc) {
     SOKOL_ASSERT((pass->slot.state == SG_RESOURCESTATE_VALID)||(pass->slot.state == SG_RESOURCESTATE_FAILED));
 }
 
-_SOKOL_PRIVATE bool _sg_uninit_buffer(sg_buffer buf_id) {
-    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
-    if (buf) {
-        if (buf->slot.ctx_id == _sg.active_context.id) {
-            _sg_destroy_buffer(buf);
-            _sg_reset_buffer(buf);
-            return true;
-        }
-        else {
-            SG_LOG("_sg_uninit_buffer: active context mismatch (must be same as for creation)");
-            _SG_TRACE_NOARGS(err_context_mismatch);
-        }
+_SOKOL_PRIVATE void _sg_uninit_buffer(_sg_buffer_t* buf) {
+    SOKOL_ASSERT(buf && ((buf->slot.state == SG_RESOURCESTATE_VALID) || (buf->slot.state == SG_RESOURCESTATE_FAILED)));
+    if (buf->slot.ctx_id == _sg.active_context.id) {
+        _sg_discard_buffer(buf);
+        _sg_reset_buffer_to_alloc_state(buf);
     }
-    return false;
+    else {
+        SG_LOG("_sg_uninit_buffer: active context mismatch (must be same as for creation)");
+        _SG_TRACE_NOARGS(err_context_mismatch);
+    }
 }
 
-_SOKOL_PRIVATE bool _sg_uninit_image(sg_image img_id) {
-    _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
-    if (img) {
-        if (img->slot.ctx_id == _sg.active_context.id) {
-            _sg_destroy_image(img);
-            _sg_reset_image(img);
-            return true;
-        }
-        else {
-            SG_LOG("_sg_uninit_image: active context mismatch (must be same as for creation)");
-            _SG_TRACE_NOARGS(err_context_mismatch);
-        }
+_SOKOL_PRIVATE void _sg_uninit_image(_sg_image_t* img) {
+    SOKOL_ASSERT(img && ((img->slot.state == SG_RESOURCESTATE_VALID) || (img->slot.state == SG_RESOURCESTATE_FAILED)));
+    if (img->slot.ctx_id == _sg.active_context.id) {
+        _sg_discard_image(img);
+        _sg_reset_image_to_alloc_state(img);
     }
-    return false;
+    else {
+        SG_LOG("_sg_uninit_image: active context mismatch (must be same as for creation)");
+        _SG_TRACE_NOARGS(err_context_mismatch);
+    }
 }
 
-_SOKOL_PRIVATE bool _sg_uninit_shader(sg_shader shd_id) {
-    _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
-    if (shd) {
-        if (shd->slot.ctx_id == _sg.active_context.id) {
-            _sg_destroy_shader(shd);
-            _sg_reset_shader(shd);
-            return true;
-        }
-        else {
-            SG_LOG("_sg_uninit_shader: active context mismatch (must be same as for creation)");
-            _SG_TRACE_NOARGS(err_context_mismatch);
-        }
+_SOKOL_PRIVATE void _sg_uninit_shader(_sg_shader_t* shd) {
+    SOKOL_ASSERT(shd && ((shd->slot.state == SG_RESOURCESTATE_VALID) || (shd->slot.state == SG_RESOURCESTATE_FAILED)));
+    if (shd->slot.ctx_id == _sg.active_context.id) {
+        _sg_discard_shader(shd);
+        _sg_reset_shader_to_alloc_state(shd);
     }
-    return false;
+    else {
+        SG_LOG("_sg_uninit_shader: active context mismatch (must be same as for creation)");
+        _SG_TRACE_NOARGS(err_context_mismatch);
+    }
 }
 
-_SOKOL_PRIVATE bool _sg_uninit_pipeline(sg_pipeline pip_id) {
-    _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
-    if (pip) {
-        if (pip->slot.ctx_id == _sg.active_context.id) {
-            _sg_destroy_pipeline(pip);
-            _sg_reset_pipeline(pip);
-            return true;
-        }
-        else {
-            SG_LOG("_sg_uninit_pipeline: active context mismatch (must be same as for creation)");
-            _SG_TRACE_NOARGS(err_context_mismatch);
-        }
+_SOKOL_PRIVATE void _sg_uninit_pipeline(_sg_pipeline_t* pip) {
+    SOKOL_ASSERT(pip && ((pip->slot.state == SG_RESOURCESTATE_VALID) || (pip->slot.state == SG_RESOURCESTATE_FAILED)));
+    if (pip->slot.ctx_id == _sg.active_context.id) {
+        _sg_discard_pipeline(pip);
+        _sg_reset_pipeline_to_alloc_state(pip);
     }
-    return false;
+    else {
+        SG_LOG("_sg_uninit_pipeline: active context mismatch (must be same as for creation)");
+        _SG_TRACE_NOARGS(err_context_mismatch);
+    }
 }
 
-_SOKOL_PRIVATE bool _sg_uninit_pass(sg_pass pass_id) {
-    _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
-    if (pass) {
-        if (pass->slot.ctx_id == _sg.active_context.id) {
-            _sg_destroy_pass(pass);
-            _sg_reset_pass(pass);
-            return true;
-        }
-        else {
-            SG_LOG("_sg_uninit_pass: active context mismatch (must be same as for creation)");
-            _SG_TRACE_NOARGS(err_context_mismatch);
-        }
+_SOKOL_PRIVATE void _sg_uninit_pass(_sg_pass_t* pass) {
+    SOKOL_ASSERT(pass && ((pass->slot.state == SG_RESOURCESTATE_VALID) || (pass->slot.state == SG_RESOURCESTATE_FAILED)));
+    if (pass->slot.ctx_id == _sg.active_context.id) {
+        _sg_discard_pass(pass);
+        _sg_reset_pass_to_alloc_state(pass);
     }
-    return false;
+    else {
+        SG_LOG("_sg_uninit_pass: active context mismatch (must be same as for creation)");
+        _SG_TRACE_NOARGS(err_context_mismatch);
+    }
 }
 
 _SOKOL_PRIVATE void _sg_setup_commit_listeners(const sg_desc* desc) {
@@ -15469,8 +15434,8 @@ SOKOL_API_IMPL void sg_shutdown(void) {
     if (_sg.active_context.id != SG_INVALID_ID) {
         _sg_context_t* ctx = _sg_lookup_context(&_sg.pools, _sg.active_context.id);
         if (ctx) {
-            _sg_destroy_all_resources(&_sg.pools, _sg.active_context.id);
-            _sg_destroy_context(ctx);
+            _sg_discard_all_resources(&_sg.pools, _sg.active_context.id);
+            _sg_discard_context(ctx);
         }
     }
     _sg_discard_backend();
@@ -15531,11 +15496,11 @@ SOKOL_API_IMPL sg_context sg_setup_context(void) {
 
 SOKOL_API_IMPL void sg_discard_context(sg_context ctx_id) {
     SOKOL_ASSERT(_sg.valid);
-    _sg_destroy_all_resources(&_sg.pools, ctx_id.id);
+    _sg_discard_all_resources(&_sg.pools, ctx_id.id);
     _sg_context_t* ctx = _sg_lookup_context(&_sg.pools, ctx_id.id);
     if (ctx) {
-        _sg_destroy_context(ctx);
-        _sg_reset_context(ctx);
+        _sg_discard_context(ctx);
+        _sg_reset_context_to_alloc_state(ctx);
         _sg_reset_slot(&ctx->slot);
         _sg_pool_free_index(&_sg.pools.context_pool, _sg_slot_index(ctx_id.id));
     }
@@ -15602,152 +15567,192 @@ SOKOL_API_IMPL sg_pass sg_alloc_pass(void) {
 
 SOKOL_API_IMPL void sg_dealloc_buffer(sg_buffer buf_id) {
     SOKOL_ASSERT(_sg.valid);
-    _sg_dealloc_buffer(buf_id);
+    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+    if (buf) {
+        _sg_dealloc_buffer(buf);
+    }
     _SG_TRACE_ARGS(dealloc_buffer, buf_id);
 }
 
 SOKOL_API_IMPL void sg_dealloc_image(sg_image img_id) {
     SOKOL_ASSERT(_sg.valid);
-    _sg_dealloc_image(img_id);
+    _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
+    if (img) {
+        _sg_dealloc_image(img);
+    }
     _SG_TRACE_ARGS(dealloc_image, img_id);
 }
 
 SOKOL_API_IMPL void sg_dealloc_shader(sg_shader shd_id) {
     SOKOL_ASSERT(_sg.valid);
-    _sg_dealloc_shader(shd_id);
+    _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
+    if (shd) {
+        _sg_dealloc_shader(shd);
+    }
     _SG_TRACE_ARGS(dealloc_shader, shd_id);
 }
 
 SOKOL_API_IMPL void sg_dealloc_pipeline(sg_pipeline pip_id) {
     SOKOL_ASSERT(_sg.valid);
-    _sg_dealloc_pipeline(pip_id);
+    _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
+    if (pip) {
+        _sg_dealloc_pipeline(pip);
+    }
     _SG_TRACE_ARGS(dealloc_pipeline, pip_id);
 }
 
 SOKOL_API_IMPL void sg_dealloc_pass(sg_pass pass_id) {
     SOKOL_ASSERT(_sg.valid);
-    _sg_dealloc_pass(pass_id);
+    _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
+    if (pass) {
+        _sg_dealloc_pass(pass);
+    }
     _SG_TRACE_ARGS(dealloc_pass, pass_id);
 }
 
 SOKOL_API_IMPL void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
-    sg_buffer_desc desc_def = _sg_buffer_desc_defaults(desc);
-    _sg_init_buffer(buf_id, &desc_def);
+    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+    if (buf && (buf->slot.state == SG_RESOURCESTATE_ALLOC)) {
+        sg_buffer_desc desc_def = _sg_buffer_desc_defaults(desc);
+        _sg_init_buffer(buf, &desc_def);
+    }
     _SG_TRACE_ARGS(init_buffer, buf_id, &desc_def);
 }
 
 SOKOL_API_IMPL void sg_init_image(sg_image img_id, const sg_image_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
-    sg_image_desc desc_def = _sg_image_desc_defaults(desc);
-    _sg_init_image(img_id, &desc_def);
+    _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
+    if (img && (img->slot.state == SG_RESOURCESTATE_ALLOC)) {
+        sg_image_desc desc_def = _sg_image_desc_defaults(desc);
+        _sg_init_image(img, &desc_def);
+    }
     _SG_TRACE_ARGS(init_image, img_id, &desc_def);
 }
 
 SOKOL_API_IMPL void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
-    sg_shader_desc desc_def = _sg_shader_desc_defaults(desc);
-    _sg_init_shader(shd_id, &desc_def);
+    _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
+    if (shd && (shd->slot.state == SG_RESOURCESTATE_ALLOC)) {
+        sg_shader_desc desc_def = _sg_shader_desc_defaults(desc);
+        _sg_init_shader(shd, &desc_def);
+    }
     _SG_TRACE_ARGS(init_shader, shd_id, &desc_def);
 }
 
 SOKOL_API_IMPL void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
-    sg_pipeline_desc desc_def = _sg_pipeline_desc_defaults(desc);
-    _sg_init_pipeline(pip_id, &desc_def);
+    _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
+    if (pip && (pip->slot.state == SG_RESOURCESTATE_ALLOC)) {
+        sg_pipeline_desc desc_def = _sg_pipeline_desc_defaults(desc);
+        _sg_init_pipeline(pip, &desc_def);
+    }
     _SG_TRACE_ARGS(init_pipeline, pip_id, &desc_def);
 }
 
 SOKOL_API_IMPL void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
-    sg_pass_desc desc_def = _sg_pass_desc_defaults(desc);
-    _sg_init_pass(pass_id, &desc_def);
+    _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
+    if (pass && (pass->slot.state == SG_RESOURCESTATE_ALLOC)) {
+        sg_pass_desc desc_def = _sg_pass_desc_defaults(desc);
+        _sg_init_pass(pass, &desc_def);
+    }
     _SG_TRACE_ARGS(init_pass, pass_id, &desc_def);
 }
 
-SOKOL_API_IMPL bool sg_uninit_buffer(sg_buffer buf_id) {
+SOKOL_API_IMPL void sg_uninit_buffer(sg_buffer buf_id) {
     SOKOL_ASSERT(_sg.valid);
-    bool res = _sg_uninit_buffer(buf_id);
+    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+    if (buf && ((buf->slot.state == SG_RESOURCESTATE_VALID) || (buf->slot.state == SG_RESOURCESTATE_FAILED))) {
+        _sg_uninit_buffer(buf);
+    }
     _SG_TRACE_ARGS(uninit_buffer, buf_id);
-    return res;
 }
 
-SOKOL_API_IMPL bool sg_uninit_image(sg_image img_id) {
+SOKOL_API_IMPL void sg_uninit_image(sg_image img_id) {
     SOKOL_ASSERT(_sg.valid);
-    bool res = _sg_uninit_image(img_id);
+    _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
+    if (img && ((img->slot.state == SG_RESOURCESTATE_VALID) || (img->slot.state == SG_RESOURCESTATE_FAILED))) {
+        _sg_uninit_image(img);
+    }
     _SG_TRACE_ARGS(uninit_image, img_id);
-    return res;
 }
 
-SOKOL_API_IMPL bool sg_uninit_shader(sg_shader shd_id) {
+SOKOL_API_IMPL void sg_uninit_shader(sg_shader shd_id) {
     SOKOL_ASSERT(_sg.valid);
-    bool res = _sg_uninit_shader(shd_id);
+    _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
+    if (shd && ((shd->slot.state == SG_RESOURCESTATE_VALID) || (shd->slot.state == SG_RESOURCESTATE_FAILED))) {
+        _sg_uninit_shader(shd);
+    }
     _SG_TRACE_ARGS(uninit_shader, shd_id);
-    return res;
 }
 
-SOKOL_API_IMPL bool sg_uninit_pipeline(sg_pipeline pip_id) {
+SOKOL_API_IMPL void sg_uninit_pipeline(sg_pipeline pip_id) {
     SOKOL_ASSERT(_sg.valid);
-    bool res = _sg_uninit_pipeline(pip_id);
+    _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
+    if (pip && ((pip->slot.state == SG_RESOURCESTATE_VALID) || (pip->slot.state == SG_RESOURCESTATE_FAILED))) {
+        _sg_uninit_pipeline(pip);
+    }
     _SG_TRACE_ARGS(uninit_pipeline, pip_id);
-    return res;
 }
 
-SOKOL_API_IMPL bool sg_uninit_pass(sg_pass pass_id) {
+SOKOL_API_IMPL void sg_uninit_pass(sg_pass pass_id) {
     SOKOL_ASSERT(_sg.valid);
-    bool res = _sg_uninit_pass(pass_id);
+    _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
+    if (pass && ((pass->slot.state == SG_RESOURCESTATE_VALID) || (pass->slot.state == SG_RESOURCESTATE_FAILED))) {
+        _sg_uninit_pass(pass);
+    }
     _SG_TRACE_ARGS(uninit_pass, pass_id);
-    return res;
 }
 
 /*-- set allocated resource to failed state ----------------------------------*/
 SOKOL_API_IMPL void sg_fail_buffer(sg_buffer buf_id) {
     SOKOL_ASSERT(_sg.valid);
-    SOKOL_ASSERT(buf_id.id != SG_INVALID_ID);
     _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
-    SOKOL_ASSERT(buf && buf->slot.state == SG_RESOURCESTATE_ALLOC);
-    buf->slot.ctx_id = _sg.active_context.id;
-    buf->slot.state = SG_RESOURCESTATE_FAILED;
+    if (buf && buf->slot.state == SG_RESOURCESTATE_ALLOC) {
+        buf->slot.ctx_id = _sg.active_context.id;
+        buf->slot.state = SG_RESOURCESTATE_FAILED;
+    }
     _SG_TRACE_ARGS(fail_buffer, buf_id);
 }
 
 SOKOL_API_IMPL void sg_fail_image(sg_image img_id) {
     SOKOL_ASSERT(_sg.valid);
-    SOKOL_ASSERT(img_id.id != SG_INVALID_ID);
     _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
-    SOKOL_ASSERT(img && img->slot.state == SG_RESOURCESTATE_ALLOC);
-    img->slot.ctx_id = _sg.active_context.id;
-    img->slot.state = SG_RESOURCESTATE_FAILED;
+    if (img && img->slot.state == SG_RESOURCESTATE_ALLOC) {
+        img->slot.ctx_id = _sg.active_context.id;
+        img->slot.state = SG_RESOURCESTATE_FAILED;
+    }
     _SG_TRACE_ARGS(fail_image, img_id);
 }
 
 SOKOL_API_IMPL void sg_fail_shader(sg_shader shd_id) {
     SOKOL_ASSERT(_sg.valid);
-    SOKOL_ASSERT(shd_id.id != SG_INVALID_ID);
     _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
-    SOKOL_ASSERT(shd && shd->slot.state == SG_RESOURCESTATE_ALLOC);
-    shd->slot.ctx_id = _sg.active_context.id;
-    shd->slot.state = SG_RESOURCESTATE_FAILED;
+    if (shd && shd->slot.state == SG_RESOURCESTATE_ALLOC) {
+        shd->slot.ctx_id = _sg.active_context.id;
+        shd->slot.state = SG_RESOURCESTATE_FAILED;
+    }
     _SG_TRACE_ARGS(fail_shader, shd_id);
 }
 
 SOKOL_API_IMPL void sg_fail_pipeline(sg_pipeline pip_id) {
     SOKOL_ASSERT(_sg.valid);
-    SOKOL_ASSERT(pip_id.id != SG_INVALID_ID);
     _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
-    SOKOL_ASSERT(pip && pip->slot.state == SG_RESOURCESTATE_ALLOC);
-    pip->slot.ctx_id = _sg.active_context.id;
-    pip->slot.state = SG_RESOURCESTATE_FAILED;
+    if (pip && pip->slot.state == SG_RESOURCESTATE_ALLOC) {
+        pip->slot.ctx_id = _sg.active_context.id;
+        pip->slot.state = SG_RESOURCESTATE_FAILED;
+    }
     _SG_TRACE_ARGS(fail_pipeline, pip_id);
 }
 
 SOKOL_API_IMPL void sg_fail_pass(sg_pass pass_id) {
     SOKOL_ASSERT(_sg.valid);
-    SOKOL_ASSERT(pass_id.id != SG_INVALID_ID);
     _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
-    SOKOL_ASSERT(pass && pass->slot.state == SG_RESOURCESTATE_ALLOC);
-    pass->slot.ctx_id = _sg.active_context.id;
-    pass->slot.state = SG_RESOURCESTATE_FAILED;
+    if (pass && pass->slot.state == SG_RESOURCESTATE_ALLOC) {
+        pass->slot.ctx_id = _sg.active_context.id;
+        pass->slot.state = SG_RESOURCESTATE_FAILED;
+    }
     _SG_TRACE_ARGS(fail_pass, pass_id);
 }
 
@@ -15791,10 +15796,10 @@ SOKOL_API_IMPL sg_resource_state sg_query_pass_state(sg_pass pass_id) {
 SOKOL_API_IMPL sg_buffer sg_make_buffer(const sg_buffer_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     SOKOL_ASSERT(desc);
-    sg_buffer_desc desc_def = _sg_buffer_desc_defaults(desc);
     sg_buffer buf_id = _sg_alloc_buffer();
     if (buf_id.id != SG_INVALID_ID) {
-        _sg_init_buffer(buf_id, &desc_def);
+        sg_buffer_desc desc_def = _sg_buffer_desc_defaults(desc);
+        _sg_init_buffer(_sg_buffer_at(&_sg.pools, buf_id.id), &desc_def);
     }
     else {
         SG_LOG("buffer pool exhausted!");
@@ -15810,7 +15815,7 @@ SOKOL_API_IMPL sg_image sg_make_image(const sg_image_desc* desc) {
     sg_image_desc desc_def = _sg_image_desc_defaults(desc);
     sg_image img_id = _sg_alloc_image();
     if (img_id.id != SG_INVALID_ID) {
-        _sg_init_image(img_id, &desc_def);
+        _sg_init_image(_sg_image_at(&_sg.pools, img_id.id), &desc_def);
     }
     else {
         SG_LOG("image pool exhausted!");
@@ -15826,7 +15831,7 @@ SOKOL_API_IMPL sg_shader sg_make_shader(const sg_shader_desc* desc) {
     sg_shader_desc desc_def = _sg_shader_desc_defaults(desc);
     sg_shader shd_id = _sg_alloc_shader();
     if (shd_id.id != SG_INVALID_ID) {
-        _sg_init_shader(shd_id, &desc_def);
+        _sg_init_shader(_sg_shader_at(&_sg.pools, shd_id.id), &desc_def);
     }
     else {
         SG_LOG("shader pool exhausted!");
@@ -15842,7 +15847,7 @@ SOKOL_API_IMPL sg_pipeline sg_make_pipeline(const sg_pipeline_desc* desc) {
     sg_pipeline_desc desc_def = _sg_pipeline_desc_defaults(desc);
     sg_pipeline pip_id = _sg_alloc_pipeline();
     if (pip_id.id != SG_INVALID_ID) {
-        _sg_init_pipeline(pip_id, &desc_def);
+        _sg_init_pipeline(_sg_pipeline_at(&_sg.pools, pip_id.id), &desc_def);
     }
     else {
         SG_LOG("pipeline pool exhausted!");
@@ -15858,7 +15863,7 @@ SOKOL_API_IMPL sg_pass sg_make_pass(const sg_pass_desc* desc) {
     sg_pass_desc desc_def = _sg_pass_desc_defaults(desc);
     sg_pass pass_id = _sg_alloc_pass();
     if (pass_id.id != SG_INVALID_ID) {
-        _sg_init_pass(pass_id, &desc_def);
+        _sg_init_pass(_sg_pass_at(&_sg.pools, pass_id.id), &desc_def);
     }
     else {
         SG_LOG("pass pool exhausted!");
@@ -15872,40 +15877,60 @@ SOKOL_API_IMPL sg_pass sg_make_pass(const sg_pass_desc* desc) {
 SOKOL_API_IMPL void sg_destroy_buffer(sg_buffer buf_id) {
     SOKOL_ASSERT(_sg.valid);
     _SG_TRACE_ARGS(destroy_buffer, buf_id);
-    if (_sg_uninit_buffer(buf_id)) {
-        _sg_dealloc_buffer(buf_id);
+    _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+    if (buf) {
+        if ((buf->slot.state == SG_RESOURCESTATE_VALID) || (buf->slot.state == SG_RESOURCESTATE_FAILED)) {
+            _sg_uninit_buffer(buf);
+        }
+        _sg_dealloc_buffer(buf);
     }
 }
 
 SOKOL_API_IMPL void sg_destroy_image(sg_image img_id) {
     SOKOL_ASSERT(_sg.valid);
     _SG_TRACE_ARGS(destroy_image, img_id);
-    if (_sg_uninit_image(img_id)) {
-        _sg_dealloc_image(img_id);
+    _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
+    if (img) {
+        if ((img->slot.state == SG_RESOURCESTATE_VALID) || (img->slot.state == SG_RESOURCESTATE_FAILED)) {
+            _sg_uninit_image(img);
+        }
+        _sg_dealloc_image(img);
     }
 }
 
 SOKOL_API_IMPL void sg_destroy_shader(sg_shader shd_id) {
     SOKOL_ASSERT(_sg.valid);
     _SG_TRACE_ARGS(destroy_shader, shd_id);
-    if (_sg_uninit_shader(shd_id)) {
-        _sg_dealloc_shader(shd_id);
+    _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
+    if (shd) {
+        if ((shd->slot.state == SG_RESOURCESTATE_VALID) || (shd->slot.state == SG_RESOURCESTATE_FAILED)) {
+            _sg_uninit_shader(shd);
+        }
+        _sg_dealloc_shader(shd);
     }
 }
 
 SOKOL_API_IMPL void sg_destroy_pipeline(sg_pipeline pip_id) {
     SOKOL_ASSERT(_sg.valid);
     _SG_TRACE_ARGS(destroy_pipeline, pip_id);
-    if (_sg_uninit_pipeline(pip_id)) {
-        _sg_dealloc_pipeline(pip_id);
+    _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
+    if (pip) {
+        if ((pip->slot.state == SG_RESOURCESTATE_VALID) || (pip->slot.state == SG_RESOURCESTATE_FAILED)) {
+            _sg_uninit_pipeline(pip);
+        }
+        _sg_dealloc_pipeline(pip);
     }
 }
 
 SOKOL_API_IMPL void sg_destroy_pass(sg_pass pass_id) {
     SOKOL_ASSERT(_sg.valid);
     _SG_TRACE_ARGS(destroy_pass, pass_id);
-    if (_sg_uninit_pass(pass_id)) {
-        _sg_dealloc_pass(pass_id);
+    _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
+    if (pass) {
+        if ((pass->slot.state == SG_RESOURCESTATE_VALID) || (pass->slot.state == SG_RESOURCESTATE_FAILED)) {
+            _sg_uninit_pass(pass);
+        }
+        _sg_dealloc_pass(pass);
     }
 }
 

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -15423,8 +15423,10 @@ _SOKOL_PRIVATE void _sg_init_pass(_sg_pass_t* pass, const sg_pass_desc* desc) {
         for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
             if (desc->color_attachments[i].image.id) {
                 att_imgs[i] = _sg_lookup_image(&_sg.pools, desc->color_attachments[i].image.id);
-                /* FIXME: this shouldn't be an assertion, but result in a SG_RESOURCESTATE_FAILED pass */
-                SOKOL_ASSERT(att_imgs[i] && att_imgs[i]->slot.state == SG_RESOURCESTATE_VALID);
+                if (!(att_imgs[i] && att_imgs[i]->slot.state == SG_RESOURCESTATE_VALID)) {
+                    pass->slot.state = SG_RESOURCESTATE_FAILED;
+                    return;
+                }
             }
             else {
                 att_imgs[i] = 0;
@@ -15433,8 +15435,10 @@ _SOKOL_PRIVATE void _sg_init_pass(_sg_pass_t* pass, const sg_pass_desc* desc) {
         const int ds_att_index = SG_MAX_COLOR_ATTACHMENTS;
         if (desc->depth_stencil_attachment.image.id) {
             att_imgs[ds_att_index] = _sg_lookup_image(&_sg.pools, desc->depth_stencil_attachment.image.id);
-            /* FIXME: this shouldn't be an assertion, but result in a SG_RESOURCESTATE_FAILED pass */
-            SOKOL_ASSERT(att_imgs[ds_att_index] && att_imgs[ds_att_index]->slot.state == SG_RESOURCESTATE_VALID);
+            if (!(att_imgs[ds_att_index] && att_imgs[ds_att_index]->slot.state == SG_RESOURCESTATE_VALID)) {
+                pass->slot.state = SG_RESOURCESTATE_FAILED;
+                return;
+            }
         }
         else {
             att_imgs[ds_att_index] = 0;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -771,7 +771,7 @@
         sg_pipeline sg_make_pipeline(const sg_pipeline_desc* desc)
         sg_pass sg_make_pass(const sg_pass_desc* desc)
 
-    The result will be either of three cases:
+    The result will be one of three cases:
 
         1. The returned handle is invalid. This happens when there are no more
            free slots in the resource pool for this resource type. An invalid
@@ -806,18 +806,18 @@
     of states:
 
         - INITIAL: the resource slot associated with the new resource is currently
-          free (technically, there is no resource yet, just a pool slot)
+          free (technically, there is no resource yet, just an empty pool slot)
         - ALLOC: a handle for the new resource has been allocated, this just means
           a pool slot has been reserved.
         - VALID or FAILED: in VALID state any 3D API backend resource objects have
           been successfully created, otherwise if anything went wrong, the resource
           will be in FAILED state.
 
-    Sometimes it makes sense to first grab a handle, but initialize the underlying
-    resource at a later time. For instance when loading data asynchronously from
-    a slow data source, you may know that you what buffers and textures
-    are needed at an early stage of the loading process, but actually loading
-    the buffer or texture content can only be completed at a later time.
+    Sometimes it makes sense to first grab a handle, but initialize the
+    underlying resource at a later time. For instance when loading data
+    asynchronously from a slow data source, you may know what buffers and
+    textures are needed at an early stage of the loading process, but actually
+    loading the buffer or texture content can only be completed at a later time.
 
     For such situations, sokol-gfx resource objects can be created in two steps.
     You can allocate a handle upfront with one of the 'alloc functions':
@@ -828,7 +828,7 @@
         sg_pipeline sg_alloc_pipeline(void)
         sg_pass sg_alloc_pass(void)
 
-    This will return a handle with the underlying resource object in an incomplete
+    This will return a handle with the underlying resource object in the
     ALLOC state:
 
         sg_image img = sg_alloc_image();
@@ -842,9 +842,9 @@
     that involve resources which are not in VALID state.
 
     At a later time (for instance once the texture has completed loading
-    asynchronously), the resource creation can be completed by calling
-    one of the 'init functions', those functions take a resource handle
-    and 'desc struct':
+    asynchronously), the resource creation can be completed by calling one of
+    the 'init functions', those functions take an existing resource handle and
+    'desc struct':
 
         void sg_init_buffer(sg_buffer buf, const sg_buffer_desc* desc)
         void sg_init_image(sg_image img, const sg_image_desc* desc)
@@ -870,8 +870,7 @@
     Calling the 'uninit functions' with a resource that is not in the VALID or
     FAILED state is a no-op.
 
-    To finally free the pool slot for recycling that has been reserved for a
-    resource in ALLOC state, call the 'dealloc functions':
+    To finally free the pool slot for recycling call the 'dealloc functions':
 
         void sg_dealloc_buffer(sg_buffer buf)
         void sg_dealloc_image(sg_image img)
@@ -895,7 +894,7 @@
     do the right thing (for instance if the resource is in ALLOC state, the destroy
     function will be equivalent to the 'dealloc function' and skip the 'uninit part').
 
-    And finally, to close the circle, the 'fail functions' can be called to manually
+    And finally to close the circle, the 'fail functions' can be called to manually
     put a resource in ALLOC state into the FAILED state:
 
         sg_fail_buffer(sg_buffer buf)

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2528,9 +2528,11 @@ typedef struct sg_pass_info {
     .pipeline_pool_size     64
     .pass_pool_size         16
     .context_pool_size      16
-    .sampler_cache_size     64
     .uniform_buffer_size    4 MB (4*1024*1024)
     .staging_buffer_size    8 MB (8*1024*1024)
+    .sampler_cache_size     64
+    .max_commit_listeners   1024
+    .disable_validation     false
 
     .allocator.alloc        0 (in this case, malloc() will be called)
     .allocator.free         0 (in this case, free() will be called)
@@ -2717,6 +2719,7 @@ typedef struct sg_desc {
     int staging_buffer_size;
     int sampler_cache_size;
     int max_commit_listeners;
+    bool disable_validation;    // disable validation layer even in debug mode, useful for tests
     sg_allocator allocator;
     sg_logger logger; // optional log function override
     sg_context_desc context;
@@ -14471,6 +14474,9 @@ _SOKOL_PRIVATE bool _sg_validate_buffer_desc(const sg_buffer_desc* desc) {
         _SOKOL_UNUSED(desc);
         return true;
     #else
+        if (_sg.desc.disable_validation) {
+            return true;
+        }
         SOKOL_ASSERT(desc);
         SOKOL_VALIDATE_BEGIN();
         SOKOL_VALIDATE(desc->_start_canary == 0, _SG_VALIDATE_BUFFERDESC_CANARY);
@@ -14521,6 +14527,9 @@ _SOKOL_PRIVATE bool _sg_validate_image_desc(const sg_image_desc* desc) {
         _SOKOL_UNUSED(desc);
         return true;
     #else
+        if (_sg.desc.disable_validation) {
+            return true;
+        }
         SOKOL_ASSERT(desc);
         SOKOL_VALIDATE_BEGIN();
         SOKOL_VALIDATE(desc->_start_canary == 0, _SG_VALIDATE_IMAGEDESC_CANARY);
@@ -14593,6 +14602,9 @@ _SOKOL_PRIVATE bool _sg_validate_shader_desc(const sg_shader_desc* desc) {
         _SOKOL_UNUSED(desc);
         return true;
     #else
+        if (_sg.desc.disable_validation) {
+            return true;
+        }
         SOKOL_ASSERT(desc);
         SOKOL_VALIDATE_BEGIN();
         SOKOL_VALIDATE(desc->_start_canary == 0, _SG_VALIDATE_SHADERDESC_CANARY);
@@ -14702,6 +14714,9 @@ _SOKOL_PRIVATE bool _sg_validate_pipeline_desc(const sg_pipeline_desc* desc) {
         _SOKOL_UNUSED(desc);
         return true;
     #else
+        if (_sg.desc.disable_validation) {
+            return true;
+        }
         SOKOL_ASSERT(desc);
         SOKOL_VALIDATE_BEGIN();
         SOKOL_VALIDATE(desc->_start_canary == 0, _SG_VALIDATE_PIPELINEDESC_CANARY);
@@ -14746,6 +14761,9 @@ _SOKOL_PRIVATE bool _sg_validate_pass_desc(const sg_pass_desc* desc) {
         _SOKOL_UNUSED(desc);
         return true;
     #else
+        if (_sg.desc.disable_validation) {
+            return true;
+        }
         SOKOL_ASSERT(desc);
         SOKOL_VALIDATE_BEGIN();
         SOKOL_VALIDATE(desc->_start_canary == 0, _SG_VALIDATE_PASSDESC_CANARY);
@@ -14816,6 +14834,9 @@ _SOKOL_PRIVATE bool _sg_validate_begin_pass(_sg_pass_t* pass) {
         _SOKOL_UNUSED(pass);
         return true;
     #else
+        if (_sg.desc.disable_validation) {
+            return true;
+        }
         SOKOL_VALIDATE_BEGIN();
         SOKOL_VALIDATE(pass->slot.state == SG_RESOURCESTATE_VALID, _SG_VALIDATE_BEGINPASS_PASS);
 
@@ -14842,6 +14863,9 @@ _SOKOL_PRIVATE bool _sg_validate_apply_pipeline(sg_pipeline pip_id) {
         _SOKOL_UNUSED(pip_id);
         return true;
     #else
+        if (_sg.desc.disable_validation) {
+            return true;
+        }
         SOKOL_VALIDATE_BEGIN();
         /* the pipeline object must be alive and valid */
         SOKOL_VALIDATE(pip_id.id != SG_INVALID_ID, _SG_VALIDATE_APIP_PIPELINE_VALID_ID);
@@ -14889,6 +14913,9 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bindings) {
         _SOKOL_UNUSED(bindings);
         return true;
     #else
+        if (_sg.desc.disable_validation) {
+            return true;
+        }
         SOKOL_VALIDATE_BEGIN();
 
         /* a pipeline object must have been applied */
@@ -14980,6 +15007,9 @@ _SOKOL_PRIVATE bool _sg_validate_apply_uniforms(sg_shader_stage stage_index, int
         _SOKOL_UNUSED(data);
         return true;
     #else
+        if (_sg.desc.disable_validation) {
+            return true;
+        }
         SOKOL_ASSERT((stage_index == SG_SHADERSTAGE_VS) || (stage_index == SG_SHADERSTAGE_FS));
         SOKOL_ASSERT((ub_index >= 0) && (ub_index < SG_MAX_SHADERSTAGE_UBS));
         SOKOL_VALIDATE_BEGIN();
@@ -15005,6 +15035,9 @@ _SOKOL_PRIVATE bool _sg_validate_update_buffer(const _sg_buffer_t* buf, const sg
         _SOKOL_UNUSED(data);
         return true;
     #else
+        if (_sg.desc.disable_validation) {
+            return true;
+        }
         SOKOL_ASSERT(buf && data && data->ptr);
         SOKOL_VALIDATE_BEGIN();
         SOKOL_VALIDATE(buf->cmn.usage != SG_USAGE_IMMUTABLE, _SG_VALIDATE_UPDATEBUF_USAGE);
@@ -15021,6 +15054,9 @@ _SOKOL_PRIVATE bool _sg_validate_append_buffer(const _sg_buffer_t* buf, const sg
         _SOKOL_UNUSED(data);
         return true;
     #else
+        if (_sg.desc.disable_validation) {
+            return true;
+        }
         SOKOL_ASSERT(buf && data && data->ptr);
         SOKOL_VALIDATE_BEGIN();
         SOKOL_VALIDATE(buf->cmn.usage != SG_USAGE_IMMUTABLE, _SG_VALIDATE_APPENDBUF_USAGE);
@@ -15036,6 +15072,9 @@ _SOKOL_PRIVATE bool _sg_validate_update_image(const _sg_image_t* img, const sg_i
         _SOKOL_UNUSED(data);
         return true;
     #else
+        if (_sg.desc.disable_validation) {
+            return true;
+        }
         SOKOL_ASSERT(img && data);
         SOKOL_VALIDATE_BEGIN();
         SOKOL_VALIDATE(img->cmn.usage != SG_USAGE_IMMUTABLE, _SG_VALIDATE_UPDIMG_USAGE);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -771,7 +771,7 @@
         sg_pipeline sg_make_pipeline(const sg_pipeline_desc* desc)
         sg_pass sg_make_pass(const sg_pass_desc* desc)
 
-    The result will be one of three cases:
+    This will result in one of three cases:
 
         1. The returned handle is invalid. This happens when there are no more
            free slots in the resource pool for this resource type. An invalid

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -6462,7 +6462,7 @@ _SOKOL_PRIVATE void _sg_gl_cache_invalidate_program(GLuint prog) {
     }
 }
 
-/* called from _sg_gl_destroy_pipeline() */
+/* called from _sg_gl_discard_pipeline() */
 _SOKOL_PRIVATE void _sg_gl_cache_invalidate_pipeline(_sg_pipeline_t* pip) {
     if (pip == _sg.gl.cache.cur_pipeline) {
         _sg.gl.cache.cur_pipeline = 0;
@@ -7100,7 +7100,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_pipeline(_sg_pipeline_t* pip, _sg
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_gl_destroy_pipeline(_sg_pipeline_t* pip) {
+_SOKOL_PRIVATE void _sg_gl_discard_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
     _sg_gl_cache_invalidate_pipeline(pip);
 }
@@ -7266,7 +7266,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_pass(_sg_pass_t* pass, _sg_image_
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_gl_destroy_pass(_sg_pass_t* pass) {
+_SOKOL_PRIVATE void _sg_gl_discard_pass(_sg_pass_t* pass) {
     SOKOL_ASSERT(pass);
     SOKOL_ASSERT(pass != _sg.gl.cur_pass);
     _SG_GL_CHECK_ERROR();
@@ -9386,7 +9386,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_pipeline(_sg_pipeline_t* pip, 
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_d3d11_destroy_pipeline(_sg_pipeline_t* pip) {
+_SOKOL_PRIVATE void _sg_d3d11_discard_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
     if (pip == _sg.d3d11.cur_pipeline) {
         _sg.d3d11.cur_pipeline = 0;
@@ -9500,7 +9500,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_pass(_sg_pass_t* pass, _sg_ima
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_d3d11_destroy_pass(_sg_pass_t* pass) {
+_SOKOL_PRIVATE void _sg_d3d11_discard_pass(_sg_pass_t* pass) {
     SOKOL_ASSERT(pass);
     SOKOL_ASSERT(pass != _sg.d3d11.cur_pass);
     for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
@@ -11114,7 +11114,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_mtl_create_pipeline(_sg_pipeline_t* pip, _s
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_mtl_destroy_pipeline(_sg_pipeline_t* pip) {
+_SOKOL_PRIVATE void _sg_mtl_discard_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
     /* it's valid to call release resource with a 'null resource' */
     _sg_mtl_release_resource(_sg.mtl.frame_index, pip->mtl.rps);
@@ -11150,7 +11150,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_mtl_create_pass(_sg_pass_t* pass, _sg_image
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_mtl_destroy_pass(_sg_pass_t* pass) {
+_SOKOL_PRIVATE void _sg_mtl_discard_pass(_sg_pass_t* pass) {
     SOKOL_ASSERT(pass);
     _SOKOL_UNUSED(pass);
 }
@@ -12892,7 +12892,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_pipeline(_sg_pipeline_t* pip, _
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_wgpu_destroy_pipeline(_sg_pipeline_t* pip) {
+_SOKOL_PRIVATE void _sg_wgpu_discard_pipeline(_sg_pipeline_t* pip) {
     SOKOL_ASSERT(pip);
     if (pip == _sg.wgpu.cur_pipeline) {
         _sg.wgpu.cur_pipeline = 0;
@@ -12963,7 +12963,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_pass(_sg_pass_t* pass, _sg_imag
     return SG_RESOURCESTATE_VALID;
 }
 
-_SOKOL_PRIVATE void _sg_wgpu_destroy_pass(_sg_pass_t* pass) {
+_SOKOL_PRIVATE void _sg_wgpu_discard_pass(_sg_pass_t* pass) {
     SOKOL_ASSERT(pass);
     for (uint32_t i = 0; i < pass->cmn.num_color_atts; i++) {
         if (pass->wgpu.color_atts[i].render_tex_view) {
@@ -15637,10 +15637,10 @@ SOKOL_API_IMPL void sg_dealloc_pass(sg_pass pass_id) {
 
 SOKOL_API_IMPL void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
+    sg_buffer_desc desc_def = _sg_buffer_desc_defaults(desc);
     _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
     if (buf) {
         if (buf->slot.state == SG_RESOURCESTATE_ALLOC) {
-            sg_buffer_desc desc_def = _sg_buffer_desc_defaults(desc);
             _sg_init_buffer(buf, &desc_def);
             SOKOL_ASSERT((buf->slot.state == SG_RESOURCESTATE_VALID) || (buf->slot.state == SG_RESOURCESTATE_FAILED));
         }
@@ -15653,10 +15653,10 @@ SOKOL_API_IMPL void sg_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc)
 
 SOKOL_API_IMPL void sg_init_image(sg_image img_id, const sg_image_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
+    sg_image_desc desc_def = _sg_image_desc_defaults(desc);
     _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
     if (img) {
         if (img->slot.state == SG_RESOURCESTATE_ALLOC) {
-            sg_image_desc desc_def = _sg_image_desc_defaults(desc);
             _sg_init_image(img, &desc_def);
             SOKOL_ASSERT((img->slot.state == SG_RESOURCESTATE_VALID) || (img->slot.state == SG_RESOURCESTATE_FAILED));
         }
@@ -15669,10 +15669,10 @@ SOKOL_API_IMPL void sg_init_image(sg_image img_id, const sg_image_desc* desc) {
 
 SOKOL_API_IMPL void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
+    sg_shader_desc desc_def = _sg_shader_desc_defaults(desc);
     _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
     if (shd) {
         if (shd->slot.state == SG_RESOURCESTATE_ALLOC) {
-            sg_shader_desc desc_def = _sg_shader_desc_defaults(desc);
             _sg_init_shader(shd, &desc_def);
             SOKOL_ASSERT((shd->slot.state == SG_RESOURCESTATE_VALID) || (shd->slot.state == SG_RESOURCESTATE_FAILED));
         }
@@ -15685,10 +15685,10 @@ SOKOL_API_IMPL void sg_init_shader(sg_shader shd_id, const sg_shader_desc* desc)
 
 SOKOL_API_IMPL void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
+    sg_pipeline_desc desc_def = _sg_pipeline_desc_defaults(desc);
     _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
     if (pip) {
         if (pip->slot.state == SG_RESOURCESTATE_ALLOC) {
-            sg_pipeline_desc desc_def = _sg_pipeline_desc_defaults(desc);
             _sg_init_pipeline(pip, &desc_def);
             SOKOL_ASSERT((pip->slot.state == SG_RESOURCESTATE_VALID) || (pip->slot.state == SG_RESOURCESTATE_FAILED));
         }
@@ -15701,10 +15701,10 @@ SOKOL_API_IMPL void sg_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc*
 
 SOKOL_API_IMPL void sg_init_pass(sg_pass pass_id, const sg_pass_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
+    sg_pass_desc desc_def = _sg_pass_desc_defaults(desc);
     _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
     if (pass) {
         if (pass->slot.state == SG_RESOURCESTATE_ALLOC) {
-            sg_pass_desc desc_def = _sg_pass_desc_defaults(desc);
             _sg_init_pass(pass, &desc_def);
             SOKOL_ASSERT((pass->slot.state == SG_RESOURCESTATE_VALID) || (pass->slot.state == SG_RESOURCESTATE_FAILED));
         }
@@ -15906,11 +15906,11 @@ SOKOL_API_IMPL sg_resource_state sg_query_pass_state(sg_pass pass_id) {
 SOKOL_API_IMPL sg_buffer sg_make_buffer(const sg_buffer_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     SOKOL_ASSERT(desc);
+    sg_buffer_desc desc_def = _sg_buffer_desc_defaults(desc);
     sg_buffer buf_id = _sg_alloc_buffer();
     if (buf_id.id != SG_INVALID_ID) {
         _sg_buffer_t* buf = _sg_buffer_at(&_sg.pools, buf_id.id);
         SOKOL_ASSERT(buf && (buf->slot.state == SG_RESOURCESTATE_ALLOC));
-        sg_buffer_desc desc_def = _sg_buffer_desc_defaults(desc);
         _sg_init_buffer(buf, &desc_def);
         SOKOL_ASSERT((buf->slot.state == SG_RESOURCESTATE_VALID) || (buf->slot.state == SG_RESOURCESTATE_FAILED));
     }
@@ -15925,11 +15925,11 @@ SOKOL_API_IMPL sg_buffer sg_make_buffer(const sg_buffer_desc* desc) {
 SOKOL_API_IMPL sg_image sg_make_image(const sg_image_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     SOKOL_ASSERT(desc);
+    sg_image_desc desc_def = _sg_image_desc_defaults(desc);
     sg_image img_id = _sg_alloc_image();
     if (img_id.id != SG_INVALID_ID) {
         _sg_image_t* img = _sg_image_at(&_sg.pools, img_id.id);
         SOKOL_ASSERT(img && (img->slot.state == SG_RESOURCESTATE_ALLOC));
-        sg_image_desc desc_def = _sg_image_desc_defaults(desc);
         _sg_init_image(img, &desc_def);
         SOKOL_ASSERT((img->slot.state == SG_RESOURCESTATE_VALID) || (img->slot.state == SG_RESOURCESTATE_FAILED));
     }
@@ -15944,11 +15944,11 @@ SOKOL_API_IMPL sg_image sg_make_image(const sg_image_desc* desc) {
 SOKOL_API_IMPL sg_shader sg_make_shader(const sg_shader_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     SOKOL_ASSERT(desc);
+    sg_shader_desc desc_def = _sg_shader_desc_defaults(desc);
     sg_shader shd_id = _sg_alloc_shader();
     if (shd_id.id != SG_INVALID_ID) {
         _sg_shader_t* shd = _sg_shader_at(&_sg.pools, shd_id.id);
         SOKOL_ASSERT(shd && (shd->slot.state == SG_RESOURCESTATE_ALLOC));
-        sg_shader_desc desc_def = _sg_shader_desc_defaults(desc);
         _sg_init_shader(shd, &desc_def);
         SOKOL_ASSERT((shd->slot.state == SG_RESOURCESTATE_VALID) || (shd->slot.state == SG_RESOURCESTATE_FAILED));
     }
@@ -15963,11 +15963,11 @@ SOKOL_API_IMPL sg_shader sg_make_shader(const sg_shader_desc* desc) {
 SOKOL_API_IMPL sg_pipeline sg_make_pipeline(const sg_pipeline_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     SOKOL_ASSERT(desc);
+    sg_pipeline_desc desc_def = _sg_pipeline_desc_defaults(desc);
     sg_pipeline pip_id = _sg_alloc_pipeline();
     if (pip_id.id != SG_INVALID_ID) {
         _sg_pipeline_t* pip = _sg_pipeline_at(&_sg.pools, pip_id.id);
         SOKOL_ASSERT(pip && (pip->slot.state == SG_RESOURCESTATE_ALLOC));
-        sg_pipeline_desc desc_def = _sg_pipeline_desc_defaults(desc);
         _sg_init_pipeline(pip, &desc_def);
         SOKOL_ASSERT((pip->slot.state == SG_RESOURCESTATE_VALID) || (pip->slot.state == SG_RESOURCESTATE_FAILED));
     }
@@ -15982,11 +15982,11 @@ SOKOL_API_IMPL sg_pipeline sg_make_pipeline(const sg_pipeline_desc* desc) {
 SOKOL_API_IMPL sg_pass sg_make_pass(const sg_pass_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     SOKOL_ASSERT(desc);
+    sg_pass_desc desc_def = _sg_pass_desc_defaults(desc);
     sg_pass pass_id = _sg_alloc_pass();
     if (pass_id.id != SG_INVALID_ID) {
         _sg_pass_t* pass = _sg_pass_at(&_sg.pools, pass_id.id);
         SOKOL_ASSERT(pass && (pass->slot.state == SG_RESOURCESTATE_ALLOC));
-        sg_pass_desc desc_def = _sg_pass_desc_defaults(desc);
         _sg_init_pass(pass, &desc_def);
         SOKOL_ASSERT((pass->slot.state == SG_RESOURCESTATE_VALID) || (pass->slot.state == SG_RESOURCESTATE_FAILED));
     }

--- a/tests/functional/sokol_gfx_test.c
+++ b/tests/functional/sokol_gfx_test.c
@@ -13,8 +13,57 @@
 
 static int num_log_called = 0;
 static void test_logger(const char* msg, void* userdata) {
-    (void)msg; (void)userdata;
+    (void)userdata;
     num_log_called++;
+    puts(msg);
+}
+
+static void setup_with_logger(void) {
+    num_log_called = 0;
+    sg_setup(&(sg_desc){
+        .logger = { .log_cb = test_logger }
+    });
+}
+
+static sg_buffer create_buffer(void) {
+    static const float data[] = { 1, 2, 3, 4 };
+    return sg_make_buffer(&(sg_buffer_desc){ .data = SG_RANGE(data) });
+}
+
+static sg_image create_image(void) {
+    return sg_make_image(&(sg_image_desc){
+        .render_target = true,
+        .width = 256,
+        .height = 128
+    });
+}
+
+static sg_shader create_shader(void) {
+    return sg_make_shader(&(sg_shader_desc){0});
+}
+
+static sg_pipeline create_pipeline(void) {
+    return sg_make_pipeline(&(sg_pipeline_desc){
+        .layout = {
+            .attrs[0].format = SG_VERTEXFORMAT_FLOAT3
+        },
+        .shader = sg_make_shader(&(sg_shader_desc){0})
+    });
+}
+
+static sg_pass create_pass(void) {
+    sg_image_desc img_desc = {
+        .render_target = true,
+        .width = 128,
+        .height = 128,
+    };
+    return sg_make_pass(&(sg_pass_desc){
+        .color_attachments = {
+            [0].image = sg_make_image(&img_desc),
+            [1].image = sg_make_image(&img_desc),
+            [2].image = sg_make_image(&img_desc)
+        },
+    });
 }
 
 UTEST(sokol_gfx, init_shutdown) {
@@ -1030,13 +1079,217 @@ UTEST(sokol_gfx, commit_listener_array_full) {
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, alloc_destroy) {
-    num_log_called = 0;
-    sg_setup(&(sg_desc){
-        .logger = { .log_cb = test_logger }
-    });
-    sg_buffer vbuf = sg_alloc_buffer();
-    sg_destroy_buffer(vbuf);
-    T(0 == num_log_called);
+UTEST(sokol_gfx, buffer_double_destroy_is_ok) {
+    sg_setup(&(sg_desc){0});
+    sg_buffer buf = create_buffer();
+    T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_VALID);
+    sg_destroy_buffer(buf);
+    T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_INVALID);
+    sg_destroy_buffer(buf);
+    T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_INVALID);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, image_double_destroy_is_ok) {
+    sg_setup(&(sg_desc){0});
+    sg_image img = create_image();
+    T(sg_query_image_state(img) == SG_RESOURCESTATE_VALID);
+    sg_destroy_image(img);
+    T(sg_query_image_state(img) == SG_RESOURCESTATE_INVALID);
+    sg_destroy_image(img);
+    T(sg_query_image_state(img) == SG_RESOURCESTATE_INVALID);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, shader_double_destroy_is_ok) {
+    sg_setup(&(sg_desc){0});
+    sg_shader shd = create_shader();
+    T(sg_query_shader_state(shd) == SG_RESOURCESTATE_VALID);
+    sg_destroy_shader(shd);
+    T(sg_query_shader_state(shd) == SG_RESOURCESTATE_INVALID);
+    sg_destroy_shader(shd);
+    T(sg_query_shader_state(shd) == SG_RESOURCESTATE_INVALID);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, pipeline_double_destroy_is_ok) {
+    sg_setup(&(sg_desc){0});
+    sg_pipeline pip = create_pipeline();
+    T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_VALID);
+    sg_destroy_pipeline(pip);
+    T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_INVALID);
+    sg_destroy_pipeline(pip);
+    T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_INVALID);
+    sg_shutdown();
+}
+
+UTEST(sokoL_gfx, pass_double_destroy_is_ok) {
+    sg_setup(&(sg_desc){0});
+    sg_pass pass = create_pass();
+    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_VALID);
+    sg_destroy_pass(pass);
+    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_INVALID);
+    sg_destroy_pass(pass);
+    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_INVALID);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, make_dealloc_buffer_warns) {
+    setup_with_logger();
+    sg_buffer buf = create_buffer();
+    T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_VALID);
+    sg_dealloc_buffer(buf);
+    T(num_log_called == 1);
+    T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_VALID);
+    sg_destroy_buffer(buf);
+    T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_INVALID);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, make_dealloc_image_warns) {
+    setup_with_logger();
+    sg_image img = create_image();
+    T(sg_query_image_state(img) == SG_RESOURCESTATE_VALID);
+    sg_dealloc_image(img);
+    T(num_log_called == 1);
+    T(sg_query_image_state(img) == SG_RESOURCESTATE_VALID);
+    sg_destroy_image(img);
+    T(sg_query_image_state(img) == SG_RESOURCESTATE_INVALID);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, make_dealloc_shader_warns) {
+    setup_with_logger();
+    sg_shader shd = create_shader();
+    T(sg_query_shader_state(shd) == SG_RESOURCESTATE_VALID);
+    sg_dealloc_shader(shd);
+    T(num_log_called == 1);
+    T(sg_query_shader_state(shd) == SG_RESOURCESTATE_VALID);
+    sg_destroy_shader(shd);
+    T(sg_query_shader_state(shd) == SG_RESOURCESTATE_INVALID);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, make_dealloc_pipeline_warns) {
+    setup_with_logger();
+    sg_pipeline pip = create_pipeline();
+    T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_VALID);
+    sg_dealloc_pipeline(pip);
+    T(num_log_called == 1);
+    T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_VALID);
+    sg_destroy_pipeline(pip);
+    T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_INVALID);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, make_dealloc_pass_warns) {
+    setup_with_logger();
+    sg_pass pass = create_pass();
+    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_VALID);
+    sg_dealloc_pass(pass);
+    T(num_log_called == 1);
+    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_VALID);
+    sg_destroy_pass(pass);
+    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_INVALID);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, alloc_uninit_buffer_warns) {
+    setup_with_logger();
+    sg_buffer buf = sg_alloc_buffer();
+    T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_ALLOC);
+    sg_uninit_buffer(buf);
+    T(num_log_called == 1);
+    T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_ALLOC);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, alloc_uninit_image_warns) {
+    setup_with_logger();
+    sg_image img = sg_alloc_image();
+    T(sg_query_image_state(img) == SG_RESOURCESTATE_ALLOC);
+    sg_uninit_image(img);
+    T(num_log_called == 1);
+    T(sg_query_image_state(img) == SG_RESOURCESTATE_ALLOC);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, alloc_uninit_shader_warns) {
+    setup_with_logger();
+    sg_shader shd = sg_alloc_shader();
+    T(sg_query_shader_state(shd) == SG_RESOURCESTATE_ALLOC);
+    sg_uninit_shader(shd);
+    T(num_log_called == 1);
+    T(sg_query_shader_state(shd) == SG_RESOURCESTATE_ALLOC);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, alloc_uninit_pipeline_warns) {
+    setup_with_logger();
+    sg_pipeline pip = sg_alloc_pipeline();
+    T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_ALLOC);
+    sg_uninit_pipeline(pip);
+    T(num_log_called == 1);
+    T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_ALLOC);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, alloc_uninit_pass_warns) {
+    setup_with_logger();
+    sg_pass pass = sg_alloc_pass();
+    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_ALLOC);
+    sg_uninit_pass(pass);
+    T(num_log_called == 1);
+    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_ALLOC);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, alloc_destroy_buffer_is_ok) {
+    setup_with_logger();
+    sg_buffer buf = sg_alloc_buffer();
+    T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_ALLOC);
+    sg_destroy_buffer(buf);
+    T(num_log_called == 0);
+    T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_INVALID);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, alloc_destroy_image_is_ok) {
+    setup_with_logger();
+    sg_image img = sg_alloc_image();
+    T(sg_query_image_state(img) == SG_RESOURCESTATE_ALLOC);
+    sg_destroy_image(img);
+    T(num_log_called == 0);
+    T(sg_query_image_state(img) == SG_RESOURCESTATE_INVALID);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, alloc_destroy_shader_is_ok) {
+    setup_with_logger();
+    sg_shader shd = sg_alloc_shader();
+    T(sg_query_shader_state(shd) == SG_RESOURCESTATE_ALLOC);
+    sg_destroy_shader(shd);
+    T(num_log_called == 0);
+    T(sg_query_shader_state(shd) == SG_RESOURCESTATE_INVALID);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, alloc_destroy_pipeline_is_ok) {
+    setup_with_logger();
+    sg_pipeline pip = sg_alloc_pipeline();
+    T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_ALLOC);
+    sg_destroy_pipeline(pip);
+    T(num_log_called == 0);
+    T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_INVALID);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, alloc_destroy_pass_is_ok) {
+    setup_with_logger();
+    sg_pass pass = sg_alloc_pass();
+    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_ALLOC);
+    sg_destroy_pass(pass);
+    T(num_log_called == 0);
+    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_INVALID);
     sg_shutdown();
 }

--- a/tests/functional/sokol_gfx_test.c
+++ b/tests/functional/sokol_gfx_test.c
@@ -1293,3 +1293,42 @@ UTEST(sokol_gfx, alloc_destroy_pass_is_ok) {
     T(sg_query_pass_state(pass) == SG_RESOURCESTATE_INVALID);
     sg_shutdown();
 }
+
+UTEST(sokol_gfx, make_pipeline_with_nonvalid_shader) {
+    sg_setup(&(sg_desc){
+        .disable_validation = true,
+    });
+    sg_shader shd = sg_alloc_shader();
+    T(sg_query_shader_state(shd) == SG_RESOURCESTATE_ALLOC);
+    sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
+        .shader = shd,
+        .layout = {
+            .attrs[0].format = SG_VERTEXFORMAT_FLOAT3
+        },
+    });
+    T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_FAILED);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, make_pass_with_nonvalid_color_images) {
+    sg_setup(&(sg_desc){
+        .disable_validation = true,
+    });
+    sg_pass pass = sg_make_pass(&(sg_pass_desc){
+        .color_attachments = {
+            [0].image = sg_alloc_image(),
+            [1].image = sg_alloc_image(),
+        },
+        .depth_stencil_attachment = {
+            .image = sg_make_image(&(sg_image_desc){
+                .render_target = true,
+                .width = 128,
+                .height = 128
+            })
+        }
+    });
+    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
+    sg_destroy_pass(pass);
+    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_INVALID);
+    sg_shutdown();
+}

--- a/tests/functional/sokol_gfx_test.c
+++ b/tests/functional/sokol_gfx_test.c
@@ -11,6 +11,12 @@
 
 #define T(b) EXPECT_TRUE(b)
 
+static int num_log_called = 0;
+static void test_logger(const char* msg, void* userdata) {
+    (void)msg; (void)userdata;
+    num_log_called++;
+}
+
 UTEST(sokol_gfx, init_shutdown) {
     sg_setup(&(sg_desc){0});
     T(sg_isvalid());
@@ -1021,5 +1027,16 @@ UTEST(sokol_gfx, commit_listener_array_full) {
     sg_commit();
     T(commit_listener.num_called == 3);
     T(commit_listener.userdata == 128);
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, alloc_destroy) {
+    num_log_called = 0;
+    sg_setup(&(sg_desc){
+        .logger = { .log_cb = test_logger }
+    });
+    sg_buffer vbuf = sg_alloc_buffer();
+    sg_destroy_buffer(vbuf);
+    T(0 == num_log_called);
     sg_shutdown();
 }


### PR DESCRIPTION
- clarify destroy vs uninit vs dealloc behaviour for resources in various resource states
- destroy / uninit / dealloc functions are safe to call for resources in any state, will generally do the right thing, or at most put a warning log message
- uninit functions no longer have return value, instead it's safe to call uninit and dealloc on resources in any state
- new documentation blurb about two-step resource creation/destruction
- some general internal code cleanup and better naming in the resource creation/destruction code
- a new sg_desc.disable_validation boolean to disable the validation layer even in debug mode (useful for unit tests)
- cleanup an old FIXME in sg_create_pass(): creating a pass with invalid images now creates a pass object in FAILED states (assuming that the validation layer is disabled, because that chokes first on that error)
- calling sg_shutdown() with leftover resources in ALLOC state no longer produces a warning log message about a context mismatch

- ~~[ ] TODO: clean up resource dependency code (pipeline => shader, pass => images) a'la sokol-spine (internal _sg_shader_ref and _sg_image_ref structs with pointer and handle, check that those deps are valid in sg_apply_pipeline and sg_begin_pass - just in the validation layer, .... or?)~~ (that's for another time, requires a surprising amount of internal code changes - better to do this in a separate PR, and only when tackling the validation layer on vs off behaviour (e.g. API abuse with switched off validation layer ideally shouldn't result in 'undefined behaviour'(???????)

Test samples on:
- [x] macOS Metal
- [x] macOS GL
- [x] iOS Metal
- [x] iOS GL
- [x] Linux
- [x] Windows D3D11
- [x] Windows GL
- [x] Android
- [x] Emscripten
