### PR TITLE
sokol_imgui.h: proper support for user images with samplers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 ## Updates
 
+#### 23-Jul-2023
+
+**sokol_imgui.h**: Add proper support for injecting user-provided sokol-gfx
+images and samplers into Dear ImGui UIs. With the introduction of separate
+sampler objects in sokol_gfx.h there's a temporary feature regression in
+sokol_imgui.h and sokol_nuklear.h in that user provided images had to use a
+shared sampler that's hardwired into the respective headers. This update fixes
+this problem for sokol_imgui.h, with a similar fix for sokol_nuklear.h coming
+up next.
+
+The sokol_imgui.h changes in detail are:
+
+- a new object type `simgui_image_t` which wraps a sokol-gfx image and sampler
+  object under a common handle
+- two new function `simgui_make_image()` and `simgui_destroy_image()` to
+  create and destroy such a new `simgui_image_t` object.
+- the existing function `simgui_imtextureid()` has been changed to take
+  an `simgui_image_t`
+- sokol_imgui.h now also uses the same error-handling and logging callback
+  as the other sokol headers (this was needed because creating an `simgui_image_t`
+  object may fail because the object pool is exhausted) - don't forget
+  to provide a logging callback (for instance via sokol_log.h), otherwise
+  sokol_imgui.h will be entirely silent in case of errors.
+
+Please also read the new documentation section `ON USER-PROVIDED IMAGES AND SAMPLERS`
+in sokol_imgui.h, and also check out the new sample:
+
+https://floooh.github.io/sokol-html5/imgui-images-sapp.html
+
 #### 16-Jul-2023
 
 **BREAKING CHANGES**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ in sokol_imgui.h, and also check out the new sample:
 
 https://floooh.github.io/sokol-html5/imgui-images-sapp.html
 
+Associated PR: https://github.com/floooh/sokol/pull/861
+
 #### 16-Jul-2023
 
 **BREAKING CHANGES**

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple
 [STB-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt)
 cross-platform libraries for C and C++, written in C.
 
-[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**17-Jul-2023** BREAKING CHANGES: sokol_gfx.h now has separate sampler objects!)
+[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**23-Jul-2023** proper image/sampler pair support in sokol_imgui.h)
 
 [![Build](/../../actions/workflows/main.yml/badge.svg)](/../../actions/workflows/main.yml) [![Bindings](/../../actions/workflows/gen_bindings.yml/badge.svg)](/../../actions/workflows/gen_bindings.yml) [![build](https://github.com/floooh/sokol-zig/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-zig/actions/workflows/main.yml) [![build](https://github.com/floooh/sokol-nim/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-nim/actions/workflows/main.yml) [![Odin](https://github.com/floooh/sokol-odin/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-odin/actions/workflows/main.yml)[![Rust](https://github.com/floooh/sokol-rust/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-rust/actions/workflows/main.yml)
 

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -3334,7 +3334,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_embedded_image(sg_imgui_t* ctx, sg_image img,
             igSliderFloat("Scale", scale, 0.125f, 8.0f, "%.3f", ImGuiSliderFlags_Logarithmic);
             float w = (float)img_ui->desc.width * (*scale);
             float h = (float)img_ui->desc.height * (*scale);
-            igImage((ImTextureID)simgui_imtextureid(img_ui->simgui_img), IMVEC2(w, h), IMVEC2(0,0), IMVEC2(1,1), IMVEC4(1,1,1,1), IMVEC4(0,0,0,0));
+            igImage(simgui_imtextureid(img_ui->simgui_img), IMVEC2(w, h), IMVEC2(0,0), IMVEC2(1,1), IMVEC4(1,1,1,1), IMVEC4(0,0,0,0));
             igPopID();
         } else {
             igText("Image not renderable.");

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -250,6 +250,7 @@ typedef struct sg_imgui_image_t {
     float ui_scale;
     sg_imgui_str_t label;
     sg_image_desc desc;
+    simgui_image_t simgui_img;
 } sg_imgui_image_t;
 
 typedef struct sg_imgui_sampler_t {
@@ -1517,12 +1518,18 @@ _SOKOL_PRIVATE void _sg_imgui_image_created(sg_imgui_t* ctx, sg_image res_id, in
     img->desc = *desc;
     img->ui_scale = 1.0f;
     img->label = _sg_imgui_make_str(desc->label);
+    simgui_image_desc_t simgui_img_desc;
+    _sg_imgui_clear(&simgui_img_desc, sizeof(simgui_img_desc));
+    simgui_img_desc.image = res_id;
+    // keep sampler at default, which will use sokol_imgui.h's default nearest-filtering sampler
+    img->simgui_img = simgui_make_image(&simgui_img_desc);
 }
 
 _SOKOL_PRIVATE void _sg_imgui_image_destroyed(sg_imgui_t* ctx, int slot_index) {
     SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->images.num_slots));
     sg_imgui_image_t* img = &ctx->images.slots[slot_index];
     img->res_id.id = SG_INVALID_ID;
+    simgui_destroy_image(img->simgui_img);
 }
 
 _SOKOL_PRIVATE void _sg_imgui_sampler_created(sg_imgui_t* ctx, sg_sampler res_id, int slot_index, const sg_sampler_desc* desc) {
@@ -3327,7 +3334,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_embedded_image(sg_imgui_t* ctx, sg_image img,
             igSliderFloat("Scale", scale, 0.125f, 8.0f, "%.3f", ImGuiSliderFlags_Logarithmic);
             float w = (float)img_ui->desc.width * (*scale);
             float h = (float)img_ui->desc.height * (*scale);
-            igImage((ImTextureID)(intptr_t)img.id, IMVEC2(w, h), IMVEC2(0,0), IMVEC2(1,1), IMVEC4(1,1,1,1), IMVEC4(0,0,0,0));
+            igImage((ImTextureID)simgui_imtextureid(img_ui->simgui_img), IMVEC2(w, h), IMVEC2(0,0), IMVEC2(1,1), IMVEC4(1,1,1,1), IMVEC4(0,0,0,0));
             igPopID();
         } else {
             igText("Image not renderable.");

--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -521,7 +521,7 @@ typedef struct simgui_frame_desc_t {
 SOKOL_IMGUI_API_DECL void simgui_setup(const simgui_desc_t* desc);
 SOKOL_IMGUI_API_DECL void simgui_new_frame(const simgui_frame_desc_t* desc);
 SOKOL_IMGUI_API_DECL void simgui_render(void);
-SOKOL_IMGUI_API_DECL simgui_image_t simgui_make_image(simgui_image_desc_t* desc);
+SOKOL_IMGUI_API_DECL simgui_image_t simgui_make_image(const simgui_image_desc_t* desc);
 SOKOL_IMGUI_API_DECL void simgui_destroy_image(simgui_image_t img);
 SOKOL_IMGUI_API_DECL void* simgui_imtextureid(simgui_image_t img);
 SOKOL_IMGUI_API_DECL void simgui_add_focus_event(bool focus);
@@ -544,6 +544,7 @@ SOKOL_IMGUI_API_DECL void simgui_shutdown(void);
 
 // reference-based equivalents for C++
 inline void simgui_setup(const simgui_desc_t& desc) { return simgui_setup(&desc); }
+inline simgui_image_t simgui_make_image(const simgui_image_desc_t& desc) { return simgui_make_image(&desc); }
 inline void simgui_new_frame(const simgui_frame_desc_t& desc) { return simgui_new_frame(&desc); }
 
 #endif
@@ -2456,7 +2457,7 @@ SOKOL_API_IMPL void simgui_shutdown(void) {
     _simgui.init_cookie = 0;
 }
 
-SOKOL_API_IMPL simgui_image_t simgui_make_image(simgui_image_desc_t* desc) {
+SOKOL_API_IMPL simgui_image_t simgui_make_image(const simgui_image_desc_t* desc) {
     SOKOL_ASSERT(_SIMGUI_INIT_COOKIE == _simgui.init_cookie);
     SOKOL_ASSERT(desc);
     const simgui_image_desc_t desc_def = _simgui_image_desc_defaults(desc);


### PR DESCRIPTION
Adds the following to sokol_imgui.h:

- `simgui_image_t` which groups a sokol-gfx image and sampler
- `simgui_image_desc_t` desc struct to create an `simgui_image_t`
- `simgui_make_image()` to create an `simgui_image_t` object
- `simgui_destroy_image()` to destroy an `simgui_image_t` object
- `simgui_imtextureid()` has been changes to take an `simgui_image_t` handle instead of sg_image
- `simgui_desc.image_pool_size`
- `simgui_desc.logger`: added logging support
- allocation failure now results in a log-panic
- added an 'init_cookie' to make sure that API functions are only called between setup/discard

TODO:
- [x] fix sokol_gfx_imgui.h
- [x] fix existing sokol samples
- [x] add a new sokol sample to demonstrate using custom images with sokol_imgui.h
- [x] add documentation
- [x] changelog + readme