### PR TITLE
OpenGL: two stage texture binding bug

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3920,6 +3920,10 @@ typedef struct {
     GLuint texture;
 } _sg_gl_texture_bind_slot;
 
+enum {
+    _SG_GL_IMAGE_CACHE_SIZE = SG_MAX_SHADERSTAGE_IMAGES * SG_NUM_SHADER_STAGES,
+};
+
 typedef struct {
     sg_depth_state depth;
     sg_stencil_state stencil;
@@ -3937,7 +3941,7 @@ typedef struct {
     GLuint stored_vertex_buffer;
     GLuint stored_index_buffer;
     GLuint prog;
-    _sg_gl_texture_bind_slot textures[SG_MAX_SHADERSTAGE_IMAGES];
+    _sg_gl_texture_bind_slot textures[_SG_GL_IMAGE_CACHE_SIZE];
     _sg_gl_texture_bind_slot stored_texture;
     int cur_ib_offset;
     GLenum cur_primitive_type;
@@ -6562,7 +6566,7 @@ _SOKOL_PRIVATE void _sg_gl_cache_active_texture(GLenum texture) {
 }
 
 _SOKOL_PRIVATE void _sg_gl_cache_clear_texture_bindings(bool force) {
-    for (int i = 0; (i < SG_MAX_SHADERSTAGE_IMAGES) && (i < _sg.gl.max_combined_texture_image_units); i++) {
+    for (int i = 0; (i < _SG_GL_IMAGE_CACHE_SIZE) && (i < _sg.gl.max_combined_texture_image_units); i++) {
         if (force || (_sg.gl.cache.textures[i].texture != 0)) {
             GLenum gl_texture_slot = (GLenum) (GL_TEXTURE0 + i);
             glActiveTexture(gl_texture_slot);
@@ -6586,7 +6590,7 @@ _SOKOL_PRIVATE void _sg_gl_cache_bind_texture(int slot_index, GLenum target, GLu
        target=0 will unbind the previous binding, texture=0 will clear
        the new binding
     */
-    SOKOL_ASSERT(slot_index < SG_MAX_SHADERSTAGE_IMAGES);
+    SOKOL_ASSERT(slot_index < _SG_GL_IMAGE_CACHE_SIZE);
     if (slot_index >= _sg.gl.max_combined_texture_image_units) {
         return;
     }
@@ -6607,12 +6611,12 @@ _SOKOL_PRIVATE void _sg_gl_cache_bind_texture(int slot_index, GLenum target, GLu
 }
 
 _SOKOL_PRIVATE void _sg_gl_cache_store_texture_binding(int slot_index) {
-    SOKOL_ASSERT(slot_index < SG_MAX_SHADERSTAGE_IMAGES);
+    SOKOL_ASSERT(slot_index < _SG_GL_IMAGE_CACHE_SIZE);
     _sg.gl.cache.stored_texture = _sg.gl.cache.textures[slot_index];
 }
 
 _SOKOL_PRIVATE void _sg_gl_cache_restore_texture_binding(int slot_index) {
-    SOKOL_ASSERT(slot_index < SG_MAX_SHADERSTAGE_IMAGES);
+    SOKOL_ASSERT(slot_index < _SG_GL_IMAGE_CACHE_SIZE);
     _sg_gl_texture_bind_slot* slot = &_sg.gl.cache.stored_texture;
     if (slot->texture != 0) {
         /* we only care restoring valid ids */
@@ -6625,7 +6629,7 @@ _SOKOL_PRIVATE void _sg_gl_cache_restore_texture_binding(int slot_index) {
 
 /* called from _sg_gl_destroy_texture() */
 _SOKOL_PRIVATE void _sg_gl_cache_invalidate_texture(GLuint tex) {
-    for (int i = 0; i < SG_MAX_SHADERSTAGE_IMAGES; i++) {
+    for (int i = 0; i < _SG_GL_IMAGE_CACHE_SIZE; i++) {
         _sg_gl_texture_bind_slot* slot = &_sg.gl.cache.textures[i];
         if (tex == slot->texture) {
             _sg_gl_cache_active_texture((GLenum)(GL_TEXTURE0 + i));


### PR DESCRIPTION
There was a specific problem with the OpenGL backend: despite the API providing support for at least 12(`SG_MAX_SHADERSTAGE_IMAGES`) slots for textures for the vertex shader and 12 for the fragment shader, the OpenGL implementation could bind only SG_MAX_SHADERSTAGE_IMAGES combined for both stages because of the length of the binding cache.

I propose fixing this issue by increasing the cache size to the value of `SG_MAX_SHADERSTAGE_IMAGES * SG_NUM_SHADER_STAGES` so that all images can be bound. The actual number of supported images is known at runtime, `_sg.gl.max_combined_texture_image_units`, and is already used to prevent unsupported bindings.

PS: the previous PR #766 could be used to work around these restrictions as well, but that is an independent improvement with its own goal to provide the possibility to increase limits itself (there are shaders where a total of 24 textures is not enough).