### PR TITLE
sokol_gfx.h gl: explicitely set GL_TEXTURE_MAX_LEVEL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ because of an incomplete-framebuffer error. This is fixed now. The changes in de
   and Vulkan)
 
 Ticket: https://github.com/floooh/sokol/issues/923
+
 PR: https://github.com/floooh/sokol/pull/924
 
 There's also a new render-to-mipmap sample which covers to close this 'feature gap':

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 ## Updates
 
+#### 27-Oct-2023
+
+Fix broken render-to-mipmap in the sokol_gfx.h GL backend.
+
+There was a subtle bug / feature gap lurking in sokol_gfx.h GL backend: trying
+to render to any mipmap except the top-level mipmap resulted in a black screen
+because of an incomplete-framebuffer error. This is fixed now. The changes in detail:
+
+- creating a texture in the GL backend now sets the GL_TEXTURE_MAX_LEVEL property
+  (this is the fix to make everything work)
+- the framebuffer completeness check in the GL backend now has more detailed error logging
+- in the validation layer, the requirement that a sampler that's used with a
+  single-mipmap-texture must use `.mipmap_filter = SG_FILTER_NONE` has been
+  relaxed (a later update will remove SG_FILTER_NONE entirely since it's not needed anymore
+  and the concept of a "none" mipmap filter only exists in GL and Metal, but not D3D, WebGPU
+  and Vulkan)
+
+There's also a new render-to-mipmap sample which covers to close this 'feature gap':
+
+https://floooh.github.io/sokol-html5/miprender-sapp.html
+
+A couple of similar samples will follow over the next few days
+(rendering to texture array layers and 3d texture slices).
+
 #### 26-Oct-2023
 
 - sokol_app.h gl: fix a regression introduced in https://github.com/floooh/sokol/pull/916

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Fix broken render-to-mipmap in the sokol_gfx.h GL backend.
 
-There was a subtle bug / feature gap lurking in sokol_gfx.h GL backend: trying
+There was a subtle bug / "feature gap" lurking in sokol_gfx.h GL backend: trying
 to render to any mipmap except the top-level mipmap resulted in a black screen
 because of an incomplete-framebuffer error. This is fixed now. The changes in detail:
 
@@ -16,6 +16,9 @@ because of an incomplete-framebuffer error. This is fixed now. The changes in de
   relaxed (a later update will remove SG_FILTER_NONE entirely since it's not needed anymore
   and the concept of a "none" mipmap filter only exists in GL and Metal, but not D3D, WebGPU
   and Vulkan)
+
+Ticket: https://github.com/floooh/sokol/issues/923
+PR: https://github.com/floooh/sokol/pull/924
 
 There's also a new render-to-mipmap sample which covers to close this 'feature gap':
 

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4309,6 +4309,11 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
         #define GL_COMPARE_REF_TO_TEXTURE 0x884E
         #define GL_TEXTURE_CUBE_MAP_SEAMLESS 0x884F
         #define GL_TEXTURE_MAX_LEVEL 0x813D
+        #define GL_FRAMEBUFFER_UNDEFINED 0x8219
+        #define GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT 0x8CD6
+        #define GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT 0x8CD7
+        #define GL_FRAMEBUFFER_UNSUPPORTED 0x8CDD
+        #define GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE 0x8D56
     #endif
 
     #ifndef GL_UNSIGNED_INT_2_10_10_10_REV


### PR DESCRIPTION
- explicitly set GL_TEXTURE_MAX_LEVEL in _sg_gl_create_texture()
- more detailed error logging when framebuffer completeness checks fail

TODO:
- add missing GL defines for Windows GL loader
- can we actually remove SG_FILTER_NONE now???

Ticket: https://github.com/floooh/sokol/issues/923

Related:
- https://github.com/floooh/sokol/issues/912
- https://github.com/floooh/sokol/pull/911