### PR TITLE
Typo in docs on pipeline stencil

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2226,9 +2226,9 @@ typedef struct sg_shader_desc {
         .enabled:           false
         .front/back:
             .compare:       SG_COMPAREFUNC_ALWAYS
+            .fail_op:       SG_STENCILOP_KEEP
             .depth_fail_op: SG_STENCILOP_KEEP
             .pass_op:       SG_STENCILOP_KEEP
-            .compare:       SG_COMPAREFUNC_ALWAYS
         .read_mask:         0
         .write_mask:        0
         .ref:               0


### PR DESCRIPTION
Noticed a small typo here, updated the docs for you based on what the default enums are