### PR TITLE
Add define guard around sokol-main stub

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -11200,6 +11200,7 @@ SOKOL_API_IMPL void sapp_run(const sapp_desc* desc) {
 }
 
 /* this is just a stub so the linker doesn't complain */
+#ifndef SOKOL_REMOVE_MAIN_STUB
 sapp_desc sokol_main(int argc, char* argv[]) {
     _SOKOL_UNUSED(argc);
     _SOKOL_UNUSED(argv);
@@ -11207,6 +11208,7 @@ sapp_desc sokol_main(int argc, char* argv[]) {
     _sapp_clear(&desc, sizeof(desc));
     return desc;
 }
+#endif
 #else
 /* likewise, in normal mode, sapp_run() is just an empty stub */
 SOKOL_API_IMPL void sapp_run(const sapp_desc* desc) {


### PR DESCRIPTION
When working on [a project that targets android and ios](github.com/geooot/zig-sokol-crossplatform-starter), this stub function was giving me problems.

In [my code](https://github.com/geooot/zig-sokol-crossplatform-starter/blob/main/core/main.zig#L130-L136), i both define main and sokol_main since the ios version used the main function but the android target used sokol_main. But the linker complained since there was two definitions of sokol_main.

With this guard, I can just define `SOKOL_REMOVE_MAIN_STUB` to not include it during build.