### PR TITLE
macOS: workaround wobbly MTKView resizing

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -3560,6 +3560,7 @@ _SOKOL_PRIVATE void _sapp_macos_update_dimensions(void) {
     else {
         _sapp.dpi_scale = 1.0f;
     }
+    _sapp.macos.view.layer.contentsScale = _sapp.dpi_scale; // NOTE: needed because we set layerContentsPlacement to a non-scaling value in windowWillStartLiveResize.
     const NSRect bounds = [_sapp.macos.view bounds];
     _sapp.window_width = (int)roundf(bounds.size.width);
     _sapp.window_height = (int)roundf(bounds.size.height);
@@ -3914,6 +3915,24 @@ _SOKOL_PRIVATE void _sapp_macos_frame(void) {
         return NO;
     }
 }
+
+#if defined(SOKOL_METAL)
+- (void)windowWillStartLiveResize:(NSNotification *)notification {
+    // Work around the MTKView resizing glitch by "anchoring" the layer to the window corner opposite
+    // to the currently manipulated corner (or edge). This prevents the content stretching back and
+    // forth during resizing. This is a workaround for this issue: https://github.com/floooh/sokol/issues/700
+    // Can be removed if/when migrating to CAMetalLayer: https://github.com/floooh/sokol/issues/727
+    bool resizing_from_left = _sapp.mouse.x < _sapp.window_width/2;
+    bool resizing_from_top = _sapp.mouse.y < _sapp.window_height/2;
+    NSViewLayerContentsPlacement placement;
+    if (resizing_from_left) {
+        placement = resizing_from_top ? NSViewLayerContentsPlacementBottomRight : NSViewLayerContentsPlacementTopRight;
+    } else {
+        placement = resizing_from_top ? NSViewLayerContentsPlacementBottomLeft : NSViewLayerContentsPlacementTopLeft;
+    }
+    _sapp.macos.view.layerContentsPlacement = placement;
+}
+#endif
 
 - (void)windowDidResize:(NSNotification*)notification {
     _SOKOL_UNUSED(notification);


### PR DESCRIPTION
Workaround for the MTKView resizing glitch by "anchoring" the layer to the window corner opposite to the currently manipulated corner (or edge). This prevents the content stretching back and forth during resizing. This is basically this: https://github.com/floooh/sokol/issues/700

As pointed out in the [glitchess resizing](https://thume.ca/2019/06/19/glitchless-metal-window-resizing/) blogpost, `layerContentsPlacement = .topLeft` helps because it prevents stretching the content of the layer while waiting for the correctly sized frame to be rendered. However it works only if the rendered elements are top left aligned. If there are elements that are rendered in the bottom right of the frame and the user resizes from the top left of the window, these elements will appear to shake as they get moved when resizing, then "aligned back" when the frame is rendered.

My solution is to detect which corner is being resized and set layerContentsPlacement accordingly in windowWillStartLiveResize.

Before:

https://github.com/floooh/sokol/assets/6556843/2172ed47-7ef7-476e-ac92-a5c74077e04d

Notice the blue squares stretching while resizing. Pausing the video near the end makes it even more obvious. 

After:

https://github.com/floooh/sokol/assets/6556843/7047c9ba-244d-4421-ac43-7ada9a393b53

Notice the blue squares stability independent of which corner is being dragged. Pausing the video makes the latency apparent in the form of grey padding on the resized sides. Barely noticeable at 120 fps.

This workaround can be removed if/when migrating to CAMetalLayer: https://github.com/floooh/sokol/issues/727

Untested: dragging a window from a high dpi to a non high dpi monitor (I can test this in a few days if needed).
