### PR TITLE
sokol_gfx.h mtl: new attempt to fix swapchain lifetime issues

### DIFF
--- a/.github/workflows/gen_bindings.yml
+++ b/.github/workflows/gen_bindings.yml
@@ -150,7 +150,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # FIXME: macOS Odin vs Homebrew LLVM currently seems broken
+        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v3
@@ -174,7 +176,7 @@ jobs:
         name: prepare-macos
         run: |
           brew install llvm@14
-          curl -L https://f001.backblazeb2.com/file/odin-binaries/nightly/odin-macos-amd64-nightly%2B2023-08-27.zip --output odin.zip
+          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2023-08/odin-macos-amd64-dev-2023-08.zip --output odin.zip
           unzip odin.zip
           chmod a+x ./odin
           ./build_clibs_macos.sh

--- a/.github/workflows/gen_bindings.yml
+++ b/.github/workflows/gen_bindings.yml
@@ -165,16 +165,16 @@ jobs:
         name: prepare-linux
         run: |
           sudo apt-get update
-          sudo apt-get install libglu1-mesa-dev mesa-common-dev xorg-dev libasound-dev llvm-11
-          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2023-07/odin-ubuntu-amd64-dev-2023-07.zip --output odin.zip
+          sudo apt-get install libglu1-mesa-dev mesa-common-dev xorg-dev libasound-dev llvm-14
+          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2023-08/odin-ubuntu-amd64-dev-2023-08.zip --output odin.zip
           unzip odin.zip
           chmod a+x ./odin
           ./build_clibs_linux.sh
       - if: runner.os == 'macOS'
         name: prepare-macos
         run: |
-          brew install llvm@11
-          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2023-07/odin-macos-amd64-dev-2023-07.zip --output odin.zip
+          brew install llvm@14
+          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2023-08/odin-macos-amd64-dev-2023-08.zip --output odin.zip
           unzip odin.zip
           chmod a+x ./odin
           ./build_clibs_macos.sh
@@ -182,7 +182,7 @@ jobs:
         name: prepare-windows
         shell: cmd
         run: |
-          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2023-07/odin-windows-amd64-dev-2023-07.zip --output odin.zip
+          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2023-08/odin-windows-amd64-dev-2023-08.zip --output odin.zip
           unzip odin.zip
           build_clibs_windows.cmd
       - name: build

--- a/.github/workflows/gen_bindings.yml
+++ b/.github/workflows/gen_bindings.yml
@@ -174,7 +174,7 @@ jobs:
         name: prepare-macos
         run: |
           brew install llvm@14
-          curl -L https://github.com/odin-lang/Odin/releases/download/dev-2023-08/odin-macos-amd64-dev-2023-08.zip --output odin.zip
+          curl -L https://f001.backblazeb2.com/file/odin-binaries/nightly/odin-macos-amd64-nightly%2B2023-08-27.zip --output odin.zip
           unzip odin.zip
           chmod a+x ./odin
           ./build_clibs_macos.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Updates
 
+#### 28-Aug-2023
+
+**sokol_gfx.h metal**: A new attempt at fixing a rare Metal validation layer
+error for MTKView swapchain resources. See ticket PR https://github.com/floooh/sokol/pull/873
+for details.
+
 #### 26-Jul-2023
 
 **sokol_nuklear.h**: The same image+sampler support has been added as in sokol_imgui.h


### PR DESCRIPTION
See https://github.com/floooh/sokol/issues/872

This does away with the separate retained-reference command buffer for the present call, and instead uses the regular 'deferred release queue' for the default pass MTLRenderPassDescriptor. Since the render-pass-descriptor holds a strong-ref to swapchain surfaces this should make sure that those surfaces outlive their command buffer when they are released by MTKView because of a window resize. This means there's a memory spike during window resize, but I guess there's no way around that.

This also replaces the changes from https://github.com/floooh/sokol/pull/763 with a different approach.