### PR TITLE
sokol_nuklear.h: add support for custom images and samplers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### 26-Jul-2023
 
-**sokol_nuklear.h**: The same image+sampler support has been added as in sokol_nuklear.h
+**sokol_nuklear.h**: The same image+sampler support has been added as in sokol_imgui.h
 three days ago:
 
 - a new object type `snk_image_t` which wraps a sokol-gfx image and sampler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 ## Updates
 
+#### 26-Jul-2023
+
+**sokol_nuklear.h**: The same image+sampler support has been added as in sokol_nuklear.h
+three days ago:
+
+- a new object type `snk_image_t` which wraps a sokol-gfx image and sampler
+  under a common handle
+- new functions:
+  - snk_make_image()
+  - snk_destroy_image()
+  - snk_query_image_desc()
+  - snk_image_from_nkhandle()
+- the function snk_nkhandle() now takes an snk_image_t handle instead of an sg_image handle
+- the nuklear.h header needs to be included before the declaration (not just the implementation),
+  this was already required before, but now you get a proper error message if the include is missing
+- the 'standard' logging- and error-reporting callback has been added as in the other sokol headers
+  (don't forget to add a logging callback in snk_setup(), otherwise sokol-nuklear will be silent)
+- since sokol-nuklear now needs to allocate memory, an allocator can now be provided to the
+  snk_setup() call (otherwise malloc/free will be used)
+
+Please also read the new documentation section `ON USER-PROVIDED IMAGES AND SAMPLERS`
+in sokol_nuklear.h, and also check out the (rewritten) sample:
+
+https://floooh.github.io/sokol-html5/nuklear-images-sapp.html
+
+Associated PR: https://github.com/floooh/sokol/pull/862
+
 #### 23-Jul-2023
 
 **sokol_imgui.h**: Add proper support for injecting user-provided sokol-gfx

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple
 [STB-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt)
 cross-platform libraries for C and C++, written in C.
 
-[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**23-Jul-2023** proper image/sampler pair support in sokol_imgui.h)
+[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**26-Jul-2023** proper image/sampler pair support in sokol_nuklear.h)
 
 [![Build](/../../actions/workflows/main.yml/badge.svg)](/../../actions/workflows/main.yml) [![Bindings](/../../actions/workflows/gen_bindings.yml/badge.svg)](/../../actions/workflows/gen_bindings.yml) [![build](https://github.com/floooh/sokol-zig/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-zig/actions/workflows/main.yml) [![build](https://github.com/floooh/sokol-nim/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-nim/actions/workflows/main.yml) [![Odin](https://github.com/floooh/sokol-odin/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-odin/actions/workflows/main.yml)[![Rust](https://github.com/floooh/sokol-rust/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-rust/actions/workflows/main.yml)
 

--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -2212,6 +2212,13 @@ static simgui_desc_t _simgui_desc_defaults(const simgui_desc_t* desc) {
     return res;
 }
 
+// ██████  ██    ██ ██████  ██      ██  ██████
+// ██   ██ ██    ██ ██   ██ ██      ██ ██
+// ██████  ██    ██ ██████  ██      ██ ██
+// ██      ██    ██ ██   ██ ██      ██ ██
+// ██       ██████  ██████  ███████ ██  ██████
+//
+// >>public
 SOKOL_API_IMPL void simgui_setup(const simgui_desc_t* desc) {
     SOKOL_ASSERT(desc);
     _simgui_clear(&_simgui, sizeof(_simgui));

--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -223,14 +223,6 @@
 
         simgui_shutdown()
 
-    --- use the following helper function to create an ImTextureID handle from
-        a sokol-gfx image (note that you cannot provide your own sampler currently):
-
-        ImTextureID tex_id = simgui_imtextureid(img);
-
-        ...an invalid handle {SG_INVALID_ID} will be replaced with the
-        default font texture or default sampler object
-
 
     ON USER-PROVIDED IMAGES AND SAMPLERS
     ====================================

--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -487,7 +487,7 @@ typedef struct simgui_allocator_t {
 /*
     simgui_logger
 
-    Used in simgui_desc to provide a logging function. Please be aware
+    Used in simgui_desc_t to provide a logging function. Please be aware
     that without logging function, sokol-imgui will be completely
     silent, e.g. it will not report errors, warnings and
     validation layer messages. For maximum error verbosity,


### PR DESCRIPTION
Same as https://github.com/floooh/sokol/pull/861, but for sokol_nuklear.h

- [x] rewrite nuklear-images-sapp to match imgui-images-sapp
- [x] fix samples (add logging)
- [x] documentation (snk_image_t, allocators, logging)
- [x] changelog + readme