### PR TITLE
Fix warning relating to glTexParameterfv

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -5594,7 +5594,7 @@ _SOKOL_PRIVATE void _sg_dummy_update_image(_sg_image_t* img, const sg_image_data
     _SG_XMACRO(glClearColor,                      void, (GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)) \
     _SG_XMACRO(glBlendColor,                      void, (GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)) \
     _SG_XMACRO(glTexParameterf,                   void, (GLenum target, GLenum pname, GLfloat param)) \
-    _SG_XMACRO(glTexParameterfv,                  void, (GLenum target, GLenum pname, GLfloat* params)) \
+    _SG_XMACRO(glTexParameterfv,                  void, (GLenum target, GLenum pname, const GLfloat* params)) \
     _SG_XMACRO(glGetShaderInfoLog,                void, (GLuint shader, GLsizei bufSize, GLsizei * length, GLchar * infoLog)) \
     _SG_XMACRO(glDepthFunc,                       void, (GLenum func)) \
     _SG_XMACRO(glStencilOp ,                      void, (GLenum fail, GLenum zfail, GLenum zpass)) \


### PR DESCRIPTION
Fix warning C4113: 'PFN_glTexParameterfv' differs in parameter lists from 'PFNGLTEXPARAMETERFVPROC'

See https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexParameter.xhtml for reference (third parameter should be `const` qualified).