### PR TITLE
Use `emscripten_set_main_loop` in sokol app

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -5782,8 +5782,8 @@ _SOKOL_PRIVATE void _sapp_emsc_unregister_eventhandlers() {
     #endif
 }
 
-_SOKOL_PRIVATE EM_BOOL _sapp_emsc_frame(double time, void* userData) {
-    _SOKOL_UNUSED(userData);
+_SOKOL_PRIVATE void _sapp_emsc_frame() {
+    const double time = emscripten_performance_now();
     _sapp_timing_external(&_sapp.timing, time / 1000.0);
 
     #if defined(SOKOL_WGPU)
@@ -5824,9 +5824,8 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_frame(double time, void* userData) {
         _sapp_emsc_unregister_eventhandlers();
         _sapp_call_cleanup();
         _sapp_discard_state();
-        return EM_FALSE;
+        emscripten_cancel_main_loop();
     }
-    return EM_TRUE;
 }
 
 _SOKOL_PRIVATE void _sapp_emsc_run(const sapp_desc* desc) {
@@ -5859,7 +5858,7 @@ _SOKOL_PRIVATE void _sapp_emsc_run(const sapp_desc* desc) {
     sapp_set_icon(&desc->icon);
 
     /* start the frame loop */
-    emscripten_request_animation_frame_loop(_sapp_emsc_frame, 0);
+    emscripten_set_main_loop(_sapp_emsc_frame, 0, false);
 
     /* NOT A BUG: do not call _sapp_discard_state() here, instead this is
        called in _sapp_emsc_frame() when the application is ordered to quit


### PR DESCRIPTION
Problem: It appears that Emscripten's async APIs don't get a chance to call user callbacks in Sokol App. For instance, when using [`emscripten_async_wget_data`](https://emscripten.org/docs/api_reference/emscripten.h.html#c.emscripten_async_wget_data), Firefox shows the request completed with 200 OK, and the data available, but the user callbacks are never called.

Root Cause: From [docs about `emscripten_request_animation_frame_loop`](https://emscripten.org/docs/api_reference/html5.h.html#c.emscripten_request_animation_frame_loop), it seems to be intended as a low level API, and is likely not handling callbacks. Switching to `emscripten_set_main_loop` fires the callbacks, and still uses [`requestAnimationFrame` under the hood](https://emscripten.org/docs/api_reference/emscripten.h.html#c.emscripten_set_main_loop).

Proposal: Use `emscripten_set_main_loop` instead of `emscripten_request_animation_frame_loop` in Sokol App.

NOTE: I haven't dug too deeply into what else `emscripten_set_main_loop` does, or if it duplicates functionality elsewhere in Sokol App. Maybe we just need to hook up the async API callbacks explicitly somewhere else?

I don't mean to open a glut of pull requests, but I thought that maybe others could benefit from some of these findings. If I've misunderstood something or these PRs are not helpful, please just let me know and I'll close them! :-)