### PR TITLE
sokol_imgui.h: improve touch input with new Dear ImGui 1.89.5 function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Updates
 
-- **20-May-2023**: some minor event-related cleanup in sokol_app.h:
+- **20-May-2023**: some minor event-related cleanup in sokol_app.h and
+  a touchscreen fix in sokol_imgui.h
+
     - in the event `SAPP_EVENTTYPE_FILESDROPPED`:
         - the `sapp_event.modifier` field now contains the active modifier keys
           at the time of the file drop operations on the platforms macOS, Emscripten
@@ -16,6 +18,12 @@
           could be a very big value on some desktop platforms
 
     Many thanks to @castano for the initial PR (https://github.com/floooh/sokol/pull/830)!
+
+    - In sokol_imgui.h, the new io.AddMouseSourceEvent() function in Dear ImGui 1.89.5
+      is called to differentiate between mouse- and touch-events, this makes ui tabs
+      work with a single tap (previously a double-tap on the tab was needed). The code
+      won't break if the ImGui version is older (in this case the function simply isn't called)
+
 
 - **19-May-2023**: _**BREAKING CHANGES**_ in sokol_gfx.h: Render passes are now more 'harmonized'
   with Metal and WebGPU by exposing a 'store action', and making MSAA resolve attachments

--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -2268,24 +2268,70 @@ _SOKOL_PRIVATE void _simgui_add_focus_event(ImGuiIO* io, bool focus) {
 
 _SOKOL_PRIVATE void _simgui_add_mouse_pos_event(ImGuiIO* io, float x, float y) {
     #if defined(__cplusplus)
+        #if (IMGUI_VERSION_NUM >= 18950)
+        io->AddMouseSourceEvent(ImGuiMouseSource_Mouse);
+        #endif
         io->AddMousePosEvent(x, y);
     #else
+        #if (IMGUI_VERSION_NUM >= 18950)
+        ImGuiIO_AddMouseSourceEvent(io, ImGuiMouseSource_Mouse);
+        #endif
+        ImGuiIO_AddMousePosEvent(io, x, y);
+    #endif
+}
+
+_SOKOL_PRIVATE void _simgui_add_touch_pos_event(ImGuiIO* io, float x, float y) {
+    #if defined(__cplusplus)
+        #if (IMGUI_VERSION_NUM >= 18950)
+        io->AddMouseSourceEvent(ImGuiMouseSource_TouchScreen);
+        #endif
+        io->AddMousePosEvent(x, y);
+    #else
+        #if (IMGUI_VERSION_NUM >= 18950)
+        ImGuiIO_AddMouseSourceEvent(io, ImGuiMouseSource_TouchScreen);
+        #endif
         ImGuiIO_AddMousePosEvent(io, x, y);
     #endif
 }
 
 _SOKOL_PRIVATE void _simgui_add_mouse_button_event(ImGuiIO* io, int mouse_button, bool down) {
     #if defined(__cplusplus)
+        #if (IMGUI_VERSION_NUM >= 18950)
+        io->AddMouseSourceEvent(ImGuiMouseSource_Mouse);
+        #endif
         io->AddMouseButtonEvent(mouse_button, down);
     #else
+        #if (IMGUI_VERSION_NUM >= 18950)
+        ImGuiIO_AddMouseSourceEvent(io, ImGuiMouseSource_Mouse);
+        #endif
+        ImGuiIO_AddMouseButtonEvent(io, mouse_button, down);
+    #endif
+}
+
+_SOKOL_PRIVATE void _simgui_add_touch_button_event(ImGuiIO* io, int mouse_button, bool down) {
+    #if defined(__cplusplus)
+        #if (IMGUI_VERSION_NUM >= 18950)
+        io->AddMouseSourceEvent(ImGuiMouseSource_TouchScreen);
+        #endif
+        io->AddMouseButtonEvent(mouse_button, down);
+    #else
+        #if (IMGUI_VERSION_NUM >= 18950)
+        ImGuiIO_AddMouseSourceEvent(io, ImGuiMouseSource_TouchScreen);
+        #endif
         ImGuiIO_AddMouseButtonEvent(io, mouse_button, down);
     #endif
 }
 
 _SOKOL_PRIVATE void _simgui_add_mouse_wheel_event(ImGuiIO* io, float wheel_x, float wheel_y) {
     #if defined(__cplusplus)
+        #if (IMGUI_VERSION_NUM >= 18950)
+        io->AddMouseSourceEvent(ImGuiMouseSource_Mouse);
+        #endif
         io->AddMouseWheelEvent(wheel_x, wheel_y);
     #else
+        #if (IMGUI_VERSION_NUM >= 18950)
+        ImGuiIO_AddMouseSourceEvent(io, ImGuiMouseSource_Mouse);
+        #endif
         ImGuiIO_AddMouseWheelEvent(io, wheel_x, wheel_y);
     #endif
 }
@@ -2377,18 +2423,18 @@ SOKOL_API_IMPL bool simgui_handle_event(const sapp_event* ev) {
             _simgui_add_mouse_wheel_event(io, ev->scroll_x, ev->scroll_y);
             break;
         case SAPP_EVENTTYPE_TOUCHES_BEGAN:
-            _simgui_add_mouse_pos_event(io, ev->touches[0].pos_x / dpi_scale, ev->touches[0].pos_y / dpi_scale);
-            _simgui_add_mouse_button_event(io, 0, true);
+            _simgui_add_touch_pos_event(io, ev->touches[0].pos_x / dpi_scale, ev->touches[0].pos_y / dpi_scale);
+            _simgui_add_touch_button_event(io, 0, true);
             break;
         case SAPP_EVENTTYPE_TOUCHES_MOVED:
-            _simgui_add_mouse_pos_event(io, ev->touches[0].pos_x / dpi_scale, ev->touches[0].pos_y / dpi_scale);
+            _simgui_add_touch_pos_event(io, ev->touches[0].pos_x / dpi_scale, ev->touches[0].pos_y / dpi_scale);
             break;
         case SAPP_EVENTTYPE_TOUCHES_ENDED:
-            _simgui_add_mouse_pos_event(io, ev->touches[0].pos_x / dpi_scale, ev->touches[0].pos_y / dpi_scale);
-            _simgui_add_mouse_button_event(io, 0, false);
+            _simgui_add_touch_pos_event(io, ev->touches[0].pos_x / dpi_scale, ev->touches[0].pos_y / dpi_scale);
+            _simgui_add_touch_button_event(io, 0, false);
             break;
         case SAPP_EVENTTYPE_TOUCHES_CANCELLED:
-            _simgui_add_mouse_button_event(io, 0, false);
+            _simgui_add_touch_button_event(io, 0, false);
             break;
         case SAPP_EVENTTYPE_KEY_DOWN:
             _simgui_update_modifiers(io, ev->modifiers);


### PR DESCRIPTION
Dear ImGui 1.89.5 has a new IO function io.AddMouseSourceEvent() which allows to differentiate between mouse- and touch-events, which in turn fixes ui tab selection (this now works with a single tap, previously a double-tap was needed).
