### PR TITLE
sokol_gfx.h: expose backend-specific resources and resource injection tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### 30-Oct-2023
 
-Some sokol_gfx.h backend-specific updates and tweaks (very minor chance that this is breaking):
+Some sokol_gfx.h backend-specific updates and tweaks (very minor chance that this is breaking if you are injecting textures into the D3D11 backend).
 
 - a new set of public API functions to access the native backend 3D-API resource objects of
   sokol-gfx resource objects:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 ## Updates
 
+#### 30-Oct-2023
+
+Some sokol_gfx.h backend-specific updates and tweaks (very minor chance that this is breaking):
+
+- a new set of public API functions to access the native backend 3D-API resource objects of
+  sokol-gfx resource objects:
+
+  ```
+  sg_[api]_[type]_info sg_[api]_query_[type]_info(sg_[type])
+  ```
+  ...where `[api]` is any of `[gl, d3d11, mtl, wgpu]` and `[type]` is any of `[buffer, image, sampler, shader, pipeline, pass]`.
+
+  This is mainly useful when mixing native 3D-API code with sokol-gfx code.
+
+  See issue https://github.com/floooh/sokol/issues/931 for details.
+
+- WebGPU backend: `sg_make_image()` will no longer automatically create a WebGPU texture-view object when injecting a WebGPU texture object, instead
+this must now be explicitly provided.
+
+- D3D11 backend: `sg_make_image()` will no longer automatically create a
+shader-resource-view object when injecting a D3D11 texture object, and
+vice versa, a texture object will no longer be looked up from an injected
+shader-resource-view object (e.g. the injection rules are now more straightforward and explicit). See issue https://github.com/floooh/sokol/issues/930 for details.
+
+For the detailed changes, see PR https://github.com/floooh/sokol/pull/932.
+
 #### 27-Oct-2023
 
 Fix broken render-to-mipmap in the sokol_gfx.h GL backend.

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3900,6 +3900,35 @@ typedef struct sg_mtl_pipeline_info {
     void* dss;      // id<MTLDepthStencilState>
 } sg_mtl_pipeline_info;
 
+typedef struct sg_wgpu_buffer_info {
+    void* buf;  // WGPUBuffer
+} sg_wgpu_buffer_info;
+
+typedef struct sg_wgpu_image_info {
+    void* tex;  // WGPUTexture
+    void* view; // WGPUTextureView
+} sg_wgpu_image_info;
+
+typedef struct sg_wgpu_sampler_info {
+    void* smp;  // WGPUSampler
+} sg_wgpu_sampler_info;
+
+typedef struct sg_wgpu_shader_info {
+    void* vs_mod;   // WGPUShaderModule
+    void* fs_mod;   // WGPUShaderModule
+    void* bgl;      // WGPUBindGroupLayout;
+} sg_wgpu_shader_info;
+
+typedef struct sg_wgpu_pipeline_info {
+    void* pip;      // WGPURenderPipeline
+} sg_wgpu_pipeline_info;
+
+typedef struct sg_wgpu_pass_info {
+    void* color_view[SG_MAX_COLOR_ATTACHMENTS];     // WGPUTextureView
+    void* resolve_view[SG_MAX_COLOR_ATTACHMENTS];    // WGPUTextureView
+    void* ds_view;  // WGPUTextureView
+} sg_wgpu_pass_info;
+
 // D3D11: return ID3D11Device
 SOKOL_GFX_API_DECL const void* sg_d3d11_device(void);
 // D3D11: return ID3D11DeviceContext
@@ -3940,6 +3969,18 @@ SOKOL_GFX_API_DECL const void* sg_wgpu_queue(void);
 SOKOL_GFX_API_DECL const void* sg_wgpu_command_encoder(void);
 // WebGPU: return WGPURenderPassEncoder of currrent pass
 SOKOL_GFX_API_DECL const void* sg_wgpu_render_pass_encoder(void);
+// WebGPU: get internal buffer resource objects
+SOKOL_GFX_API_DECL sg_wgpu_buffer_info sg_wgpu_query_buffer_info(sg_buffer buf);
+// WebGPU: get internal image resource objects
+SOKOL_GFX_API_DECL sg_wgpu_image_info sg_wgpu_query_image_info(sg_image img);
+// WebGPU: get internal sampler resource objects
+SOKOL_GFX_API_DECL sg_wgpu_sampler_info sg_wgpu_query_sampler_info(sg_sampler smp);
+// WebGPU: get internal shader resource objects
+SOKOL_GFX_API_DECL sg_wgpu_shader_info sg_wgpu_query_shader_info(sg_shader shd);
+// WebGPU: get internal pipeline resource objects
+SOKOL_GFX_API_DECL sg_wgpu_pipeline_info sg_wgpu_query_pipeline_info(sg_pipeline pip);
+// WebGPU: get internal pass resource objects
+SOKOL_GFX_API_DECL sg_wgpu_pass_info sg_wgpu_query_pass_info(sg_pass pass);
 
 #ifdef __cplusplus
 } // extern "C"
@@ -18325,33 +18366,33 @@ SOKOL_API_IMPL sg_pass_desc sg_query_pass_defaults(const sg_pass_desc* desc) {
 }
 
 SOKOL_API_IMPL const void* sg_d3d11_device(void) {
-#if defined(SOKOL_D3D11)
-    return (const void*) _sg.d3d11.dev;
-#else
-    return 0;
-#endif
+    #if defined(SOKOL_D3D11)
+        return (const void*) _sg.d3d11.dev;
+    #else
+        return 0;
+    #endif
 }
 
 SOKOL_API_IMPL const void* sg_d3d11_device_context(void) {
-#if defined(SOKOL_D3D11)
-    return (const void*) _sg.d3d11.ctx;
-#else
-    return 0;
-#endif
+    #if defined(SOKOL_D3D11)
+        return (const void*) _sg.d3d11.ctx;
+    #else
+        return 0;
+    #endif
 }
 
 SOKOL_API_IMPL sg_d3d11_buffer_info sg_d3d11_query_buffer_info(sg_buffer buf_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_d3d11_buffer_info res;
     _sg_clear(&res, sizeof(res));
-#if defined(SOKOL_D3D11)
-    const _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
-    if (buf) {
-        res.buf = (void*) buf->d3d11.buf;
-    }
-#else
-    _SOKOL_UNUSED(buf_id);
-#endif
+    #if defined(SOKOL_D3D11)
+        const _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+        if (buf) {
+            res.buf = (void*) buf->d3d11.buf;
+        }
+    #else
+        _SOKOL_UNUSED(buf_id);
+    #endif
     return res;
 }
 
@@ -18359,17 +18400,17 @@ SOKOL_API_IMPL sg_d3d11_image_info sg_d3d11_query_image_info(sg_image img_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_d3d11_image_info res;
     _sg_clear(&res, sizeof(res));
-#if defined(SOKOL_D3D11)
-    const _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
-    if (img) {
-        res.tex2d = (void*) img->d3d11.tex2d;
-        res.tex3d = (void*) img->d3d11.tex3d;
-        res.res = (void*) img->d3d11.res;
-        res.srv = (void*) img->d3d11.srv;
-    }
-#else
-    _SOKOL_UNUSED(img_id);
-#endif
+    #if defined(SOKOL_D3D11)
+        const _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
+        if (img) {
+            res.tex2d = (void*) img->d3d11.tex2d;
+            res.tex3d = (void*) img->d3d11.tex3d;
+            res.res = (void*) img->d3d11.res;
+            res.srv = (void*) img->d3d11.srv;
+        }
+    #else
+        _SOKOL_UNUSED(img_id);
+    #endif
     return res;
 }
 
@@ -18377,14 +18418,14 @@ SOKOL_API_IMPL sg_d3d11_sampler_info sg_d3d11_query_sampler_info(sg_sampler smp_
     SOKOL_ASSERT(_sg.valid);
     sg_d3d11_sampler_info res;
     _sg_clear(&res, sizeof(res));
-#if defined(SOKOL_D3D11)
-    const _sg_sampler_t* smp = _sg_lookup_sampler(&_sg.pools, smp_id.id);
-    if (smp) {
-        res.smp = (void*) smp->d3d11.smp;
-    }
-#else
-    _SOKOL_UNUSED(smp_id);
-#endif
+    #if defined(SOKOL_D3D11)
+        const _sg_sampler_t* smp = _sg_lookup_sampler(&_sg.pools, smp_id.id);
+        if (smp) {
+            res.smp = (void*) smp->d3d11.smp;
+        }
+    #else
+        _SOKOL_UNUSED(smp_id);
+    #endif
     return res;
 }
 
@@ -18392,19 +18433,19 @@ SOKOL_API_IMPL sg_d3d11_shader_info sg_d3d11_query_shader_info(sg_shader shd_id)
     SOKOL_ASSERT(_sg.valid);
     sg_d3d11_shader_info res;
     _sg_clear(&res, sizeof(res));
-#if defined(SOKOL_D3D11)
-    const _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
-    if (shd) {
-        for (int i = 0; i < SG_MAX_SHADERSTAGE_UBS; i++) {
-            res.vs_cbufs[i] = (void*) shd->d3d11.stage[SG_SHADERSTAGE_VS].cbufs[i];
-            res.fs_cbufs[i] = (void*) shd->d3d11.stage[SG_SHADERSTAGE_FS].cbufs[i];
+    #if defined(SOKOL_D3D11)
+        const _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
+        if (shd) {
+            for (int i = 0; i < SG_MAX_SHADERSTAGE_UBS; i++) {
+                res.vs_cbufs[i] = (void*) shd->d3d11.stage[SG_SHADERSTAGE_VS].cbufs[i];
+                res.fs_cbufs[i] = (void*) shd->d3d11.stage[SG_SHADERSTAGE_FS].cbufs[i];
+            }
+            res.vs = (void*) shd->d3d11.vs;
+            res.fs = (void*) shd->d3d11.fs;
         }
-        res.vs = (void*) shd->d3d11.vs;
-        res.fs = (void*) shd->d3d11.fs;
-    }
-#else
-    _SOKOL_UNUSED(shd_id);
-#endif
+    #else
+        _SOKOL_UNUSED(shd_id);
+    #endif
     return res;
 }
 
@@ -18412,17 +18453,17 @@ SOKOL_API_IMPL sg_d3d11_pipeline_info sg_d3d11_query_pipeline_info(sg_pipeline p
     SOKOL_ASSERT(_sg.valid);
     sg_d3d11_pipeline_info res;
     _sg_clear(&res, sizeof(res));
-#if defined(SOKOL_D3D11)
-    const _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
-    if (pip) {
-        res.il = pip->d3d11.il;
-        res.rs = pip->d3d11.rs;
-        res.dss = pip->d3d11.dss;
-        res.bs = pip->d3d11.bs;
-    }
-#else
-    _SOKOL_UNUSED(pip_id);
-#endif
+    #if defined(SOKOL_D3D11)
+        const _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
+        if (pip) {
+            res.il = pip->d3d11.il;
+            res.rs = pip->d3d11.rs;
+            res.dss = pip->d3d11.dss;
+            res.bs = pip->d3d11.bs;
+        }
+    #else
+        _SOKOL_UNUSED(pip_id);
+    #endif
     return res;
 }
 
@@ -18430,31 +18471,31 @@ SOKOL_API_IMPL sg_d3d11_pass_info sg_d3d11_query_pass_info(sg_pass pass_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_d3d11_pass_info res;
     _sg_clear(&res, sizeof(res));
-#if defined(SOKOL_D3D11)
-    const _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
-    if (pass) {
-        for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
-            res.color_rtv[i] = pass->d3d11.color_atts[i].view.rtv;
-            res.resolve_rtv[i] = pass->d3d11.resolve_atts[i].view.rtv;
+    #if defined(SOKOL_D3D11)
+        const _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
+        if (pass) {
+            for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
+                res.color_rtv[i] = pass->d3d11.color_atts[i].view.rtv;
+                res.resolve_rtv[i] = pass->d3d11.resolve_atts[i].view.rtv;
+            }
+            res.dsv = pass->d3d11.ds_att.view.dsv;
         }
-        res.dsv = pass->d3d11.ds_att.view.dsv;
-    }
-#else
-    _SOKOL_UNUSED(pass_id);
-#endif
+    #else
+        _SOKOL_UNUSED(pass_id);
+    #endif
     return res;
 }
 
 SOKOL_API_IMPL const void* sg_mtl_device(void) {
-#if defined(SOKOL_METAL)
-    if (nil != _sg.mtl.device) {
-        return (__bridge const void*) _sg.mtl.device;
-    } else {
+    #if defined(SOKOL_METAL)
+        if (nil != _sg.mtl.device) {
+            return (__bridge const void*) _sg.mtl.device;
+        } else {
+            return 0;
+        }
+    #else
         return 0;
-    }
-#else
-    return 0;
-#endif
+    #endif
 }
 
 SOKOL_API_IMPL const void* sg_mtl_render_command_encoder(void) {
@@ -18473,19 +18514,19 @@ SOKOL_API_IMPL sg_mtl_buffer_info sg_mtl_query_buffer_info(sg_buffer buf_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_mtl_buffer_info res;
     _sg_clear(&res, sizeof(res));
-#if defined(SOKOL_METAL)
-    const _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
-    if (buf) {
-        for (int i = 0; i < SG_NUM_INFLIGHT_FRAMES; i++) {
-            if (buf->mtl.buf[i] != 0) {
-                res.buf[i] = (__bridge void*) _sg_mtl_id(buf->mtl.buf[i]);
+    #if defined(SOKOL_METAL)
+        const _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+        if (buf) {
+            for (int i = 0; i < SG_NUM_INFLIGHT_FRAMES; i++) {
+                if (buf->mtl.buf[i] != 0) {
+                    res.buf[i] = (__bridge void*) _sg_mtl_id(buf->mtl.buf[i]);
+                }
             }
+            res.active_slot = buf->cmn.active_slot;
         }
-        res.active_slot = buf->cmn.active_slot;
-    }
-#else
-    _SOKOL_UNUSED(buf_id);
-#endif
+    #else
+        _SOKOL_UNUSED(buf_id);
+    #endif
     return res;
 }
 
@@ -18493,19 +18534,19 @@ SOKOL_API_IMPL sg_mtl_image_info sg_mtl_query_image_info(sg_image img_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_mtl_image_info res;
     _sg_clear(&res, sizeof(res));
-#if defined(SOKOL_METAL)
-    const _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
-    if (img) {
-        for (int i = 0; i < SG_NUM_INFLIGHT_FRAMES; i++) {
-            if (img->mtl.tex[i] != 0) {
-                res.tex[i] = (__bridge void*) _sg_mtl_id(img->mtl.tex[i]);
+    #if defined(SOKOL_METAL)
+        const _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
+        if (img) {
+            for (int i = 0; i < SG_NUM_INFLIGHT_FRAMES; i++) {
+                if (img->mtl.tex[i] != 0) {
+                    res.tex[i] = (__bridge void*) _sg_mtl_id(img->mtl.tex[i]);
+                }
             }
+            res.active_slot = img->cmn.active_slot;
         }
-        res.active_slot = img->cmn.active_slot;
-    }
-#else
-    _SOKOL_UNUSED(img_id);
-#endif
+    #else
+        _SOKOL_UNUSED(img_id);
+    #endif
     return res;
 }
 
@@ -18513,16 +18554,16 @@ SOKOL_API_IMPL sg_mtl_sampler_info sg_mtl_query_sampler_info(sg_sampler smp_id) 
     SOKOL_ASSERT(_sg.valid);
     sg_mtl_sampler_info res;
     _sg_clear(&res, sizeof(res));
-#if defined(SOKOL_METAL)
-    const _sg_sampler_t* smp = _sg_lookup_sampler(&_sg.pools, smp_id.id);
-    if (smp) {
-        if (smp->mtl.sampler_state != 0) {
-            res.smp = (__bridge void*) _sg_mtl_id(smp->mtl.sampler_state);
+    #if defined(SOKOL_METAL)
+        const _sg_sampler_t* smp = _sg_lookup_sampler(&_sg.pools, smp_id.id);
+        if (smp) {
+            if (smp->mtl.sampler_state != 0) {
+                res.smp = (__bridge void*) _sg_mtl_id(smp->mtl.sampler_state);
+            }
         }
-    }
-#else
-    _SOKOL_UNUSED(smp_id);
-#endif
+    #else
+        _SOKOL_UNUSED(smp_id);
+    #endif
     return res;
 }
 
@@ -18530,29 +18571,29 @@ SOKOL_API_IMPL sg_mtl_shader_info sg_mtl_query_shader_info(sg_shader shd_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_mtl_shader_info res;
     _sg_clear(&res, sizeof(res));
-#if defined(SOKOL_METAL)
-    const _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
-    if (shd) {
-        const int vs_lib  = shd->mtl.stage[SG_SHADERSTAGE_VS].mtl_lib;
-        const int vs_func = shd->mtl.stage[SG_SHADERSTAGE_VS].mtl_func;
-        const int fs_lib  = shd->mtl.stage[SG_SHADERSTAGE_FS].mtl_lib;
-        const int fs_func = shd->mtl.stage[SG_SHADERSTAGE_FS].mtl_func;
-        if (vs_lib != 0) {
-            res.vs_lib = (__bridge void*) _sg_mtl_id(vs_lib);
+    #if defined(SOKOL_METAL)
+        const _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
+        if (shd) {
+            const int vs_lib  = shd->mtl.stage[SG_SHADERSTAGE_VS].mtl_lib;
+            const int vs_func = shd->mtl.stage[SG_SHADERSTAGE_VS].mtl_func;
+            const int fs_lib  = shd->mtl.stage[SG_SHADERSTAGE_FS].mtl_lib;
+            const int fs_func = shd->mtl.stage[SG_SHADERSTAGE_FS].mtl_func;
+            if (vs_lib != 0) {
+                res.vs_lib = (__bridge void*) _sg_mtl_id(vs_lib);
+            }
+            if (fs_lib != 0) {
+                res.fs_lib = (__bridge void*) _sg_mtl_id(fs_lib);
+            }
+            if (vs_func != 0) {
+                res.vs_func = (__bridge void*) _sg_mtl_id(vs_func);
+            }
+            if (fs_func != 0) {
+                res.fs_func = (__bridge void*) _sg_mtl_id(fs_func);
+            }
         }
-        if (fs_lib != 0) {
-            res.fs_lib = (__bridge void*) _sg_mtl_id(fs_lib);
-        }
-        if (vs_func != 0) {
-            res.vs_func = (__bridge void*) _sg_mtl_id(vs_func);
-        }
-        if (fs_func != 0) {
-            res.fs_func = (__bridge void*) _sg_mtl_id(fs_func);
-        }
-    }
-#else
-    _SOKOL_UNUSED(shd_id);
-#endif
+    #else
+        _SOKOL_UNUSED(shd_id);
+    #endif
     return res;
 }
 
@@ -18560,19 +18601,19 @@ SOKOL_API_IMPL sg_mtl_pipeline_info sg_mtl_query_pipeline_info(sg_pipeline pip_i
     SOKOL_ASSERT(_sg.valid);
     sg_mtl_pipeline_info res;
     _sg_clear(&res, sizeof(res));
-#if defined(SOKOL_METAL)
-    const _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
-    if (pip) {
-        if (pip->mtl.rps != 0) {
-            res.rps = (__bridge void*) _sg_mtl_id(pip->mtl.rps);
+    #if defined(SOKOL_METAL)
+        const _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
+        if (pip) {
+            if (pip->mtl.rps != 0) {
+                res.rps = (__bridge void*) _sg_mtl_id(pip->mtl.rps);
+            }
+            if (pip->mtl.dss != 0) {
+                res.dss = (__bridge void*) _sg_mtl_id(pip->mtl.dss);
+            }
         }
-        if (pip->mtl.dss != 0) {
-            res.dss = (__bridge void*) _sg_mtl_id(pip->mtl.dss);
-        }
-    }
-#else
-    _SOKOL_UNUSED(pip_id);
-#endif
+    #else
+        _SOKOL_UNUSED(pip_id);
+    #endif
     return res;
 }
 
@@ -18606,6 +18647,103 @@ SOKOL_API_IMPL const void* sg_wgpu_render_pass_encoder(void) {
     #else
         return 0;
     #endif
+}
+
+SOKOL_API_IMPL sg_wgpu_buffer_info sg_wgpu_query_buffer_info(sg_buffer buf_id) {
+    SOKOL_ASSERT(_sg.valid);
+    sg_wgpu_buffer_info res;
+    _sg_clear(&res, sizeof(res));
+    #if defined(SOKOL_WGPU)
+        const _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
+        if (buf) {
+            res.buf = (void*) buf->wgpu.buf;
+        }
+    #else
+        _SOKOL_UNUSED(buf_id);
+    #endif
+    return res;
+}
+
+SOKOL_API_IMPL sg_wgpu_image_info sg_wgpu_query_image_info(sg_image img_id) {
+    SOKOL_ASSERT(_sg.valid);
+    sg_wgpu_image_info res;
+    _sg_clear(&res, sizeof(res));
+    #if defined(SOKOL_WGPU)
+        const _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
+        if (img) {
+            res.tex = (void*) img->wgpu.tex;
+            res.view = (void*) img->wgpu.view;
+        }
+    #else
+        _SOKOL_UNUSED(img_id);
+    #endif
+    return res;
+}
+
+SOKOL_API_IMPL sg_wgpu_sampler_info sg_wgpu_query_sampler_info(sg_sampler smp_id) {
+    SOKOL_ASSERT(_sg.valid);
+    sg_wgpu_sampler_info res;
+    _sg_clear(&res, sizeof(res));
+    #if defined(SOKOL_WGPU)
+        const _sg_sampler_t* smp = _sg_lookup_sampler(&_sg.pools, smp_id.id);
+        if (smp) {
+            res.smp = (void*) smp->wgpu.smp;
+        }
+    #else
+        _SOKOL_UNUSED(smp_id);
+    #endif
+    return res;
+}
+
+SOKOL_API_IMPL sg_wgpu_shader_info sg_wgpu_query_shader_info(sg_shader shd_id) {
+    SOKOL_ASSERT(_sg.valid);
+    sg_wgpu_shader_info res;
+    _sg_clear(&res, sizeof(res));
+    #if defined(SOKOL_WGPU)
+        const _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
+        if (shd) {
+            res.vs_mod = (void*) shd->wgpu.stage[SG_SHADERSTAGE_VS].module;
+            res.fs_mod = (void*) shd->wgpu.stage[SG_SHADERSTAGE_FS].module;
+            res.bgl = (void*) shd->wgpu.bind_group_layout;
+        }
+    #else
+        _SOKOL_UNUSED(shd_id);
+    #endif
+    return res;
+}
+
+SOKOL_API_IMPL sg_wgpu_pipeline_info sg_wgpu_query_pipeline_info(sg_pipeline pip_id) {
+    SOKOL_ASSERT(_sg.valid);
+    sg_wgpu_pipeline_info res;
+    _sg_clear(&res, sizeof(res));
+    #if defined(SOKOL_WGPU)
+        const _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
+        if (pip) {
+            res.pip = (void*) pip->wgpu.pip;
+        }
+    #else
+        _SOKOL_UNUSED(pip_id);
+    #endif
+    return res;
+}
+
+SOKOL_API_IMPL sg_wgpu_pass_info sg_wgpu_query_pass_info(sg_pass pass_id) {
+    SOKOL_ASSERT(_sg.valid);
+    sg_wgpu_pass_info res;
+    _sg_clear(&res, sizeof(res));
+    #if defined(SOKOL_WGPU)
+        const _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
+        if (pass) {
+            for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
+                res.color_view[i] = (void*) pass->wgpu.color_atts[i].view;
+                res.resolve_view[i] = (void*) pass->wgpu.resolve_atts[i].view;
+            }
+            res.ds_view = (void*) pass->wgpu.ds_att.view;
+        }
+    #else
+        _SOKOL_UNUSED(pass_id);
+    #endif
+    return res;
 }
 
 #ifdef _MSC_VER

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2529,15 +2529,16 @@ typedef struct sg_image_data {
     .mtl_textures[SG_NUM_INFLIGHT_FRAMES]
     .d3d11_texture
     .d3d11_shader_resource_view
+    .wgpu_texture
+    .wgpu_texture_view
 
     For GL, you can also specify the texture target or leave it empty to use
     the default texture target for the image type (GL_TEXTURE_2D for
     SG_IMAGETYPE_2D etc)
 
-    For D3D11, you can provide either a D3D11 texture, or a
-    shader-resource-view, or both. If only a texture is provided, a matching
-    shader-resource-view will be created. If only a shader-resource-view is
-    provided, the texture will be looked up from the shader-resource-view.
+    For D3D11 and WebGPU, either only provide a texture, or both a texture and
+    shader-resource-view / texture-view object. If you want to use access the
+    injected texture in a shader you *must* provide a shader-resource-view.
 
     The same rules apply as for injecting native buffers (see sg_buffer_desc
     documentation for more details).

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -9941,7 +9941,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
     SOKOL_ASSERT((0 == img->d3d11.tex2d) && (0 == img->d3d11.tex3d) && (0 == img->d3d11.res) && (0 == img->d3d11.srv));
     HRESULT hr;
 
-    const bool injected = (0 != desc->d3d11_texture) || (0 != desc->d3d11_shader_resource_view);
+    const bool injected = (0 != desc->d3d11_texture);
     const bool msaa = (img->cmn.sample_count > 1);
     img->d3d11.format = _sg_d3d11_texture_pixel_format(img->cmn.pixel_format);
     if (img->d3d11.format == DXGI_FORMAT_UNKNOWN) {
@@ -9960,16 +9960,8 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
         // first check for injected texture and/or resource view
         if (injected) {
             img->d3d11.tex2d = (ID3D11Texture2D*) desc->d3d11_texture;
+            _sg_d3d11_AddRef(img->d3d11.tex2d);
             img->d3d11.srv = (ID3D11ShaderResourceView*) desc->d3d11_shader_resource_view;
-            if (img->d3d11.tex2d) {
-                _sg_d3d11_AddRef(img->d3d11.tex2d);
-            } else {
-                // if only a shader-resource-view was provided, but no texture, lookup
-                // the texture from the shader-resource-view, this also bumps the refcount
-                SOKOL_ASSERT(img->d3d11.srv);
-                _sg_d3d11_GetResource((ID3D11View*)img->d3d11.srv, (ID3D11Resource**)&img->d3d11.tex2d);
-                SOKOL_ASSERT(img->d3d11.tex2d);
-            }
             if (img->d3d11.srv) {
                 _sg_d3d11_AddRef(img->d3d11.srv);
             }
@@ -10049,14 +10041,8 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
         // 3D texture - same procedure, first check if injected, than create non-injected
         if (injected) {
             img->d3d11.tex3d = (ID3D11Texture3D*) desc->d3d11_texture;
+            _sg_d3d11_AddRef(img->d3d11.tex3d);
             img->d3d11.srv = (ID3D11ShaderResourceView*) desc->d3d11_shader_resource_view;
-            if (img->d3d11.tex3d) {
-                _sg_d3d11_AddRef(img->d3d11.tex3d);
-            } else {
-                SOKOL_ASSERT(img->d3d11.srv);
-                _sg_d3d11_GetResource((ID3D11View*)img->d3d11.srv, (ID3D11Resource**)&img->d3d11.tex3d);
-                SOKOL_ASSERT(img->d3d11.tex3d);
-            }
             if (img->d3d11.srv) {
                 _sg_d3d11_AddRef(img->d3d11.srv);
             }

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3841,93 +3841,93 @@ SOKOL_GFX_API_DECL void sg_discard_context(sg_context ctx_id);
 */
 
 typedef struct sg_d3d11_buffer_info {
-    void* buf;      // ID3D11Buffer*
+    const void* buf;      // ID3D11Buffer*
 } sg_d3d11_buffer_info;
 
 typedef struct sg_d3d11_image_info {
-    void* tex2d;    // ID3D11Texture2D*
-    void* tex3d;    // ID3D11Texture3D*
-    void* res;      // ID3D11Resource* (either tex2d or tex3d)
-    void* srv;      // ID3D11ShaderResourceView*
+    const void* tex2d;    // ID3D11Texture2D*
+    const void* tex3d;    // ID3D11Texture3D*
+    const void* res;      // ID3D11Resource* (either tex2d or tex3d)
+    const void* srv;      // ID3D11ShaderResourceView*
 } sg_d3d11_image_info;
 
 typedef struct sg_d3d11_sampler_info {
-    void* smp;      // ID3D11SamplerState*
+    const void* smp;      // ID3D11SamplerState*
 } sg_d3d11_sampler_info;
 
 typedef struct sg_d3d11_shader_info {
-    void* vs_cbufs[SG_MAX_SHADERSTAGE_UBS]; // ID3D11Buffer* (vertex stage constant buffers)
-    void* fs_cbufs[SG_MAX_SHADERSTAGE_UBS]; // ID3D11BUffer* (fragment stage constant buffers)
-    void* vs;   // ID3D11VertexShader*
-    void* fs;   // ID3D11PixelShader*
+    const void* vs_cbufs[SG_MAX_SHADERSTAGE_UBS]; // ID3D11Buffer* (vertex stage constant buffers)
+    const void* fs_cbufs[SG_MAX_SHADERSTAGE_UBS]; // ID3D11BUffer* (fragment stage constant buffers)
+    const void* vs;   // ID3D11VertexShader*
+    const void* fs;   // ID3D11PixelShader*
 } sg_d3d11_shader_info;
 
 typedef struct sg_d3d11_pipeline_info {
-    void* il;   // ID3D11InputLayout*
-    void* rs;   // ID3D11RasterizerState*
-    void* dss;  // ID3D11DepthStencilState*
-    void* bs;   // ID3D11BlendState*
+    const void* il;   // ID3D11InputLayout*
+    const void* rs;   // ID3D11RasterizerState*
+    const void* dss;  // ID3D11DepthStencilState*
+    const void* bs;   // ID3D11BlendState*
 } sg_d3d11_pipeline_info;
 
 typedef struct sg_d3d11_pass_info {
-    void* color_rtv[SG_MAX_COLOR_ATTACHMENTS];      // ID3D11RenderTargetView
-    void* resolve_rtv[SG_MAX_COLOR_ATTACHMENTS];    // ID3D11RenderTargetView
-    void* dsv;  // ID3D11DepthStencilView
+    const void* color_rtv[SG_MAX_COLOR_ATTACHMENTS];      // ID3D11RenderTargetView
+    const void* resolve_rtv[SG_MAX_COLOR_ATTACHMENTS];    // ID3D11RenderTargetView
+    const void* dsv;  // ID3D11DepthStencilView
 } sg_d3d11_pass_info;
 
 typedef struct sg_mtl_buffer_info {
-    void* buf[SG_NUM_INFLIGHT_FRAMES];  // id<MTLBuffer>
+    const void* buf[SG_NUM_INFLIGHT_FRAMES];  // id<MTLBuffer>
     int active_slot;
 } sg_mtl_buffer_info;
 
 typedef struct sg_mtl_image_info {
-    void* tex[SG_NUM_INFLIGHT_FRAMES]; // id<MTLTexture>
+    const void* tex[SG_NUM_INFLIGHT_FRAMES]; // id<MTLTexture>
     int active_slot;
 } sg_mtl_image_info;
 
 typedef struct sg_mtl_sampler_info {
-    void* smp;  // id<MTLSamplerState>
+    const void* smp;  // id<MTLSamplerState>
 } sg_mtl_sampler_info;
 
 typedef struct sg_mtl_shader_info {
-    void* vs_lib;   // id<MTLLibrary>
-    void* fs_lib;   // id<MTLLibrary>
-    void* vs_func;  // id<MTLFunction>
-    void* fs_func;  // id<MTLFunction>
+    const void* vs_lib;   // id<MTLLibrary>
+    const void* fs_lib;   // id<MTLLibrary>
+    const void* vs_func;  // id<MTLFunction>
+    const void* fs_func;  // id<MTLFunction>
 } sg_mtl_shader_info;
 
 typedef struct sg_mtl_pipeline_info {
-    void* rps;      // id<MTLRenderPipelineState>
-    void* dss;      // id<MTLDepthStencilState>
+    const void* rps;      // id<MTLRenderPipelineState>
+    const void* dss;      // id<MTLDepthStencilState>
 } sg_mtl_pipeline_info;
 
 typedef struct sg_wgpu_buffer_info {
-    void* buf;  // WGPUBuffer
+    const void* buf;  // WGPUBuffer
 } sg_wgpu_buffer_info;
 
 typedef struct sg_wgpu_image_info {
-    void* tex;  // WGPUTexture
-    void* view; // WGPUTextureView
+    const void* tex;  // WGPUTexture
+    const void* view; // WGPUTextureView
 } sg_wgpu_image_info;
 
 typedef struct sg_wgpu_sampler_info {
-    void* smp;  // WGPUSampler
+    const void* smp;  // WGPUSampler
 } sg_wgpu_sampler_info;
 
 typedef struct sg_wgpu_shader_info {
-    void* vs_mod;   // WGPUShaderModule
-    void* fs_mod;   // WGPUShaderModule
-    void* bgl;      // WGPUBindGroupLayout;
+    const void* vs_mod;   // WGPUShaderModule
+    const void* fs_mod;   // WGPUShaderModule
+    const void* bgl;      // WGPUBindGroupLayout;
 } sg_wgpu_shader_info;
 
 typedef struct sg_wgpu_pipeline_info {
-    void* pip;      // WGPURenderPipeline
+    const void* pip;      // WGPURenderPipeline
 } sg_wgpu_pipeline_info;
 
 typedef struct sg_wgpu_pass_info {
-    void* color_view[SG_MAX_COLOR_ATTACHMENTS];     // WGPUTextureView
-    void* resolve_view[SG_MAX_COLOR_ATTACHMENTS];    // WGPUTextureView
-    void* ds_view;  // WGPUTextureView
+    const void* color_view[SG_MAX_COLOR_ATTACHMENTS];     // WGPUTextureView
+    const void* resolve_view[SG_MAX_COLOR_ATTACHMENTS];    // WGPUTextureView
+    const void* ds_view;  // WGPUTextureView
 } sg_wgpu_pass_info;
 
 typedef struct sg_gl_buffer_info {
@@ -18429,7 +18429,7 @@ SOKOL_API_IMPL sg_d3d11_buffer_info sg_d3d11_query_buffer_info(sg_buffer buf_id)
     #if defined(SOKOL_D3D11)
         const _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
         if (buf) {
-            res.buf = (void*) buf->d3d11.buf;
+            res.buf = (const void*) buf->d3d11.buf;
         }
     #else
         _SOKOL_UNUSED(buf_id);
@@ -18444,10 +18444,10 @@ SOKOL_API_IMPL sg_d3d11_image_info sg_d3d11_query_image_info(sg_image img_id) {
     #if defined(SOKOL_D3D11)
         const _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
         if (img) {
-            res.tex2d = (void*) img->d3d11.tex2d;
-            res.tex3d = (void*) img->d3d11.tex3d;
-            res.res = (void*) img->d3d11.res;
-            res.srv = (void*) img->d3d11.srv;
+            res.tex2d = (const void*) img->d3d11.tex2d;
+            res.tex3d = (const void*) img->d3d11.tex3d;
+            res.res = (const void*) img->d3d11.res;
+            res.srv = (const void*) img->d3d11.srv;
         }
     #else
         _SOKOL_UNUSED(img_id);
@@ -18462,7 +18462,7 @@ SOKOL_API_IMPL sg_d3d11_sampler_info sg_d3d11_query_sampler_info(sg_sampler smp_
     #if defined(SOKOL_D3D11)
         const _sg_sampler_t* smp = _sg_lookup_sampler(&_sg.pools, smp_id.id);
         if (smp) {
-            res.smp = (void*) smp->d3d11.smp;
+            res.smp = (const void*) smp->d3d11.smp;
         }
     #else
         _SOKOL_UNUSED(smp_id);
@@ -18478,11 +18478,11 @@ SOKOL_API_IMPL sg_d3d11_shader_info sg_d3d11_query_shader_info(sg_shader shd_id)
         const _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
         if (shd) {
             for (int i = 0; i < SG_MAX_SHADERSTAGE_UBS; i++) {
-                res.vs_cbufs[i] = (void*) shd->d3d11.stage[SG_SHADERSTAGE_VS].cbufs[i];
-                res.fs_cbufs[i] = (void*) shd->d3d11.stage[SG_SHADERSTAGE_FS].cbufs[i];
+                res.vs_cbufs[i] = (const void*) shd->d3d11.stage[SG_SHADERSTAGE_VS].cbufs[i];
+                res.fs_cbufs[i] = (const void*) shd->d3d11.stage[SG_SHADERSTAGE_FS].cbufs[i];
             }
-            res.vs = (void*) shd->d3d11.vs;
-            res.fs = (void*) shd->d3d11.fs;
+            res.vs = (const void*) shd->d3d11.vs;
+            res.fs = (const void*) shd->d3d11.fs;
         }
     #else
         _SOKOL_UNUSED(shd_id);
@@ -18497,10 +18497,10 @@ SOKOL_API_IMPL sg_d3d11_pipeline_info sg_d3d11_query_pipeline_info(sg_pipeline p
     #if defined(SOKOL_D3D11)
         const _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
         if (pip) {
-            res.il = pip->d3d11.il;
-            res.rs = pip->d3d11.rs;
-            res.dss = pip->d3d11.dss;
-            res.bs = pip->d3d11.bs;
+            res.il = (const void*) pip->d3d11.il;
+            res.rs = (const void*) pip->d3d11.rs;
+            res.dss = (const void*) pip->d3d11.dss;
+            res.bs = (const void*) pip->d3d11.bs;
         }
     #else
         _SOKOL_UNUSED(pip_id);
@@ -18516,10 +18516,10 @@ SOKOL_API_IMPL sg_d3d11_pass_info sg_d3d11_query_pass_info(sg_pass pass_id) {
         const _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
         if (pass) {
             for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
-                res.color_rtv[i] = pass->d3d11.color_atts[i].view.rtv;
-                res.resolve_rtv[i] = pass->d3d11.resolve_atts[i].view.rtv;
+                res.color_rtv[i] = (const void*) pass->d3d11.color_atts[i].view.rtv;
+                res.resolve_rtv[i] = (const void*) pass->d3d11.resolve_atts[i].view.rtv;
             }
-            res.dsv = pass->d3d11.ds_att.view.dsv;
+            res.dsv = (const void*) pass->d3d11.ds_att.view.dsv;
         }
     #else
         _SOKOL_UNUSED(pass_id);
@@ -18660,7 +18660,7 @@ SOKOL_API_IMPL sg_mtl_pipeline_info sg_mtl_query_pipeline_info(sg_pipeline pip_i
 
 SOKOL_API_IMPL const void* sg_wgpu_device(void) {
     #if defined(SOKOL_WGPU)
-        return _sg.wgpu.dev;
+        return (const void*) _sg.wgpu.dev;
     #else
         return 0;
     #endif
@@ -18668,7 +18668,7 @@ SOKOL_API_IMPL const void* sg_wgpu_device(void) {
 
 SOKOL_API_IMPL const void* sg_wgpu_queue(void) {
     #if defined(SOKOL_WGPU)
-        return _sg.wgpu.queue;
+        return (const void*) _sg.wgpu.queue;
     #else
         return 0;
     #endif
@@ -18676,7 +18676,7 @@ SOKOL_API_IMPL const void* sg_wgpu_queue(void) {
 
 SOKOL_API_IMPL const void* sg_wgpu_command_encoder(void) {
     #if defined(SOKOL_WGPU)
-        return _sg.wgpu.cmd_enc;
+        return (const void*) _sg.wgpu.cmd_enc;
     #else
         return 0;
     #endif
@@ -18684,7 +18684,7 @@ SOKOL_API_IMPL const void* sg_wgpu_command_encoder(void) {
 
 SOKOL_API_IMPL const void* sg_wgpu_render_pass_encoder(void) {
     #if defined(SOKOL_WGPU)
-        return _sg.wgpu.pass_enc;
+        return (const void*) _sg.wgpu.pass_enc;
     #else
         return 0;
     #endif
@@ -18697,7 +18697,7 @@ SOKOL_API_IMPL sg_wgpu_buffer_info sg_wgpu_query_buffer_info(sg_buffer buf_id) {
     #if defined(SOKOL_WGPU)
         const _sg_buffer_t* buf = _sg_lookup_buffer(&_sg.pools, buf_id.id);
         if (buf) {
-            res.buf = (void*) buf->wgpu.buf;
+            res.buf = (const void*) buf->wgpu.buf;
         }
     #else
         _SOKOL_UNUSED(buf_id);
@@ -18712,8 +18712,8 @@ SOKOL_API_IMPL sg_wgpu_image_info sg_wgpu_query_image_info(sg_image img_id) {
     #if defined(SOKOL_WGPU)
         const _sg_image_t* img = _sg_lookup_image(&_sg.pools, img_id.id);
         if (img) {
-            res.tex = (void*) img->wgpu.tex;
-            res.view = (void*) img->wgpu.view;
+            res.tex = (const void*) img->wgpu.tex;
+            res.view = (const void*) img->wgpu.view;
         }
     #else
         _SOKOL_UNUSED(img_id);
@@ -18728,7 +18728,7 @@ SOKOL_API_IMPL sg_wgpu_sampler_info sg_wgpu_query_sampler_info(sg_sampler smp_id
     #if defined(SOKOL_WGPU)
         const _sg_sampler_t* smp = _sg_lookup_sampler(&_sg.pools, smp_id.id);
         if (smp) {
-            res.smp = (void*) smp->wgpu.smp;
+            res.smp = (const void*) smp->wgpu.smp;
         }
     #else
         _SOKOL_UNUSED(smp_id);
@@ -18743,9 +18743,9 @@ SOKOL_API_IMPL sg_wgpu_shader_info sg_wgpu_query_shader_info(sg_shader shd_id) {
     #if defined(SOKOL_WGPU)
         const _sg_shader_t* shd = _sg_lookup_shader(&_sg.pools, shd_id.id);
         if (shd) {
-            res.vs_mod = (void*) shd->wgpu.stage[SG_SHADERSTAGE_VS].module;
-            res.fs_mod = (void*) shd->wgpu.stage[SG_SHADERSTAGE_FS].module;
-            res.bgl = (void*) shd->wgpu.bind_group_layout;
+            res.vs_mod = (const void*) shd->wgpu.stage[SG_SHADERSTAGE_VS].module;
+            res.fs_mod = (const void*) shd->wgpu.stage[SG_SHADERSTAGE_FS].module;
+            res.bgl = (const void*) shd->wgpu.bind_group_layout;
         }
     #else
         _SOKOL_UNUSED(shd_id);
@@ -18760,7 +18760,7 @@ SOKOL_API_IMPL sg_wgpu_pipeline_info sg_wgpu_query_pipeline_info(sg_pipeline pip
     #if defined(SOKOL_WGPU)
         const _sg_pipeline_t* pip = _sg_lookup_pipeline(&_sg.pools, pip_id.id);
         if (pip) {
-            res.pip = (void*) pip->wgpu.pip;
+            res.pip = (const void*) pip->wgpu.pip;
         }
     #else
         _SOKOL_UNUSED(pip_id);
@@ -18776,10 +18776,10 @@ SOKOL_API_IMPL sg_wgpu_pass_info sg_wgpu_query_pass_info(sg_pass pass_id) {
         const _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
         if (pass) {
             for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
-                res.color_view[i] = (void*) pass->wgpu.color_atts[i].view;
-                res.resolve_view[i] = (void*) pass->wgpu.resolve_atts[i].view;
+                res.color_view[i] = (const void*) pass->wgpu.color_atts[i].view;
+                res.resolve_view[i] = (const void*) pass->wgpu.resolve_atts[i].view;
             }
-            res.ds_view = (void*) pass->wgpu.ds_att.view;
+            res.ds_view = (const void*) pass->wgpu.ds_att.view;
         }
     #else
         _SOKOL_UNUSED(pass_id);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3833,7 +3833,7 @@ SOKOL_GFX_API_DECL sg_context sg_setup_context(void);
 SOKOL_GFX_API_DECL void sg_activate_context(sg_context ctx_id);
 SOKOL_GFX_API_DECL void sg_discard_context(sg_context ctx_id);
 
-/* Backend-specific helper functions, these may come in handy for mixing
+/* Backend-specific structs and functions, these may come in handy for mixing
    sokol-gfx rendering with 'native backend' rendering functions.
 
    This group of functions will be expanded as needed.
@@ -3841,6 +3841,8 @@ SOKOL_GFX_API_DECL void sg_discard_context(sg_context ctx_id);
 
 // D3D11: return ID3D11Device
 SOKOL_GFX_API_DECL const void* sg_d3d11_device(void);
+// D3D11: return ID3D11DeviceContext
+SOKOL_GFX_API_DECL const void* sg_d3d11_device_context(void);
 // Metal: return __bridge-casted MTLDevice
 SOKOL_GFX_API_DECL const void* sg_mtl_device(void);
 // Metal: return __bridge-casted MTLRenderCommandEncoder in current pass (or zero if outside pass)
@@ -18240,6 +18242,14 @@ SOKOL_API_IMPL sg_pass_desc sg_query_pass_defaults(const sg_pass_desc* desc) {
 SOKOL_API_IMPL const void* sg_d3d11_device(void) {
 #if defined(SOKOL_D3D11)
     return (const void*) _sg.d3d11.dev;
+#else
+    return 0;
+#endif
+}
+
+SOKOL_API_IMPL const void* sg_d3d11_device_context(void) {
+#if defined(SOKOL_D3D11)
+    return (const void*) _sg.d3d11.ctx;
 #else
     return 0;
 #endif

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -18303,7 +18303,7 @@ SOKOL_API_IMPL const void* sg_d3d11_device_context(void) {
 #endif
 }
 
-SOKOL_GFX_API_IMPL sg_d3d11_buffer_info sg_d3d11_query_buffer_info(sg_buffer buf_id) {
+SOKOL_API_IMPL sg_d3d11_buffer_info sg_d3d11_query_buffer_info(sg_buffer buf_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_d3d11_buffer_info res;
     _sg_clear(&res, sizeof(res));
@@ -18312,11 +18312,13 @@ SOKOL_GFX_API_IMPL sg_d3d11_buffer_info sg_d3d11_query_buffer_info(sg_buffer buf
     if (buf) {
         res.buf = (void*) buf->d3d11.buf;
     }
+#else
+    _SOKOL_UNUSED(buf_id);
 #endif
     return res;
 }
 
-SOKOL_GFX_API_IMPL sg_d3d11_image_info sg_d3d11_query_image_info(sg_image img_id) {
+SOKOL_API_IMPL sg_d3d11_image_info sg_d3d11_query_image_info(sg_image img_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_d3d11_image_info res;
     _sg_clear(&res, sizeof(res));
@@ -18328,11 +18330,13 @@ SOKOL_GFX_API_IMPL sg_d3d11_image_info sg_d3d11_query_image_info(sg_image img_id
         res.res = (void*) img->d3d11.res;
         res.srv = (void*) img->d3d11.srv;
     }
+#else
+    _SOKOL_UNUSED(img_id);
 #endif
     return res;
 }
 
-SOKOL_GFX_API_IMPL sg_d3d11_sampler_info sg_d3d11_query_sampler_info(sg_sampler smp_id) {
+SOKOL_API_IMPL sg_d3d11_sampler_info sg_d3d11_query_sampler_info(sg_sampler smp_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_d3d11_sampler_info res;
     _sg_clear(&res, sizeof(res));
@@ -18341,11 +18345,13 @@ SOKOL_GFX_API_IMPL sg_d3d11_sampler_info sg_d3d11_query_sampler_info(sg_sampler 
     if (smp) {
         res.smp = (void*) smp->d3d11.smp;
     }
+#else
+    _SOKOL_UNUSED(smp_id);
 #endif
     return res;
 }
 
-SOKOL_GFX_API_IMPL sg_d3d11_shader_info sg_d3d11_query_shader_info(sg_shader shd_id) {
+SOKOL_API_IMPL sg_d3d11_shader_info sg_d3d11_query_shader_info(sg_shader shd_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_d3d11_shader_info res;
     _sg_clear(&res, sizeof(res));
@@ -18359,11 +18365,13 @@ SOKOL_GFX_API_IMPL sg_d3d11_shader_info sg_d3d11_query_shader_info(sg_shader shd
         res.vs = (void*) shd->d3d11.vs;
         res.fs = (void*) shd->d3d11.fs;
     }
+#else
+    _SOKOL_UNUSED(shd_id);
 #endif
     return res;
 }
 
-SOKOL_GFX_API_IMPL sg_d3d11_pipeline_info sg_d3d11_query_pipeline_info(sg_pipeline pip_id) {
+SOKOL_API_IMPL sg_d3d11_pipeline_info sg_d3d11_query_pipeline_info(sg_pipeline pip_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_d3d11_pipeline_info res;
     _sg_clear(&res, sizeof(res));
@@ -18375,11 +18383,13 @@ SOKOL_GFX_API_IMPL sg_d3d11_pipeline_info sg_d3d11_query_pipeline_info(sg_pipeli
         res.dss = pip->d3d11.dss;
         res.bs = pip->d3d11.bs;
     }
+#else
+    _SOKOL_UNUSED(pip_id);
 #endif
     return res;
 }
 
-SOKOL_GFX_API_IMPL sg_d3d11_pass_info sg_d3d11_query_pass_info(sg_pass pass_id) {
+SOKOL_API_IMPL sg_d3d11_pass_info sg_d3d11_query_pass_info(sg_pass pass_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_d3d11_pass_info res;
     _sg_clear(&res, sizeof(res));
@@ -18387,11 +18397,13 @@ SOKOL_GFX_API_IMPL sg_d3d11_pass_info sg_d3d11_query_pass_info(sg_pass pass_id) 
     const _sg_pass_t* pass = _sg_lookup_pass(&_sg.pools, pass_id.id);
     if (pass) {
         for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
-            res.color_rtv[i] = pass->d3d11.color_atts[i].rtv;
-            res.resolve_rtv[i] = pass->d3d11.resolve_attrs[i].rtv;
+            res.color_rtv[i] = pass->d3d11.color_atts[i].view.rtv;
+            res.resolve_rtv[i] = pass->d3d11.resolve_atts[i].view.rtv;
         }
-        res.dsv = pass->d3d11.ds_att.dsv;
+        res.dsv = pass->d3d11.ds_att.view.dsv;
     }
+#else
+    _SOKOL_UNUSED(pass_id);
 #endif
     return res;
 }


### PR DESCRIPTION
Fixes https://github.com/floooh/sokol/issues/931.

Fixes https://github.com/floooh/sokol/issues/930

TODO:

- [x] d3d11 texture view injection fixes
- [x] update sokol_gfx.h documentation
- [x] update changelog

