### PR TITLE
Windows OpenGL startup time optimization

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -6565,10 +6565,52 @@ _SOKOL_PRIVATE int _sapp_wgl_attrib(int pixel_format, int attrib) {
     return value;
 }
 
+_SOKOL_PRIVATE void _sapp_wgl_attribiv(int pixel_format, int num_attribs, const int* attribs, int* results) {
+    SOKOL_ASSERT(_sapp.wgl.arb_pixel_format);
+    if (!_sapp.wgl.GetPixelFormatAttribivARB(_sapp.win32.dc, pixel_format, 0, num_attribs, attribs, results)) {
+        _SAPP_PANIC(WIN32_GET_PIXELFORMAT_ATTRIB_FAILED);
+    }
+}
+
 _SOKOL_PRIVATE int _sapp_wgl_find_pixel_format(void) {
     SOKOL_ASSERT(_sapp.win32.dc);
     SOKOL_ASSERT(_sapp.wgl.arb_pixel_format);
     const _sapp_gl_fbconfig* closest;
+
+    const int QUERY_TAGS[] = {
+      WGL_SUPPORT_OPENGL_ARB,
+      WGL_DRAW_TO_WINDOW_ARB,
+      WGL_PIXEL_TYPE_ARB,
+      WGL_ACCELERATION_ARB,
+      WGL_DOUBLE_BUFFER_ARB,
+      WGL_RED_BITS_ARB,
+      WGL_GREEN_BITS_ARB,
+      WGL_BLUE_BITS_ARB,
+      WGL_ALPHA_BITS_ARB,
+      WGL_DEPTH_BITS_ARB,
+      WGL_STENCIL_BITS_ARB,
+      WGL_SAMPLES_ARB,
+    };
+    const int RESULT_SUPPORT_OPENGL_INDEX = 0;
+    const int RESULT_DRAW_TO_WINDOW_INDEX = 1;
+    const int RESULT_PIXEL_TYPE_INDEX = 2;
+    const int RESULT_ACCELERATION_INDEX = 3;
+    const int RESULT_DOUBLE_BUFFER_INDEX = 4;
+    const int RESULT_RED_BITS_INDEX = 5;
+    const int RESULT_GREEN_BITS_INDEX = 6;
+    const int RESULT_BLUE_BITS_INDEX = 7;
+    const int RESULT_ALPHA_BITS_INDEX = 8;
+    const int RESULT_DEPTH_BITS_INDEX = 9;
+    const int RESULT_STENCIL_BITS_INDEX = 10;
+    const int RESULT_SAMPLES_INDEX = 11;
+
+    int query_results[12] = {0};
+    // Drop the last item if multisample extension is not supported.
+    //  If in future querying with multiple extensions, will have to shuffle index values to have active extensions on the end.
+    int query_count = 12;
+    if (!_sapp.wgl.arb_multisample) {
+        query_count = 11;
+    }
 
     int native_count = _sapp_wgl_attrib(1, WGL_NUMBER_PIXEL_FORMATS_ARB);
     _sapp_gl_fbconfig* usable_configs = (_sapp_gl_fbconfig*) _sapp_malloc_clear((size_t)native_count * sizeof(_sapp_gl_fbconfig));
@@ -6578,27 +6620,27 @@ _SOKOL_PRIVATE int _sapp_wgl_find_pixel_format(void) {
         const int n = i + 1;
         _sapp_gl_fbconfig* u = usable_configs + usable_count;
         _sapp_gl_init_fbconfig(u);
-        if (!_sapp_wgl_attrib(n, WGL_SUPPORT_OPENGL_ARB) || !_sapp_wgl_attrib(n, WGL_DRAW_TO_WINDOW_ARB)) {
+        _sapp_wgl_attribiv(n, query_count, QUERY_TAGS, query_results);
+
+        if (query_results[RESULT_SUPPORT_OPENGL_INDEX] == 0
+          || query_results[RESULT_DRAW_TO_WINDOW_INDEX] == 0
+          || query_results[RESULT_PIXEL_TYPE_INDEX] != WGL_TYPE_RGBA_ARB
+          || query_results[RESULT_ACCELERATION_INDEX] == WGL_NO_ACCELERATION_ARB)
+        {
             continue;
         }
-        if (_sapp_wgl_attrib(n, WGL_PIXEL_TYPE_ARB) != WGL_TYPE_RGBA_ARB) {
-            continue;
-        }
-        if (_sapp_wgl_attrib(n, WGL_ACCELERATION_ARB) == WGL_NO_ACCELERATION_ARB) {
-            continue;
-        }
-        u->red_bits     = _sapp_wgl_attrib(n, WGL_RED_BITS_ARB);
-        u->green_bits   = _sapp_wgl_attrib(n, WGL_GREEN_BITS_ARB);
-        u->blue_bits    = _sapp_wgl_attrib(n, WGL_BLUE_BITS_ARB);
-        u->alpha_bits   = _sapp_wgl_attrib(n, WGL_ALPHA_BITS_ARB);
-        u->depth_bits   = _sapp_wgl_attrib(n, WGL_DEPTH_BITS_ARB);
-        u->stencil_bits = _sapp_wgl_attrib(n, WGL_STENCIL_BITS_ARB);
-        if (_sapp_wgl_attrib(n, WGL_DOUBLE_BUFFER_ARB)) {
+        u->red_bits     = query_results[RESULT_RED_BITS_INDEX];
+        u->green_bits   = query_results[RESULT_GREEN_BITS_INDEX];
+        u->blue_bits    = query_results[RESULT_BLUE_BITS_INDEX];
+        u->alpha_bits   = query_results[RESULT_ALPHA_BITS_INDEX];
+        u->depth_bits   = query_results[RESULT_DEPTH_BITS_INDEX];
+        u->stencil_bits = query_results[RESULT_STENCIL_BITS_INDEX];
+        if (query_results[RESULT_DOUBLE_BUFFER_INDEX]) {
             u->doublebuffer = true;
         }
-        if (_sapp.wgl.arb_multisample) {
-            u->samples = _sapp_wgl_attrib(n, WGL_SAMPLES_ARB);
-        }
+
+        u->samples = query_results[RESULT_SAMPLES_INDEX]; // Note: If arb_multisample is not supported  - just takes the default 0
+
         u->handle = (uintptr_t)n;
         usable_count++;
     }


### PR DESCRIPTION
By doing all attribute queries at once it decreases startup time by ~65ms and also makes my binary 1.5kb smaller.
Win10, Nvidia 3070

Tested with code similar to

```c++
static void init_userdata_cb(void* in_app) {
  printf("Startup time %f\n", stm_ms(stm_diff(stm_now(), start_ticks)));
}

sapp_desc sokol_main(int argc, char* argv[]) {
  stm_setup();
  start_ticks = stm_now();

  return sapp_desc{
      .init_userdata_cb = init_userdata_cb,
  }
}
```
