### PR TITLE
sokol_gfx.h: add sg_query_[buffer|image|shader|pipeline|pass]_desc() functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
   'creation blueprint' for creating similar resoures without the need
   to keep and pass around the original desc structs.
 
+  >MINOR BREAKING CHANGE: the struct members ```sg_image_info.width``` and
+  ```sg_image_info.height``` have been removed, this information is now
+  returned by ```sg_query_image_desc()```.
+
   PR: https://github.com/floooh/sokol/pull/796, fixes: https://github.com/floooh/sokol/issues/568
 
 - **17-Feb-2023**: sokol_app.h on macOS now has a proper fix for the problem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 ## Updates
 
+- **20-Feb-2023**: sokol_gfx.h has a new set of functions to get a 'best-effort'
+  desc struct with the creation parameters of a specific resource object:
+
+    ```c
+    sg_buffer_desc sg_query_buffer_desc(sg_buffer buf);
+    sg_image_desc sg_query_image_desc(sg_image img);
+    sg_shader_desc sg_query_shader_desc(sg_shader shd);
+    sg_pipeline_desc sg_query_pipeline_desc(sg_pipeline pip);
+    sg_pass_desc sg_query_pass_desc(sg_pass pass);
+    ```
+
+  The returned structs will *not* be an exact copy of the desc struct that
+  was used for creation the resource object, instead:
+
+    - references to external data (like buffer and image content or
+      shader sources) will be zeroed
+    - any attributes that have not been kept around internally after
+      creation will be zeroed (the ```sg_shader_desc``` struct is most
+      affected by this, the other structs are fairly complete).
+
+  Calling the functions with an invalid or dangling resource handle
+  will return a completely zeroed struct (thus it may make sense
+  to first check the resource state via ```sg_query_*_state()```)
+
+  Nevertheless, those functions may be useful to get a partially filled out
+  'creation blueprint' for creating similar resoures without the need
+  to keep and pass around the original desc structs.
+
+  PR: https://github.com/floooh/sokol/pull/796, fixes: https://github.com/floooh/sokol/issues/568
+
 - **17-Feb-2023**: sokol_app.h on macOS now has a proper fix for the problem
   that macOS doesn't send key-up events while the Cmd key is held down.
   Previously this was handled through a workaround of immediately sending a

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Simple
 [STB-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt)
 cross-platform libraries for C and C++, written in C.
 
-[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**13-Feb-2023** logging has been replaced with a
-combined logging- and error-reporting callback, **ACTION REQUIRED** (see changelog for details))
+[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**20-Feb-2023** a new set of functions in sokol_gfx.h
+to get a pre-filled 'desc struct' for a resource)
 
 [![Build](/../../actions/workflows/main.yml/badge.svg)](/../../actions/workflows/main.yml) [![Bindings](/../../actions/workflows/gen_bindings.yml/badge.svg)](/../../actions/workflows/gen_bindings.yml) [![build](https://github.com/floooh/sokol-zig/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-zig/actions/workflows/main.yml) [![build](https://github.com/floooh/sokol-nim/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-nim/actions/workflows/main.yml) [![Odin](https://github.com/floooh/sokol-odin/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-odin/actions/workflows/main.yml)
 

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -16973,6 +16973,24 @@ SOKOL_API_IMPL sg_pipeline_desc sg_query_pipeline_desc(sg_pipeline pip_id) {
     return desc;
 }
 
+SOKOL_API_IMPL sg_pass_desc sg_query_pass_desc(sg_pass pass_id) {
+    SOKOL_ASSERT(_sg.valid);
+    sg_pass_desc desc;
+    _sg_clear(&desc, sizeof(desc));
+    const _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
+    if (pass) {
+        for (int i = 0; i < pass->cmn.num_color_atts; i++) {
+            desc.color_attachments[i].image = pass->cmn.color_atts[i].image_id;
+            desc.color_attachments[i].mip_level = pass->cmn.color_atts[i].mip_level;
+            desc.color_attachments[i].slice = pass->cmn.color_atts[i].slice;
+        }
+        desc.depth_stencil_attachment.image = pass->cmn.ds_att.image_id;
+        desc.depth_stencil_attachment.mip_level = pass->cmn.ds_att.mip_level;
+        desc.depth_stencil_attachment.slice = pass->cmn.ds_att.slice;
+    }
+    return desc;
+}
+
 SOKOL_API_IMPL sg_buffer_desc sg_query_buffer_defaults(const sg_buffer_desc* desc) {
     SOKOL_ASSERT(_sg.valid && desc);
     return _sg_buffer_desc_defaults(desc);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -9719,9 +9719,9 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_pipeline(_sg_pipeline_t* pip, 
     rs_desc.FillMode = D3D11_FILL_SOLID;
     rs_desc.CullMode = _sg_d3d11_cull_mode(desc->cull_mode);
     rs_desc.FrontCounterClockwise = desc->face_winding == SG_FACEWINDING_CCW;
-    rs_desc.DepthBias = (INT) pip->cmn.depth_bias;
-    rs_desc.DepthBiasClamp = pip->cmn.depth_bias_clamp;
-    rs_desc.SlopeScaledDepthBias = pip->cmn.depth_bias_slope_scale;
+    rs_desc.DepthBias = (INT) pip->cmn.depth.bias;
+    rs_desc.DepthBiasClamp = pip->cmn.depth.bias_clamp;
+    rs_desc.SlopeScaledDepthBias = pip->cmn.depth.bias_slope_scale;
     rs_desc.DepthClipEnable = TRUE;
     rs_desc.ScissorEnable = TRUE;
     rs_desc.MultisampleEnable = desc->sample_count > 1;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -301,8 +301,8 @@
         by calling sg_query_desc(). This will return an sg_desc struct with
         the default values patched in instead of any zero-initialized values
 
-    --- you can get a desc struct matching the attributes of a specific
-        resource object via:
+    --- you can get a desc struct matching the creation attributes of a
+        specific resource object via:
 
             sg_buffer_desc sg_query_buffer_desc(sg_buffer buf)
             sg_image_desc sg_query_image_desc(sg_image img)
@@ -310,18 +310,31 @@
             sg_pipeline_desc sg_query_pipeline_desc(sg_pipeline pip)
             sg_pass_desc sg_query_pass_desc(sg_pass pass)
 
-        ...but NOTE that the returned desc structs may be incomplete,
-        only attributes that is kept around internally after resource creation
-        will be filled in, and in some cases (like shaders) that's very little.
-        The returned desc structs might still be useful as partial blueprint
-        for creating similar resources if filled up with the missing
-        properties. Missing properties will be set to zero.
+        ...but NOTE that the returned desc structs may be incomplete, only
+        creation attributes that are kept around internally after resource
+        creation will be filled in, and in some cases (like shaders) that's
+        very little. Any missing attributes will be set to zero. The returned
+        desc structs might still be useful as partial blueprint for creating
+        similar resources if filled up with the missing attributes.
 
-        Also calling the functions on an invalid resource will return
-        completely zeroed structs (it makes sense to check with sg_query_*_state()
-        first)
+        Calling the query-desc functions on an invalid resource will return
+        completely zeroed structs (it makes sense to check  the resource state
+        with sg_query_*_state() first)
 
-    --- you can inspect various internal resource attributes via:
+    --- you can query the default resource creation parameters through the functions
+
+            sg_buffer_desc sg_query_buffer_defaults(const sg_buffer_desc* desc)
+            sg_image_desc sg_query_image_defaults(const sg_image_desc* desc)
+            sg_shader_desc sg_query_shader_defaults(const sg_shader_desc* desc)
+            sg_pipeline_desc sg_query_pipeline_defaults(const sg_pipeline_desc* desc)
+            sg_pass_desc sg_query_pass_defaults(const sg_pass_desc* desc)
+
+        These functions take a pointer to a desc structure which may contain
+        zero-initialized items for default values. These zero-init values
+        will be replaced with their concrete values in the returned desc
+        struct.
+
+    --- you can inspect various internal resource runtime values via:
 
             sg_buffer_info sg_query_buffer_info(sg_buffer buf)
             sg_image_info sg_query_image_info(sg_image img)
@@ -337,19 +350,6 @@
         for, or whether the GLES3 backend had to fall back to GLES2 with:
 
             sg_backend sg_query_backend(void)
-
-    --- you can query the default resource creation parameters through the functions
-
-            sg_buffer_desc sg_query_buffer_defaults(const sg_buffer_desc* desc)
-            sg_image_desc sg_query_image_defaults(const sg_image_desc* desc)
-            sg_shader_desc sg_query_shader_defaults(const sg_shader_desc* desc)
-            sg_pipeline_desc sg_query_pipeline_defaults(const sg_pipeline_desc* desc)
-            sg_pass_desc sg_query_pass_defaults(const sg_pass_desc* desc)
-
-        These functions take a pointer to a desc structure which may contain
-        zero-initialized items for default values. These zero-init values
-        will be replaced with their concrete values in the returned desc
-        struct.
 
 
     ON INITIALIZATION:
@@ -3053,7 +3053,7 @@ SOKOL_GFX_API_DECL sg_image_info sg_query_image_info(sg_image img);
 SOKOL_GFX_API_DECL sg_shader_info sg_query_shader_info(sg_shader shd);
 SOKOL_GFX_API_DECL sg_pipeline_info sg_query_pipeline_info(sg_pipeline pip);
 SOKOL_GFX_API_DECL sg_pass_info sg_query_pass_info(sg_pass pass);
-/* get pre-filled desc struct matching a specific resource (NOTE that references to external data will be zeroed) */
+/* get desc structs matching a specific resource (NOTE that not all creation attributes may be provided) */
 SOKOL_GFX_API_DECL sg_buffer_desc sg_query_buffer_desc(sg_buffer buf);
 SOKOL_GFX_API_DECL sg_image_desc sg_query_image_desc(sg_image img);
 SOKOL_GFX_API_DECL sg_shader_desc sg_query_shader_desc(sg_shader shd);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3778,6 +3778,8 @@ typedef struct {
     sg_wrap wrap_w;
     sg_border_color border_color;
     uint32_t max_anisotropy;
+    float min_lod;
+    float max_lod;
 } _sg_image_common_t;
 
 _SOKOL_PRIVATE void _sg_image_common_init(_sg_image_common_t* cmn, const sg_image_desc* desc) {
@@ -3800,6 +3802,8 @@ _SOKOL_PRIVATE void _sg_image_common_init(_sg_image_common_t* cmn, const sg_imag
     cmn->wrap_w = desc->wrap_w;
     cmn->border_color = desc->border_color;
     cmn->max_anisotropy = desc->max_anisotropy;
+    cmn->min_lod = desc->min_lod;
+    cmn->max_lod = desc->max_lod;
 }
 
 typedef struct {
@@ -16875,6 +16879,34 @@ SOKOL_API_IMPL sg_buffer_desc sg_query_buffer_desc(sg_buffer buf_id) {
         desc.size = (size_t)buf->cmn.size;
         desc.type = buf->cmn.type;
         desc.usage = buf->cmn.usage;
+    }
+    return desc;
+}
+
+SOKOL_API_IMPL sg_image_desc sg_query_image_desc(sg_image img_id) {
+    SOKOL_ASSERT(_sg.valid);
+    sg_image_desc desc;
+    _sg_clear(&desc, sizeof(desc));
+    const _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
+    if (img) {
+        desc.type = img->cmn.type;
+        desc.render_target = img->cmn.render_target;
+        desc.width = img->cmn.width;
+        desc.height = img->cmn.height;
+        desc.num_slices = img->cmn.num_slices;
+        desc.num_mipmaps = img->cmn.num_mipmaps;
+        desc.usage = img->cmn.usage;
+        desc.pixel_format = img->cmn.pixel_format;
+        desc.sample_count = img->cmn.sample_count;
+        desc.min_filter = img->cmn.min_filter;
+        desc.mag_filter = img->cmn.mag_filter;
+        desc.wrap_u = img->cmn.wrap_u;
+        desc.wrap_v = img->cmn.wrap_v;
+        desc.wrap_w = img->cmn.wrap_w;
+        desc.border_color = img->cmn.border_color;
+        desc.max_anisotropy = img->cmn.max_anisotropy;
+        desc.min_lod = img->cmn.min_lod;
+        desc.max_lod = img->cmn.max_lod;
     }
     return desc;
 }

--- a/tests/functional/sokol_gfx_test.c
+++ b/tests/functional/sokol_gfx_test.c
@@ -451,9 +451,9 @@ UTEST(sokol_gfx, make_destroy_pipelines) {
         T(pipptr->slot.state == SG_RESOURCESTATE_VALID);
         T(pipptr->shader == _sg_lookup_shader(&_sg.pools, desc.shader.id));
         T(pipptr->cmn.shader_id.id == desc.shader.id);
-        T(pipptr->cmn.color_attachment_count == 1);
-        T(pipptr->cmn.color_formats[0] == SG_PIXELFORMAT_RGBA8);
-        T(pipptr->cmn.depth_format == SG_PIXELFORMAT_DEPTH_STENCIL);
+        T(pipptr->cmn.color_count == 1);
+        T(pipptr->cmn.colors[0].pixel_format == SG_PIXELFORMAT_RGBA8);
+        T(pipptr->cmn.depth.pixel_format == SG_PIXELFORMAT_DEPTH_STENCIL);
         T(pipptr->cmn.sample_count == 1);
         T(pipptr->cmn.index_type == SG_INDEXTYPE_NONE);
         T(pipptr->cmn.vertex_layout_valid[0]);
@@ -983,6 +983,80 @@ UTEST(sokol_gfx, query_shader_desc) {
     T(s0_desc.fs.images[0].image_type == SG_IMAGETYPE_ARRAY);
     T(s0_desc.fs.images[0].sampler_type == SG_SAMPLERTYPE_UINT);
 
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, query_pipeline_desc) {
+    setup(&(sg_desc){0});
+
+    sg_shader shd = sg_make_shader(&(sg_shader_desc){0});
+    sg_pipeline p0 = sg_make_pipeline(&(sg_pipeline_desc){
+        .shader = shd,
+        .layout = {
+            .attrs = {
+                [0] = { .format = SG_VERTEXFORMAT_FLOAT4 },
+                [1] = { .format = SG_VERTEXFORMAT_FLOAT2 },
+            }
+        },
+        .label = "p0",
+    });
+
+    const sg_pipeline_desc p0_desc = sg_query_pipeline_desc(p0);
+    T(p0_desc.shader.id == shd.id);
+    T(p0_desc.layout.buffers[0].stride == 24);
+    T(p0_desc.layout.buffers[0].step_func == SG_VERTEXSTEP_PER_VERTEX);
+    T(p0_desc.layout.buffers[0].step_rate == 1);
+    T(p0_desc.layout.buffers[1].stride == 0);
+    T(p0_desc.layout.buffers[1].step_func == 0);
+    T(p0_desc.layout.buffers[1].step_rate == 0);
+    T(p0_desc.layout.attrs[0].format == SG_VERTEXFORMAT_FLOAT4);
+    T(p0_desc.layout.attrs[0].offset == 0);
+    T(p0_desc.layout.attrs[0].buffer_index == 0);
+    T(p0_desc.layout.attrs[1].format == SG_VERTEXFORMAT_FLOAT2);
+    T(p0_desc.layout.attrs[1].offset == 16);
+    T(p0_desc.layout.attrs[1].buffer_index == 0);
+    T(p0_desc.layout.attrs[2].format == 0);
+    T(p0_desc.layout.attrs[2].offset == 0);
+    T(p0_desc.layout.attrs[2].buffer_index == 0);
+    T(p0_desc.depth.pixel_format == SG_PIXELFORMAT_DEPTH_STENCIL);
+    T(p0_desc.depth.compare == SG_COMPAREFUNC_ALWAYS);
+    T(p0_desc.depth.write_enabled == false);
+    T(p0_desc.depth.bias == 0.0f);
+    T(p0_desc.depth.bias_slope_scale == 0.0f);
+    T(p0_desc.depth.bias_clamp == 0.0f);
+    T(p0_desc.stencil.enabled == false);
+    T(p0_desc.stencil.front.compare == SG_COMPAREFUNC_ALWAYS);
+    T(p0_desc.stencil.front.fail_op == SG_STENCILOP_KEEP);
+    T(p0_desc.stencil.front.depth_fail_op == SG_STENCILOP_KEEP);
+    T(p0_desc.stencil.front.pass_op == SG_STENCILOP_KEEP);
+    T(p0_desc.stencil.back.compare == SG_COMPAREFUNC_ALWAYS);
+    T(p0_desc.stencil.back.fail_op == SG_STENCILOP_KEEP);
+    T(p0_desc.stencil.back.depth_fail_op == SG_STENCILOP_KEEP);
+    T(p0_desc.stencil.back.pass_op == SG_STENCILOP_KEEP);
+    T(p0_desc.stencil.read_mask == 0);
+    T(p0_desc.stencil.write_mask == 0);
+    T(p0_desc.stencil.ref == 0);
+    T(p0_desc.color_count == 1);
+    T(p0_desc.colors[0].pixel_format == SG_PIXELFORMAT_RGBA8);
+    T(p0_desc.colors[0].write_mask == SG_COLORMASK_RGBA);
+    T(p0_desc.colors[0].blend.enabled == false);
+    T(p0_desc.colors[0].blend.src_factor_rgb == SG_BLENDFACTOR_ONE);
+    T(p0_desc.colors[0].blend.dst_factor_rgb == SG_BLENDFACTOR_ZERO);
+    T(p0_desc.colors[0].blend.op_rgb == SG_BLENDOP_ADD);
+    T(p0_desc.colors[0].blend.src_factor_alpha == SG_BLENDFACTOR_ONE);
+    T(p0_desc.colors[0].blend.dst_factor_alpha == SG_BLENDFACTOR_ZERO);
+    T(p0_desc.colors[0].blend.op_alpha == SG_BLENDOP_ADD);
+    T(p0_desc.primitive_type == SG_PRIMITIVETYPE_TRIANGLES);
+    T(p0_desc.index_type == SG_INDEXTYPE_NONE);
+    T(p0_desc.cull_mode == SG_CULLMODE_NONE);
+    T(p0_desc.face_winding == SG_FACEWINDING_CW);
+    T(p0_desc.sample_count == 1);
+    T(p0_desc.blend_color.r == 0.0f);
+    T(p0_desc.blend_color.g == 0.0f);
+    T(p0_desc.blend_color.b == 0.0f);
+    T(p0_desc.blend_color.a == 0.0f);
+    T(p0_desc.alpha_to_coverage_enabled == false);
+    T(p0_desc.label == 0);
     sg_shutdown();
 }
 

--- a/tests/functional/sokol_gfx_test.c
+++ b/tests/functional/sokol_gfx_test.c
@@ -23,13 +23,16 @@ static void test_logger(const char* tag, uint32_t log_level, uint32_t log_item_i
     (void)user_data;
     num_log_called++;
     log_item = log_item_id;
+    if (message_or_null) {
+        printf("%s\n", message_or_null);
+    }
 }
 
-static void setup_with_logger(void) {
+static void setup(const sg_desc* desc) {
     num_log_called = 0;
-    sg_setup(&(sg_desc){
-        .logger = { .func = test_logger }
-    });
+    sg_desc desc_with_logger = *desc;
+    desc_with_logger.logger.func = test_logger;
+    sg_setup(&desc_with_logger);
 }
 
 static sg_buffer create_buffer(void) {
@@ -74,14 +77,14 @@ static sg_pass create_pass(void) {
 }
 
 UTEST(sokol_gfx, init_shutdown) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     T(sg_isvalid());
     sg_shutdown();
     T(!sg_isvalid());
 }
 
 UTEST(sokol_gfx, query_desc) {
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .buffer_pool_size = 1024,
         .shader_pool_size = 128,
         .pass_pool_size = 64,
@@ -99,13 +102,13 @@ UTEST(sokol_gfx, query_desc) {
 }
 
 UTEST(sokol_gfx, query_backend) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     T(sg_query_backend() == SG_BACKEND_DUMMY);
     sg_shutdown();
 }
 
 UTEST(sokol_gfx, pool_size) {
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .buffer_pool_size = 1024,
         .image_pool_size = 2048,
         .shader_pool_size = 128,
@@ -131,7 +134,7 @@ UTEST(sokol_gfx, pool_size) {
 }
 
 UTEST(sokol_gfx, alloc_fail_destroy_buffers) {
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .buffer_pool_size = 3
     });
     T(sg_isvalid());
@@ -162,7 +165,7 @@ UTEST(sokol_gfx, alloc_fail_destroy_buffers) {
 }
 
 UTEST(sokol_gfx, alloc_fail_destroy_images) {
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .image_pool_size = 3
     });
     T(sg_isvalid());
@@ -193,7 +196,7 @@ UTEST(sokol_gfx, alloc_fail_destroy_images) {
 }
 
 UTEST(sokol_gfx, alloc_fail_destroy_shaders) {
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .shader_pool_size = 3
     });
     T(sg_isvalid());
@@ -224,7 +227,7 @@ UTEST(sokol_gfx, alloc_fail_destroy_shaders) {
 }
 
 UTEST(sokol_gfx, alloc_fail_destroy_pipelines) {
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .pipeline_pool_size = 3
     });
     T(sg_isvalid());
@@ -256,7 +259,7 @@ UTEST(sokol_gfx, alloc_fail_destroy_pipelines) {
 }
 
 UTEST(sokol_gfx, alloc_fail_destroy_passes) {
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .pass_pool_size = 3
     });
     T(sg_isvalid());
@@ -287,7 +290,7 @@ UTEST(sokol_gfx, alloc_fail_destroy_passes) {
 }
 
 UTEST(sokol_gfx, make_destroy_buffers) {
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .buffer_pool_size = 3
     });
     T(sg_isvalid());
@@ -328,7 +331,7 @@ UTEST(sokol_gfx, make_destroy_buffers) {
 }
 
 UTEST(sokol_gfx, make_destroy_images) {
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .image_pool_size = 3
     });
     T(sg_isvalid());
@@ -382,7 +385,7 @@ UTEST(sokol_gfx, make_destroy_images) {
 }
 
 UTEST(sokol_gfx, make_destroy_shaders) {
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .shader_pool_size = 3
     });
     T(sg_isvalid());
@@ -421,7 +424,7 @@ UTEST(sokol_gfx, make_destroy_shaders) {
 }
 
 UTEST(sokol_gfx, make_destroy_pipelines) {
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .pipeline_pool_size = 3
     });
     T(sg_isvalid());
@@ -468,7 +471,7 @@ UTEST(sokol_gfx, make_destroy_pipelines) {
 }
 
 UTEST(sokol_gfx, make_destroy_passes) {
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .pass_pool_size = 3
     });
     T(sg_isvalid());
@@ -516,7 +519,7 @@ UTEST(sokol_gfx, make_destroy_passes) {
 }
 
 UTEST(sokol_gfx, generation_counter) {
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .buffer_pool_size = 1,
     });
 
@@ -534,7 +537,7 @@ UTEST(sokol_gfx, generation_counter) {
 }
 
 UTEST(sokol_gfx, query_buffer_defaults) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_buffer_desc desc;
     desc = sg_query_buffer_defaults(&(sg_buffer_desc){0});
     T(desc.type == SG_BUFFERTYPE_VERTEXBUFFER);
@@ -553,7 +556,7 @@ UTEST(sokol_gfx, query_buffer_defaults) {
 }
 
 UTEST(sokol_gfx, query_image_defaults) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     const sg_image_desc desc = sg_query_image_defaults(&(sg_image_desc){0});
     T(desc.type == SG_IMAGETYPE_2D);
     T(!desc.render_target);
@@ -572,7 +575,7 @@ UTEST(sokol_gfx, query_image_defaults) {
 }
 
 UTEST(sokol_gfx, query_shader_defaults) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     const sg_shader_desc desc = sg_query_shader_defaults(&(sg_shader_desc){0});
     T(0 == strcmp(desc.vs.entry, "main"));
     T(0 == strcmp(desc.fs.entry, "main"));
@@ -580,7 +583,7 @@ UTEST(sokol_gfx, query_shader_defaults) {
 }
 
 UTEST(sokol_gfx, query_pipeline_defaults) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     const sg_pipeline_desc desc = sg_query_pipeline_defaults(&(sg_pipeline_desc){
         .layout.attrs = {
             [0].format = SG_VERTEXFORMAT_FLOAT3,
@@ -635,7 +638,7 @@ UTEST(sokol_gfx, query_pipeline_defaults) {
 
 // test that color attachment defaults are set in all attachments
 UTEST(sokol_gfx, query_mrt_pipeline_defaults) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     const sg_pipeline_desc desc = sg_query_pipeline_defaults(&(sg_pipeline_desc){
         .color_count = 3,
     });
@@ -656,7 +659,7 @@ UTEST(sokol_gfx, query_mrt_pipeline_defaults) {
 
 // test that first color attachment values are duplicated to other attachments
 UTEST(sokol_gfx, multiple_color_state) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     const sg_pipeline_desc desc = sg_query_pipeline_defaults(&(sg_pipeline_desc){
         .color_count = 3,
         .colors = {
@@ -724,7 +727,7 @@ UTEST(sokol_gfx, multiple_color_state) {
 }
 
 UTEST(sokol_gfx, query_pass_defaults) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     /* sg_pass_desc doesn't actually have any meaningful default values */
     const sg_pass_desc desc = sg_query_pass_defaults(&(sg_pass_desc){0});
     T(desc.color_attachments[0].image.id == SG_INVALID_ID);
@@ -733,7 +736,7 @@ UTEST(sokol_gfx, query_pass_defaults) {
 }
 
 UTEST(sokol_gfx, query_buffer_info) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_buffer buf = sg_make_buffer(&(sg_buffer_desc){
         .size = 256,
         .type = SG_BUFFERTYPE_VERTEXBUFFER,
@@ -746,7 +749,7 @@ UTEST(sokol_gfx, query_buffer_info) {
 }
 
 UTEST(sokol_gfx, query_image_info) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_image img = sg_make_image(&(sg_image_desc){
         .render_target = true,
         .width = 256,
@@ -756,13 +759,11 @@ UTEST(sokol_gfx, query_image_info) {
     const sg_image_info info = sg_query_image_info(img);
     T(info.slot.state == SG_RESOURCESTATE_VALID);
     T(info.num_slots == 1);
-    T(info.width == 256);
-    T(info.height == 128);
     sg_shutdown();
 }
 
 UTEST(sokol_gfx, query_shader_info) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_shader shd = sg_make_shader(&(sg_shader_desc){
         .attrs = {
             [0] = { .name = "pos" }
@@ -776,7 +777,7 @@ UTEST(sokol_gfx, query_shader_info) {
 }
 
 UTEST(sokol_gfx, query_pipeline_info) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
             .attrs[0].format = SG_VERTEXFORMAT_FLOAT3
@@ -795,7 +796,7 @@ UTEST(sokol_gfx, query_pipeline_info) {
 }
 
 UTEST(sokol_gfx, query_pass_info) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_image_desc img_desc = {
         .render_target = true,
         .width = 128,
@@ -813,8 +814,53 @@ UTEST(sokol_gfx, query_pass_info) {
     sg_shutdown();
 }
 
+UTEST(sokol_gfx, query_buffer_desc) {
+    setup(&(sg_desc){0});
+
+    sg_buffer b0 = sg_make_buffer(&(sg_buffer_desc){
+        .size = 32,
+        .usage = SG_USAGE_STREAM,
+        .label = "bla",
+    });
+    const sg_buffer_desc b0_desc = sg_query_buffer_desc(b0);
+    T(b0_desc.size == 32);
+    T(b0_desc.type == SG_BUFFERTYPE_VERTEXBUFFER);
+    T(b0_desc.usage == SG_USAGE_STREAM);
+    T(b0_desc.data.ptr == 0);
+    T(b0_desc.data.size == 0);
+    T(b0_desc.gl_buffers[0] == 0);
+    T(b0_desc.mtl_buffers[0] == 0);
+    T(b0_desc.d3d11_buffer == 0);
+    T(b0_desc.wgpu_buffer == 0);
+
+    float vtx_data[16];
+    sg_buffer b1 = sg_make_buffer(&(sg_buffer_desc){
+        .data = SG_RANGE(vtx_data)
+    });
+    const sg_buffer_desc b1_desc = sg_query_buffer_desc(b1);
+    T(b1_desc.size == sizeof(vtx_data));
+    T(b1_desc.type == SG_BUFFERTYPE_VERTEXBUFFER);
+    T(b1_desc.usage == SG_USAGE_IMMUTABLE);
+    T(b1_desc.data.ptr == 0);
+    T(b1_desc.data.size == 0);
+
+    uint16_t idx_data[8];
+    sg_buffer b2 = sg_make_buffer(&(sg_buffer_desc){
+        .type = SG_BUFFERTYPE_INDEXBUFFER,
+        .data = SG_RANGE(idx_data),
+    });
+    const sg_buffer_desc b2_desc = sg_query_buffer_desc(b2);
+    T(b2_desc.size == sizeof(idx_data));
+    T(b2_desc.type == SG_BUFFERTYPE_INDEXBUFFER);
+    T(b2_desc.usage == SG_USAGE_IMMUTABLE);
+    T(b2_desc.data.ptr == 0);
+    T(b2_desc.data.size == 0);
+
+    sg_shutdown();
+}
+
 UTEST(sokol_gfx, buffer_resource_states) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_buffer buf = sg_alloc_buffer();
     T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_ALLOC);
     sg_init_buffer(buf, &(sg_buffer_desc){ .usage = SG_USAGE_STREAM, .size = 128 });
@@ -827,7 +873,7 @@ UTEST(sokol_gfx, buffer_resource_states) {
 }
 
 UTEST(sokol_gfx, image_resource_states) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_image img = sg_alloc_image();
     T(sg_query_image_state(img) == SG_RESOURCESTATE_ALLOC);
     sg_init_image(img, &(sg_image_desc){ .render_target = true, .width = 16, .height = 16 });
@@ -840,7 +886,7 @@ UTEST(sokol_gfx, image_resource_states) {
 }
 
 UTEST(sokol_gfx, shader_resource_states) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_shader shd = sg_alloc_shader();
     T(sg_query_shader_state(shd) == SG_RESOURCESTATE_ALLOC);
     sg_init_shader(shd, &(sg_shader_desc){0});
@@ -853,7 +899,7 @@ UTEST(sokol_gfx, shader_resource_states) {
 }
 
 UTEST(sokol_gfx, pipeline_resource_states) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_pipeline pip = sg_alloc_pipeline();
     T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_ALLOC);
     sg_init_pipeline(pip, &(sg_pipeline_desc){
@@ -869,7 +915,7 @@ UTEST(sokol_gfx, pipeline_resource_states) {
 }
 
 UTEST(sokol_gfx, pass_resource_states) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_pass pass = sg_alloc_pass();
     T(sg_query_pass_state(pass) == SG_RESOURCESTATE_ALLOC);
     sg_init_pass(pass, &(sg_pass_desc){
@@ -884,7 +930,7 @@ UTEST(sokol_gfx, pass_resource_states) {
 }
 
 UTEST(sokol_gfx, query_buffer_will_overflow) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_buffer buf = sg_make_buffer(&(sg_buffer_desc){
         .size = 64,
         .usage = SG_USAGE_STREAM
@@ -914,7 +960,7 @@ static void commit_listener_func(void* ud) {
 
 UTEST(sokol_gfx, commit_listener_called) {
     reset_commit_listener();
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     const bool added = sg_add_commit_listener((sg_commit_listener){
         .func = commit_listener_func,
         .user_data = (void*)23,
@@ -929,7 +975,7 @@ UTEST(sokol_gfx, commit_listener_called) {
 
 UTEST(sokol_gfx, commit_listener_add_twice) {
     reset_commit_listener();
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     const sg_commit_listener listener = {
         .func = commit_listener_func,
         .user_data = (void*)23,
@@ -946,7 +992,7 @@ UTEST(sokol_gfx, commit_listener_add_twice) {
 
 UTEST(sokol_gfx, commit_listener_same_func_diff_ud) {
     reset_commit_listener();
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     T(sg_add_commit_listener((sg_commit_listener){
         .func = commit_listener_func,
         .user_data = (void*)23,
@@ -964,7 +1010,7 @@ UTEST(sokol_gfx, commit_listener_same_func_diff_ud) {
 
 UTEST(sokol_gfx, commit_listener_add_remove_add) {
     reset_commit_listener();
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     const sg_commit_listener listener = {
         .func = commit_listener_func,
         .user_data = (void*)23,
@@ -985,7 +1031,7 @@ UTEST(sokol_gfx, commit_listener_add_remove_add) {
 
 UTEST(sokol_gfx, commit_listener_remove_non_existant) {
     reset_commit_listener();
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     const sg_commit_listener l0 = {
         .func = commit_listener_func,
         .user_data = (void*)23,
@@ -1008,7 +1054,7 @@ UTEST(sokol_gfx, commit_listener_remove_non_existant) {
 
 UTEST(sokol_gfx, commit_listener_multi_add_remove) {
     reset_commit_listener();
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     const sg_commit_listener l0 = {
         .func = commit_listener_func,
         .user_data = (void*)23,
@@ -1054,7 +1100,7 @@ UTEST(sokol_gfx, commit_listener_multi_add_remove) {
 
 UTEST(sokol_gfx, commit_listener_array_full) {
     reset_commit_listener();
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .max_commit_listeners = 3,
     });
     const sg_commit_listener l0 = {
@@ -1087,7 +1133,7 @@ UTEST(sokol_gfx, commit_listener_array_full) {
 }
 
 UTEST(sokol_gfx, buffer_double_destroy_is_ok) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_buffer buf = create_buffer();
     T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_VALID);
     sg_destroy_buffer(buf);
@@ -1098,7 +1144,7 @@ UTEST(sokol_gfx, buffer_double_destroy_is_ok) {
 }
 
 UTEST(sokol_gfx, image_double_destroy_is_ok) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_image img = create_image();
     T(sg_query_image_state(img) == SG_RESOURCESTATE_VALID);
     sg_destroy_image(img);
@@ -1109,7 +1155,7 @@ UTEST(sokol_gfx, image_double_destroy_is_ok) {
 }
 
 UTEST(sokol_gfx, shader_double_destroy_is_ok) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_shader shd = create_shader();
     T(sg_query_shader_state(shd) == SG_RESOURCESTATE_VALID);
     sg_destroy_shader(shd);
@@ -1120,7 +1166,7 @@ UTEST(sokol_gfx, shader_double_destroy_is_ok) {
 }
 
 UTEST(sokol_gfx, pipeline_double_destroy_is_ok) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_pipeline pip = create_pipeline();
     T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_VALID);
     sg_destroy_pipeline(pip);
@@ -1131,7 +1177,7 @@ UTEST(sokol_gfx, pipeline_double_destroy_is_ok) {
 }
 
 UTEST(sokoL_gfx, pass_double_destroy_is_ok) {
-    sg_setup(&(sg_desc){0});
+    setup(&(sg_desc){0});
     sg_pass pass = create_pass();
     T(sg_query_pass_state(pass) == SG_RESOURCESTATE_VALID);
     sg_destroy_pass(pass);
@@ -1142,7 +1188,7 @@ UTEST(sokoL_gfx, pass_double_destroy_is_ok) {
 }
 
 UTEST(sokol_gfx, make_dealloc_buffer_warns) {
-    setup_with_logger();
+    setup(&(sg_desc){0});
     sg_buffer buf = create_buffer();
     T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_VALID);
     sg_dealloc_buffer(buf);
@@ -1155,7 +1201,7 @@ UTEST(sokol_gfx, make_dealloc_buffer_warns) {
 }
 
 UTEST(sokol_gfx, make_dealloc_image_warns) {
-    setup_with_logger();
+    setup(&(sg_desc){0});
     sg_image img = create_image();
     T(sg_query_image_state(img) == SG_RESOURCESTATE_VALID);
     sg_dealloc_image(img);
@@ -1168,7 +1214,7 @@ UTEST(sokol_gfx, make_dealloc_image_warns) {
 }
 
 UTEST(sokol_gfx, make_dealloc_shader_warns) {
-    setup_with_logger();
+    setup(&(sg_desc){0});
     sg_shader shd = create_shader();
     T(sg_query_shader_state(shd) == SG_RESOURCESTATE_VALID);
     sg_dealloc_shader(shd);
@@ -1181,7 +1227,7 @@ UTEST(sokol_gfx, make_dealloc_shader_warns) {
 }
 
 UTEST(sokol_gfx, make_dealloc_pipeline_warns) {
-    setup_with_logger();
+    setup(&(sg_desc){0});
     sg_pipeline pip = create_pipeline();
     T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_VALID);
     sg_dealloc_pipeline(pip);
@@ -1194,7 +1240,7 @@ UTEST(sokol_gfx, make_dealloc_pipeline_warns) {
 }
 
 UTEST(sokol_gfx, make_dealloc_pass_warns) {
-    setup_with_logger();
+    setup(&(sg_desc){0});
     sg_pass pass = create_pass();
     T(sg_query_pass_state(pass) == SG_RESOURCESTATE_VALID);
     sg_dealloc_pass(pass);
@@ -1207,7 +1253,7 @@ UTEST(sokol_gfx, make_dealloc_pass_warns) {
 }
 
 UTEST(sokol_gfx, alloc_uninit_buffer_warns) {
-    setup_with_logger();
+    setup(&(sg_desc){0});
     sg_buffer buf = sg_alloc_buffer();
     T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_ALLOC);
     sg_uninit_buffer(buf);
@@ -1218,7 +1264,7 @@ UTEST(sokol_gfx, alloc_uninit_buffer_warns) {
 }
 
 UTEST(sokol_gfx, alloc_uninit_image_warns) {
-    setup_with_logger();
+    setup(&(sg_desc){0});
     sg_image img = sg_alloc_image();
     T(sg_query_image_state(img) == SG_RESOURCESTATE_ALLOC);
     sg_uninit_image(img);
@@ -1229,7 +1275,7 @@ UTEST(sokol_gfx, alloc_uninit_image_warns) {
 }
 
 UTEST(sokol_gfx, alloc_uninit_shader_warns) {
-    setup_with_logger();
+    setup(&(sg_desc){0});
     sg_shader shd = sg_alloc_shader();
     T(sg_query_shader_state(shd) == SG_RESOURCESTATE_ALLOC);
     sg_uninit_shader(shd);
@@ -1240,7 +1286,7 @@ UTEST(sokol_gfx, alloc_uninit_shader_warns) {
 }
 
 UTEST(sokol_gfx, alloc_uninit_pipeline_warns) {
-    setup_with_logger();
+    setup(&(sg_desc){0});
     sg_pipeline pip = sg_alloc_pipeline();
     T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_ALLOC);
     sg_uninit_pipeline(pip);
@@ -1251,7 +1297,7 @@ UTEST(sokol_gfx, alloc_uninit_pipeline_warns) {
 }
 
 UTEST(sokol_gfx, alloc_uninit_pass_warns) {
-    setup_with_logger();
+    setup(&(sg_desc){0});
     sg_pass pass = sg_alloc_pass();
     T(sg_query_pass_state(pass) == SG_RESOURCESTATE_ALLOC);
     sg_uninit_pass(pass);
@@ -1262,7 +1308,7 @@ UTEST(sokol_gfx, alloc_uninit_pass_warns) {
 }
 
 UTEST(sokol_gfx, alloc_destroy_buffer_is_ok) {
-    setup_with_logger();
+    setup(&(sg_desc){0});
     sg_buffer buf = sg_alloc_buffer();
     T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_ALLOC);
     sg_destroy_buffer(buf);
@@ -1272,7 +1318,7 @@ UTEST(sokol_gfx, alloc_destroy_buffer_is_ok) {
 }
 
 UTEST(sokol_gfx, alloc_destroy_image_is_ok) {
-    setup_with_logger();
+    setup(&(sg_desc){0});
     sg_image img = sg_alloc_image();
     T(sg_query_image_state(img) == SG_RESOURCESTATE_ALLOC);
     sg_destroy_image(img);
@@ -1282,7 +1328,7 @@ UTEST(sokol_gfx, alloc_destroy_image_is_ok) {
 }
 
 UTEST(sokol_gfx, alloc_destroy_shader_is_ok) {
-    setup_with_logger();
+    setup(&(sg_desc){0});
     sg_shader shd = sg_alloc_shader();
     T(sg_query_shader_state(shd) == SG_RESOURCESTATE_ALLOC);
     sg_destroy_shader(shd);
@@ -1292,7 +1338,7 @@ UTEST(sokol_gfx, alloc_destroy_shader_is_ok) {
 }
 
 UTEST(sokol_gfx, alloc_destroy_pipeline_is_ok) {
-    setup_with_logger();
+    setup(&(sg_desc){0});
     sg_pipeline pip = sg_alloc_pipeline();
     T(sg_query_pipeline_state(pip) == SG_RESOURCESTATE_ALLOC);
     sg_destroy_pipeline(pip);
@@ -1302,7 +1348,7 @@ UTEST(sokol_gfx, alloc_destroy_pipeline_is_ok) {
 }
 
 UTEST(sokol_gfx, alloc_destroy_pass_is_ok) {
-    setup_with_logger();
+    setup(&(sg_desc){0});
     sg_pass pass = sg_alloc_pass();
     T(sg_query_pass_state(pass) == SG_RESOURCESTATE_ALLOC);
     sg_destroy_pass(pass);
@@ -1312,7 +1358,7 @@ UTEST(sokol_gfx, alloc_destroy_pass_is_ok) {
 }
 
 UTEST(sokol_gfx, make_pipeline_with_nonvalid_shader) {
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .disable_validation = true,
     });
     sg_shader shd = sg_alloc_shader();
@@ -1328,7 +1374,7 @@ UTEST(sokol_gfx, make_pipeline_with_nonvalid_shader) {
 }
 
 UTEST(sokol_gfx, make_pass_with_nonvalid_color_images) {
-    sg_setup(&(sg_desc){
+    setup(&(sg_desc){
         .disable_validation = true,
     });
     sg_pass pass = sg_make_pass(&(sg_pass_desc){

--- a/tests/functional/sokol_gfx_test.c
+++ b/tests/functional/sokol_gfx_test.c
@@ -856,6 +856,76 @@ UTEST(sokol_gfx, query_buffer_desc) {
     T(b2_desc.data.ptr == 0);
     T(b2_desc.data.size == 0);
 
+    // invalid buffer (returns zeroed desc)
+    sg_buffer b3 = sg_make_buffer(&(sg_buffer_desc){
+        .size = 32,
+        .usage = SG_USAGE_STREAM,
+        .label = "bla",
+    });
+    sg_destroy_buffer(b3);
+    const sg_buffer_desc b3_desc = sg_query_buffer_desc(b3);
+    T(b3_desc.size == 0);
+    T(b3_desc.type == 0);
+    T(b3_desc.usage == 0);
+
+    sg_shutdown();
+}
+
+UTEST(sokol_gfx, query_image_desc) {
+    setup(&(sg_desc){0});
+
+    sg_image i0 = sg_make_image(&(sg_image_desc){
+        .width = 256,
+        .height = 512,
+        .pixel_format = SG_PIXELFORMAT_R8,
+        .mag_filter = SG_FILTER_LINEAR,
+        .wrap_v = SG_WRAP_CLAMP_TO_EDGE,
+        .usage = SG_USAGE_DYNAMIC,
+        .border_color = SG_BORDERCOLOR_OPAQUE_WHITE,
+        .max_anisotropy = 4,
+        .min_lod = 0.5f,
+        .max_lod = 0.75f,
+    });
+    const sg_image_desc i0_desc = sg_query_image_desc(i0);
+    T(i0_desc.type == SG_IMAGETYPE_2D);
+    T(i0_desc.render_target == false);
+    T(i0_desc.width == 256);
+    T(i0_desc.height == 512);
+    T(i0_desc.num_slices == 1);
+    T(i0_desc.num_mipmaps == 1);
+    T(i0_desc.usage == SG_USAGE_DYNAMIC);
+    T(i0_desc.pixel_format == SG_PIXELFORMAT_R8);
+    T(i0_desc.sample_count == 1);
+    T(i0_desc.min_filter == SG_FILTER_NEAREST);
+    T(i0_desc.mag_filter == SG_FILTER_LINEAR);
+    T(i0_desc.wrap_u == SG_WRAP_REPEAT);
+    T(i0_desc.wrap_v == SG_WRAP_CLAMP_TO_EDGE);
+    T(i0_desc.wrap_w == SG_WRAP_REPEAT);
+    T(i0_desc.border_color == SG_BORDERCOLOR_OPAQUE_WHITE);
+    T(i0_desc.max_anisotropy == 4);
+    T(i0_desc.min_lod == 0.5f);
+    T(i0_desc.max_lod == 0.75f);
+    T(i0_desc.data.subimage[0][0].ptr == 0);
+    T(i0_desc.data.subimage[0][0].size == 0);
+    T(i0_desc.gl_textures[0] == 0);
+    T(i0_desc.gl_texture_target == 0);
+    T(i0_desc.mtl_textures[0] == 0);
+    T(i0_desc.d3d11_texture == 0);
+    T(i0_desc.d3d11_shader_resource_view == 0);
+    T(i0_desc.wgpu_texture == 0);
+
+    sg_destroy_image(i0);
+    const sg_image_desc i1_desc = sg_query_image_desc(i0);
+    T(i1_desc.type == 0);
+    T(i1_desc.render_target == false);
+    T(i1_desc.width == 0);
+    T(i1_desc.height == 0);
+    T(i1_desc.num_slices == 0);
+    T(i1_desc.num_mipmaps == 0);
+    T(i1_desc.usage == 0);
+    T(i1_desc.pixel_format == 0);
+    T(i1_desc.sample_count == 0);
+
     sg_shutdown();
 }
 

--- a/tests/functional/sokol_gfx_test.c
+++ b/tests/functional/sokol_gfx_test.c
@@ -1060,6 +1060,50 @@ UTEST(sokol_gfx, query_pipeline_desc) {
     sg_shutdown();
 }
 
+UTEST(sokol_gfx, query_pass_desc) {
+    setup(&(sg_desc){0});
+
+    const sg_image_desc color_img_desc = {
+        .render_target = true,
+        .width = 128,
+        .height = 128,
+    };
+    const sg_image_desc depth_img_desc = {
+        .render_target = true,
+        .width = 128,
+        .height = 128,
+        .pixel_format = SG_PIXELFORMAT_DEPTH,
+    };
+    sg_image color_img_0 = sg_make_image(&color_img_desc);
+    sg_image color_img_1 = sg_make_image(&color_img_desc);
+    sg_image color_img_2 = sg_make_image(&color_img_desc);
+    sg_image depth_img = sg_make_image(&depth_img_desc);
+
+    sg_pass p0 = sg_make_pass(&(sg_pass_desc){
+        .color_attachments = {
+            [0].image = color_img_0,
+            [1].image = color_img_1,
+            [2].image = color_img_2,
+        },
+        .depth_stencil_attachment.image = depth_img,
+    });
+    const sg_pass_desc p0_desc = sg_query_pass_desc(p0);
+    T(p0_desc.color_attachments[0].image.id == color_img_0.id);
+    T(p0_desc.color_attachments[0].mip_level == 0);
+    T(p0_desc.color_attachments[0].slice == 0);
+    T(p0_desc.color_attachments[1].image.id == color_img_1.id);
+    T(p0_desc.color_attachments[1].mip_level == 0);
+    T(p0_desc.color_attachments[1].slice == 0);
+    T(p0_desc.color_attachments[2].image.id == color_img_2.id);
+    T(p0_desc.color_attachments[2].mip_level == 0);
+    T(p0_desc.color_attachments[2].slice == 0);
+    T(p0_desc.depth_stencil_attachment.image.id == depth_img.id);
+    T(p0_desc.depth_stencil_attachment.mip_level == 0);
+    T(p0_desc.depth_stencil_attachment.slice == 0);
+
+    sg_shutdown();
+}
+
 UTEST(sokol_gfx, buffer_resource_states) {
     setup(&(sg_desc){0});
     sg_buffer buf = sg_alloc_buffer();

--- a/tests/functional/sokol_gfx_test.c
+++ b/tests/functional/sokol_gfx_test.c
@@ -929,6 +929,63 @@ UTEST(sokol_gfx, query_image_desc) {
     sg_shutdown();
 }
 
+UTEST(sokol_gfx, query_shader_desc) {
+    setup(&(sg_desc){0});
+
+    sg_shader s0 = sg_make_shader(&(sg_shader_desc){
+        .attrs = {
+            [0] = { .name = "pos", .sem_name = "POS", .sem_index = 1 },
+        },
+        .vs = {
+            .source = "vs_source",
+            .uniform_blocks = {
+                [0] = {
+                    .size = 128,
+                    .layout = SG_UNIFORMLAYOUT_STD140,
+                    .uniforms = {
+                        [0] = { .name = "blub", .type = SG_UNIFORMTYPE_FLOAT4, .array_count = 1 },
+                        [1] = { .name = "blob", .type = SG_UNIFORMTYPE_FLOAT2, .array_count = 1 },
+                    }
+                }
+            },
+            .images = {
+                [0] = { .name = "img0", .image_type = SG_IMAGETYPE_2D, .sampler_type = SG_SAMPLERTYPE_FLOAT },
+            }
+        },
+        .fs = {
+            .source = "fs_source",
+            .images = {
+                [0] = { .name = "img1", .image_type = SG_IMAGETYPE_ARRAY, .sampler_type = SG_SAMPLERTYPE_UINT },
+            }
+        },
+        .label = "label",
+    });
+    const sg_shader_desc s0_desc = sg_query_shader_desc(s0);
+    T(s0_desc.attrs[0].name == 0);
+    T(s0_desc.attrs[0].sem_name == 0);
+    T(s0_desc.attrs[0].sem_index == 0);
+    T(s0_desc.vs.source == 0);
+    T(s0_desc.vs.uniform_blocks[0].size == 128);
+    T(s0_desc.vs.uniform_blocks[0].layout == 0);
+    T(s0_desc.vs.uniform_blocks[0].uniforms[0].name == 0);
+    T(s0_desc.vs.uniform_blocks[0].uniforms[0].type == 0);
+    T(s0_desc.vs.uniform_blocks[0].uniforms[0].array_count == 0);
+    T(s0_desc.vs.images[0].name == 0);
+    T(s0_desc.vs.images[0].image_type == SG_IMAGETYPE_2D);
+    T(s0_desc.vs.images[0].sampler_type == SG_SAMPLERTYPE_FLOAT);
+    T(s0_desc.fs.source == 0);
+    T(s0_desc.fs.uniform_blocks[0].size == 0);
+    T(s0_desc.fs.uniform_blocks[0].layout == 0);
+    T(s0_desc.fs.uniform_blocks[0].uniforms[0].name == 0);
+    T(s0_desc.fs.uniform_blocks[0].uniforms[0].type == 0);
+    T(s0_desc.fs.uniform_blocks[0].uniforms[0].array_count == 0);
+    T(s0_desc.fs.images[0].name == 0);
+    T(s0_desc.fs.images[0].image_type == SG_IMAGETYPE_ARRAY);
+    T(s0_desc.fs.images[0].sampler_type == SG_SAMPLERTYPE_UINT);
+
+    sg_shutdown();
+}
+
 UTEST(sokol_gfx, buffer_resource_states) {
     setup(&(sg_desc){0});
     sg_buffer buf = sg_alloc_buffer();


### PR DESCRIPTION
Adds a set of functions for obtaining a (more or less complete) ```sg_*_desc``` struct of an existing resource. The structs may only be partially filled, any parameters which have not been kept around internally will be zeroed (but anything except sg_shader_desc structs is quite complete).

Related to issue https://github.com/floooh/sokol/issues/568 

- [x] sg_query_buffer_desc() + test
- [x] sg_query_image_desc() + test
- [x] sg_query_shader_desc() + test
- [x] sg_query_pipeline_desc() + test
- [x] sg_query_pass_desc() + test
- [x] update docs
- [x] update changelog