### PR TITLE
In nim bindings, set NDEBUG in release mode

### DIFF
--- a/bindgen/gen_nim.py
+++ b/bindgen/gen_nim.py
@@ -566,6 +566,8 @@ def gen_extra(inp):
     #    l('')
     c_source_path = '/'.join(c_source_paths[inp['prefix']].split('/')[3:])
     l('{.passc:"-DSOKOL_NIM_IMPL".}')
+    l('when defined(release):')
+    l('  {.passc:"-DNDEBUG".}')
     l(f'{{.compile:"{c_source_path}".}}')
 
 def gen_module(inp, dep_prefixes):


### PR DESCRIPTION
related to [this discussion](https://github.com/floooh/sokol-nim/pull/25), this PR adds a simple check that sets NDEBUG when the Nim compiler is called with the release flag