### PR TITLE
sokol_audio.h: Include alloca.h on Linux

### DIFF
--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -780,6 +780,7 @@ inline void saudio_setup(const saudio_desc& desc) { return saudio_setup(&desc); 
         #include "aaudio/AAudio.h"
     #endif
 #elif defined(_SAUDIO_LINUX)
+    #include <alloca.h>
     #define _SAUDIO_PTHREADS (1)
     #include <pthread.h>
     #define ALSA_PCM_NEW_HW_PARAMS_API


### PR DESCRIPTION
Required by a `snd_pcm_hw_params_alloca` call in `_saudio_alsa_backend_init`.

This change makes it so the implementation links correctly on Linux in `-std=c99` mode, instead of relying on implicit `alloca` only provided by GNU extensions.