### PR TITLE
sokol_gfx.h metal: fix Intel Mac compilation and validation layer problems.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Updates
 
+#### 22-Sep-2023
+
+- sokol_gfx.h: Fixed a Metal validation error on Intel Macs when creating textures (Intel Macs
+  have unified memory, but don't support textures in shared storage mode). This was a regression
+  in the image/sampler split update in mid-July 2023. Fixes issue https://github.com/floooh/sokol/issues/905
+  via PR https://github.com/floooh/sokol/pull/907.
+
 #### 19-Sep-2023
 
 - sokol_fetch.h: fixed a minor issue where a request that was cancelled before it was dispatched

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -10739,6 +10739,7 @@ _SOKOL_PRIVATE void _sg_mtl_init_caps(void) {
     _sg.features.mrt_independent_write_mask = true;
 
     _sg.features.image_clamp_to_border = false;
+    #if (MAC_OS_X_VERSION_MAX_ALLOWED >= 120000) || (__IPHONE_OS_VERSION_MAX_ALLOWED >= 140000)
     if (@available(macOS 12.0, iOS 14.0, *)) {
         _sg.features.image_clamp_to_border = [_sg.mtl.device supportsFamily:MTLGPUFamilyApple7]
                                              || [_sg.mtl.device supportsFamily:MTLGPUFamilyApple8]
@@ -10749,6 +10750,7 @@ _SOKOL_PRIVATE void _sg_mtl_init_caps(void) {
             }
         }
     }
+    #endif
 
     #if defined(_SG_TARGET_MACOS)
         _sg.limits.max_image_size_2d = 16 * 1024;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -10744,11 +10744,13 @@ _SOKOL_PRIVATE void _sg_mtl_init_caps(void) {
         _sg.features.image_clamp_to_border = [_sg.mtl.device supportsFamily:MTLGPUFamilyApple7]
                                              || [_sg.mtl.device supportsFamily:MTLGPUFamilyApple8]
                                              || [_sg.mtl.device supportsFamily:MTLGPUFamilyMac2];
+        #if (MAC_OS_X_VERSION_MAX_ALLOWED >= 130000) || (__IPHONE_OS_VERSION_MAX_ALLOWED >= 160000)
         if (!_sg.features.image_clamp_to_border) {
             if (@available(macOS 13.0, iOS 16.0, *)) {
                 _sg.features.image_clamp_to_border = [_sg.mtl.device supportsFamily:MTLGPUFamilyMetal3];
             }
         }
+        #endif
     }
     #endif
 


### PR DESCRIPTION
Issue: https://github.com/floooh/sokol/issues/905

- fixed compilation of sokol_gfx.h on older macOS SDKs
- fix validation layer error because textures were created with shared-storage-mode, but this isn't supported on Intel Macs

TODO:
- [ ] update changelog