### PR TITLE
Allow overriding the gl error check macro

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3994,7 +3994,9 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
     #ifndef GL_LUMINANCE
     #define GL_LUMINANCE 0x1909
     #endif
+    #ifndef _SG_GL_CHECK_ERROR
     #define _SG_GL_CHECK_ERROR() { SOKOL_ASSERT(glGetError() == GL_NO_ERROR); }
+    #endif
 #endif
 
 // ███████ ████████ ██████  ██    ██  ██████ ████████ ███████


### PR DESCRIPTION
Our project had horrible development performance due to all of sokol's `glGetError` calls (that function is super slow in chromium), this PR allows us to disable sokol's gl error checks, while leaving all of sokols asserts enabled for development. At the end of the frame we `assert(glGetError()==0)` as a sanity check. if that assert ever gets triggered, we can re-enable sokol's default `_SG_GL_CHECK_ERROR` definition for debugging