### PR TITLE
add callbacks for default gl framebuffer. 

### DIFF
--- a/bindgen/gen_rust.py
+++ b/bindgen/gen_rust.py
@@ -355,6 +355,8 @@ def funcptr_result_c(field_type):
     res_type = field_type[: field_type.index("(*)")].strip()
     if res_type == "void":
         return ""
+    elif is_prim_type(res_type):
+        return as_rust_prim_type(res_type)
     elif util.is_const_void_ptr(res_type):
         return " -> *const core::ffi::c_void"
     elif util.is_void_ptr(res_type):

--- a/bindgen/gen_zig.py
+++ b/bindgen/gen_zig.py
@@ -271,6 +271,8 @@ def funcptr_result_c(field_type):
     res_type = field_type[:field_type.index('(*)')].strip()
     if res_type == 'void':
         return 'void'
+    elif is_prim_type(res_type):
+        return as_zig_prim_type(res_type)
     elif util.is_const_void_ptr(res_type):
         return '?*const anyopaque'
     elif util.is_void_ptr(res_type):

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3246,8 +3246,8 @@ typedef struct sg_wgpu_context_desc {
 } sg_wgpu_context_desc;
 
 typedef struct sg_gl_context_desc {
-    unsigned int (*default_framebuffer_cb)(void);
-    unsigned int (*default_framebuffer_userdata_cb)(void*);
+    uint32_t (*default_framebuffer_cb)(void);
+    uint32_t (*default_framebuffer_userdata_cb)(void*);
     void* user_data;
 } sg_gl_context_desc;
 

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -7043,6 +7043,7 @@ _SOKOL_PRIVATE void _sg_gl_reset_state_cache(void) {
 }
 
 _SOKOL_PRIVATE void _sg_gl_setup_backend(const sg_desc* desc) {
+    _SOKOL_UNUSED(desc);
     SOKOL_ASSERT(desc->context.gl.default_framebuffer_cb == NULL || desc->context.gl.default_framebuffer_userdata_cb == NULL);
     
     // assumes that _sg.gl is already zero-initialized

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3245,6 +3245,12 @@ typedef struct sg_wgpu_context_desc {
     void* user_data;
 } sg_wgpu_context_desc;
 
+typedef struct sg_gl_context_desc {
+    GLuint (*default_framebuffer_cb)(void);
+    GLuint (*default_framebuffer_userdata_cb)(void*);
+    void* user_data;
+} sg_gl_context_desc;
+
 typedef struct sg_context_desc {
     sg_pixel_format color_format;
     sg_pixel_format depth_format;
@@ -3252,6 +3258,7 @@ typedef struct sg_context_desc {
     sg_metal_context_desc metal;
     sg_d3d11_context_desc d3d11;
     sg_wgpu_context_desc wgpu;
+    sg_gl_context_desc gl;
 } sg_context_desc;
 
 /*
@@ -7036,7 +7043,8 @@ _SOKOL_PRIVATE void _sg_gl_reset_state_cache(void) {
 }
 
 _SOKOL_PRIVATE void _sg_gl_setup_backend(const sg_desc* desc) {
-    _SOKOL_UNUSED(desc);
+    SOKOL_ASSERT(desc->context.gl.default_framebuffer_cb == NULL || desc->context.gl.default_framebuffer_userdata_cb == NULL);
+    
     // assumes that _sg.gl is already zero-initialized
     _sg.gl.valid = true;
 
@@ -7725,6 +7733,12 @@ _SOKOL_PRIVATE void _sg_gl_begin_pass(_sg_pass_t* pass, const sg_pass_action* ac
         #if defined(SOKOL_GLCORE33)
         glDisable(GL_FRAMEBUFFER_SRGB);
         #endif
+        if (_sg.desc.context.gl.default_framebuffer_userdata_cb) {
+            _sg.gl.cur_context->default_framebuffer = _sg.desc.context.gl.default_framebuffer_userdata_cb(_sg.desc.context.gl.user_data);
+        } else if (_sg.desc.context.gl.default_framebuffer_cb) {
+            _sg.gl.cur_context->default_framebuffer = _sg.desc.context.gl.default_framebuffer_cb();
+        }
+
         glBindFramebuffer(GL_FRAMEBUFFER, _sg.gl.cur_context->default_framebuffer);
     }
     glViewport(0, 0, w, h);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -7044,7 +7044,7 @@ _SOKOL_PRIVATE void _sg_gl_reset_state_cache(void) {
 
 _SOKOL_PRIVATE void _sg_gl_setup_backend(const sg_desc* desc) {
     _SOKOL_UNUSED(desc);
-    SOKOL_ASSERT(desc->context.gl.default_framebuffer_cb == NULL || desc->context.gl.default_framebuffer_userdata_cb == NULL);
+    SOKOL_ASSERT(desc->context.gl.default_framebuffer_cb == 0 || desc->context.gl.default_framebuffer_userdata_cb == 0);
     
     // assumes that _sg.gl is already zero-initialized
     _sg.gl.valid = true;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3246,8 +3246,8 @@ typedef struct sg_wgpu_context_desc {
 } sg_wgpu_context_desc;
 
 typedef struct sg_gl_context_desc {
-    GLuint (*default_framebuffer_cb)(void);
-    GLuint (*default_framebuffer_userdata_cb)(void*);
+    unsigned int (*default_framebuffer_cb)(void);
+    unsigned int (*default_framebuffer_userdata_cb)(void*);
     void* user_data;
 } sg_gl_context_desc;
 


### PR DESCRIPTION
fixes #892

There is a simpler fix of adding this function, but I figured you might not want to add backend-specific public apis.
```
void sg_set_default_gl_framebuffer(GLuint framebuffer) {
    _sg.gl.cur_context->default_framebuffer = framebuffer;
}
```
This is nicer for the end user than the callback approach, because you don't have to create the callback and a global. and set the global before calling sg_begin_default_pass.


