### PR TITLE
Mipmaps on GL/GLES require GL_TEXTURE_MAX_LEVEL set explicitly.

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -7189,6 +7189,9 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_image(_sg_image_t* img, const sg_
             SOKOL_ASSERT(img->gl.tex[slot]);
             _sg_gl_cache_store_texture_sampler_binding(0);
             _sg_gl_cache_bind_texture_sampler(0, img->gl.target, img->gl.tex[slot], 0);
+            if (img->cmn.num_mipmaps) {
+                glTexParameteri(img->gl.target, GL_TEXTURE_MAX_LEVEL, img->cmn.num_mipmaps - 1);
+            }
             const int num_faces = img->cmn.type == SG_IMAGETYPE_CUBE ? 6 : 1;
             int data_index = 0;
             for (int face_index = 0; face_index < num_faces; face_index++) {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3908,6 +3908,7 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
         #define GL_TEXTURE_COMPARE_MODE 0x884C
         #define GL_TEXTURE_COMPARE_FUNC 0x884D
         #define GL_COMPARE_REF_TO_TEXTURE 0x884E
+        #define GL_TEXTURE_MAX_LEVEL 0x813D
     #endif
 
     #ifndef GL_UNSIGNED_INT_2_10_10_10_REV


### PR DESCRIPTION
Problem: Any texture with a mipmap sampler was black on GL/GLES but working on e.g. Metal (ARM).
Cause: GL texture was incomplete: (See: [mipmap completeness](https://www.khronos.org/opengl/wiki/Texture#Mipmap_completeness), [mipmap range](https://www.khronos.org/opengl/wiki/Texture#Mipmap_range))
Fix: set GL_TEXTURE_MAX_LEVEL based on `num_mipmaps` when creating the texture.
Verified: textures load with mipamp samplers on desktop GL 3.3 (Manjaro) and WASM (Emscripten, GLES3, Firefox).

Hopefully this fix is conceptually in the right place in the code. Let me know if not, and I can update.

As an aside, this approach doesn't support loading smaller LODs progressively into mip levels over several frames like many engines do. Not sure if any of the other backends support such usage, so the point may be moot.