### PR TITLE
Fix character input on HTML5 mobile.

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4779,7 +4779,7 @@ EM_JS(void, sapp_js_create_textfield, (void), {
     });
     _sapp_inp.addEventListener("input", (ev) => {
         // put some upper limit on the max text field input length
-        if (ev.target.value.length < SAPP_EMSC_MAX_INPUT_CODE_POINTS) {
+        if (ev.target.value.length < 32) {
             withStackSave(() => {
                 const cstr = allocateUTF8OnStack(ev.target.value);
                 __sapp_emsc_ontextinput(cstr);

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4611,7 +4611,6 @@ _SOKOL_PRIVATE void _sapp_ios_show_keyboard(bool shown) {
 // >>emscripten
 #if defined(_SAPP_EMSCRIPTEN)
 
-
 #if defined(EM_JS_DEPS)
 EM_JS_DEPS(sokol_app, "$withStackSave,$allocateUTF8OnStack");
 #endif

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4637,9 +4637,9 @@ static void _sapp_emsc_vkbd_emit_chars(void) {
 }
 
 static void _sapp_emsc_vkbd_utf8_input(const uint8_t* utf8_str) {
-    #define _SAPP_EMSC_NEXT(x) uint8_t x = *utf8_str++; if (0 == x) { break; }; x &= ~0xC0;
+    #define _SAPP_EMSC_NEXT(x) uint32_t x = *utf8_str++; if (0 == x) { break; }; x &= ~0xC0u;
     for (size_t i = 0; i < _SAPP_EMSC_VKBD_MAX_CODEPOINTS; i++) {
-        uint8_t c0 = *utf8_str++;
+        uint32_t c0 = *utf8_str++;
         if (0 == c0) { break; }
         uint32_t c32 = 0;
         if ((c0 & 0x80) == 0) {
@@ -4648,18 +4648,18 @@ static void _sapp_emsc_vkbd_utf8_input(const uint8_t* utf8_str) {
         } else if ((c0 & 0xE0) == 0xC0) {
             // 2-byte sequence
             _SAPP_EMSC_NEXT(c1);
-            c32 = ((c0 & ~0xC0) << 6) | c1;
+            c32 = ((c0 & ~0xC0u) << 6) | c1;
         } else if ((c0 & 0xF0) == 0xE0) {
             // 3-byte sequence
             _SAPP_EMSC_NEXT(c1);
             _SAPP_EMSC_NEXT(c2);
-            c32 = ((c0 & ~0xE0)<<12) | (c1 << 6) | c2;
+            c32 = ((c0 & ~0xE0u)<<12) | (c1 << 6) | c2;
         } else if ((c0 & 0xF8) == 0xF0) {
             // 4-byte sequence
             _SAPP_EMSC_NEXT(c1);
             _SAPP_EMSC_NEXT(c2);
             _SAPP_EMSC_NEXT(c3);
-            c32 = ((c0 & ~0xF0)<<18) | (c1<<12) | (c2<<6) | c3;
+            c32 = ((c0 & ~0xF0u)<<18) | (c1<<12) | (c2<<6) | c3;
         }
         _sapp_emsc_vkbd_append(c32);
     }


### PR DESCRIPTION
Android/iOS differences:

- imgui-sapp on Android works completely as expected when tapping the multi-line text input field
- imgui-sapp on iOS requires a double click to show and hide the keyboard (e.g. the request to open or hide the keyboard only happens in the **next** handled event)

Remaining problems:

- When calling ```sapp_show_keyboard(true)``` in chips emulators inside TOUCHES_BEGAN input handler, iOS Safari zooms the canvas in.
- Same situation, on iOS Safari, the keyboard is closed on each tap on the keyboard.
- ...those things do not happen in imgui-sapp though when double-tapping the multiline text input field.
- ...on Android, when calling ```sapp_show_keyboard(true)``` inside TOUCHES_BEGAN, keyboard shows up then immediately disappears in the next frame.
- ...on Android, calling ```sapp_show_keyboard(true)``` in TOUCHES_ENDED, keyboard shows up but then canvas zooms in (similar to Safari), and keyboard disappears after each key press (also similar to Android)

...why do the emulators and the imgui-sample behave so differently? Only difference seems to be that ```sapp_show_keyboard``` is called outside the event handler when using sokol_imgui.h??

...implementing that same behaviour in the emulators doesn't make a difference though...

...but maybe the same tap which causes the helper input text field to become focused also unfocuses it immediately? But when that's the case why doesn't it happen in the imgui-sapp sample?

...all this mess is probably a good reason to go with the original plan to remove this mobile text input hack completely. It's brittle as f*ck.