### PR TITLE
Mouse wheel message is setting invalid mouse position.

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -7242,11 +7242,9 @@ _SOKOL_PRIVATE LRESULT CALLBACK _sapp_win32_wndproc(HWND hWnd, UINT uMsg, WPARAM
                 }
                 break;
             case WM_MOUSEWHEEL:
-                _sapp_win32_mouse_update(lParam);
                 _sapp_win32_scroll_event(0.0f, (float)((SHORT)HIWORD(wParam)));
                 break;
             case WM_MOUSEHWHEEL:
-                _sapp_win32_mouse_update(lParam);
                 _sapp_win32_scroll_event((float)((SHORT)HIWORD(wParam)), 0.0f);
                 break;
             case WM_CHAR:


### PR DESCRIPTION
The MOUSEWHEEL messages provide the mouse position in absolute coordinates, so updating it the same way you respond to other mouse messages is not correct. One solution would be to translate the mouse coordinates to client space, but it's not clear to me why this is being updated here. 

This problem was introduced recently and my application was working fine before it. I can implement a different workaround if the mouse_update call is necessary for reasons that I'm not aware of. For example, we could pass a flag to transform the coordinates when necessary.