### PR TITLE
Fail buffer creation if metal buffer couldn't be allocated

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -10982,6 +10982,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_mtl_create_buffer(_sg_buffer_t* buf, const 
             } else {
                 mtl_buf = [_sg.mtl.device newBufferWithLength:(NSUInteger)buf->cmn.size options:mtl_options];
             }
+            if (!mtl_buf) return SG_RESOURCESTATE_FAILED;
         }
         buf->mtl.buf[slot] = _sg_mtl_add_resource(mtl_buf);
         _SG_OBJC_RELEASE(mtl_buf);


### PR DESCRIPTION
Before this change, the underlying resource could fail to be created and you wouldn't ever know.
This same issue exists **in other backends** (buffers in GL) and for **other resource types** (images in metal). Let me know if you'd prefer those other fixes to be put into this PR. I didn't go ahead with all that work because I wasn't sure if this silent failure was by design (though I can't think of why it would be?)

Background: I have some code that destroys, then doubles the size of a buffer every time appending would've caused an overflow. I needed to know when doubling it failed so I could back off a bit. Let me know if theres a better way to go about that.