### PR TITLE
Render pass cleanup (implements #904)

### DIFF
--- a/.github/workflows/gen_bindings.yml
+++ b/.github/workflows/gen_bindings.yml
@@ -57,6 +57,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: floooh/sokol-rust
+          submodules: recursive
           path: bindgen/sokol-rust
       - name: generate
         run: |

--- a/.github/workflows/gen_bindings.yml
+++ b/.github/workflows/gen_bindings.yml
@@ -57,7 +57,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: floooh/sokol-rust
-          submodules: recursive
           path: bindgen/sokol-rust
       - name: generate
         run: |
@@ -222,7 +221,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: floooh/sokol-rust
-          submodules: recursive
       - uses: actions/download-artifact@v3
         with:
           name: ignore-me-rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 ## Updates
 
+### 29-Feb-2024:
+
+**BREAKING CHANGES** in sokol_gfx.h, sokol_app.h, sokol_glue.h and sokol_gfx_imgui.h
+(the 'big render pass cleanup').
+
+- In sokol_gfx.h, the concepts of 'render contexts' and 'default render passes' have
+  been removed and replaced with a unified `sg_begin_pass()` which handles both
+  rendering into 'offscreen-passes' and 'swapchain-passes'.
+
+  [Please read this blog
+  post](https://floooh.github.io/2024/02/26/sokol-spring-cleaning-2024.html)
+  carefully for a detailed overview what has changed, why the changes make
+  sense, and how existing code needs to be updated.
+
+- There are also minimal related changes in the sokol_app.h and a complete
+  rewrite of the sokol_glue.h APIs, also detailed in the above blog post.
+
+- The namespace-prefix for the header sokol_gfx_imgui.h has been changed from
+  `sg_imgui_` to `sgimgui_`.
+
+- In sokol_gfx.h with the Metal backend, a runtime configuration flag has been
+  added to `sg_desc` to create a Metal command buffer with
+  'retained-references'. See issue
+  [#981](https://github.com/floooh/sokol/issues/981) for details.
+
+- Also in sokol_gfx.h, the struct item `sg_limits.gl_max_vertex_uniform_vectors` has been changed
+  to `sg_limits.gl_max_vertex_uniform_components` (note that there are 4x more 'components'
+  than 'vectors'). See issue [#714](https://github.com/floooh/sokol/issues/714) for details.
+
+- All sampples, language binding examples and 'side projects' have been updated, see the above blog post
+  for links to the respective PRs.
+
 ### 27-Feb-2024:
 
 - Merged PR https://github.com/floooh/sokol/pull/1001, this is a small fix for GLES3 to avoid

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Simple
 [STB-style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt)
 cross-platform libraries for C and C++, written in C.
 
-[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**27-Jan-2024**: restored old event bubbling behaviour in sokol_app.h html5)
+[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**29-Feb-2024**: **BREAKING CHANGES** 'unified render pass'
+cleanup in sokol_gfx.h)
 
 [![Build](/../../actions/workflows/main.yml/badge.svg)](/../../actions/workflows/main.yml) [![Bindings](/../../actions/workflows/gen_bindings.yml/badge.svg)](/../../actions/workflows/gen_bindings.yml) [![build](https://github.com/floooh/sokol-zig/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-zig/actions/workflows/main.yml) [![build](https://github.com/floooh/sokol-nim/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-nim/actions/workflows/main.yml) [![Odin](https://github.com/floooh/sokol-odin/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-odin/actions/workflows/main.yml)[![Rust](https://github.com/floooh/sokol-rust/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-rust/actions/workflows/main.yml)
 

--- a/README.md
+++ b/README.md
@@ -94,104 +94,6 @@ A blog post with more background info: [A Tour of sokol_gfx.h](http://floooh.git
 - does *not* provide shader dialect cross-translation (**BUT** there's now an 'official' shader-cross-compiler solution which
 seamlessly integrates with sokol_gfx.h and IDEs: [see here for details](https://github.com/floooh/sokol-tools/blob/master/docs/sokol-shdc.md)
 
-A triangle in C99 with GLFW:
-
-```c
-#define SOKOL_IMPL
-#define SOKOL_GLCORE33
-#include "sokol_gfx.h"
-#include "sokol_log.h"
-#define GLFW_INCLUDE_NONE
-#include "GLFW/glfw3.h"
-
-int main() {
-
-    /* create window and GL context via GLFW */
-    glfwInit();
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
-    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-    GLFWwindow* w = glfwCreateWindow(640, 480, "Sokol Triangle GLFW", 0, 0);
-    glfwMakeContextCurrent(w);
-    glfwSwapInterval(1);
-
-    /* setup sokol_gfx */
-    sg_setup(&(sg_desc){
-        .logger.func = slog_func,
-    });
-
-    /* a vertex buffer */
-    const float vertices[] = {
-        // positions            // colors
-         0.0f,  0.5f, 0.5f,     1.0f, 0.0f, 0.0f, 1.0f,
-         0.5f, -0.5f, 0.5f,     0.0f, 1.0f, 0.0f, 1.0f,
-        -0.5f, -0.5f, 0.5f,     0.0f, 0.0f, 1.0f, 1.0f
-    };
-    sg_buffer vbuf = sg_make_buffer(&(sg_buffer_desc){
-        .data = SG_RANGE(vertices)
-    });
-
-    /* a shader */
-    sg_shader shd = sg_make_shader(&(sg_shader_desc){
-        .vs.source =
-            "#version 330\n"
-            "layout(location=0) in vec4 position;\n"
-            "layout(location=1) in vec4 color0;\n"
-            "out vec4 color;\n"
-            "void main() {\n"
-            "  gl_Position = position;\n"
-            "  color = color0;\n"
-            "}\n",
-        .fs.source =
-            "#version 330\n"
-            "in vec4 color;\n"
-            "out vec4 frag_color;\n"
-            "void main() {\n"
-            "  frag_color = color;\n"
-            "}\n"
-    });
-
-    /* a pipeline state object (default render states are fine for triangle) */
-    sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
-        .shader = shd,
-        .layout = {
-            .attrs = {
-                [0].format=SG_VERTEXFORMAT_FLOAT3,
-                [1].format=SG_VERTEXFORMAT_FLOAT4
-            }
-        }
-    });
-
-    /* resource bindings */
-    sg_bindings bind = {
-        .vertex_buffers[0] = vbuf
-    };
-
-    /* default pass action (clear to grey) */
-    sg_pass_action pass_action = {0};
-
-    /* draw loop */
-    while (!glfwWindowShouldClose(w)) {
-        int cur_width, cur_height;
-        glfwGetFramebufferSize(w, &cur_width, &cur_height);
-        sg_begin_default_pass(&pass_action, cur_width, cur_height);
-        sg_apply_pipeline(pip);
-        sg_apply_bindings(&bind);
-        sg_draw(0, 3, 1);
-        sg_end_pass();
-        sg_commit();
-        glfwSwapBuffers(w);
-        glfwPollEvents();
-    }
-
-    /* cleanup */
-    sg_shutdown();
-    glfwTerminate();
-    return 0;
-}
-```
-
 # sokol_app.h
 
 A minimal cross-platform application-wrapper library:
@@ -203,32 +105,57 @@ A minimal cross-platform application-wrapper library:
 - supported platforms: Win32, MacOS, Linux (X11), iOS, WASM, Android, UWP
 - supported 3D-APIs: GL3.3 (GLX/WGL), Metal, D3D11, GLES3/WebGL2
 
-A simple clear-loop sample using sokol_app.h and sokol_gfx.h (does not include
-separate sokol.c/.m implementation file which is necessary
-to split the Objective-C code from the C code of the sample):
+The vanilla Hello-Triangle using sokol_gfx.h, sokol_app.h and the
+sokol-shdc shader compiler (shader code not shown):
 
 ```c
-#include "sokol_gfx.h"
 #include "sokol_app.h"
+#include "sokol_gfx.h"
 #include "sokol_log.h"
 #include "sokol_glue.h"
+#include "triangle-sapp.glsl.h"
 
-sg_pass_action pass_action;
+static struct {
+    sg_pipeline pip;
+    sg_bindings bind;
+    sg_pass_action pass_action;
+} state;
 
-void init(void) {
+static void init(void) {
     sg_setup(&(sg_desc){
-        .context = sapp_sgcontext(),
+        .environment = sglue_environment(),
         .logger.func = slog_func,
     });
-    pass_action = (sg_pass_action) {
-        .colors[0] = { .load_action=SG_LOADACTION_CLEAR, .clear_value={1.0f, 0.0f, 0.0f, 1.0f} }
+
+    float vertices[] = {
+         0.0f,  0.5f, 0.5f,     1.0f, 0.0f, 0.0f, 1.0f,
+         0.5f, -0.5f, 0.5f,     0.0f, 1.0f, 0.0f, 1.0f,
+        -0.5f, -0.5f, 0.5f,     0.0f, 0.0f, 1.0f, 1.0f
+    };
+    state.bind.vertex_buffers[0] = sg_make_buffer(&(sg_buffer_desc){
+        .data = SG_RANGE(vertices),
+    });
+
+    state.pip = sg_make_pipeline(&(sg_pipeline_desc){
+        .shader = sg_make_shader(triangle_shader_desc(sg_query_backend())),
+        .layout = {
+            .attrs = {
+                [ATTR_vs_position].format = SG_VERTEXFORMAT_FLOAT3,
+                [ATTR_vs_color0].format = SG_VERTEXFORMAT_FLOAT4
+            }
+        },
+    });
+
+    state.pass_action = (sg_pass_action) {
+        .colors[0] = { .load_action=SG_LOADACTION_CLEAR, .clear_value={0.0f, 0.0f, 0.0f, 1.0f } }
     };
 }
 
 void frame(void) {
-    float g = pass_action.colors[0].clear_value.g + 0.01f;
-    pass_action.colors[0].clear_value.g = (g > 1.0f) ? 0.0f : g;
-    sg_begin_default_pass(&pass_action, sapp_width(), sapp_height());
+    sg_begin_pass(&(sg_pass){ .action = state.pass_action, .swapchain = sglue_swapchain() });
+    sg_apply_pipeline(state.pip);
+    sg_apply_bindings(&state.bind);
+    sg_draw(0, 3, 1);
     sg_end_pass();
     sg_commit();
 }
@@ -238,13 +165,15 @@ void cleanup(void) {
 }
 
 sapp_desc sokol_main(int argc, char* argv[]) {
+    (void)argc; (void)argv;
     return (sapp_desc){
         .init_cb = init,
         .frame_cb = frame,
         .cleanup_cb = cleanup,
-        .width = 400,
-        .height = 300,
-        .window_title = "Clear Sample",
+        .width = 640,
+        .height = 480,
+        .window_title = "Triangle",
+        .icon.sokol_default = true,
         .logger.func = slog_func,
     };
 }

--- a/bindgen/gen_all.py
+++ b/bindgen/gen_all.py
@@ -4,7 +4,7 @@ tasks = [
     [ '../sokol_log.h',            'slog_',     [] ],
     [ '../sokol_gfx.h',            'sg_',       [] ],
     [ '../sokol_app.h',            'sapp_',     [] ],
-    [ '../sokol_glue.h',           'sglue_',     ['sg_', 'sapp_'] ],
+    [ '../sokol_glue.h',           'sglue_',     ['sg_'] ],
     [ '../sokol_time.h',           'stm_',      [] ],
     [ '../sokol_audio.h',          'saudio_',   [] ],
     [ '../util/sokol_gl.h',        'sgl_',      ['sg_'] ],

--- a/bindgen/gen_all.py
+++ b/bindgen/gen_all.py
@@ -4,7 +4,7 @@ tasks = [
     [ '../sokol_log.h',            'slog_',     [] ],
     [ '../sokol_gfx.h',            'sg_',       [] ],
     [ '../sokol_app.h',            'sapp_',     [] ],
-    [ '../sokol_glue.h',           'sapp_sg',   ['sg_'] ],
+    [ '../sokol_glue.h',           'sglue_',     ['sg_', 'sapp_'] ],
     [ '../sokol_time.h',           'stm_',      [] ],
     [ '../sokol_audio.h',          'saudio_',   [] ],
     [ '../util/sokol_gl.h',        'sgl_',      ['sg_'] ],

--- a/bindgen/gen_all.py
+++ b/bindgen/gen_all.py
@@ -31,11 +31,7 @@ for task in tasks:
     gen_zig.gen(c_header_path, main_prefix, dep_prefixes)
 
 # Rust
-rust_tasks = [
-    *tasks,
-    [ '../util/sokol_imgui.h', 'simgui_', ['sg_', 'sapp_'] ],
-]
 gen_rust.prepare()
-for task in rust_tasks:
+for task in tasks:
     [c_header_path, main_prefix, dep_prefixes] = task
     gen_rust.gen(c_header_path, main_prefix, dep_prefixes)

--- a/bindgen/gen_all.py
+++ b/bindgen/gen_all.py
@@ -4,7 +4,7 @@ tasks = [
     [ '../sokol_log.h',            'slog_',     [] ],
     [ '../sokol_gfx.h',            'sg_',       [] ],
     [ '../sokol_app.h',            'sapp_',     [] ],
-    [ '../sokol_glue.h',           'sglue_',     ['sg_'] ],
+    [ '../sokol_glue.h',           'sglue_',    ['sg_'] ],
     [ '../sokol_time.h',           'stm_',      [] ],
     [ '../sokol_audio.h',          'saudio_',   [] ],
     [ '../util/sokol_gl.h',        'sgl_',      ['sg_'] ],
@@ -31,7 +31,11 @@ for task in tasks:
     gen_zig.gen(c_header_path, main_prefix, dep_prefixes)
 
 # Rust
+rust_tasks = [
+    *tasks,
+    [ '../util/sokol_imgui.h', 'simgui_', ['sg_', 'sapp_'] ],
+]
 gen_rust.prepare()
-for task in tasks:
+for task in rust_tasks:
     [c_header_path, main_prefix, dep_prefixes] = task
     gen_rust.gen(c_header_path, main_prefix, dep_prefixes)

--- a/bindgen/gen_nim.py
+++ b/bindgen/gen_nim.py
@@ -13,24 +13,24 @@ module_names = {
     'slog_':    'log',
     'sg_':      'gfx',
     'sapp_':    'app',
-    'sapp_sg':  'glue',
     'stm_':     'time',
     'saudio_':  'audio',
     'sgl_':     'gl',
     'sdtx_':    'debugtext',
     'sshape_':  'shape',
+    'sglue_':   'glue',
 }
 
 c_source_paths = {
     'slog_':    'sokol-nim/src/sokol/c/sokol_log.c',
     'sg_':      'sokol-nim/src/sokol/c/sokol_gfx.c',
     'sapp_':    'sokol-nim/src/sokol/c/sokol_app.c',
-    'sapp_sg':  'sokol-nim/src/sokol/c/sokol_glue.c',
     'stm_':     'sokol-nim/src/sokol/c/sokol_time.c',
     'saudio_':  'sokol-nim/src/sokol/c/sokol_audio.c',
     'sgl_':     'sokol-nim/src/sokol/c/sokol_gl.c',
     'sdtx_':    'sokol-nim/src/sokol/c/sokol_debugtext.c',
     'sshape_':  'sokol-nim/src/sokol/c/sokol_shape.c',
+    'sglue_':   'sokol-nim/src/sokol/c/sokol_glue.c',
 }
 
 c_callbacks = [
@@ -46,8 +46,6 @@ overrides = {
     'sgl_error':                    'sgl_get_error',
     'sgl_deg':                      'sgl_as_degrees',
     'sgl_rad':                      'sgl_as_radians',
-    'sg_context_desc.color_format': 'int',
-    'sg_context_desc.depth_format': 'int',
     'SGL_NO_ERROR':                 'SGL_ERROR_NO_ERROR',
     'SG_BUFFERTYPE_VERTEXBUFFER':   'SG_BUFFERTYPE_VERTEX_BUFFER',
     'SG_BUFFERTYPE_INDEXBUFFER':    'SG_BUFFERTYPE_INDEX_BUFFER',

--- a/bindgen/gen_odin.py
+++ b/bindgen/gen_odin.py
@@ -15,7 +15,6 @@ module_names = {
     'slog_':    'log',
     'sg_':      'gfx',
     'sapp_':    'app',
-    'sapp_sg':  'glue',
     'stm_':     'time',
     'saudio_':  'audio',
     'sgl_':     'gl',

--- a/bindgen/gen_odin.py
+++ b/bindgen/gen_odin.py
@@ -21,6 +21,7 @@ module_names = {
     'sgl_':     'gl',
     'sdtx_':    'debugtext',
     'sshape_':  'shape',
+    'sglue_':   'glue',
 }
 
 system_libs = {
@@ -75,6 +76,7 @@ c_source_names = {
     'sgl_':     'sokol_gl.c',
     'sdtx_':    'sokol_debugtext.c',
     'sshape_':  'sokol_shape.c',
+    'sglue_':   'sokol_glue.c',
 }
 
 ignores = [
@@ -87,10 +89,6 @@ ignores = [
 # NOTE: syntax for function results: "func_name.RESULT"
 overrides = {
     'context':                              'ctx',  # reserved keyword
-    'sapp_sgcontext':                       'sapp_sgctx',
-    'sapp_sgcontext':                       'sapp_sgctx',
-    'sg_context_desc.color_format':         'int',
-    'sg_context_desc.depth_format':         'int',
     'SGL_NO_ERROR':                         'SGL_ERROR_NO_ERROR',
 }
 

--- a/bindgen/gen_rust.py
+++ b/bindgen/gen_rust.py
@@ -19,14 +19,12 @@ module_names = {
     "sgl_": "gl",
     "sdtx_": "debugtext",
     "sshape_": "shape",
-    "sapp_sg": "glue",
     "simgui_": "imgui",
-    "sg_imgui_": "gfx_imgui",
+    "sglue_": "glue",
 }
 
 module_requires_rust_feature = {
     module_names["simgui_"]: "imgui",
-    module_names["sg_imgui_"]: "imgui",
 }
 
 c_source_paths = {
@@ -38,14 +36,14 @@ c_source_paths = {
     "sgl_": "sokol-rust/src/sokol/c/sokol_gl.c",
     "sdtx_": "sokol-rust/src/sokol/c/sokol_debugtext.c",
     "sshape_": "sokol-rust/src/sokol/c/sokol_shape.c",
-    "sapp_sg": "sokol-rust/src/sokol/c/sokol_glue.c",
     "simgui_": "sokol-rust/src/sokol/c/sokol_imgui.c",
-    "sg_imgui_": "sokol-rust/src/sokol/c/sokol_gfx_imgui.c",
+    "sglue_": "sokol-rust/src/sokol/c/sokol_glue.c",
 }
 
 ignores = [
     "sdtx_printf",
     "sdtx_vprintf",
+    "simgui_add_key_event",
     # "sg_install_trace_hooks",
     # "sg_trace_hooks",
 ]

--- a/bindgen/gen_zig.py
+++ b/bindgen/gen_zig.py
@@ -52,8 +52,6 @@ overrides = {
     'sgl_error':                            'sgl_get_error',   # 'error' is reserved in Zig
     'sgl_deg':                              'sgl_as_degrees',
     'sgl_rad':                              'sgl_as_radians',
-    'sg_context_desc.color_format':         'int',
-    'sg_context_desc.depth_format':         'int',
     'sg_apply_uniforms.ub_index':           'uint32_t',
     'sg_draw.base_element':                 'uint32_t',
     'sg_draw.num_elements':                 'uint32_t',

--- a/bindgen/gen_zig.py
+++ b/bindgen/gen_zig.py
@@ -20,6 +20,7 @@ module_names = {
     'sgl_':     'gl',
     'sdtx_':    'debugtext',
     'sshape_':  'shape',
+    'sglue_':   'glue',
 }
 
 c_source_paths = {
@@ -31,6 +32,7 @@ c_source_paths = {
     'sgl_':     'sokol-zig/src/sokol/c/sokol_gl.c',
     'sdtx_':    'sokol-zig/src/sokol/c/sokol_debugtext.c',
     'sshape_':  'sokol-zig/src/sokol/c/sokol_shape.c',
+    'sglue_':   'sokol-zig/src/sokol/c/sokol_glue.c',
 }
 
 ignores = [

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2050,6 +2050,9 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #if defined(SOKOL_WGPU)
         #include <webgpu/webgpu.h>
     #endif
+    #if defined(SOKOL_GLES3)
+        #include <GLES3/gl3.h>
+    #endif
     #include <emscripten/emscripten.h>
     #include <emscripten/html5.h>
 #elif defined(_SAPP_WIN32)
@@ -5564,8 +5567,10 @@ _SOKOL_PRIVATE void _sapp_emsc_webgl_init(void) {
     EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context(_sapp.html5_canvas_selector, &attrs);
     // FIXME: error message?
     emscripten_webgl_make_context_current(ctx);
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, (GLint*)&_sapp.gl.framebuffer);
 
-    /* some WebGL extension are not enabled automatically by emscripten */
+    // FIXME: remove PVRTC support here and in sokol-gfx at some point
+    // some WebGL extension are not enabled automatically by emscripten
     emscripten_webgl_enable_extension(ctx, "WEBKIT_WEBGL_compressed_texture_pvrtc");
 }
 #endif

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -313,6 +313,10 @@
             objects and values required for rendering. If sokol_app.h
             is not compiled with SOKOL_WGPU, these functions return null.
 
+        const uint32_t sapp_gl_get_framebuffer(void)
+            This returns the 'default framebuffer' of the GL context.
+            Typically this will be zero.
+
         const void* sapp_android_get_native_activity(void);
             On Android, get the native activity ANativeActivity pointer, otherwise
             a null pointer.

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2583,6 +2583,8 @@ typedef struct {
     PFNWGLGETEXTENSIONSSTRINGEXTPROC GetExtensionsStringEXT;
     PFNWGLGETEXTENSIONSSTRINGARBPROC GetExtensionsStringARB;
     PFNWGLCREATECONTEXTATTRIBSARBPROC CreateContextAttribsARB;
+    // special case glGetIntegerv
+    void (*GetIntegerv)(uint32_t pname, int32_t* data);
     bool ext_swap_control;
     bool arb_multisample;
     bool arb_pixel_format;
@@ -2794,7 +2796,7 @@ typedef struct {
 
 #if defined(_SAPP_ANY_GL)
 typedef struct {
-    GLuint framebuffer;
+    uint32_t framebuffer;
 } _sapp_gl_t;
 #endif
 
@@ -6586,7 +6588,7 @@ _SOKOL_PRIVATE void _sapp_wgl_init(void) {
     SOKOL_ASSERT(_sapp.wgl.GetCurrentDC);
     _sapp.wgl.MakeCurrent = (PFN_wglMakeCurrent)(void*) GetProcAddress(_sapp.wgl.opengl32, "wglMakeCurrent");
     SOKOL_ASSERT(_sapp.wgl.MakeCurrent);
-    _sapp.wgl.GetIntegerv = (void(*)(uint32_t, int32_t*) GetProcAddress(_sapp.wgl.opengl32, "glGetIntegerv");
+    _sapp.wgl.GetIntegerv = (void(*)(uint32_t, int32_t*)) GetProcAddress(_sapp.wgl.opengl32, "glGetIntegerv");
     SOKOL_ASSERT(_sapp.wgl.GetIntegerv);
 
     _sapp.wgl.msg_hwnd = CreateWindowExW(WS_EX_OVERLAPPEDWINDOW,
@@ -6853,7 +6855,7 @@ _SOKOL_PRIVATE void _sapp_wgl_create_context(void) {
         _sapp.wgl.SwapIntervalEXT(_sapp.swap_interval);
     }
     const uint32_t gl_framebuffer_binding = 0x8CA6;
-    _sapp.wgl.GetIntegerv(gl_framebuffer_binding, &_sapp.gl.framebuffer);
+    _sapp.wgl.GetIntegerv(gl_framebuffer_binding, (int32_t*)&_sapp.gl.framebuffer);
 }
 
 _SOKOL_PRIVATE void _sapp_wgl_destroy_context(void) {

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -288,11 +288,6 @@
             Before being used as Objective-C object, the void* must be converted
             back with a (ARC) __bridge cast.
 
-        const void* sapp_win32_get_hwnd(void)
-            On Windows, get the window's HWND, otherwise a null pointer. The
-            HWND has been cast to a void pointer in order to be tunneled
-            through code which doesn't include Windows.h.
-
         const void* sapp_d3d11_get_device(void)
         const void* sapp_d3d11_get_device_context(void)
         const void* sapp_d3d11_get_render_view(void)
@@ -304,6 +299,11 @@
             return a null pointer. Note that the returned pointers to the
             render-target-view and depth-stencil-view may change from one
             frame to the next!
+
+        const void* sapp_win32_get_hwnd(void)
+            On Windows, get the window's HWND, otherwise a null pointer. The
+            HWND has been cast to a void pointer in order to be tunneled
+            through code which doesn't include Windows.h.
 
         const void* sapp_wgpu_get_device(void)
         const void* sapp_wgpu_get_render_view(void)

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2123,6 +2123,7 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #include <android/native_activity.h>
     #include <android/looper.h>
     #include <EGL/egl.h>
+    #include <GLES3/gl3.h>
 #elif defined(_SAPP_LINUX)
     #define GL_GLEXT_PROTOTYPES
     #include <X11/Xlib.h>
@@ -8121,6 +8122,7 @@ _SOKOL_PRIVATE bool _sapp_android_init_egl_surface(ANativeWindow* window) {
         return false;
     }
     _sapp.android.surface = surface;
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, (GLint*)&_sapp.gl.framebuffer);
     return true;
 }
 
@@ -9811,7 +9813,7 @@ _SOKOL_PRIVATE void _sapp_glx_choose_visual(Visual** visual, int* depth) {
 
 _SOKOL_PRIVATE void _sapp_glx_make_current(void) {
     _sapp.glx.MakeCurrent(_sapp.x11.display, _sapp.glx.window, _sapp.glx.ctx);
-    glGetIntegerv(GL_FRAMEBUFFER_BINDING, (GLint*)&_sapp.gl.framebuffer); 
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, (GLint*)&_sapp.gl.framebuffer);
 }
 
 _SOKOL_PRIVATE void _sapp_glx_create_context(void) {

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -266,8 +266,9 @@
             Return the MSAA sample count of the default framebuffer.
 
         const void* sapp_metal_get_device(void)
-        const void* sapp_metal_get_renderpass_descriptor(void)
-        const void* sapp_metal_get_drawable(void)
+        const void* sapp_metal_get_current_drawable(void)
+        const void* sapp_metal_get_depth_stencil_texture(void)
+        const void* sapp_metal_get_msaa_color_texture(void)
             If the Metal backend has been selected, these functions return pointers
             to various Metal API objects required for rendering, otherwise
             they return a null pointer. These void pointers are actually
@@ -1849,10 +1850,12 @@ SOKOL_APP_API_DECL void sapp_html5_fetch_dropped_file(const sapp_html5_fetch_req
 
 /* Metal: get bridged pointer to Metal device object */
 SOKOL_APP_API_DECL const void* sapp_metal_get_device(void);
-/* Metal: get bridged pointer to this frame's renderpass descriptor */
-SOKOL_APP_API_DECL const void* sapp_metal_get_renderpass_descriptor(void);
-/* Metal: get bridged pointer to current drawable */
-SOKOL_APP_API_DECL const void* sapp_metal_get_drawable(void);
+/* Metal: get bridged pointer to MTKView's current drawable of type CAMetalDrawable */
+SOKOL_APP_API_DECL const void* sapp_metal_get_current_drawable(void);
+/* Metal: get bridged pointer to MTKView's depth-stencil texture of type MTLTexture */
+SOKOL_APP_API_DECL const void* sapp_metal_get_depth_stencil_texture(void);
+/* Metal: get bridged pointer to MTKView's msaa-color-texture of type MTLTexture (may be null) */
+SOKOL_APP_API_DECL const void* sapp_metal_get_msaa_color_texture(void);
 /* macOS: get bridged pointer to macOS NSWindow */
 SOKOL_APP_API_DECL const void* sapp_macos_get_window(void);
 /* iOS: get bridged pointer to iOS UIWindow */
@@ -11525,22 +11528,7 @@ SOKOL_API_IMPL const void* sapp_metal_get_device(void) {
     #endif
 }
 
-SOKOL_API_IMPL const void* sapp_metal_get_renderpass_descriptor(void) {
-    SOKOL_ASSERT(_sapp.valid);
-    #if defined(SOKOL_METAL)
-        #if defined(_SAPP_MACOS)
-            const void* obj = (__bridge const void*) [_sapp.macos.view currentRenderPassDescriptor];
-        #else
-            const void* obj = (__bridge const void*) [_sapp.ios.view currentRenderPassDescriptor];
-        #endif
-        SOKOL_ASSERT(obj);
-        return obj;
-    #else
-        return 0;
-    #endif
-}
-
-SOKOL_API_IMPL const void* sapp_metal_get_drawable(void) {
+SOKOL_API_IMPL const void* sapp_metal_get_current_drawable(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(SOKOL_METAL)
         #if defined(_SAPP_MACOS)
@@ -11549,6 +11537,34 @@ SOKOL_API_IMPL const void* sapp_metal_get_drawable(void) {
             const void* obj = (__bridge const void*) [_sapp.ios.view currentDrawable];
         #endif
         SOKOL_ASSERT(obj);
+        return obj;
+    #else
+        return 0;
+    #endif
+}
+
+SOKOL_API_IMPL const void* sapp_metal_get_depth_stencil_texture(void) {
+    SOKOL_ASSERT(_sapp.valid);
+    #if defined(SOKOL_METAL)
+        #if defined(_SAPP_MACOS)
+            const void* obj = (__bridge const void*) [_sapp.macos.view depthStencilTexture];
+        #else
+            const void* obj = (__bridge const void*) [_sapp.ios.view depthStencilTexture];
+        #endif
+        return obj;
+    #else
+        return 0;
+    #endif
+}
+
+SOKOL_API_IMPL const void* sapp_metal_get_msaa_color_texture(void) {
+    SOKOL_ASSERT(_sapp.valid);
+    #if defined(SOKOL_METAL)
+        #if defined(_SAPP_MACOS)
+            const void* obj = (__bridge const void*) [_sapp.macos.view multisampleColorTexture];
+        #else
+            const void* obj = (__bridge const void*) [_sapp.ios.view multisampleColorTexture];
+        #endif
         return obj;
     #else
         return 0;

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1493,7 +1493,6 @@ typedef struct sapp_range {
     Note that the actual image pixel format depends on the use case:
 
     - window icon pixels are RGBA8
-    - cursor images are ??? (FIXME)
 */
 typedef struct sapp_image_desc {
     int width;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -16113,7 +16113,6 @@ _SOKOL_PRIVATE bool _sg_validate_begin_pass(const sg_pass* pass) {
                 _SG_VALIDATE(pass->swapchain.d3d11.render_view == 0, VALIDATE_BEGINPASS_SWAPCHAIN_D3D11_EXPECT_RENDERVIEW_NOTSET);
                 _SG_VALIDATE(pass->swapchain.d3d11.depth_stencil_view == 0, VALIDATE_BEGINPASS_SWAPCHAIN_D3D11_EXPECT_DEPTHSTENCILVIEW_NOTSET);
                 _SG_VALIDATE(pass->swapchain.d3d11.resolve_view == 0, VALIDATE_BEGINPASS_SWAPCHAIN_D3D11_EXPECT_RESOLVEVIEW_NOTSET);
-                // FIXME: resolve_view
             #elif defined(SOKOL_WGPU)
                 _SG_VALIDATE(pass->swapchain.wgpu.render_view == 0, VALIDATE_BEGINPASS_SWAPCHAIN_WGPU_EXPECT_RENDERVIEW_NOTSET);
                 _SG_VALIDATE(pass->swapchain.wgpu.depth_stencil_view == 0, VALIDATE_BEGINPASS_SWAPCHAIN_WGPU_EXPECT_DEPTHSTENCILVIEW_NOTSET);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3842,7 +3842,7 @@ SOKOL_GFX_API_DECL void sg_init_image(sg_image img, const sg_image_desc* desc);
 SOKOL_GFX_API_DECL void sg_init_sampler(sg_sampler smg, const sg_sampler_desc* desc);
 SOKOL_GFX_API_DECL void sg_init_shader(sg_shader shd, const sg_shader_desc* desc);
 SOKOL_GFX_API_DECL void sg_init_pipeline(sg_pipeline pip, const sg_pipeline_desc* desc);
-SOKOL_GFX_API_DECL void sg_init_attchments(sg_attachments attachments, const sg_attachments_desc* desc);
+SOKOL_GFX_API_DECL void sg_init_attachments(sg_attachments attachments, const sg_attachments_desc* desc);
 SOKOL_GFX_API_DECL void sg_uninit_buffer(sg_buffer buf);
 SOKOL_GFX_API_DECL void sg_uninit_image(sg_image img);
 SOKOL_GFX_API_DECL void sg_uninit_sampler(sg_sampler smp);
@@ -4058,7 +4058,7 @@ inline sg_image sg_make_image(const sg_image_desc& desc) { return sg_make_image(
 inline sg_sampler sg_make_sampler(const sg_sampler_desc& desc) { return sg_make_sampler(&desc); }
 inline sg_shader sg_make_shader(const sg_shader_desc& desc) { return sg_make_shader(&desc); }
 inline sg_pipeline sg_make_pipeline(const sg_pipeline_desc& desc) { return sg_make_pipeline(&desc); }
-inline sg_pass sg_make_attchments(const sg_attachments_desc& desc) { return sg_make_attachments(&desc); }
+inline sg_attachments sg_make_attchments(const sg_attachments_desc& desc) { return sg_make_attachments(&desc); }
 inline void sg_update_image(sg_image img, const sg_image_data& data) { return sg_update_image(img, &data); }
 
 inline void sg_begin_pass(const sg_pass& pass) { return sg_begin_pass(&pass); }
@@ -4070,7 +4070,7 @@ inline sg_image_desc sg_query_image_defaults(const sg_image_desc& desc) { return
 inline sg_sampler_desc sg_query_sampler_defaults(const sg_sampler_desc& desc) { return sg_query_sampler_defaults(&desc); }
 inline sg_shader_desc sg_query_shader_defaults(const sg_shader_desc& desc) { return sg_query_shader_defaults(&desc); }
 inline sg_pipeline_desc sg_query_pipeline_defaults(const sg_pipeline_desc& desc) { return sg_query_pipeline_defaults(&desc); }
-inline sg_pass_desc sg_query_attachments_defaults(const sg_attachments_desc& desc) { return sg_query_attachments_defaults(&desc); }
+inline sg_attachments_desc sg_query_attachments_defaults(const sg_attachments_desc& desc) { return sg_query_attachments_defaults(&desc); }
 
 inline void sg_init_buffer(sg_buffer buf, const sg_buffer_desc& desc) { return sg_init_buffer(buf, &desc); }
 inline void sg_init_image(sg_image img, const sg_image_desc& desc) { return sg_init_image(img, &desc); }

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4207,6 +4207,7 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
         #endif
     #endif
     #import <Metal/Metal.h>
+    #import <QuartzCore/CoreAnimation.h> // needed for CAMetalDrawable
 #elif defined(SOKOL_WGPU)
     #include <webgpu/webgpu.h>
     #if defined(__EMSCRIPTEN__)
@@ -4954,7 +4955,7 @@ typedef struct {
 
 typedef struct {
     _sg_slot_t slot;
-    _sg_attachemnts_common_t cmn;
+    _sg_attachments_common_t cmn;
     struct {
         _sg_dummy_attachment_t colors[SG_MAX_COLOR_ATTACHMENTS];
         _sg_dummy_attachment_t resolves[SG_MAX_COLOR_ATTACHMENTS];
@@ -6381,12 +6382,13 @@ _SOKOL_PRIVATE _sg_image_t* _sg_dummy_attachments_ds_image(const _sg_attachments
     return atts->dmy.depth_stencil.image;
 }
 
-_SOKOL_PRIVATE void _sg_dummy_begin_pass(const sg_pass_action* action, _sg_attachments* atts, const sg_swapchain* swapchain) {
+_SOKOL_PRIVATE void _sg_dummy_begin_pass(const sg_pass_action* action, _sg_attachments_t* atts, const sg_swapchain* swapchain, const char* label) {
     SOKOL_ASSERT(action);
     SOKOL_ASSERT(swapchain);
     _SOKOL_UNUSED(action);
     _SOKOL_UNUSED(atts);
     _SOKOL_UNUSED(swapchain);
+    _SOKOL_UNUSED(label);
 }
 
 _SOKOL_PRIVATE void _sg_dummy_end_pass(void) {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -6384,7 +6384,7 @@ _SOKOL_PRIVATE _sg_image_t* _sg_dummy_attachments_ds_image(const _sg_attachments
     return atts->dmy.depth_stencil.image;
 }
 
-_SOKOL_PRIVATE void _sg_dummy_begin_pass(const sg_pass* pass);
+_SOKOL_PRIVATE void _sg_dummy_begin_pass(const sg_pass* pass) {
     SOKOL_ASSERT(pass);
     _SOKOL_UNUSED(pass);
 }

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4716,6 +4716,15 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
     #endif
 #endif
 
+#if defined(SOKOL_GLES3)
+    // on WebGL2, GL_FRAMEBUFFER_UNDEFINED technically doesn't exist (it is defined
+    // in the Emscripten headers, but may not exist in other WebGL2 shims)
+    // see: https://github.com/floooh/sokol/pull/933
+    #ifndef GL_FRAMEBUFFER_UNDEFINED
+    #define GL_FRAMEBUFFER_UNDEFINED 0x8219
+    #endif
+#endif
+
 // ███████ ████████ ██████  ██    ██  ██████ ████████ ███████
 // ██         ██    ██   ██ ██    ██ ██         ██    ██
 // ███████    ██    ██████  ██    ██ ██         ██    ███████

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -18339,7 +18339,7 @@ SOKOL_API_IMPL sg_d3d11_pipeline_info sg_d3d11_query_pipeline_info(sg_pipeline p
     return res;
 }
 
-SOKOL_API_IMPL sg_d3d11_attachments_info sg_d3d11_query_pass_info(sg_attachments atts_id) {
+SOKOL_API_IMPL sg_d3d11_attachments_info sg_d3d11_query_attachments_info(sg_attachments atts_id) {
     SOKOL_ASSERT(_sg.valid);
     sg_d3d11_attachments_info res;
     _sg_clear(&res, sizeof(res));

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -6359,12 +6359,12 @@ _SOKOL_PRIVATE _sg_image_t* _sg_dummy_attachments_ds_image(const _sg_attachments
     return atts->dmy.depth_stencil.image;
 }
 
-_SOKOL_PRIVATE void _sg_dummy_begin_pass(_sg_attachments_t* atts, const sg_pass_action* action, int w, int h) {
+_SOKOL_PRIVATE void _sg_dummy_begin_pass(const sg_pass_action* action, _sg_attachments* atts, const sg_swapchain* swapchain) {
     SOKOL_ASSERT(action);
-    _SOKOL_UNUSED(atts);
+    SOKOL_ASSERT(swapchain);
     _SOKOL_UNUSED(action);
-    _SOKOL_UNUSED(w);
-    _SOKOL_UNUSED(h);
+    _SOKOL_UNUSED(atts);
+    _SOKOL_UNUSED(swapchain);
 }
 
 _SOKOL_PRIVATE void _sg_dummy_end_pass(void) {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2960,7 +2960,6 @@ typedef struct sg_trace_hooks {
     void (*update_buffer)(sg_buffer buf, const sg_range* data, void* user_data);
     void (*update_image)(sg_image img, const sg_image_data* data, void* user_data);
     void (*append_buffer)(sg_buffer buf, const sg_range* data, int result, void* user_data);
-    void (*begin_default_pass)(const sg_pass_action* pass_action, int width, int height, void* user_data);
     void (*begin_pass)(const sg_pass* pass, void* user_data);
     void (*apply_viewport)(int x, int y, int width, int height, bool origin_top_left, void* user_data);
     void (*apply_scissor_rect)(int x, int y, int width, int height, bool origin_top_left, void* user_data);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2360,6 +2360,7 @@ typedef struct sg_metal_swapchain {
 typedef struct sg_d3d11_swapchain {
     const void* render_target_view;     // ID3D11RenderTargetView
     const void* depth_stencil_view;     // ID3D11DepthStencilView
+    // FIXME: MSAA resolve should happen in sokol-gfx!
 } sg_d3d11_swapchain;
 
 typedef struct sg_wgpu_swapchain {
@@ -3422,6 +3423,30 @@ typedef struct sg_frame_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_COLOR_ATTACHMENT_IMAGE, "sg_begin_pass: one or more color attachment images are not valid") \
     _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_RESOLVE_ATTACHMENT_IMAGE, "sg_begin_pass: one or more resolve attachment images are not valid") \
     _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_DEPTHSTENCIL_ATTACHMENT_IMAGE, "sg_begin_pass: one or more depth-stencil attachment images are not valid") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_WIDTH, "sg_begin_pass: expected pass.swapchain.width > 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_WIDTH_NOTSET, "sg_begin_pass: expected pass.swapchain.width == 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_HEIGHT, "sg_begin_pass: expected pass.swapchain.height > 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_HEIGHT_NOTSET, "sg_begin_pass: expected pass.swapchain.height == 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_SAMPLECOUNT, "sg_begin_pass: expected pass.swapchain.sample_count > 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_SAMPLECOUNT_NOTSET, "sg_begin_pass: expected pass.swapchain.sample_count == 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_COLORFORMAT, "sg_begin_pass: expected pass.swapchain.color_format to be valid") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_COLORFORMAT_NOTSET, "sg_begin_pass: expected pass.swapchain.color_format to be unset") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_DEPTHFORMAT_NOTSET, "sg_begin_pass: expected pass.swapchain.depth_format to be unset") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_METAL_EXPECT_RENDERPASSDESCRIPTOR, "sg_begin_pass: expected pass.swapchain.metal.render_pass_descriptor != 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_METAL_EXPECT_RENDERPASSDESCRIPTOR_NOTSET, "sg_begin_pass: expected pass.swapchain.metal.render_pass_descriptor == 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_METAL_EXPECT_DRAWABLE, "sg_begin_pass: expected pass.swapchain.metal.drawable != 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_METAL_EXPECT_DRAWABLE_NOTSET, "sg_begin_pass: expected pass.swapchain.metal.drawable == 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_D3D11_EXPECT_RTV, "sg_begin_pass: expected pass.swapchain.d3d11.render_target_view != 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_D3D11_EXPECT_RTV_NOTSET, "sg_begin_pass: expected pass.swapchain.d3d11.render_target_view == 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_D3D11_EXPECT_DSV, "sg_begin_pass: expected pass.swapchain.d3d11.depth_stencil_view != 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_D3D11_EXPECT_DSV_NOTSET, "sg_begin_pass: expected pass.swapchain.d3d11.depth_stencil_view == 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_WGPU_EXPECT_RENDERVIEW, "sg_begin_pass: expected pass.swapchain.wgpu.render_view != 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_WGPU_EXPECT_RENDERVIEW_NOTSET, "sg_begin_pass: expected pass.swapchain.wgpu.render_view == 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_WGPU_EXPECT_RESOLVEVIEW, "sg_begin_pass: expected pass.swapchain.wgpu.resolve_view != 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_WGPU_EXPECT_RESOLVEVIEW_NOTSET, "sg_begin_pass: expected pass.swapchain.wgpu.resolve_view == 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_WGPU_EXPECT_DEPTHSTENCILVIEW, "sg_begin_pass: expected pass.swapchain.wgpu.depth_stencil_view != 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_WGPU_EXPECT_DEPTHSTENCILVIEW_NOTSET, "sg_begin_pass: expected pass.swapchain.wgpu.depth_stencil_view == 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BEGINPASS_SWAPCHAIN_GL_EXPECT_FRAMEBUFFER_NOTSET, "sg_begin_pass: expected pass.swapchain.gl.framebuffer == 0") \
     _SG_LOGITEM_XMACRO(VALIDATE_APIP_PIPELINE_VALID_ID, "sg_apply_pipeline: invalid pipeline id provided") \
     _SG_LOGITEM_XMACRO(VALIDATE_APIP_PIPELINE_EXISTS, "sg_apply_pipeline: pipeline object no longer alive") \
     _SG_LOGITEM_XMACRO(VALIDATE_APIP_PIPELINE_VALID, "sg_apply_pipeline: pipeline object not in valid state") \
@@ -15942,7 +15967,28 @@ _SOKOL_PRIVATE bool _sg_validate_begin_pass(const sg_pass* pass) {
         _sg_validate_begin();
         if (pass->attachments.id == SG_INVALID_ID) {
             // this is a swapchain pass
-            // FIXME: validate swapchain params!
+            _SG_VALIDATE(pass->swapchain.width > 0, VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_WIDTH);
+            _SG_VALIDATE(pass->swapchain.height > 0, VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_HEIGHT);
+            _SG_VALIDATE(pass->swapchain.sample_count > 0, VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_SAMPLECOUNT);
+            _SG_VALIDATE(pass->swapchain.color_format > SG_PIXELFORMAT_NONE, VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_COLORFORMAT);
+            // NOTE: depth buffer is optional, so depth_format is allowed to be invalid
+            // NOTE: the GL framebuffer handle may actually be 0
+            #if defined(SOKOL_METAL)
+                _SG_VALIDATE(pass->swapchain.metal.render_pass_descriptor != 0, VALIDATE_BEGINPASS_SWAPCHAIN_METAL_EXPECT_RENDERPASSDESCRIPTOR);
+                _SG_VALIDATE(pass->swapchain.metal.drawable != 0, VALIDATE_BEGINPASS_SWAPCHAIN_METAL_EXPECT_DRAWABLE);
+            #elif defined(SOKOL_D3D11)
+                _SG_VALIDATE(pass->swapchain.d3d11.render_target_view != 0, VALIDATE_BEGINPASS_SWAPCHAIN_D3D11_EXPECT_RTV);
+                _SG_VALIDATE(pass->swapchain.d3d11.depth_stencil_view != 0, VALIDATE_BEGINPASS_SWAPCHAIN_D3D11_EXPECT_DSV);
+                // FIXME: resolve_view
+            #elif defined(SOKOL_WGPU)
+                _SG_VALIDATE(pass->swapchain.wgpu.render_view != 0, VALIDATE_BEGINPASS_SWAPCHAIN_WGPU_EXPECT_RENDERVIEW);
+                _SG_VALIDATE(pass->swapchain.wgpu.depth_stencil_view != 0, VALIDATE_BEGINPASS_SWAPCHAIN_WGPU_EXPECT_DEPTHSTENCILVIEW);
+                if (pass->swapchain.sample_count > 0) {
+                    _SG_VALIDATE(pass->swapchain.wgpu.resolve_view != 0, VALIDATE_BEGINPASS_SWAPCHAIN_WGPU_EXPECT_RESOLVEVIEW);
+                } else {
+                    _SG_VALIDATE(pass->swapchain.wgpu.resolve_view == 0, VALIDATE_BEGINPASS_SWAPCHAIN_WGPU_EXPECT_RESOLVEVIEW_NOTSET);
+                }
+            #endif
         } else {
             // this is an 'offscreen pass'
             const _sg_attachments_t* atts = _sg_lookup_attachments(&_sg.pools, pass->attachments.id);
@@ -15968,7 +16014,26 @@ _SOKOL_PRIVATE bool _sg_validate_begin_pass(const sg_pass* pass) {
                 _SG_VALIDATE(ds_img->slot.state == SG_RESOURCESTATE_VALID, VALIDATE_BEGINPASS_DEPTHSTENCIL_ATTACHMENT_IMAGE);
                 _SG_VALIDATE(ds_img->slot.id == att->image_id.id, VALIDATE_BEGINPASS_DEPTHSTENCIL_ATTACHMENT_IMAGE);
             }
-            // FIXME: swapchain params must be all zero!
+            // swapchain params must be all zero!
+            _SG_VALIDATE(pass->swapchain.width == 0, VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_WIDTH_NOTSET);
+            _SG_VALIDATE(pass->swapchain.height == 0, VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_HEIGHT_NOTSET);
+            _SG_VALIDATE(pass->swapchain.sample_count == 0, VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_SAMPLECOUNT_NOTSET);
+            _SG_VALIDATE(pass->swapchain.color_format == _SG_PIXELFORMAT_DEFAULT, VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_COLORFORMAT_NOTSET);
+            _SG_VALIDATE(pass->swapchain.depth_format == _SG_PIXELFORMAT_DEFAULT, VALIDATE_BEGINPASS_SWAPCHAIN_EXPECT_DEPTHFORMAT_NOTSET);
+            #if defined(SOKOL_METAL)
+                _SG_VALIDATE(pass->swapchain.metal.render_pass_descriptor == 0, VALIDATE_BEGINPASS_SWAPCHAIN_METAL_EXPECT_RENDERPASSDESCRIPTOR_NOTSET);
+                _SG_VALIDATE(pass->swapchain.metal.drawable == 0, VALIDATE_BEGINPASS_SWAPCHAIN_METAL_EXPECT_DRAWABLE_NOTSET);
+            #elif defined(SOKOL_D3D11)
+                _SG_VALIDATE(pass->swapchain.d3d11.render_target_view == 0, VALIDATE_BEGINPASS_SWAPCHAIN_D3D11_EXPECT_RTV_NOTSET);
+                _SG_VALIDATE(pass->swapchain.d3d11.depth_stencil_view == 0, VALIDATE_BEGINPASS_SWAPCHAIN_D3D11_EXPECT_DSV_NOTSET);
+                // FIXME: resolve_view
+            #elif defined(SOKOL_WGPU)
+                _SG_VALIDATE(pass->swapchain.wgpu.render_view == 0, VALIDATE_BEGINPASS_SWAPCHAIN_WGPU_EXPECT_RENDERVIEW_NOTSET);
+                _SG_VALIDATE(pass->swapchain.wgpu.depth_stencil_view == 0, VALIDATE_BEGINPASS_SWAPCHAIN_WGPU_EXPECT_DEPTHSTENCILVIEW_NOTSET);
+                _SG_VALIDATE(pass->swapchain.wgpu.resolve_view == 0, VALIDATE_BEGINPASS_SWAPCHAIN_WGPU_EXPECT_RESOLVEVIEW_NOTSET);
+            #elif defined(_SOKOL_ANY_GL)
+                _SG_VALIDATE(pass->swapchain.gl.framebuffer == 0, VALIDATE_BEGINPASS_SWAPCHAIN_GL_EXPECT_FRAMEBUFFER_NOTSET);
+            #endif
         }
         return _sg_validate_end();
     #endif

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -16872,15 +16872,18 @@ _SOKOL_PRIVATE sg_desc _sg_desc_defaults(const sg_desc* desc) {
 
 _SOKOL_PRIVATE sg_pass _sg_pass_defaults(const sg_pass* pass) {
     sg_pass res = *pass;
-    res.swapchain.sample_count = _sg_def(res.swapchain.sample_count, 1);
-    #if defined(SOKOL_WGPU)
-        SOKOL_ASSERT(SG_PIXELFORMAT_NONE < res.swapchain.color_format);
-    #elif (defined(SOKOL_METAL) || defined(SOKOL_D3D11))
-        res.swapchain.color_format = _sg_def(res.swapchain.color_format, SG_PIXELFORMAT_BGRA8);
-    #else
-        res.swapchain.color_format = _sg_def(res.swapchain.color_format, SG_PIXELFORMAT_RGBA8);
-    #endif
-    res.swapchain.depth_format = _sg_def(res.swapchain.depth_format, SG_PIXELFORMAT_DEPTH_STENCIL);
+    if (res.attachments.id == SG_INVALID_ID) {
+        // this is a swapchain-pass
+        res.swapchain.sample_count = _sg_def(res.swapchain.sample_count, 1);
+        #if defined(SOKOL_WGPU)
+            SOKOL_ASSERT(SG_PIXELFORMAT_NONE < res.swapchain.color_format);
+        #elif (defined(SOKOL_METAL) || defined(SOKOL_D3D11))
+            res.swapchain.color_format = _sg_def(res.swapchain.color_format, SG_PIXELFORMAT_BGRA8);
+        #else
+            res.swapchain.color_format = _sg_def(res.swapchain.color_format, SG_PIXELFORMAT_RGBA8);
+        #endif
+        res.swapchain.depth_format = _sg_def(res.swapchain.depth_format, SG_PIXELFORMAT_DEPTH_STENCIL);
+    }
     res.action = _sg_pass_action_defaults(&res.action);
     return res;
 }

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -14422,8 +14422,8 @@ _SOKOL_PRIVATE void _sg_wgpu_begin_pass(const sg_pass* pass) {
         if (wgpu_depth_stencil_view) {
             SOKOL_ASSERT(swapchain->depth_format > SG_PIXELFORMAT_NONE);
             _sg_wgpu_init_ds_att(&wgpu_ds_att, action, swapchain->depth_format, wgpu_depth_stencil_view);
+            wgpu_pass_desc.depthStencilAttachment = &wgpu_ds_att;
         }
-        wgpu_pass_desc.depthStencilAttachment = &wgpu_ds_att;
     }
     _sg.wgpu.pass_enc = wgpuCommandEncoderBeginRenderPass(_sg.wgpu.cmd_enc, &wgpu_pass_desc);
     SOKOL_ASSERT(_sg.wgpu.pass_enc);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -8694,10 +8694,10 @@ _SOKOL_PRIVATE void _sg_gl_end_pass(void) {
                 invalidate_atts[att_index++] = (GLenum)(GL_COLOR_ATTACHMENT0 + i);
             }
         }
-        if ((_sg.gl.depth_store_action == SG_STOREACTION_DONTCARE) && (_sg.gl.cur_pass->cmn.ds_att.image_id.id != SG_INVALID_ID)) {
+        if ((_sg.gl.depth_store_action == SG_STOREACTION_DONTCARE) && (_sg.cur_pass.atts->cmn.depth_stencil.image_id.id != SG_INVALID_ID)) {
             invalidate_atts[att_index++] = GL_DEPTH_ATTACHMENT;
         }
-        if ((_sg.gl.stencil_store_action == SG_STOREACTION_DONTCARE) && (_sg.gl.cur_pass->cmn.ds_att.image_id.id != SG_INVALID_ID)) {
+        if ((_sg.gl.stencil_store_action == SG_STOREACTION_DONTCARE) && (_sg.cur_pass.atts->cmn.depth_stencil.image_id.id != SG_INVALID_ID)) {
             invalidate_atts[att_index++] = GL_STENCIL_ATTACHMENT;
         }
         if (att_index > 0) {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -10471,7 +10471,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_attachments(_sg_attachments_t*
 
     // copy image pointers
     for (int i = 0; i < atts->cmn.num_colors; i++) {
-        const sg_attachment_desc* color_desc = &desc->color_attachments[i];
+        const sg_attachment_desc* color_desc = &desc->colors[i];
         _SOKOL_UNUSED(color_desc);
         SOKOL_ASSERT(color_desc->image.id != SG_INVALID_ID);
         SOKOL_ASSERT(0 == atts->d3d11.colors[i].image);
@@ -10479,7 +10479,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_attachments(_sg_attachments_t*
         SOKOL_ASSERT(_sg_is_valid_rendertarget_color_format(color_images[i]->cmn.pixel_format));
         atts->d3d11.colors[i].image = color_images[i];
 
-        const sg_attachment_desc* resolve_desc = &desc->resolve_attachments[i];
+        const sg_attachment_desc* resolve_desc = &desc->resolves[i];
         if (resolve_desc->image.id != SG_INVALID_ID) {
             SOKOL_ASSERT(0 == atts->d3d11.resolves[i].image);
             SOKOL_ASSERT(resolve_images[i] && (resolve_images[i]->slot.id == resolve_desc->image.id));
@@ -10488,7 +10488,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_attachments(_sg_attachments_t*
         }
     }
     SOKOL_ASSERT(0 == atts->d3d11.depth_stencil.image);
-    const sg_attachment_desc* ds_desc = &desc->depth_stencil_attachment;
+    const sg_attachment_desc* ds_desc = &desc->depth_stencil;
     if (ds_desc->image.id != SG_INVALID_ID) {
         SOKOL_ASSERT(ds_img && (ds_img->slot.id == ds_desc->image.id));
         SOKOL_ASSERT(_sg_is_valid_rendertarget_depth_format(ds_img->cmn.pixel_format));

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -16931,15 +16931,9 @@ _SOKOL_PRIVATE sg_pass _sg_pass_defaults(const sg_pass* pass) {
     sg_pass res = *pass;
     if (res.attachments.id == SG_INVALID_ID) {
         // this is a swapchain-pass
-        res.swapchain.sample_count = _sg_def(res.swapchain.sample_count, 1);
-        #if defined(SOKOL_WGPU)
-            SOKOL_ASSERT(SG_PIXELFORMAT_NONE < res.swapchain.color_format);
-        #elif (defined(SOKOL_METAL) || defined(SOKOL_D3D11))
-            res.swapchain.color_format = _sg_def(res.swapchain.color_format, SG_PIXELFORMAT_BGRA8);
-        #else
-            res.swapchain.color_format = _sg_def(res.swapchain.color_format, SG_PIXELFORMAT_RGBA8);
-        #endif
-        res.swapchain.depth_format = _sg_def(res.swapchain.depth_format, SG_PIXELFORMAT_DEPTH_STENCIL);
+        res.swapchain.sample_count = _sg_def(res.swapchain.sample_count, _sg.desc.environment.defaults.sample_count);
+        res.swapchain.color_format = _sg_def(res.swapchain.color_format, _sg.desc.environment.defaults.color_format);
+        res.swapchain.depth_format = _sg_def(res.swapchain.depth_format, _sg.desc.environment.defaults.depth_format);
     }
     res.action = _sg_pass_action_defaults(&res.action);
     return res;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4242,8 +4242,13 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
                 #include <GLES3/gl3.h>
             #endif
         #elif defined(__linux__) || defined(__unix__)
-            #define GL_GLEXT_PROTOTYPES
-            #include <GL/gl.h>
+            #if defined(SOKOL_GLCORE33)
+                #define GL_GLEXT_PROTOTYPES
+                #include <GL/gl.h>
+            #else
+                #include <GLES3/gl3.h>
+                #include <GLES3/gl3ext.h>
+            #endif
         #endif
     #endif
 

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -5345,8 +5345,8 @@ typedef struct {
     const _sg_pipeline_t* cur_pipeline;
     sg_pipeline cur_pipeline_id;
     const _sg_buffer_t* cur_indexbuffer;
-    int cur_indexbuffer_offset;
     sg_buffer cur_indexbuffer_id;
+    int cur_indexbuffer_offset;
     int cur_vertexbuffer_offsets[SG_MAX_VERTEX_BUFFERS];
     sg_buffer cur_vertexbuffer_ids[SG_MAX_VERTEX_BUFFERS];
     sg_image cur_vs_image_ids[SG_MAX_SHADERSTAGE_IMAGES];

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -1651,7 +1651,7 @@ typedef struct sg_limits {
     int max_image_size_array;       // max width/height of SG_IMAGETYPE_ARRAY images
     int max_image_array_layers;     // max number of layers in SG_IMAGETYPE_ARRAY images
     int max_vertex_attrs;           // max number of vertex attributes, clamped to SG_MAX_VERTEX_ATTRIBUTES
-    int gl_max_vertex_uniform_vectors;  // <= GL_MAX_VERTEX_UNIFORM_VECTORS (only on GL backends)
+    int gl_max_vertex_uniform_components;    // <= GL_MAX_VERTEX_UNIFORM_COMPONENTS (only on GL backends)
     int gl_max_combined_texture_image_units; // <= GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS (only on GL backends)
 } sg_limits;
 
@@ -4490,7 +4490,7 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
         #define GL_CLAMP_TO_BORDER 0x812D
         #define GL_TEXTURE_BORDER_COLOR 0x1004
         #define GL_CURRENT_PROGRAM 0x8B8D
-        #define GL_MAX_VERTEX_UNIFORM_VECTORS 0x8DFB
+        #define GL_MAX_VERTEX_UNIFORM_COMPONENTS  0x8B4A
         #define GL_UNPACK_ALIGNMENT 0x0CF5
         #define GL_FRAMEBUFFER_SRGB 0x8DB9
         #define GL_TEXTURE_COMPARE_MODE 0x884C
@@ -7262,9 +7262,9 @@ _SOKOL_PRIVATE void _sg_gl_init_limits(void) {
         gl_int = SG_MAX_VERTEX_ATTRIBUTES;
     }
     _sg.limits.max_vertex_attrs = gl_int;
-    glGetIntegerv(GL_MAX_VERTEX_UNIFORM_VECTORS, &gl_int);
+    glGetIntegerv(GL_MAX_VERTEX_UNIFORM_COMPONENTS, &gl_int);
     _SG_GL_CHECK_ERROR();
-    _sg.limits.gl_max_vertex_uniform_vectors = gl_int;
+    _sg.limits.gl_max_vertex_uniform_components = gl_int;
     glGetIntegerv(GL_MAX_3D_TEXTURE_SIZE, &gl_int);
     _SG_GL_CHECK_ERROR();
     _sg.limits.max_image_size_3d = gl_int;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -2960,7 +2960,7 @@ typedef struct sg_trace_hooks {
     void (*update_buffer)(sg_buffer buf, const sg_range* data, void* user_data);
     void (*update_image)(sg_image img, const sg_image_data* data, void* user_data);
     void (*append_buffer)(sg_buffer buf, const sg_range* data, int result, void* user_data);
-    void (*begin_pass)(const sg_pass* pass, void* user_data);
+    void (*begin_pass)(const sg_pass* pass, const sg_pass_action* resolved_pass_action, void* user_data);
     void (*apply_viewport)(int x, int y, int width, int height, bool origin_top_left, void* user_data);
     void (*apply_scissor_rect)(int x, int y, int width, int height, bool origin_top_left, void* user_data);
     void (*apply_pipeline)(sg_pipeline pip, void* user_data);
@@ -12393,7 +12393,7 @@ _SOKOL_PRIVATE void _sg_mtl_begin_pass(const sg_pass_action* action, _sg_attachm
         pass_desc.depthAttachment.texture = ds_tex;
         pass_desc.depthAttachment.storeAction = MTLStoreActionDontCare;
         pass_desc.stencilAttachment.texture = ds_tex;
-        pass_desc.stencilAttachment.loadAction = MTLStoreActionDontCare;
+        pass_desc.stencilAttachment.storeAction = MTLStoreActionDontCare;
 
         // configure load actions and clear values
         pass_desc.colorAttachments[0].loadAction = _sg_mtl_load_action(action->colors[0].load_action);
@@ -17588,10 +17588,10 @@ SOKOL_API_IMPL void sg_begin_pass(const sg_pass* pass) {
     }
     _sg.cur_pass.valid = true;  // may be overruled by backend begin-pass functions
     _sg.cur_pass.in_pass = true;
-    sg_pass_action pa;
-    _sg_resolve_pass_action(&pass->action, &pa);
-    _sg_begin_pass(&pa, _sg.cur_pass.atts, &pass->swapchain, pass->label);
-    _SG_TRACE_ARGS(begin_pass, pass);
+    sg_pass_action resolved_action;
+    _sg_resolve_pass_action(&pass->action, &resolved_action);
+    _sg_begin_pass(&resolved_action, _sg.cur_pass.atts, &pass->swapchain, pass->label);
+    _SG_TRACE_ARGS(begin_pass, pass, &resolved_action);
 }
 
 SOKOL_API_IMPL void sg_apply_viewport(int x, int y, int width, int height, bool origin_top_left) {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -8557,11 +8557,11 @@ _SOKOL_PRIVATE void _sg_gl_end_pass(void) {
         #if defined(SOKOL_GLES3)
         // need to restore framebuffer binding before invalidate if the MSAA resolve had changed the binding
         if (fb_draw_bound) {
-            glBindFramebuffer(GL_FRAMEBUFFER, pass->gl.fb);
+            glBindFramebuffer(GL_FRAMEBUFFER, atts->gl.fb);
         }
         GLenum invalidate_atts[SG_MAX_COLOR_ATTACHMENTS + 2] = { 0 };
         int att_index = 0;
-        for (int i = 0; i < num_atts; i++) {
+        for (int i = 0; i < num_color_atts; i++) {
             if (_sg.gl.color_store_actions[i] == SG_STOREACTION_DONTCARE) {
                 invalidate_atts[att_index++] = (GLenum)(GL_COLOR_ATTACHMENT0 + i);
             }

--- a/sokol_glue.h
+++ b/sokol_glue.h
@@ -42,12 +42,23 @@
     PROVIDED FUNCTIONS
     ==================
 
-    - if sokol_app.h and sokol_gfx.h is included:
+    sg_environment sglue_environment(void)
 
-        sg_context_desc sapp_sgcontext(void):
+        Returns an sg_environment struct initialized by calling sokol_app.h
+        functions. Use this in the sg_setup() call like this:
 
-            Returns an initialized sg_context_desc function initialized
-            by calling sokol_app.h functions.
+        sg_setup(&(sg_desc){
+            .environment = sglue_enviornment(),
+            ...
+        });
+
+    sg_swapchain sglue_swapchain(void)
+
+        Returns an sg_swapchain struct initialized by calling sokol_app.h
+        functions. Use this in sg_begin_pass() for a 'swapchain pass' like
+        this:
+
+        sg_begin_pass(&(sg_pass){ .swapchain = sglue_swapchain(), ... });
 
     LICENSE
     =======
@@ -93,10 +104,8 @@
 extern "C" {
 #endif
 
-#if defined(SOKOL_GFX_INCLUDED) && defined(SOKOL_APP_INCLUDED)
-SOKOL_GLUE_API_DECL sg_environment sapp_sgenvironment(void);
-SOKOL_GLUE_API_DECL sg_swapchain sapp_sgswapchain(void);
-#endif
+SOKOL_GLUE_API_DECL sg_environment sglue_environment(void);
+SOKOL_GLUE_API_DECL sg_swapchain sglue_swapchain(void);
 
 #ifdef __cplusplus
 } /* extern "C" */
@@ -112,8 +121,7 @@ SOKOL_GLUE_API_DECL sg_swapchain sapp_sgswapchain(void);
     #define SOKOL_API_IMPL
 #endif
 
-#if defined(SOKOL_GFX_INCLUDED) && defined(SOKOL_APP_INCLUDED)
-SOKOL_API_IMPL sg_environment sapp_sgenvironment(void) {
+SOKOL_API_IMPL sg_environment sglue_environment(void) {
     sg_environment env;
     memset(&env, 0, sizeof(env));
     env.defaults.color_format = (sg_pixel_format) sapp_color_format();
@@ -126,7 +134,7 @@ SOKOL_API_IMPL sg_environment sapp_sgenvironment(void) {
     return env;
 }
 
-SOKOL_API_IMPL sg_swapchain sapp_sgswapchain(void) {
+SOKOL_API_IMPL sg_swapchain sglue_swapchain(void) {
     sg_swapchain swapchain;
     memset(&swapchain, 0, sizeof(swapchain));
     swapchain.width = sapp_width();
@@ -145,6 +153,5 @@ SOKOL_API_IMPL sg_swapchain sapp_sgswapchain(void) {
     swapchain.gl.framebuffer = sapp_gl_get_framebuffer();
     return swapchain;
 }
-#endif
 
 #endif /* SOKOL_GLUE_IMPL */

--- a/sokol_glue.h
+++ b/sokol_glue.h
@@ -94,7 +94,7 @@ extern "C" {
 #endif
 
 #if defined(SOKOL_GFX_INCLUDED) && defined(SOKOL_APP_INCLUDED)
-SOKOL_GLUE_API_DECL sg_context_desc sapp_sgcontext(void);
+SOKOL_GLUE_API_DECL sg_environment sapp_sgenvironment(void);
 SOKOL_GLUE_API_DECL sg_swapchain sapp_sgswapchain(void);
 #endif
 
@@ -113,17 +113,17 @@ SOKOL_GLUE_API_DECL sg_swapchain sapp_sgswapchain(void);
 #endif
 
 #if defined(SOKOL_GFX_INCLUDED) && defined(SOKOL_APP_INCLUDED)
-SOKOL_API_IMPL sg_context_desc sapp_sgcontext(void) {
-    sg_context_desc desc;
-    memset(&desc, 0, sizeof(desc));
-    desc.color_format = (sg_pixel_format) sapp_color_format();
-    desc.depth_format = (sg_pixel_format) sapp_depth_format();
-    desc.sample_count = sapp_sample_count();
-    desc.metal.device = sapp_metal_get_device();
-    desc.d3d11.device = sapp_d3d11_get_device();
-    desc.d3d11.device_context = sapp_d3d11_get_device_context();
-    desc.wgpu.device = sapp_wgpu_get_device();
-    return desc;
+SOKOL_API_IMPL sg_environment sapp_sgenvironment(void) {
+    sg_environment env;
+    memset(&env, 0, sizeof(env));
+    env.defaults.color_format = (sg_pixel_format) sapp_color_format();
+    env.defaults.depth_format = (sg_pixel_format) sapp_depth_format();
+    env.defaults.sample_count = sapp_sample_count();
+    env.metal.device = sapp_metal_get_device();
+    env.d3d11.device = sapp_d3d11_get_device();
+    env.d3d11.device_context = sapp_d3d11_get_device_context();
+    env.wgpu.device = sapp_wgpu_get_device();
+    return env;
 }
 
 SOKOL_API_IMPL sg_swapchain sapp_sgswapchain(void) {

--- a/sokol_glue.h
+++ b/sokol_glue.h
@@ -116,12 +116,12 @@ SOKOL_GLUE_API_DECL sg_swapchain sglue_swapchain(void);
 #define SOKOL_GLUE_IMPL_INCLUDED (1)
 #include <string.h> /* memset */
 
-#ifndef SOKOL_APP_IMPL_INCLUDED
-#error "Please include the sokol_app.h implementation before the sokol_glue.h implementation"
+#ifndef SOKOL_APP_INCLUDED
+#error "Please include sokol_app.h before the sokol_glue.h implementation"
 #endif
 
 #ifndef SOKOL_API_IMPL
-    #define SOKOL_API_IMPL
+#define SOKOL_API_IMPL
 #endif
 
 

--- a/sokol_glue.h
+++ b/sokol_glue.h
@@ -136,7 +136,8 @@ SOKOL_API_IMPL sg_swapchain sapp_sgswapchain(void) {
     swapchain.depth_format = (sg_pixel_format)sapp_depth_format();
     swapchain.metal.render_pass_descriptor = sapp_metal_get_renderpass_descriptor();
     swapchain.metal.drawable = sapp_metal_get_drawable();
-    swapchain.d3d11.render_target_view = sapp_d3d11_get_render_target_view();
+    swapchain.d3d11.render_view = sapp_d3d11_get_render_view();
+    swapchain.d3d11.resolve_view = sapp_d3d11_get_resolve_view();
     swapchain.d3d11.depth_stencil_view = sapp_d3d11_get_depth_stencil_view();
     swapchain.wgpu.render_view = sapp_wgpu_get_render_view();
     swapchain.wgpu.resolve_view = sapp_wgpu_get_resolve_view();

--- a/sokol_glue.h
+++ b/sokol_glue.h
@@ -142,8 +142,9 @@ SOKOL_API_IMPL sg_swapchain sglue_swapchain(void) {
     swapchain.sample_count = sapp_sample_count();
     swapchain.color_format = (sg_pixel_format)sapp_color_format();
     swapchain.depth_format = (sg_pixel_format)sapp_depth_format();
-    swapchain.metal.render_pass_descriptor = sapp_metal_get_renderpass_descriptor();
-    swapchain.metal.drawable = sapp_metal_get_drawable();
+    swapchain.metal.current_drawable = sapp_metal_get_current_drawable();
+    swapchain.metal.depth_stencil_texture = sapp_metal_get_depth_stencil_texture();
+    swapchain.metal.msaa_color_texture = sapp_metal_get_msaa_color_texture();
     swapchain.d3d11.render_view = sapp_d3d11_get_render_view();
     swapchain.d3d11.resolve_view = sapp_d3d11_get_resolve_view();
     swapchain.d3d11.depth_stencil_view = sapp_d3d11_get_depth_stencil_view();

--- a/sokol_glue.h
+++ b/sokol_glue.h
@@ -30,14 +30,9 @@
 
     OVERVIEW
     ========
-    The sokol core headers should not depend on each other, but sometimes
-    it's useful to have a set of helper functions as "glue" between
-    two or more sokol headers.
-
-    This is what sokol_glue.h is for. Simply include the header after other
-    sokol headers (both for the implementation and declaration), and
-    depending on what headers have been included before, sokol_glue.h
-    will make available "glue functions".
+    sokol_glue.h provides glue helper functions between sokol_gfx.h and sokol_app.h,
+    so that sokol_gfx.h doesn't need to depend on sokol_app.h but can be
+    used with different window system glue libraries.
 
     PROVIDED FUNCTIONS
     ==================

--- a/sokol_glue.h
+++ b/sokol_glue.h
@@ -100,6 +100,10 @@
 #endif
 #endif
 
+#ifndef SOKOL_GFX_INCLUDED
+#error "Please include sokol_gfx.h before sokol_glue.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -117,9 +121,14 @@ SOKOL_GLUE_API_DECL sg_swapchain sglue_swapchain(void);
 #define SOKOL_GLUE_IMPL_INCLUDED (1)
 #include <string.h> /* memset */
 
+#ifndef SOKOL_APP_IMPL_INCLUDED
+#error "Please include the sokol_app.h implementation before the sokol_glue.h implementation"
+#endif
+
 #ifndef SOKOL_API_IMPL
     #define SOKOL_API_IMPL
 #endif
+
 
 SOKOL_API_IMPL sg_environment sglue_environment(void) {
     sg_environment env;

--- a/sokol_glue.h
+++ b/sokol_glue.h
@@ -141,8 +141,7 @@ SOKOL_API_IMPL sg_swapchain sapp_sgswapchain(void) {
     swapchain.wgpu.render_view = sapp_wgpu_get_render_view();
     swapchain.wgpu.resolve_view = sapp_wgpu_get_resolve_view();
     swapchain.wgpu.depth_stencil_view = sapp_wgpu_get_depth_stencil_view();
-    // FIXME!
-    // swapchain.gl.framebuffer = sapp_gl_get_framebuffer();
+    swapchain.gl.framebuffer = sapp_gl_get_framebuffer();
     return swapchain;
 }
 #endif

--- a/sokol_glue.h
+++ b/sokol_glue.h
@@ -95,6 +95,7 @@ extern "C" {
 
 #if defined(SOKOL_GFX_INCLUDED) && defined(SOKOL_APP_INCLUDED)
 SOKOL_GLUE_API_DECL sg_context_desc sapp_sgcontext(void);
+SOKOL_GLUE_API_DECL sg_swapchain sapp_sgswapchain(void);
 #endif
 
 #ifdef __cplusplus
@@ -119,17 +120,30 @@ SOKOL_API_IMPL sg_context_desc sapp_sgcontext(void) {
     desc.depth_format = (sg_pixel_format) sapp_depth_format();
     desc.sample_count = sapp_sample_count();
     desc.metal.device = sapp_metal_get_device();
-    desc.metal.renderpass_descriptor_cb = sapp_metal_get_renderpass_descriptor;
-    desc.metal.drawable_cb = sapp_metal_get_drawable;
     desc.d3d11.device = sapp_d3d11_get_device();
     desc.d3d11.device_context = sapp_d3d11_get_device_context();
-    desc.d3d11.render_target_view_cb = sapp_d3d11_get_render_target_view;
-    desc.d3d11.depth_stencil_view_cb = sapp_d3d11_get_depth_stencil_view;
     desc.wgpu.device = sapp_wgpu_get_device();
-    desc.wgpu.render_view_cb = sapp_wgpu_get_render_view;
-    desc.wgpu.resolve_view_cb = sapp_wgpu_get_resolve_view;
-    desc.wgpu.depth_stencil_view_cb = sapp_wgpu_get_depth_stencil_view;
     return desc;
+}
+
+SOKOL_API_IMPL sg_swapchain sapp_sgswapchain(void) {
+    sg_swapchain swapchain;
+    memset(&swapchain, 0, sizeof(swapchain));
+    swapchain.width = sapp_width();
+    swapchain.height = sapp_height();
+    swapchain.sample_count = sapp_sample_count();
+    swapchain.color_format = (sg_pixel_format)sapp_color_format();
+    swapchain.depth_format = (sg_pixel_format)sapp_depth_format();
+    swapchain.metal.render_pass_descriptor = sapp_metal_get_renderpass_descriptor();
+    swapchain.metal.drawable = sapp_metal_get_drawable();
+    swapchain.d3d11.render_target_view = sapp_d3d11_get_render_target_view();
+    swapchain.d3d11.depth_stencil_view = sapp_d3d11_get_depth_stencil_view();
+    swapchain.wgpu.render_view = sapp_wgpu_get_render_view();
+    swapchain.wgpu.resolve_view = sapp_wgpu_get_resolve_view();
+    swapchain.wgpu.depth_stencil_view = sapp_wgpu_get_depth_stencil_view();
+    // FIXME!
+    // swapchain.gl.framebuffer = sapp_gl_get_framebuffer();
+    return swapchain;
 }
 #endif
 

--- a/tests/compile/sokol_gfx_imgui.c
+++ b/tests/compile/sokol_gfx_imgui.c
@@ -11,7 +11,7 @@
 #include "sokol_gfx_imgui.h"
 
 void use_gfx_imgui_impl(void) {
-    sg_imgui_t ctx = {0};
-    sg_imgui_init(&ctx, &(sg_imgui_desc_t){0});
-    sg_imgui_discard(&ctx);
+    sgimgui_t ctx = {0};
+    sgimgui_init(&ctx, &(sgimgui_desc_t){0});
+    sgimgui_discard(&ctx);
 }

--- a/tests/compile/sokol_gfx_imgui.cc
+++ b/tests/compile/sokol_gfx_imgui.cc
@@ -6,8 +6,7 @@
 #include "sokol_gfx_imgui.h"
 
 void use_gfx_imgui_impl() {
-    sg_imgui_t ctx = {};
-    sg_imgui_init(&ctx, { });
-    sg_imgui_discard(&ctx);
+    sgimgui_t ctx = {};
+    sgimgui_init(&ctx, { });
+    sgimgui_discard(&ctx);
 }
-

--- a/tests/compile/sokol_glue.c
+++ b/tests/compile/sokol_glue.c
@@ -4,6 +4,6 @@
 #include "sokol_glue.h"
 
 void use_glue_impl(void) {
-    const sg_context_desc ctx = sapp_sgcontext();
-    (void)ctx;
+    const sg_environment env = sglue_environment();
+    (void)env;
 }

--- a/tests/compile/sokol_glue.cc
+++ b/tests/compile/sokol_glue.cc
@@ -4,6 +4,6 @@
 #include "sokol_glue.h"
 
 void use_glue_impl() {
-    const sg_context_desc ctx = sapp_sgcontext();
+    const sg_environment ctx = sglue_environment();
     (void)ctx;
 }

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -4,6 +4,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/assets/comsi.s3m DESTINATION ${CMAKE_BINAR
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/assets/comsi.s3m DESTINATION ${CMAKE_BINARY_DIR}/Debug)
 
 set(c_sources
+    sokol_log_test.c
     sokol_args_test.c
     sokol_audio_test.c
     sokol_debugtext_test.c

--- a/tests/functional/sokol_debugtext_test.c
+++ b/tests/functional/sokol_debugtext_test.c
@@ -3,6 +3,7 @@
 //  For best results, run with ASAN and UBSAN.
 //------------------------------------------------------------------------------
 #include "sokol_gfx.h"
+#include "sokol_log.h"
 #define SOKOL_DEBUGTEXT_IMPL
 #include "sokol_debugtext.h"
 #include "utest.h"
@@ -11,8 +12,8 @@
 #define TFLT(f0,f1) {T(fabs((f0)-(f1))<=(0.000001));}
 
 static void init(void) {
-    sg_setup(&(sg_desc){0});
-    sdtx_setup(&(sdtx_desc_t){0});
+    sg_setup(&(sg_desc){ .logger = { .func = slog_func }});
+    sdtx_setup(&(sdtx_desc_t){ .logger = { .func = slog_func }});
 }
 
 static void init_with(const sdtx_desc_t* desc) {
@@ -401,7 +402,15 @@ UTEST(sokol_debugtext, rewind_after_draw) {
     T(_sdtx.cur_ctx->cur_font == 3);
     sdtx_printf("Hello World!\n");
     T(_sdtx.cur_ctx->vertices.next != 0);
-    sg_begin_default_pass(&(sg_pass_action){ 0 }, 256, 256);
+    sg_begin_pass(&(sg_pass){
+        .swapchain = {
+            .width = 256,
+            .height = 256,
+            .sample_count = 1,
+            .color_format = SG_PIXELFORMAT_RGBA8,
+            .depth_format = SG_PIXELFORMAT_DEPTH_STENCIL,
+        }
+    });
     sdtx_draw();
     sg_end_pass();
     sg_commit();

--- a/tests/functional/sokol_gfx_test.c
+++ b/tests/functional/sokol_gfx_test.c
@@ -68,14 +68,14 @@ static sg_pipeline create_pipeline(void) {
     });
 }
 
-static sg_pass create_pass(void) {
+static sg_attachments create_attachments(void) {
     sg_image_desc img_desc = {
         .render_target = true,
         .width = 128,
         .height = 128,
     };
-    return sg_make_pass(&(sg_pass_desc){
-        .color_attachments = {
+    return sg_make_attachments(&(sg_attachments_desc){
+        .colors = {
             [0].image = sg_make_image(&img_desc),
             [1].image = sg_make_image(&img_desc),
             [2].image = sg_make_image(&img_desc)
@@ -95,7 +95,7 @@ UTEST(sokol_gfx, query_desc) {
         .buffer_pool_size = 1024,
         .sampler_pool_size = 8,
         .shader_pool_size = 128,
-        .pass_pool_size = 64,
+        .attachments_pool_size = 64,
     });
     const sg_desc desc = sg_query_desc();
     T(desc.buffer_pool_size == 1024);
@@ -103,7 +103,7 @@ UTEST(sokol_gfx, query_desc) {
     T(desc.sampler_pool_size == 8);
     T(desc.shader_pool_size == 128);
     T(desc.pipeline_pool_size == _SG_DEFAULT_PIPELINE_POOL_SIZE);
-    T(desc.pass_pool_size == 64);
+    T(desc.attachments_pool_size == 64);
     T(desc.uniform_buffer_size == _SG_DEFAULT_UB_SIZE);
     sg_shutdown();
 }
@@ -120,7 +120,7 @@ UTEST(sokol_gfx, pool_size) {
         .image_pool_size = 2048,
         .shader_pool_size = 128,
         .pipeline_pool_size = 256,
-        .pass_pool_size = 64,
+        .attachments_pool_size = 64,
     });
     T(sg_isvalid());
     /* pool slot 0 is reserved (this is the "invalid slot") */
@@ -128,12 +128,12 @@ UTEST(sokol_gfx, pool_size) {
     T(_sg.pools.image_pool.size == 2049);
     T(_sg.pools.shader_pool.size == 129);
     T(_sg.pools.pipeline_pool.size == 257);
-    T(_sg.pools.pass_pool.size == 65);
+    T(_sg.pools.attachments_pool.size == 65);
     T(_sg.pools.buffer_pool.queue_top == 1024);
     T(_sg.pools.image_pool.queue_top == 2048);
     T(_sg.pools.shader_pool.queue_top == 128);
     T(_sg.pools.pipeline_pool.queue_top == 256);
-    T(_sg.pools.pass_pool.queue_top == 64);
+    T(_sg.pools.attachments_pool.queue_top == 64);
     sg_shutdown();
 }
 
@@ -292,33 +292,33 @@ UTEST(sokol_gfx, alloc_fail_destroy_pipelines) {
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, alloc_fail_destroy_passes) {
+UTEST(sokol_gfx, alloc_fail_destroy_attachments) {
     setup(&(sg_desc){
-        .pass_pool_size = 3
+        .attachments_pool_size = 3
     });
     T(sg_isvalid());
 
-    sg_pass pass[3] = { {0} };
+    sg_attachments atts[3] = { {0} };
     for (int i = 0; i < 3; i++) {
-        pass[i] = sg_alloc_pass();
-        T(pass[i].id != SG_INVALID_ID);
-        T((2-i) == _sg.pools.pass_pool.queue_top);
-        T(sg_query_pass_state(pass[i]) == SG_RESOURCESTATE_ALLOC);
+        atts[i] = sg_alloc_attachments();
+        T(atts[i].id != SG_INVALID_ID);
+        T((2-i) == _sg.pools.attachments_pool.queue_top);
+        T(sg_query_attachments_state(atts[i]) == SG_RESOURCESTATE_ALLOC);
     }
     /* the next alloc will fail because the pool is exhausted */
-    sg_pass p3 = sg_alloc_pass();
-    T(p3.id == SG_INVALID_ID);
-    T(sg_query_pass_state(p3) == SG_RESOURCESTATE_INVALID);
+    sg_attachments a3 = sg_alloc_attachments();
+    T(a3.id == SG_INVALID_ID);
+    T(sg_query_attachments_state(a3) == SG_RESOURCESTATE_INVALID);
 
     /* before destroying, the resources must be either in valid or failed state */
     for (int i = 0; i < 3; i++) {
-        sg_fail_pass(pass[i]);
-        T(sg_query_pass_state(pass[i]) == SG_RESOURCESTATE_FAILED);
+        sg_fail_attachments(atts[i]);
+        T(sg_query_attachments_state(atts[i]) == SG_RESOURCESTATE_FAILED);
     }
     for (int i = 0; i < 3; i++) {
-        sg_destroy_pass(pass[i]);
-        T(sg_query_pass_state(pass[i]) == SG_RESOURCESTATE_INVALID);
-        T((i+1) == _sg.pools.pass_pool.queue_top);
+        sg_destroy_attachments(atts[i]);
+        T(sg_query_attachments_state(atts[i]) == SG_RESOURCESTATE_INVALID);
+        T((i+1) == _sg.pools.attachments_pool.queue_top);
     }
     sg_shutdown();
 }
@@ -534,49 +534,49 @@ UTEST(sokol_gfx, make_destroy_pipelines) {
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_destroy_passes) {
+UTEST(sokol_gfx, make_destroy_attachments) {
     setup(&(sg_desc){
-        .pass_pool_size = 3
+        .attachments_pool_size = 3
     });
     T(sg_isvalid());
 
-    sg_pass pass[3] = { {0} };
+    sg_attachments atts[3] = { {0} };
 
     sg_image_desc img_desc = {
         .render_target = true,
         .width = 128,
         .height = 128,
     };
-    sg_pass_desc pass_desc = (sg_pass_desc){
-        .color_attachments = {
+    sg_attachments_desc atts_desc = (sg_attachments_desc){
+        .colors = {
             [0].image = sg_make_image(&img_desc),
             [1].image = sg_make_image(&img_desc),
             [2].image = sg_make_image(&img_desc)
         },
     };
     for (int i = 0; i < 3; i++) {
-        pass[i] = sg_make_pass(&pass_desc);
-        T(pass[i].id != SG_INVALID_ID);
-        T((2-i) == _sg.pools.pass_pool.queue_top);
-        T(sg_query_pass_state(pass[i]) == SG_RESOURCESTATE_VALID);
-        const _sg_pass_t* passptr = _sg_lookup_pass(&_sg.pools, pass[i].id);
-        T(passptr);
-        T(passptr->slot.id == pass[i].id);
-        T(passptr->slot.state == SG_RESOURCESTATE_VALID);
-        T(passptr->cmn.num_color_atts == 3);
+        atts[i] = sg_make_attachments(&atts_desc);
+        T(atts[i].id != SG_INVALID_ID);
+        T((2-i) == _sg.pools.attachments_pool.queue_top);
+        T(sg_query_attachments_state(atts[i]) == SG_RESOURCESTATE_VALID);
+        const _sg_attachments_t* attsptr = _sg_lookup_attachments(&_sg.pools, atts[i].id);
+        T(attsptr);
+        T(attsptr->slot.id == atts[i].id);
+        T(attsptr->slot.state == SG_RESOURCESTATE_VALID);
+        T(attsptr->cmn.num_colors == 3);
         for (int ai = 0; ai < 3; ai++) {
-            const _sg_image_t* img = _sg_pass_color_image(passptr, ai);
-            T(img == _sg_lookup_image(&_sg.pools, pass_desc.color_attachments[ai].image.id));
-            T(passptr->cmn.color_atts[ai].image_id.id == pass_desc.color_attachments[ai].image.id);
+            const _sg_image_t* img = _sg_attachments_color_image(attsptr, ai);
+            T(img == _sg_lookup_image(&_sg.pools, atts_desc.colors[ai].image.id));
+            T(attsptr->cmn.colors[ai].image_id.id == atts_desc.colors[ai].image.id);
         }
     }
     /* trying to create another one fails because pool is exhausted */
-    T(sg_make_pass(&pass_desc).id == SG_INVALID_ID);
+    T(sg_make_attachments(&atts_desc).id == SG_INVALID_ID);
 
     for (int i = 0; i < 3; i++) {
-        sg_destroy_pass(pass[i]);
-        T(sg_query_pass_state(pass[i]) == SG_RESOURCESTATE_INVALID);
-        T((i+1) == _sg.pools.pass_pool.queue_top);
+        sg_destroy_attachments(atts[i]);
+        T(sg_query_attachments_state(atts[i]) == SG_RESOURCESTATE_INVALID);
+        T((i+1) == _sg.pools.attachments_pool.queue_top);
     }
     sg_shutdown();
 }
@@ -799,12 +799,12 @@ UTEST(sokol_gfx, multiple_color_state) {
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, query_pass_defaults) {
+UTEST(sokol_gfx, query_attachments_defaults) {
     setup(&(sg_desc){0});
-    /* sg_pass_desc doesn't actually have any meaningful default values */
-    const sg_pass_desc desc = sg_query_pass_defaults(&(sg_pass_desc){0});
-    T(desc.color_attachments[0].image.id == SG_INVALID_ID);
-    T(desc.color_attachments[0].mip_level == 0);
+    /* sg_attachments_desc doesn't actually have any meaningful default values */
+    const sg_attachments_desc desc = sg_query_attachments_defaults(&(sg_attachments_desc){0});
+    T(desc.colors[0].image.id == SG_INVALID_ID);
+    T(desc.colors[0].mip_level == 0);
     sg_shutdown();
 }
 
@@ -882,23 +882,23 @@ UTEST(sokol_gfx, query_pipeline_info) {
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, query_pass_info) {
+UTEST(sokol_gfx, query_attachments_info) {
     setup(&(sg_desc){0});
     sg_image_desc img_desc = {
         .render_target = true,
         .width = 128,
         .height = 128,
     };
-    sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments = {
+    sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors = {
             [0].image = sg_make_image(&img_desc),
             [1].image = sg_make_image(&img_desc),
             [2].image = sg_make_image(&img_desc)
         },
     });
-    const sg_pass_info info = sg_query_pass_info(pass);
+    const sg_attachments_info info = sg_query_attachments_info(atts);
     T(info.slot.state == SG_RESOURCESTATE_VALID);
-    T(info.slot.res_id == pass.id);
+    T(info.slot.res_id == atts.id);
     sg_shutdown();
 }
 
@@ -1205,7 +1205,7 @@ UTEST(sokol_gfx, query_pipeline_desc) {
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, query_pass_desc) {
+UTEST(sokol_gfx, query_attachments_desc) {
     setup(&(sg_desc){0});
 
     const sg_image_desc color_img_desc = {
@@ -1224,27 +1224,27 @@ UTEST(sokol_gfx, query_pass_desc) {
     sg_image color_img_2 = sg_make_image(&color_img_desc);
     sg_image depth_img = sg_make_image(&depth_img_desc);
 
-    sg_pass p0 = sg_make_pass(&(sg_pass_desc){
-        .color_attachments = {
+    sg_attachments a0 = sg_make_attachments(&(sg_attachments_desc){
+        .colors = {
             [0].image = color_img_0,
             [1].image = color_img_1,
             [2].image = color_img_2,
         },
-        .depth_stencil_attachment.image = depth_img,
+        .depth_stencil.image = depth_img,
     });
-    const sg_pass_desc p0_desc = sg_query_pass_desc(p0);
-    T(p0_desc.color_attachments[0].image.id == color_img_0.id);
-    T(p0_desc.color_attachments[0].mip_level == 0);
-    T(p0_desc.color_attachments[0].slice == 0);
-    T(p0_desc.color_attachments[1].image.id == color_img_1.id);
-    T(p0_desc.color_attachments[1].mip_level == 0);
-    T(p0_desc.color_attachments[1].slice == 0);
-    T(p0_desc.color_attachments[2].image.id == color_img_2.id);
-    T(p0_desc.color_attachments[2].mip_level == 0);
-    T(p0_desc.color_attachments[2].slice == 0);
-    T(p0_desc.depth_stencil_attachment.image.id == depth_img.id);
-    T(p0_desc.depth_stencil_attachment.mip_level == 0);
-    T(p0_desc.depth_stencil_attachment.slice == 0);
+    const sg_attachments_desc a0_desc = sg_query_attachments_desc(a0);
+    T(a0_desc.colors[0].image.id == color_img_0.id);
+    T(a0_desc.colors[0].mip_level == 0);
+    T(a0_desc.colors[0].slice == 0);
+    T(a0_desc.colors[1].image.id == color_img_1.id);
+    T(a0_desc.colors[1].mip_level == 0);
+    T(a0_desc.colors[1].slice == 0);
+    T(a0_desc.colors[2].image.id == color_img_2.id);
+    T(a0_desc.colors[2].mip_level == 0);
+    T(a0_desc.colors[2].slice == 0);
+    T(a0_desc.depth_stencil.image.id == depth_img.id);
+    T(a0_desc.depth_stencil.mip_level == 0);
+    T(a0_desc.depth_stencil.slice == 0);
 
     sg_shutdown();
 }
@@ -1317,18 +1317,18 @@ UTEST(sokol_gfx, pipeline_resource_states) {
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, pass_resource_states) {
+UTEST(sokol_gfx, attachments_resource_states) {
     setup(&(sg_desc){0});
-    sg_pass pass = sg_alloc_pass();
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_ALLOC);
-    sg_init_pass(pass, &(sg_pass_desc){
-        .color_attachments[0].image = sg_make_image(&(sg_image_desc){ .render_target=true, .width=16, .height=16})
+    sg_attachments atts = sg_alloc_attachments();
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_ALLOC);
+    sg_init_attachments(atts, &(sg_attachments_desc){
+        .colors[0].image = sg_make_image(&(sg_image_desc){ .render_target=true, .width=16, .height=16})
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_VALID);
-    sg_uninit_pass(pass);
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_ALLOC);
-    sg_dealloc_pass(pass);
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_INVALID);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_VALID);
+    sg_uninit_attachments(atts);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_ALLOC);
+    sg_dealloc_attachments(atts);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_INVALID);
     sg_shutdown();
 }
 
@@ -1590,14 +1590,14 @@ UTEST(sokol_gfx, pipeline_double_destroy_is_ok) {
     sg_shutdown();
 }
 
-UTEST(sokoL_gfx, pass_double_destroy_is_ok) {
+UTEST(sokoL_gfx, attachments_double_destroy_is_ok) {
     setup(&(sg_desc){0});
-    sg_pass pass = create_pass();
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_VALID);
-    sg_destroy_pass(pass);
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_INVALID);
-    sg_destroy_pass(pass);
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_INVALID);
+    sg_attachments atts = create_attachments();
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_VALID);
+    sg_destroy_attachments(atts);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_INVALID);
+    sg_destroy_attachments(atts);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_INVALID);
     sg_shutdown();
 }
 
@@ -1666,16 +1666,16 @@ UTEST(sokol_gfx, make_dealloc_pipeline_warns) {
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_dealloc_pass_warns) {
+UTEST(sokol_gfx, make_dealloc_attachments_warns) {
     setup(&(sg_desc){0});
-    sg_pass pass = create_pass();
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_VALID);
-    sg_dealloc_pass(pass);
-    T(log_items[0] == SG_LOGITEM_DEALLOC_PASS_INVALID_STATE);
+    sg_attachments atts = create_attachments();
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_VALID);
+    sg_dealloc_attachments(atts);
+    T(log_items[0] == SG_LOGITEM_DEALLOC_ATTACHMENTS_INVALID_STATE);
     T(num_log_called == 1);
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_VALID);
-    sg_destroy_pass(pass);
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_INVALID);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_VALID);
+    sg_destroy_attachments(atts);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_INVALID);
     sg_shutdown();
 }
 
@@ -1734,14 +1734,14 @@ UTEST(sokol_gfx, alloc_uninit_pipeline_warns) {
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, alloc_uninit_pass_warns) {
+UTEST(sokol_gfx, alloc_uninit_attachments_warns) {
     setup(&(sg_desc){0});
-    sg_pass pass = sg_alloc_pass();
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_ALLOC);
-    sg_uninit_pass(pass);
-    T(log_items[0] == SG_LOGITEM_UNINIT_PASS_INVALID_STATE);
+    sg_attachments atts = sg_alloc_attachments();
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_ALLOC);
+    sg_uninit_attachments(atts);
+    T(log_items[0] == SG_LOGITEM_UNINIT_ATTACHMENTS_INVALID_STATE);
     T(num_log_called == 1);
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_ALLOC);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_ALLOC);
     sg_shutdown();
 }
 
@@ -1796,13 +1796,13 @@ UTEST(sokol_gfx, alloc_destroy_pipeline_is_ok) {
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, alloc_destroy_pass_is_ok) {
+UTEST(sokol_gfx, alloc_destroy_attachments_is_ok) {
     setup(&(sg_desc){0});
-    sg_pass pass = sg_alloc_pass();
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_ALLOC);
-    sg_destroy_pass(pass);
+    sg_attachments atts = sg_alloc_attachments();
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_ALLOC);
+    sg_destroy_attachments(atts);
     T(num_log_called == 0);
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_INVALID);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_INVALID);
     sg_shutdown();
 }
 
@@ -1822,16 +1822,16 @@ UTEST(sokol_gfx, make_pipeline_with_nonvalid_shader) {
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_with_nonvalid_color_images) {
+UTEST(sokol_gfx, make_attachments_with_nonvalid_color_images) {
     setup(&(sg_desc){
         .disable_validation = true,
     });
-    sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments = {
+    sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors = {
             [0].image = sg_alloc_image(),
             [1].image = sg_alloc_image(),
         },
-        .depth_stencil_attachment = {
+        .depth_stencil = {
             .image = sg_make_image(&(sg_image_desc){
                 .render_target = true,
                 .width = 128,
@@ -1839,23 +1839,23 @@ UTEST(sokol_gfx, make_pass_with_nonvalid_color_images) {
             })
         }
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    sg_destroy_pass(pass);
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_INVALID);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    sg_destroy_attachments(atts);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_INVALID);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_without_color_attachments) {
+UTEST(sokol_gfx, make_attachments_without_color_attachments) {
     setup(&(sg_desc){0});
-    sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .depth_stencil_attachment.image = sg_make_image(&(sg_image_desc){
+    sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .depth_stencil.image = sg_make_image(&(sg_image_desc){
             .render_target = true,
             .width = 64,
             .height = 64,
             .pixel_format = SG_PIXELFORMAT_DEPTH,
         })
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_VALID);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_VALID);
     sg_shutdown();
 }
 
@@ -2226,71 +2226,71 @@ UTEST(sokol_gfx, make_sampler_validate_anistropic_requires_linear_filtering) {
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_start_canary) {
+UTEST(sokol_gfx, make_attachments_validate_start_canary) {
     setup(&(sg_desc){0});
-    sg_pass pass = sg_make_pass(&(sg_pass_desc){
+    sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
         ._start_canary = 1234,
-        .color_attachments[0].image = sg_make_image(&(sg_image_desc){
+        .colors[0].image = sg_make_image(&(sg_image_desc){
             .render_target = true,
             .width = 64,
             .height = 64,
         }),
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_CANARY);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_CANARY);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_end_canary) {
+UTEST(sokol_gfx, make_attachments_validate_end_canary) {
     setup(&(sg_desc){0});
-    sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0].image = sg_make_image(&(sg_image_desc){
+    sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0].image = sg_make_image(&(sg_image_desc){
             .render_target = true,
             .width = 64,
             .height = 64,
         }),
         ._end_canary = 1234,
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_CANARY);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_CANARY);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_no_cont_color_atts1) {
+UTEST(sokol_gfx, make_attachments_validate_no_cont_color_atts1) {
     setup(&(sg_desc){0});
     const sg_image_desc img_desc = { .render_target = true, .width = 64, .height = 64 };
-    sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments = {
+    sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors = {
             [0].image = sg_make_image(&img_desc),
             [2].image = sg_make_image(&img_desc),
         }
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_NO_CONT_COLOR_ATTS);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_NO_CONT_COLOR_ATTS);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_image) {
+UTEST(sokol_gfx, make_attachments_validate_image) {
     setup(&(sg_desc){0});
     const sg_image_desc img_desc = { .render_target = true, .width = 64, .height = 64 };
     const sg_image img0 = sg_make_image(&img_desc);
     const sg_image img1 = sg_make_image(&img_desc);
     sg_destroy_image(img1);
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments = {
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors = {
             [0].image = img0,
             [1].image = img1,
         }
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_IMAGE);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_IMAGE);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_miplevel) {
+UTEST(sokol_gfx, make_attachments_validate_miplevel) {
     setup(&(sg_desc){0});
     const sg_image img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2298,16 +2298,16 @@ UTEST(sokol_gfx, make_pass_validate_miplevel) {
         .height = 16,
         .num_mipmaps = 4,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = img, .mip_level = 4 }
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = img, .mip_level = 4 }
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_MIPLEVEL);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_MIPLEVEL);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_face) {
+UTEST(sokol_gfx, make_attachments_validate_face) {
     setup(&(sg_desc){0});
     const sg_image img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2315,16 +2315,16 @@ UTEST(sokol_gfx, make_pass_validate_face) {
         .width = 64,
         .height = 64,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = img, .slice = 6 }
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = img, .slice = 6 }
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_FACE);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_FACE);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_layer) {
+UTEST(sokol_gfx, make_attachments_validate_layer) {
     setup(&(sg_desc){0});
     const sg_image img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2333,16 +2333,16 @@ UTEST(sokol_gfx, make_pass_validate_layer) {
         .height = 64,
         .num_slices = 4,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = img, .slice = 5 },
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = img, .slice = 5 },
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_LAYER);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_LAYER);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_slice) {
+UTEST(sokol_gfx, make_attachments_validate_slice) {
     setup(&(sg_desc){0});
     const sg_image img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2351,32 +2351,32 @@ UTEST(sokol_gfx, make_pass_validate_slice) {
         .height = 64,
         .num_slices = 4,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = img, .slice = 5 },
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = img, .slice = 5 },
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_SLICE);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_SLICE);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_image_no_rt) {
+UTEST(sokol_gfx, make_attachments_validate_image_no_rt) {
     setup(&(sg_desc){0});
     const sg_image img = sg_make_image(&(sg_image_desc){
         .width = 8,
         .height = 8,
         .usage = SG_USAGE_DYNAMIC,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0].image = img,
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0].image = img,
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_IMAGE_NO_RT);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_IMAGE_NO_RT);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_color_inv_pixelformat) {
+UTEST(sokol_gfx, make_attachments_validate_color_inv_pixelformat) {
     setup(&(sg_desc){0});
     const sg_image_desc img_desc = {
         .render_target = true,
@@ -2385,34 +2385,34 @@ UTEST(sokol_gfx, make_pass_validate_color_inv_pixelformat) {
         .pixel_format = SG_PIXELFORMAT_DEPTH,
     };
     reset_log_items();
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0].image = sg_make_image(&img_desc),
-        .depth_stencil_attachment.image = sg_make_image(&img_desc),
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0].image = sg_make_image(&img_desc),
+        .depth_stencil.image = sg_make_image(&img_desc),
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_COLOR_INV_PIXELFORMAT);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_COLOR_INV_PIXELFORMAT);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_depth_inv_pixelformat) {
+UTEST(sokol_gfx, make_attachments_validate_depth_inv_pixelformat) {
     setup(&(sg_desc){0});
     const sg_image_desc img_desc = {
         .render_target = true,
         .width = 8,
         .height = 8,
     };
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0].image = sg_make_image(&img_desc),
-        .depth_stencil_attachment.image = sg_make_image(&img_desc),
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0].image = sg_make_image(&img_desc),
+        .depth_stencil.image = sg_make_image(&img_desc),
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_DEPTH_INV_PIXELFORMAT);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_DEPTH_INV_PIXELFORMAT);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_image_sizes) {
+UTEST(sokol_gfx, make_attachments_validate_image_sizes) {
     setup(&(sg_desc){0});
     const sg_image img0 = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2424,20 +2424,20 @@ UTEST(sokol_gfx, make_pass_validate_image_sizes) {
         .width = 32,
         .height = 32,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments = {
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors = {
             [0].image = img0,
             [1].image = img1,
         }
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_IMAGE_SIZES);
-    T(log_items[1] == SG_LOGITEM_VALIDATE_PASSDESC_IMAGE_SIZES);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_IMAGE_SIZES);
+    T(log_items[1] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_IMAGE_SIZES);
     T(log_items[2] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_image_sample_counts) {
+UTEST(sokol_gfx, make_attachments_validate_image_sample_counts) {
     setup(&(sg_desc){0});
     const sg_image img0 = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2451,19 +2451,19 @@ UTEST(sokol_gfx, make_pass_validate_image_sample_counts) {
         .height = 64,
         .sample_count = 2,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments = {
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors = {
             [0].image = img0,
             [1].image = img1,
         }
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_IMAGE_SAMPLE_COUNTS);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_IMAGE_SAMPLE_COUNTS);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_resolve_color_image_msaa) {
+UTEST(sokol_gfx, make_attachments_validate_resolve_color_image_msaa) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2477,17 +2477,17 @@ UTEST(sokol_gfx, make_pass_validate_resolve_color_image_msaa) {
         .height = 64,
         .sample_count = 1,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0].image = color_img,
-        .resolve_attachments[0].image = resolve_img,
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0].image = color_img,
+        .resolves[0].image = resolve_img,
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_RESOLVE_COLOR_IMAGE_MSAA);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_RESOLVE_COLOR_IMAGE_MSAA);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_resolve_image) {
+UTEST(sokol_gfx, make_attachments_validate_resolve_image) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2502,17 +2502,17 @@ UTEST(sokol_gfx, make_pass_validate_resolve_image) {
         .sample_count = 1,
     });
     sg_destroy_image(resolve_img);
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0].image = color_img,
-        .resolve_attachments[0].image = resolve_img,
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0].image = color_img,
+        .resolves[0].image = resolve_img,
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_RESOLVE_IMAGE);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_RESOLVE_IMAGE);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_resolve_sample_count) {
+UTEST(sokol_gfx, make_attachments_validate_resolve_sample_count) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2526,17 +2526,17 @@ UTEST(sokol_gfx, make_pass_validate_resolve_sample_count) {
         .height = 64,
         .sample_count = 4,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0].image = color_img,
-        .resolve_attachments[0].image = resolve_img,
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0].image = color_img,
+        .resolves[0].image = resolve_img,
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_RESOLVE_SAMPLE_COUNT);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_RESOLVE_SAMPLE_COUNT);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_resolve_miplevel) {
+UTEST(sokol_gfx, make_attachments_validate_resolve_miplevel) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2550,20 +2550,20 @@ UTEST(sokol_gfx, make_pass_validate_resolve_miplevel) {
         .height = 64,
         .sample_count = 1,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = color_img },
-        .resolve_attachments[0] = { .image = resolve_img, .mip_level = 1 },
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = color_img },
+        .resolves[0] = { .image = resolve_img, .mip_level = 1 },
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_RESOLVE_MIPLEVEL);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_RESOLVE_MIPLEVEL);
     // FIXME: these are confusing
-    T(log_items[1] == SG_LOGITEM_VALIDATE_PASSDESC_RESOLVE_IMAGE_SIZES);
-    T(log_items[2] == SG_LOGITEM_VALIDATE_PASSDESC_RESOLVE_IMAGE_SIZES);
+    T(log_items[1] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_RESOLVE_IMAGE_SIZES);
+    T(log_items[2] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_RESOLVE_IMAGE_SIZES);
     T(log_items[3] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_resolve_face) {
+UTEST(sokol_gfx, make_attachments_validate_resolve_face) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2578,17 +2578,17 @@ UTEST(sokol_gfx, make_pass_validate_resolve_face) {
         .height = 64,
         .sample_count = 1,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = color_img },
-        .resolve_attachments[0] = { .image = resolve_img, .slice = 6 },
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = color_img },
+        .resolves[0] = { .image = resolve_img, .slice = 6 },
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_RESOLVE_FACE);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_RESOLVE_FACE);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_resolve_layer) {
+UTEST(sokol_gfx, make_attachments_validate_resolve_layer) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2604,17 +2604,17 @@ UTEST(sokol_gfx, make_pass_validate_resolve_layer) {
         .num_slices = 4,
         .sample_count = 1,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = color_img },
-        .resolve_attachments[0] = { .image = resolve_img, .slice = 4 },
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = color_img },
+        .resolves[0] = { .image = resolve_img, .slice = 4 },
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_RESOLVE_LAYER);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_RESOLVE_LAYER);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_resolve_slice) {
+UTEST(sokol_gfx, make_attachments_validate_resolve_slice) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2630,17 +2630,17 @@ UTEST(sokol_gfx, make_pass_validate_resolve_slice) {
         .num_slices = 4,
         .sample_count = 1,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = color_img },
-        .resolve_attachments[0] = { .image = resolve_img, .slice = 4 },
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = color_img },
+        .resolves[0] = { .image = resolve_img, .slice = 4 },
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_RESOLVE_SLICE);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_RESOLVE_SLICE);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_resolve_image_no_rt) {
+UTEST(sokol_gfx, make_attachments_validate_resolve_image_no_rt) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2654,17 +2654,17 @@ UTEST(sokol_gfx, make_pass_validate_resolve_image_no_rt) {
         .usage = SG_USAGE_DYNAMIC,
         .sample_count = 1,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = color_img },
-        .resolve_attachments[0] = { .image = resolve_img },
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = color_img },
+        .resolves[0] = { .image = resolve_img },
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_RESOLVE_IMAGE_NO_RT);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_RESOLVE_IMAGE_NO_RT);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_resolve_image_sizes) {
+UTEST(sokol_gfx, make_attachments_validate_resolve_image_sizes) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2678,18 +2678,18 @@ UTEST(sokol_gfx, make_pass_validate_resolve_image_sizes) {
         .height = 32,
         .sample_count = 1,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = color_img },
-        .resolve_attachments[0] = { .image = resolve_img },
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = color_img },
+        .resolves[0] = { .image = resolve_img },
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_RESOLVE_IMAGE_SIZES);
-    T(log_items[1] == SG_LOGITEM_VALIDATE_PASSDESC_RESOLVE_IMAGE_SIZES);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_RESOLVE_IMAGE_SIZES);
+    T(log_items[1] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_RESOLVE_IMAGE_SIZES);
     T(log_items[2] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_resolve_image_format) {
+UTEST(sokol_gfx, make_attachments_validate_resolve_image_format) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2704,17 +2704,17 @@ UTEST(sokol_gfx, make_pass_validate_resolve_image_format) {
         .pixel_format = SG_PIXELFORMAT_R8,
         .sample_count = 1,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = color_img },
-        .resolve_attachments[0] = { .image = resolve_img },
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = color_img },
+        .resolves[0] = { .image = resolve_img },
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_RESOLVE_IMAGE_FORMAT);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_RESOLVE_IMAGE_FORMAT);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_depth_image) {
+UTEST(sokol_gfx, make_attachments_validate_depth_image) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2728,17 +2728,17 @@ UTEST(sokol_gfx, make_pass_validate_depth_image) {
         .pixel_format = SG_PIXELFORMAT_DEPTH,
     });
     sg_destroy_image(depth_img);
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = color_img },
-        .depth_stencil_attachment.image = depth_img,
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = color_img },
+        .depth_stencil.image = depth_img,
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_DEPTH_IMAGE);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_DEPTH_IMAGE);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_depth_miplevel) {
+UTEST(sokol_gfx, make_attachments_validate_depth_miplevel) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2751,20 +2751,20 @@ UTEST(sokol_gfx, make_pass_validate_depth_miplevel) {
         .height = 64,
         .pixel_format = SG_PIXELFORMAT_DEPTH,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = color_img },
-        .depth_stencil_attachment = { .image = depth_img, .mip_level = 1 },
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = color_img },
+        .depth_stencil = { .image = depth_img, .mip_level = 1 },
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_DEPTH_MIPLEVEL);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_DEPTH_MIPLEVEL);
     // FIXME: these additional validation errors are confusing
-    T(log_items[1] == SG_LOGITEM_VALIDATE_PASSDESC_DEPTH_IMAGE_SIZES);
-    T(log_items[2] == SG_LOGITEM_VALIDATE_PASSDESC_DEPTH_IMAGE_SIZES);
+    T(log_items[1] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_DEPTH_IMAGE_SIZES);
+    T(log_items[2] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_DEPTH_IMAGE_SIZES);
     T(log_items[3] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_depth_face) {
+UTEST(sokol_gfx, make_attachments_validate_depth_face) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2778,17 +2778,17 @@ UTEST(sokol_gfx, make_pass_validate_depth_face) {
         .height = 64,
         .pixel_format = SG_PIXELFORMAT_DEPTH,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = color_img },
-        .depth_stencil_attachment = { .image = depth_img, .slice = 6 },
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = color_img },
+        .depth_stencil = { .image = depth_img, .slice = 6 },
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_DEPTH_FACE);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_DEPTH_FACE);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_depth_layer) {
+UTEST(sokol_gfx, make_attachments_validate_depth_layer) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2803,12 +2803,12 @@ UTEST(sokol_gfx, make_pass_validate_depth_layer) {
         .num_slices = 4,
         .pixel_format = SG_PIXELFORMAT_DEPTH,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = color_img },
-        .depth_stencil_attachment = { .image = depth_img, .slice = 4 },
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = color_img },
+        .depth_stencil = { .image = depth_img, .slice = 4 },
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_DEPTH_LAYER);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_DEPTH_LAYER);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
@@ -2817,7 +2817,7 @@ UTEST(sokol_gfx, make_pass_validate_depth_layer) {
 
 // NOTE: VALIDATE_DEPTH_IMAGE_NO_RT can't actually happen because VALIDATE_IMAGEDESC_NONRT_PIXELFORMAT
 
-UTEST(sokol_gfx, make_pass_validate_depth_image_sizes) {
+UTEST(sokol_gfx, make_attachments_validate_depth_image_sizes) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2830,18 +2830,18 @@ UTEST(sokol_gfx, make_pass_validate_depth_image_sizes) {
         .height = 32,
         .pixel_format = SG_PIXELFORMAT_DEPTH,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = color_img },
-        .depth_stencil_attachment = { .image = depth_img },
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = color_img },
+        .depth_stencil = { .image = depth_img },
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_DEPTH_IMAGE_SIZES);
-    T(log_items[1] == SG_LOGITEM_VALIDATE_PASSDESC_DEPTH_IMAGE_SIZES);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_DEPTH_IMAGE_SIZES);
+    T(log_items[1] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_DEPTH_IMAGE_SIZES);
     T(log_items[2] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }
 
-UTEST(sokol_gfx, make_pass_validate_depth_image_sample_count) {
+UTEST(sokol_gfx, make_attachments_validate_depth_image_sample_count) {
     setup(&(sg_desc){0});
     const sg_image color_img = sg_make_image(&(sg_image_desc){
         .render_target = true,
@@ -2856,12 +2856,12 @@ UTEST(sokol_gfx, make_pass_validate_depth_image_sample_count) {
         .pixel_format = SG_PIXELFORMAT_DEPTH,
         .sample_count = 2,
     });
-    const sg_pass pass = sg_make_pass(&(sg_pass_desc){
-        .color_attachments[0] = { .image = color_img },
-        .depth_stencil_attachment = { .image = depth_img },
+    const sg_attachments atts = sg_make_attachments(&(sg_attachments_desc){
+        .colors[0] = { .image = color_img },
+        .depth_stencil = { .image = depth_img },
     });
-    T(sg_query_pass_state(pass) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_PASSDESC_DEPTH_IMAGE_SAMPLE_COUNT);
+    T(sg_query_attachments_state(atts) == SG_RESOURCESTATE_FAILED);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_ATTACHMENTSDESC_DEPTH_IMAGE_SAMPLE_COUNT);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }

--- a/tests/functional/sokol_log_test.c
+++ b/tests/functional/sokol_log_test.c
@@ -1,0 +1,2 @@
+#define SOKOL_LOG_IMPL
+#include "sokol_log.h"

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -59,19 +59,19 @@
 
     STEP BY STEP:
     =============
-    --- create an sg_imgui_t struct (which must be preserved between frames)
+    --- create an sgimgui_t struct (which must be preserved between frames)
         and initialize it with:
 
-            sg_imgui_init(&sg_imgui, &(sg_imgui_desc_t){ 0 });
+            sgimgui_init(&sgimgui, &(sgimgui_desc_t){ 0 });
 
         Note that from C++ you can't inline the desc structure initialization:
 
-            const sg_imgui_desc_t desc = { };
-            sg_imgui_init(&sg_imgui, &desc);
+            const sgimgui_desc_t desc = { };
+            sgimgui_init(&sgimgui, &desc);
 
         Provide optional memory allocator override functions (compatible with malloc/free) like this:
 
-            sg_imgui_init(&sg_imgui, &(sg_imgui_desc_t){
+            sgimgui_init(&sgimgui, &(sgimgui_desc_t){
                 .allocator = {
                     .alloc_fn = my_malloc,
                     .free_fn = my_free,
@@ -80,43 +80,43 @@
 
     --- somewhere in the per-frame code call:
 
-            sg_imgui_draw(&sg_imgui)
+            sgimgui_draw(&sgimgui)
 
         this won't draw anything yet, since no windows are open.
 
-    --- call the convenience function sg_imgui_draw_menu(ctx, title)
+    --- call the convenience function sgimgui_draw_menu(ctx, title)
         to render a menu which allows to open/close the provided debug windows
 
-            sg_imgui_draw_menu(&sg_imgui, "sokol-gfx");
+            sgimgui_draw_menu(&sgimgui, "sokol-gfx");
 
     --- alternative, open and close windows directly by setting the following public
-        booleans in the sg_imgui_t struct:
+        booleans in the sgimgui_t struct:
 
-            sg_imgui.caps.open = true;
-            sg_imgui.frame_stats.open = true;
-            sg_imgui.buffers.open = true;
-            sg_imgui.images.open = true;
-            sg_imgui.samplers.open = true;
-            sg_imgui.shaders.open = true;
-            sg_imgui.pipelines.open = true;
-            sg_imgui.passes.open = true;
-            sg_imgui.capture.open = true;
-            sg_imgui.frame_stats.open = true;
+            sgimgui.caps_window.open = true;
+            sgimgui.frame_stats_window.open = true;
+            sgimgui.buffer_window.open = true;
+            sgimgui.image_window.open = true;
+            sgimgui.sampler_window.open = true;
+            sgimgui.shader_window.open = true;
+            sgimgui.pipeline_window.open = true;
+            sgimgui.attachments_window.open = true;
+            sgimgui.capture_window.open = true;
+            sgimgui.frame_stats_window.open = true;
 
         ...for instance, to control the window visibility through
         menu items, the following code can be used:
 
             if (ImGui::BeginMainMenuBar()) {
                 if (ImGui::BeginMenu("sokol-gfx")) {
-                    ImGui::MenuItem("Capabilities", 0, &sg_imgui.caps.open);
-                    ImGui::MenuItem("Frame Stats", 0, &sg_imgui.frame_stats.open);
-                    ImGui::MenuItem("Buffers", 0, &sg_imgui.buffers.open);
-                    ImGui::MenuItem("Images", 0, &sg_imgui.images.open);
-                    ImGui::MenuItem("Samplers", 0, &sg_imgui.samplers.open);
-                    ImGui::MenuItem("Shaders", 0, &sg_imgui.shaders.open);
-                    ImGui::MenuItem("Pipelines", 0, &sg_imgui.pipelines.open);
-                    ImGui::MenuItem("Passes", 0, &sg_imgui.passes.open);
-                    ImGui::MenuItem("Calls", 0, &sg_imgui.capture.open);
+                    ImGui::MenuItem("Capabilities", 0, &sgimgui.caps_window.open);
+                    ImGui::MenuItem("Frame Stats", 0, &sgimgui.frame_stats_window.open);
+                    ImGui::MenuItem("Buffers", 0, &sgimgui.buffer_window.open);
+                    ImGui::MenuItem("Images", 0, &sgimgui.image_window.open);
+                    ImGui::MenuItem("Samplers", 0, &sgimgui.sampler_window.open);
+                    ImGui::MenuItem("Shaders", 0, &sgimgui.shader_window.open);
+                    ImGui::MenuItem("Pipelines", 0, &sgimgui.pipeline_window.open);
+                    ImGui::MenuItem("Attachments", 0, &sgimgui.attachments_window.open);
+                    ImGui::MenuItem("Calls", 0, &sgimgui.capture_window.open);
                     ImGui::EndMenu();
                 }
                 ImGui::EndMainMenuBar();
@@ -124,7 +124,7 @@
 
     --- before application shutdown, call:
 
-            sg_imgui_discard(&sg_imgui);
+            sgimgui_discard(&sgimgui);
 
         ...this is not strictly necessary because the application exits
         anyway, but not doing this may trigger memory leak detection tools.
@@ -134,30 +134,30 @@
 
     ALTERNATIVE DRAWING FUNCTIONS:
     ==============================
-    Instead of the convenient, but all-in-one sg_imgui_draw() function,
+    Instead of the convenient, but all-in-one sgimgui_draw() function,
     you can also use the following granular functions which might allow
     better integration with your existing UI:
 
     The following functions only render the window *content* (so you
     can integrate the UI into you own windows):
 
-        void sg_imgui_draw_buffers_content(sg_imgui_t* ctx);
-        void sg_imgui_draw_images_content(sg_imgui_t* ctx);
-        void sg_imgui_draw_samplers_content(sg_imgui_t* ctx);
-        void sg_imgui_draw_shaders_content(sg_imgui_t* ctx);
-        void sg_imgui_draw_pipelines_content(sg_imgui_t* ctx);
-        void sg_imgui_draw_passes_content(sg_imgui_t* ctx);
-        void sg_imgui_draw_capture_content(sg_imgui_t* ctx);
+        void sgimgui_draw_buffer_window_content(sgimgui_t* ctx);
+        void sgimgui_draw_image_window_content(sgimgui_t* ctx);
+        void sgimgui_draw_sampler_window_content(sgimgui_t* ctx);
+        void sgimgui_draw_shader_window_content(sgimgui_t* ctx);
+        void sgimgui_draw_pipeline_window_content(sgimgui_t* ctx);
+        void sgimgui_draw_attachments_window_content(sgimgui_t* ctx);
+        void sgimgui_draw_capture_window_content(sgimgui_t* ctx);
 
     And these are the 'full window' drawing functions:
 
-        void sg_imgui_draw_buffers_window(sg_imgui_t* ctx);
-        void sg_imgui_draw_images_window(sg_imgui_t* ctx);
-        void sg_imgui_draw_samplers_window(sg_imgui_t* ctx);
-        void sg_imgui_draw_shaders_window(sg_imgui_t* ctx);
-        void sg_imgui_draw_pipelines_window(sg_imgui_t* ctx);
-        void sg_imgui_draw_passes_window(sg_imgui_t* ctx);
-        void sg_imgui_draw_capture_window(sg_imgui_t* ctx);
+        void sgimgui_draw_buffer_window(sgimgui_t* ctx);
+        void sgimgui_draw_image_window(sgimgui_t* ctx);
+        void sgimgui_draw_sampler_window(sgimgui_t* ctx);
+        void sgimgui_draw_shader_window(sgimgui_t* ctx);
+        void sgimgui_draw_pipeline_window(sgimgui_t* ctx);
+        void sgimgui_draw_attachments_window(sgimgui_t* ctx);
+        void sgimgui_draw_capture_window(sgimgui_t* ctx);
 
     Finer-grained drawing functions may be moved to the public API
     in the future as needed.
@@ -176,7 +176,7 @@
         }
 
         ...
-            sg_imgui_init(&(&ctx, &(sg_imgui_desc_t){
+            sgimgui_init(&(&ctx, &(sgimgui_desc_t){
                 // ...
                 .allocator = {
                     .alloc_fn = my_alloc,
@@ -241,556 +241,547 @@
 extern "C" {
 #endif
 
-#define SG_IMGUI_STRBUF_LEN (96)
+#define sgimgui_STRBUF_LEN (96)
 /* max number of captured calls per frame */
-#define SG_IMGUI_MAX_FRAMECAPTURE_ITEMS (4096)
+#define sgimgui_MAX_FRAMECAPTURE_ITEMS (4096)
 
-typedef struct sg_imgui_str_t {
-    char buf[SG_IMGUI_STRBUF_LEN];
-} sg_imgui_str_t;
+typedef struct sgimgui_str_t {
+    char buf[sgimgui_STRBUF_LEN];
+} sgimgui_str_t;
 
-typedef struct sg_imgui_buffer_t {
+typedef struct sgimgui_buffer_t {
     sg_buffer res_id;
-    sg_imgui_str_t label;
+    sgimgui_str_t label;
     sg_buffer_desc desc;
-} sg_imgui_buffer_t;
+} sgimgui_buffer_t;
 
-typedef struct sg_imgui_image_t {
+typedef struct sgimgui_image_t {
     sg_image res_id;
     float ui_scale;
-    sg_imgui_str_t label;
+    sgimgui_str_t label;
     sg_image_desc desc;
     simgui_image_t simgui_img;
-} sg_imgui_image_t;
+} sgimgui_image_t;
 
-typedef struct sg_imgui_sampler_t {
+typedef struct sgimgui_sampler_t {
     sg_sampler res_id;
-    sg_imgui_str_t label;
+    sgimgui_str_t label;
     sg_sampler_desc desc;
-} sg_imgui_sampler_t;
+} sgimgui_sampler_t;
 
-typedef struct sg_imgui_shader_t {
+typedef struct sgimgui_shader_t {
     sg_shader res_id;
-    sg_imgui_str_t label;
-    sg_imgui_str_t vs_entry;
-    sg_imgui_str_t vs_d3d11_target;
-    sg_imgui_str_t vs_image_sampler_name[SG_MAX_SHADERSTAGE_IMAGESAMPLERPAIRS];
-    sg_imgui_str_t vs_uniform_name[SG_MAX_SHADERSTAGE_UBS][SG_MAX_UB_MEMBERS];
-    sg_imgui_str_t fs_entry;
-    sg_imgui_str_t fs_d3d11_target;
-    sg_imgui_str_t fs_image_sampler_name[SG_MAX_SHADERSTAGE_IMAGESAMPLERPAIRS];
-    sg_imgui_str_t fs_uniform_name[SG_MAX_SHADERSTAGE_UBS][SG_MAX_UB_MEMBERS];
-    sg_imgui_str_t attr_name[SG_MAX_VERTEX_ATTRIBUTES];
-    sg_imgui_str_t attr_sem_name[SG_MAX_VERTEX_ATTRIBUTES];
+    sgimgui_str_t label;
+    sgimgui_str_t vs_entry;
+    sgimgui_str_t vs_d3d11_target;
+    sgimgui_str_t vs_image_sampler_name[SG_MAX_SHADERSTAGE_IMAGESAMPLERPAIRS];
+    sgimgui_str_t vs_uniform_name[SG_MAX_SHADERSTAGE_UBS][SG_MAX_UB_MEMBERS];
+    sgimgui_str_t fs_entry;
+    sgimgui_str_t fs_d3d11_target;
+    sgimgui_str_t fs_image_sampler_name[SG_MAX_SHADERSTAGE_IMAGESAMPLERPAIRS];
+    sgimgui_str_t fs_uniform_name[SG_MAX_SHADERSTAGE_UBS][SG_MAX_UB_MEMBERS];
+    sgimgui_str_t attr_name[SG_MAX_VERTEX_ATTRIBUTES];
+    sgimgui_str_t attr_sem_name[SG_MAX_VERTEX_ATTRIBUTES];
     sg_shader_desc desc;
-} sg_imgui_shader_t;
+} sgimgui_shader_t;
 
-typedef struct sg_imgui_pipeline_t {
+typedef struct sgimgui_pipeline_t {
     sg_pipeline res_id;
-    sg_imgui_str_t label;
+    sgimgui_str_t label;
     sg_pipeline_desc desc;
-} sg_imgui_pipeline_t;
+} sgimgui_pipeline_t;
 
-typedef struct sg_imgui_pass_t {
-    sg_pass res_id;
-    sg_imgui_str_t label;
+typedef struct sgimgui_attachments_t {
+    sg_attachments res_id;
+    sgimgui_str_t label;
     float color_image_scale[SG_MAX_COLOR_ATTACHMENTS];
     float resolve_image_scale[SG_MAX_COLOR_ATTACHMENTS];
     float ds_image_scale;
-    sg_pass_desc desc;
-} sg_imgui_pass_t;
+    sg_attachments_desc desc;
+} sgimgui_attachments_t;
 
-typedef struct sg_imgui_buffers_t {
+typedef struct sgimgui_buffer_window_t {
     bool open;
     int num_slots;
     sg_buffer sel_buf;
-    sg_imgui_buffer_t* slots;
-} sg_imgui_buffers_t;
+    sgimgui_buffer_t* slots;
+} sgimgui_buffer_window_t;
 
-typedef struct sg_imgui_images_t {
+typedef struct sgimgui_image_window_t {
     bool open;
     int num_slots;
     sg_image sel_img;
-    sg_imgui_image_t* slots;
-} sg_imgui_images_t;
+    sgimgui_image_t* slots;
+} sgimgui_image_window_t;
 
-typedef struct sg_imgui_samplers_t {
+typedef struct sgimgui_sampler_window_t {
     bool open;
     int num_slots;
     sg_sampler sel_smp;
-    sg_imgui_sampler_t* slots;
-} sg_imgui_samplers_t;
+    sgimgui_sampler_t* slots;
+} sgimgui_sampler_window_t;
 
-typedef struct sg_imgui_shaders_t {
+typedef struct sgimgui_shader_window_t {
     bool open;
     int num_slots;
     sg_shader sel_shd;
-    sg_imgui_shader_t* slots;
-} sg_imgui_shaders_t;
+    sgimgui_shader_t* slots;
+} sgimgui_shader_window_t;
 
-typedef struct sg_imgui_pipelines_t {
+typedef struct sgimgui_pipeline_window_t {
     bool open;
     int num_slots;
     sg_pipeline sel_pip;
-    sg_imgui_pipeline_t* slots;
-} sg_imgui_pipelines_t;
+    sgimgui_pipeline_t* slots;
+} sgimgui_pipeline_window_t;
 
-typedef struct sg_imgui_passes_t {
+typedef struct sgimgui_attachments_window_t {
     bool open;
     int num_slots;
-    sg_pass sel_pass;
-    sg_imgui_pass_t* slots;
-} sg_imgui_passes_t;
+    sg_attachments sel_atts;
+    sgimgui_attachments_t* slots;
+} sgimgui_attachments_window_t;
 
-typedef enum sg_imgui_cmd_t {
-    SG_IMGUI_CMD_INVALID,
-    SG_IMGUI_CMD_RESET_STATE_CACHE,
-    SG_IMGUI_CMD_MAKE_BUFFER,
-    SG_IMGUI_CMD_MAKE_IMAGE,
-    SG_IMGUI_CMD_MAKE_SAMPLER,
-    SG_IMGUI_CMD_MAKE_SHADER,
-    SG_IMGUI_CMD_MAKE_PIPELINE,
-    SG_IMGUI_CMD_MAKE_PASS,
-    SG_IMGUI_CMD_DESTROY_BUFFER,
-    SG_IMGUI_CMD_DESTROY_IMAGE,
-    SG_IMGUI_CMD_DESTROY_SAMPLER,
-    SG_IMGUI_CMD_DESTROY_SHADER,
-    SG_IMGUI_CMD_DESTROY_PIPELINE,
-    SG_IMGUI_CMD_DESTROY_PASS,
-    SG_IMGUI_CMD_UPDATE_BUFFER,
-    SG_IMGUI_CMD_UPDATE_IMAGE,
-    SG_IMGUI_CMD_APPEND_BUFFER,
-    SG_IMGUI_CMD_BEGIN_DEFAULT_PASS,
-    SG_IMGUI_CMD_BEGIN_PASS,
-    SG_IMGUI_CMD_APPLY_VIEWPORT,
-    SG_IMGUI_CMD_APPLY_SCISSOR_RECT,
-    SG_IMGUI_CMD_APPLY_PIPELINE,
-    SG_IMGUI_CMD_APPLY_BINDINGS,
-    SG_IMGUI_CMD_APPLY_UNIFORMS,
-    SG_IMGUI_CMD_DRAW,
-    SG_IMGUI_CMD_END_PASS,
-    SG_IMGUI_CMD_COMMIT,
-    SG_IMGUI_CMD_ALLOC_BUFFER,
-    SG_IMGUI_CMD_ALLOC_IMAGE,
-    SG_IMGUI_CMD_ALLOC_SAMPLER,
-    SG_IMGUI_CMD_ALLOC_SHADER,
-    SG_IMGUI_CMD_ALLOC_PIPELINE,
-    SG_IMGUI_CMD_ALLOC_PASS,
-    SG_IMGUI_CMD_DEALLOC_BUFFER,
-    SG_IMGUI_CMD_DEALLOC_IMAGE,
-    SG_IMGUI_CMD_DEALLOC_SAMPLER,
-    SG_IMGUI_CMD_DEALLOC_SHADER,
-    SG_IMGUI_CMD_DEALLOC_PIPELINE,
-    SG_IMGUI_CMD_DEALLOC_PASS,
-    SG_IMGUI_CMD_INIT_BUFFER,
-    SG_IMGUI_CMD_INIT_IMAGE,
-    SG_IMGUI_CMD_INIT_SAMPLER,
-    SG_IMGUI_CMD_INIT_SHADER,
-    SG_IMGUI_CMD_INIT_PIPELINE,
-    SG_IMGUI_CMD_INIT_PASS,
-    SG_IMGUI_CMD_UNINIT_BUFFER,
-    SG_IMGUI_CMD_UNINIT_IMAGE,
-    SG_IMGUI_CMD_UNINIT_SAMPLER,
-    SG_IMGUI_CMD_UNINIT_SHADER,
-    SG_IMGUI_CMD_UNINIT_PIPELINE,
-    SG_IMGUI_CMD_UNINIT_PASS,
-    SG_IMGUI_CMD_FAIL_BUFFER,
-    SG_IMGUI_CMD_FAIL_IMAGE,
-    SG_IMGUI_CMD_FAIL_SAMPLER,
-    SG_IMGUI_CMD_FAIL_SHADER,
-    SG_IMGUI_CMD_FAIL_PIPELINE,
-    SG_IMGUI_CMD_FAIL_PASS,
-    SG_IMGUI_CMD_PUSH_DEBUG_GROUP,
-    SG_IMGUI_CMD_POP_DEBUG_GROUP,
-} sg_imgui_cmd_t;
+typedef enum sgimgui_cmd_t {
+    SGIMGUI_CMD_INVALID,
+    SGIMGUI_CMD_RESET_STATE_CACHE,
+    SGIMGUI_CMD_MAKE_BUFFER,
+    SGIMGUI_CMD_MAKE_IMAGE,
+    SGIMGUI_CMD_MAKE_SAMPLER,
+    SGIMGUI_CMD_MAKE_SHADER,
+    SGIMGUI_CMD_MAKE_PIPELINE,
+    SGIMGUI_CMD_MAKE_ATTACHMENTS,
+    SGIMGUI_CMD_DESTROY_BUFFER,
+    SGIMGUI_CMD_DESTROY_IMAGE,
+    SGIMGUI_CMD_DESTROY_SAMPLER,
+    SGIMGUI_CMD_DESTROY_SHADER,
+    SGIMGUI_CMD_DESTROY_PIPELINE,
+    SGIMGUI_CMD_DESTROY_ATTACHMENTS,
+    SGIMGUI_CMD_UPDATE_BUFFER,
+    SGIMGUI_CMD_UPDATE_IMAGE,
+    SGIMGUI_CMD_APPEND_BUFFER,
+    SGIMGUI_CMD_BEGIN_PASS,
+    SGIMGUI_CMD_APPLY_VIEWPORT,
+    SGIMGUI_CMD_APPLY_SCISSOR_RECT,
+    SGIMGUI_CMD_APPLY_PIPELINE,
+    SGIMGUI_CMD_APPLY_BINDINGS,
+    SGIMGUI_CMD_APPLY_UNIFORMS,
+    SGIMGUI_CMD_DRAW,
+    SGIMGUI_CMD_END_PASS,
+    SGIMGUI_CMD_COMMIT,
+    SGIMGUI_CMD_ALLOC_BUFFER,
+    SGIMGUI_CMD_ALLOC_IMAGE,
+    SGIMGUI_CMD_ALLOC_SAMPLER,
+    SGIMGUI_CMD_ALLOC_SHADER,
+    SGIMGUI_CMD_ALLOC_PIPELINE,
+    SGIMGUI_CMD_ALLOC_ATTACHMENTS,
+    SGIMGUI_CMD_DEALLOC_BUFFER,
+    SGIMGUI_CMD_DEALLOC_IMAGE,
+    SGIMGUI_CMD_DEALLOC_SAMPLER,
+    SGIMGUI_CMD_DEALLOC_SHADER,
+    SGIMGUI_CMD_DEALLOC_PIPELINE,
+    SGIMGUI_CMD_DEALLOC_ATTACHMENTS,
+    SGIMGUI_CMD_INIT_BUFFER,
+    SGIMGUI_CMD_INIT_IMAGE,
+    SGIMGUI_CMD_INIT_SAMPLER,
+    SGIMGUI_CMD_INIT_SHADER,
+    SGIMGUI_CMD_INIT_PIPELINE,
+    SGIMGUI_CMD_INIT_ATTACHMENTS,
+    SGIMGUI_CMD_UNINIT_BUFFER,
+    SGIMGUI_CMD_UNINIT_IMAGE,
+    SGIMGUI_CMD_UNINIT_SAMPLER,
+    SGIMGUI_CMD_UNINIT_SHADER,
+    SGIMGUI_CMD_UNINIT_PIPELINE,
+    SGIMGUI_CMD_UNINIT_ATTACHMENTS,
+    SGIMGUI_CMD_FAIL_BUFFER,
+    SGIMGUI_CMD_FAIL_IMAGE,
+    SGIMGUI_CMD_FAIL_SAMPLER,
+    SGIMGUI_CMD_FAIL_SHADER,
+    SGIMGUI_CMD_FAIL_PIPELINE,
+    SGIMGUI_CMD_FAIL_ATTACHMENTS,
+    SGIMGUI_CMD_PUSH_DEBUG_GROUP,
+    SGIMGUI_CMD_POP_DEBUG_GROUP,
+} sgimgui_cmd_t;
 
-typedef struct sg_imgui_args_make_buffer_t {
+typedef struct sgimgui_args_make_buffer_t {
     sg_buffer result;
-} sg_imgui_args_make_buffer_t;
+} sgimgui_args_make_buffer_t;
 
-typedef struct sg_imgui_args_make_image_t {
+typedef struct sgimgui_args_make_image_t {
     sg_image result;
-} sg_imgui_args_make_image_t;
+} sgimgui_args_make_image_t;
 
-typedef struct sg_imgui_args_make_sampler_t {
+typedef struct sgimgui_args_make_sampler_t {
     sg_sampler result;
-} sg_imgui_args_make_sampler_t;
+} sgimgui_args_make_sampler_t;
 
-typedef struct sg_imgui_args_make_shader_t {
+typedef struct sgimgui_args_make_shader_t {
     sg_shader result;
-} sg_imgui_args_make_shader_t;
+} sgimgui_args_make_shader_t;
 
-typedef struct sg_imgui_args_make_pipeline_t {
+typedef struct sgimgui_args_make_pipeline_t {
     sg_pipeline result;
-} sg_imgui_args_make_pipeline_t;
+} sgimgui_args_make_pipeline_t;
 
-typedef struct sg_imgui_args_make_pass_t {
-    sg_pass result;
-} sg_imgui_args_make_pass_t;
+typedef struct sgimgui_args_make_attachments_t {
+    sg_attachments result;
+} sgimgui_args_make_attachments_t;
 
-typedef struct sg_imgui_args_destroy_buffer_t {
+typedef struct sgimgui_args_destroy_buffer_t {
     sg_buffer buffer;
-} sg_imgui_args_destroy_buffer_t;
+} sgimgui_args_destroy_buffer_t;
 
-typedef struct sg_imgui_args_destroy_image_t {
+typedef struct sgimgui_args_destroy_image_t {
     sg_image image;
-} sg_imgui_args_destroy_image_t;
+} sgimgui_args_destroy_image_t;
 
-typedef struct sg_imgui_args_destroy_sampler_t {
+typedef struct sgimgui_args_destroy_sampler_t {
     sg_sampler sampler;
-} sg_imgui_args_destroy_sampler_t;
+} sgimgui_args_destroy_sampler_t;
 
-typedef struct sg_imgui_args_destroy_shader_t {
+typedef struct sgimgui_args_destroy_shader_t {
     sg_shader shader;
-} sg_imgui_args_destroy_shader_t;
+} sgimgui_args_destroy_shader_t;
 
-typedef struct sg_imgui_args_destroy_pipeline_t {
+typedef struct sgimgui_args_destroy_pipeline_t {
     sg_pipeline pipeline;
-} sg_imgui_args_destroy_pipeline_t;
+} sgimgui_args_destroy_pipeline_t;
 
-typedef struct sg_imgui_args_destroy_pass_t {
-    sg_pass pass;
-} sg_imgui_args_destroy_pass_t;
+typedef struct sgimgui_args_destroy_attachments_t {
+    sg_attachments attachments;
+} sgimgui_args_destroy_attachments_t;
 
-typedef struct sg_imgui_args_update_buffer_t {
+typedef struct sgimgui_args_update_buffer_t {
     sg_buffer buffer;
     size_t data_size;
-} sg_imgui_args_update_buffer_t;
+} sgimgui_args_update_buffer_t;
 
-typedef struct sg_imgui_args_update_image_t {
+typedef struct sgimgui_args_update_image_t {
     sg_image image;
-} sg_imgui_args_update_image_t;
+} sgimgui_args_update_image_t;
 
-typedef struct sg_imgui_args_append_buffer_t {
+typedef struct sgimgui_args_append_buffer_t {
     sg_buffer buffer;
     size_t data_size;
     int result;
-} sg_imgui_args_append_buffer_t;
+} sgimgui_args_append_buffer_t;
 
-typedef struct sg_imgui_args_begin_default_pass_t {
-    sg_pass_action action;
-    int width;
-    int height;
-} sg_imgui_args_begin_default_pass_t;
-
-typedef struct sg_imgui_args_begin_pass_t {
+typedef struct sgimgui_args_begin_pass_t {
     sg_pass pass;
-    sg_pass_action action;
-} sg_imgui_args_begin_pass_t;
+} sgimgui_args_begin_pass_t;
 
-typedef struct sg_imgui_args_apply_viewport_t {
+typedef struct sgimgui_args_apply_viewport_t {
     int x, y, width, height;
     bool origin_top_left;
-} sg_imgui_args_apply_viewport_t;
+} sgimgui_args_apply_viewport_t;
 
-typedef struct sg_imgui_args_apply_scissor_rect_t {
+typedef struct sgimgui_args_apply_scissor_rect_t {
     int x, y, width, height;
     bool origin_top_left;
-} sg_imgui_args_apply_scissor_rect_t;
+} sgimgui_args_apply_scissor_rect_t;
 
-typedef struct sg_imgui_args_apply_pipeline_t {
+typedef struct sgimgui_args_apply_pipeline_t {
     sg_pipeline pipeline;
-} sg_imgui_args_apply_pipeline_t;
+} sgimgui_args_apply_pipeline_t;
 
-typedef struct sg_imgui_args_apply_bindings_t {
+typedef struct sgimgui_args_apply_bindings_t {
     sg_bindings bindings;
-} sg_imgui_args_apply_bindings_t;
+} sgimgui_args_apply_bindings_t;
 
-typedef struct sg_imgui_args_apply_uniforms_t {
+typedef struct sgimgui_args_apply_uniforms_t {
     sg_shader_stage stage;
     int ub_index;
     size_t data_size;
     sg_pipeline pipeline;   /* the pipeline which was active at this call */
     size_t ubuf_pos;        /* start of copied data in capture buffer */
-} sg_imgui_args_apply_uniforms_t;
+} sgimgui_args_apply_uniforms_t;
 
-typedef struct sg_imgui_args_draw_t {
+typedef struct sgimgui_args_draw_t {
     int base_element;
     int num_elements;
     int num_instances;
-} sg_imgui_args_draw_t;
+} sgimgui_args_draw_t;
 
-typedef struct sg_imgui_args_alloc_buffer_t {
+typedef struct sgimgui_args_alloc_buffer_t {
     sg_buffer result;
-} sg_imgui_args_alloc_buffer_t;
+} sgimgui_args_alloc_buffer_t;
 
-typedef struct sg_imgui_args_alloc_image_t {
+typedef struct sgimgui_args_alloc_image_t {
     sg_image result;
-} sg_imgui_args_alloc_image_t;
+} sgimgui_args_alloc_image_t;
 
-typedef struct sg_imgui_args_alloc_sampler_t {
+typedef struct sgimgui_args_alloc_sampler_t {
     sg_sampler result;
-} sg_imgui_args_alloc_sampler_t;
+} sgimgui_args_alloc_sampler_t;
 
-typedef struct sg_imgui_args_alloc_shader_t {
+typedef struct sgimgui_args_alloc_shader_t {
     sg_shader result;
-} sg_imgui_args_alloc_shader_t;
+} sgimgui_args_alloc_shader_t;
 
-typedef struct sg_imgui_args_alloc_pipeline_t {
+typedef struct sgimgui_args_alloc_pipeline_t {
     sg_pipeline result;
-} sg_imgui_args_alloc_pipeline_t;
+} sgimgui_args_alloc_pipeline_t;
 
-typedef struct sg_imgui_args_alloc_pass_t {
-    sg_pass result;
-} sg_imgui_args_alloc_pass_t;
+typedef struct sgimgui_args_alloc_attachments_t {
+    sg_attachments result;
+} sgimgui_args_alloc_attachments_t;
 
-typedef struct sg_imgui_args_dealloc_buffer_t {
+typedef struct sgimgui_args_dealloc_buffer_t {
     sg_buffer buffer;
-} sg_imgui_args_dealloc_buffer_t;
+} sgimgui_args_dealloc_buffer_t;
 
-typedef struct sg_imgui_args_dealloc_image_t {
+typedef struct sgimgui_args_dealloc_image_t {
     sg_image image;
-} sg_imgui_args_dealloc_image_t;
+} sgimgui_args_dealloc_image_t;
 
-typedef struct sg_imgui_args_dealloc_sampler_t {
+typedef struct sgimgui_args_dealloc_sampler_t {
     sg_sampler sampler;
-} sg_imgui_args_dealloc_sampler_t;
+} sgimgui_args_dealloc_sampler_t;
 
-typedef struct sg_imgui_args_dealloc_shader_t {
+typedef struct sgimgui_args_dealloc_shader_t {
     sg_shader shader;
-} sg_imgui_args_dealloc_shader_t;
+} sgimgui_args_dealloc_shader_t;
 
-typedef struct sg_imgui_args_dealloc_pipeline_t {
+typedef struct sgimgui_args_dealloc_pipeline_t {
     sg_pipeline pipeline;
-} sg_imgui_args_dealloc_pipeline_t;
+} sgimgui_args_dealloc_pipeline_t;
 
-typedef struct sg_imgui_args_dealloc_pass_t {
-    sg_pass pass;
-} sg_imgui_args_dealloc_pass_t;
+typedef struct sgimgui_args_dealloc_attachments_t {
+    sg_attachments attachments;
+} sgimgui_args_dealloc_attachments_t;
 
-typedef struct sg_imgui_args_init_buffer_t {
+typedef struct sgimgui_args_init_buffer_t {
     sg_buffer buffer;
-} sg_imgui_args_init_buffer_t;
+} sgimgui_args_init_buffer_t;
 
-typedef struct sg_imgui_args_init_image_t {
+typedef struct sgimgui_args_init_image_t {
     sg_image image;
-} sg_imgui_args_init_image_t;
+} sgimgui_args_init_image_t;
 
-typedef struct sg_imgui_args_init_sampler_t {
+typedef struct sgimgui_args_init_sampler_t {
     sg_sampler sampler;
-} sg_imgui_args_init_sampler_t;
+} sgimgui_args_init_sampler_t;
 
-typedef struct sg_imgui_args_init_shader_t {
+typedef struct sgimgui_args_init_shader_t {
     sg_shader shader;
-} sg_imgui_args_init_shader_t;
+} sgimgui_args_init_shader_t;
 
-typedef struct sg_imgui_args_init_pipeline_t {
+typedef struct sgimgui_args_init_pipeline_t {
     sg_pipeline pipeline;
-} sg_imgui_args_init_pipeline_t;
+} sgimgui_args_init_pipeline_t;
 
-typedef struct sg_imgui_args_init_pass_t {
-    sg_pass pass;
-} sg_imgui_args_init_pass_t;
+typedef struct sgimgui_args_init_attachments_t {
+    sg_attachments attachments;
+} sgimgui_args_init_attachments_t;
 
-typedef struct sg_imgui_args_uninit_buffer_t {
+typedef struct sgimgui_args_uninit_buffer_t {
     sg_buffer buffer;
-} sg_imgui_args_uninit_buffer_t;
+} sgimgui_args_uninit_buffer_t;
 
-typedef struct sg_imgui_args_uninit_image_t {
+typedef struct sgimgui_args_uninit_image_t {
     sg_image image;
-} sg_imgui_args_uninit_image_t;
+} sgimgui_args_uninit_image_t;
 
-typedef struct sg_imgui_args_uninit_sampler_t {
+typedef struct sgimgui_args_uninit_sampler_t {
     sg_sampler sampler;
-} sg_imgui_args_uninit_sampler_t;
+} sgimgui_args_uninit_sampler_t;
 
-typedef struct sg_imgui_args_uninit_shader_t {
+typedef struct sgimgui_args_uninit_shader_t {
     sg_shader shader;
-} sg_imgui_args_uninit_shader_t;
+} sgimgui_args_uninit_shader_t;
 
-typedef struct sg_imgui_args_uninit_pipeline_t {
+typedef struct sgimgui_args_uninit_pipeline_t {
     sg_pipeline pipeline;
-} sg_imgui_args_uninit_pipeline_t;
+} sgimgui_args_uninit_pipeline_t;
 
-typedef struct sg_imgui_args_uninit_pass_t {
-    sg_pass pass;
-} sg_imgui_args_uninit_pass_t;
+typedef struct sgimgui_args_uninit_attachments_t {
+    sg_attachments attachments;
+} sgimgui_args_uninit_attachments_t;
 
-typedef struct sg_imgui_args_fail_buffer_t {
+typedef struct sgimgui_args_fail_buffer_t {
     sg_buffer buffer;
-} sg_imgui_args_fail_buffer_t;
+} sgimgui_args_fail_buffer_t;
 
-typedef struct sg_imgui_args_fail_image_t {
+typedef struct sgimgui_args_fail_image_t {
     sg_image image;
-} sg_imgui_args_fail_image_t;
+} sgimgui_args_fail_image_t;
 
-typedef struct sg_imgui_args_fail_sampler_t {
+typedef struct sgimgui_args_fail_sampler_t {
     sg_sampler sampler;
-} sg_imgui_args_fail_sampler_t;
+} sgimgui_args_fail_sampler_t;
 
-typedef struct sg_imgui_args_fail_shader_t {
+typedef struct sgimgui_args_fail_shader_t {
     sg_shader shader;
-} sg_imgui_args_fail_shader_t;
+} sgimgui_args_fail_shader_t;
 
-typedef struct sg_imgui_args_fail_pipeline_t {
+typedef struct sgimgui_args_fail_pipeline_t {
     sg_pipeline pipeline;
-} sg_imgui_args_fail_pipeline_t;
+} sgimgui_args_fail_pipeline_t;
 
-typedef struct sg_imgui_args_fail_pass_t {
-    sg_pass pass;
-} sg_imgui_args_fail_pass_t;
+typedef struct sgimgui_args_fail_attachments_t {
+    sg_attachments attachments;
+} sgimgui_args_fail_attachments_t;
 
-typedef struct sg_imgui_args_push_debug_group_t {
-    sg_imgui_str_t name;
-} sg_imgui_args_push_debug_group_t;
+typedef struct sgimgui_args_push_debug_group_t {
+    sgimgui_str_t name;
+} sgimgui_args_push_debug_group_t;
 
-typedef union sg_imgui_args_t {
-    sg_imgui_args_make_buffer_t make_buffer;
-    sg_imgui_args_make_image_t make_image;
-    sg_imgui_args_make_sampler_t make_sampler;
-    sg_imgui_args_make_shader_t make_shader;
-    sg_imgui_args_make_pipeline_t make_pipeline;
-    sg_imgui_args_make_pass_t make_pass;
-    sg_imgui_args_destroy_buffer_t destroy_buffer;
-    sg_imgui_args_destroy_image_t destroy_image;
-    sg_imgui_args_destroy_sampler_t destroy_sampler;
-    sg_imgui_args_destroy_shader_t destroy_shader;
-    sg_imgui_args_destroy_pipeline_t destroy_pipeline;
-    sg_imgui_args_destroy_pass_t destroy_pass;
-    sg_imgui_args_update_buffer_t update_buffer;
-    sg_imgui_args_update_image_t update_image;
-    sg_imgui_args_append_buffer_t append_buffer;
-    sg_imgui_args_begin_default_pass_t begin_default_pass;
-    sg_imgui_args_begin_pass_t begin_pass;
-    sg_imgui_args_apply_viewport_t apply_viewport;
-    sg_imgui_args_apply_scissor_rect_t apply_scissor_rect;
-    sg_imgui_args_apply_pipeline_t apply_pipeline;
-    sg_imgui_args_apply_bindings_t apply_bindings;
-    sg_imgui_args_apply_uniforms_t apply_uniforms;
-    sg_imgui_args_draw_t draw;
-    sg_imgui_args_alloc_buffer_t alloc_buffer;
-    sg_imgui_args_alloc_image_t alloc_image;
-    sg_imgui_args_alloc_sampler_t alloc_sampler;
-    sg_imgui_args_alloc_shader_t alloc_shader;
-    sg_imgui_args_alloc_pipeline_t alloc_pipeline;
-    sg_imgui_args_alloc_pass_t alloc_pass;
-    sg_imgui_args_dealloc_buffer_t dealloc_buffer;
-    sg_imgui_args_dealloc_image_t dealloc_image;
-    sg_imgui_args_dealloc_sampler_t dealloc_sampler;
-    sg_imgui_args_dealloc_shader_t dealloc_shader;
-    sg_imgui_args_dealloc_pipeline_t dealloc_pipeline;
-    sg_imgui_args_dealloc_pass_t dealloc_pass;
-    sg_imgui_args_init_buffer_t init_buffer;
-    sg_imgui_args_init_image_t init_image;
-    sg_imgui_args_init_sampler_t init_sampler;
-    sg_imgui_args_init_shader_t init_shader;
-    sg_imgui_args_init_pipeline_t init_pipeline;
-    sg_imgui_args_init_pass_t init_pass;
-    sg_imgui_args_uninit_buffer_t uninit_buffer;
-    sg_imgui_args_uninit_image_t uninit_image;
-    sg_imgui_args_uninit_sampler_t uninit_sampler;
-    sg_imgui_args_uninit_shader_t uninit_shader;
-    sg_imgui_args_uninit_pipeline_t uninit_pipeline;
-    sg_imgui_args_uninit_pass_t uninit_pass;
-    sg_imgui_args_fail_buffer_t fail_buffer;
-    sg_imgui_args_fail_image_t fail_image;
-    sg_imgui_args_fail_sampler_t fail_sampler;
-    sg_imgui_args_fail_shader_t fail_shader;
-    sg_imgui_args_fail_pipeline_t fail_pipeline;
-    sg_imgui_args_fail_pass_t fail_pass;
-    sg_imgui_args_push_debug_group_t push_debug_group;
-} sg_imgui_args_t;
+typedef union sgimgui_args_t {
+    sgimgui_args_make_buffer_t make_buffer;
+    sgimgui_args_make_image_t make_image;
+    sgimgui_args_make_sampler_t make_sampler;
+    sgimgui_args_make_shader_t make_shader;
+    sgimgui_args_make_pipeline_t make_pipeline;
+    sgimgui_args_make_attachments_t make_attachments;
+    sgimgui_args_destroy_buffer_t destroy_buffer;
+    sgimgui_args_destroy_image_t destroy_image;
+    sgimgui_args_destroy_sampler_t destroy_sampler;
+    sgimgui_args_destroy_shader_t destroy_shader;
+    sgimgui_args_destroy_pipeline_t destroy_pipeline;
+    sgimgui_args_destroy_attachments_t destroy_attachments;
+    sgimgui_args_update_buffer_t update_buffer;
+    sgimgui_args_update_image_t update_image;
+    sgimgui_args_append_buffer_t append_buffer;
+    sgimgui_args_begin_pass_t begin_pass;
+    sgimgui_args_apply_viewport_t apply_viewport;
+    sgimgui_args_apply_scissor_rect_t apply_scissor_rect;
+    sgimgui_args_apply_pipeline_t apply_pipeline;
+    sgimgui_args_apply_bindings_t apply_bindings;
+    sgimgui_args_apply_uniforms_t apply_uniforms;
+    sgimgui_args_draw_t draw;
+    sgimgui_args_alloc_buffer_t alloc_buffer;
+    sgimgui_args_alloc_image_t alloc_image;
+    sgimgui_args_alloc_sampler_t alloc_sampler;
+    sgimgui_args_alloc_shader_t alloc_shader;
+    sgimgui_args_alloc_pipeline_t alloc_pipeline;
+    sgimgui_args_alloc_attachments_t alloc_attachments;
+    sgimgui_args_dealloc_buffer_t dealloc_buffer;
+    sgimgui_args_dealloc_image_t dealloc_image;
+    sgimgui_args_dealloc_sampler_t dealloc_sampler;
+    sgimgui_args_dealloc_shader_t dealloc_shader;
+    sgimgui_args_dealloc_pipeline_t dealloc_pipeline;
+    sgimgui_args_dealloc_attachments_t dealloc_attachments;
+    sgimgui_args_init_buffer_t init_buffer;
+    sgimgui_args_init_image_t init_image;
+    sgimgui_args_init_sampler_t init_sampler;
+    sgimgui_args_init_shader_t init_shader;
+    sgimgui_args_init_pipeline_t init_pipeline;
+    sgimgui_args_init_attachments_t init_attachments;
+    sgimgui_args_uninit_buffer_t uninit_buffer;
+    sgimgui_args_uninit_image_t uninit_image;
+    sgimgui_args_uninit_sampler_t uninit_sampler;
+    sgimgui_args_uninit_shader_t uninit_shader;
+    sgimgui_args_uninit_pipeline_t uninit_pipeline;
+    sgimgui_args_uninit_attachments_t uninit_attachments;
+    sgimgui_args_fail_buffer_t fail_buffer;
+    sgimgui_args_fail_image_t fail_image;
+    sgimgui_args_fail_sampler_t fail_sampler;
+    sgimgui_args_fail_shader_t fail_shader;
+    sgimgui_args_fail_pipeline_t fail_pipeline;
+    sgimgui_args_fail_attachments_t fail_attachments;
+    sgimgui_args_push_debug_group_t push_debug_group;
+} sgimgui_args_t;
 
-typedef struct sg_imgui_capture_item_t {
-    sg_imgui_cmd_t cmd;
+typedef struct sgimgui_capture_item_t {
+    sgimgui_cmd_t cmd;
     uint32_t color;
-    sg_imgui_args_t args;
-} sg_imgui_capture_item_t;
+    sgimgui_args_t args;
+} sgimgui_capture_item_t;
 
-typedef struct sg_imgui_capture_bucket_t {
+typedef struct sgimgui_capture_bucket_t {
     size_t ubuf_size;       /* size of uniform capture buffer in bytes */
     size_t ubuf_pos;        /* current uniform buffer pos */
     uint8_t* ubuf;          /* buffer for capturing uniform updates */
     int num_items;
-    sg_imgui_capture_item_t items[SG_IMGUI_MAX_FRAMECAPTURE_ITEMS];
-} sg_imgui_capture_bucket_t;
+    sgimgui_capture_item_t items[sgimgui_MAX_FRAMECAPTURE_ITEMS];
+} sgimgui_capture_bucket_t;
 
 /* double-buffered call-capture buckets, one bucket is currently recorded,
    the previous bucket is displayed
 */
-typedef struct sg_imgui_capture_t {
+typedef struct sgimgui_capture_window_t {
     bool open;
     int bucket_index;      /* which bucket to record to, 0 or 1 */
     int sel_item;          /* currently selected capture item by index */
-    sg_imgui_capture_bucket_t bucket[2];
-} sg_imgui_capture_t;
+    sgimgui_capture_bucket_t bucket[2];
+} sgimgui_capture_window_t;
 
-typedef struct sg_imgui_caps_t {
+typedef struct sgimgui_caps_window_t {
     bool open;
-} sg_imgui_caps_t;
+} sgimgui_caps_window_t;
 
-typedef struct sg_imgui_frame_stats_t {
+typedef struct sgimgui_frame_stats_window_t {
     bool open;
     bool disable_sokol_imgui_stats;
     bool in_sokol_imgui;
     sg_frame_stats stats;
     // FIXME: add a ringbuffer for a stats history here
-} sg_imgui_frame_stats_t;
+} sgimgui_frame_stats_window_t;
 
 /*
-    sg_imgui_allocator_t
+    sgimgui_allocator_t
 
-    Used in sg_imgui_desc_t to provide custom memory-alloc and -free functions
+    Used in sgimgui_desc_t to provide custom memory-alloc and -free functions
     to sokol_gfx_imgui.h. If memory management should be overridden, both the
     alloc and free function must be provided (e.g. it's not valid to
     override one function but not the other).
 */
-typedef struct sg_imgui_allocator_t {
+typedef struct sgimgui_allocator_t {
     void* (*alloc_fn)(size_t size, void* user_data);
     void (*free_fn)(void* ptr, void* user_data);
     void* user_data;
-} sg_imgui_allocator_t;
+} sgimgui_allocator_t;
 
 /*
-    sg_imgui_desc_t
+    sgimgui_desc_t
 
-    Initialization options for sg_imgui_init().
+    Initialization options for sgimgui_init().
 */
-typedef struct sg_imgui_desc_t {
-    sg_imgui_allocator_t allocator; // optional memory allocation overrides (default: malloc/free)
-} sg_imgui_desc_t;
+typedef struct sgimgui_desc_t {
+    sgimgui_allocator_t allocator; // optional memory allocation overrides (default: malloc/free)
+} sgimgui_desc_t;
 
-typedef struct sg_imgui_t {
+typedef struct sgimgui_t {
     uint32_t init_tag;
-    sg_imgui_desc_t desc;
-    sg_imgui_buffers_t buffers;
-    sg_imgui_images_t images;
-    sg_imgui_samplers_t samplers;
-    sg_imgui_shaders_t shaders;
-    sg_imgui_pipelines_t pipelines;
-    sg_imgui_passes_t passes;
-    sg_imgui_capture_t capture;
-    sg_imgui_caps_t caps;
-    sg_imgui_frame_stats_t frame_stats;
+    sgimgui_desc_t desc;
+    sgimgui_buffer_window_t buffer_window;
+    sgimgui_image_window_t image_window;
+    sgimgui_sampler_window_t sampler_window;
+    sgimgui_shader_window_t shader_window;
+    sgimgui_pipeline_window_t pipeline_window;
+    sgimgui_attachments_window_t attachments_window;
+    sgimgui_capture_window_t capture_window;
+    sgimgui_caps_window_t caps_window;
+    sgimgui_frame_stats_window_t frame_stats_window;
     sg_pipeline cur_pipeline;
     sg_trace_hooks hooks;
-} sg_imgui_t;
+} sgimgui_t;
 
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_init(sg_imgui_t* ctx, const sg_imgui_desc_t* desc);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_discard(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_init(sgimgui_t* ctx, const sgimgui_desc_t* desc);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_discard(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw(sgimgui_t* ctx);
 
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_menu(sg_imgui_t* ctx, const char* title);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_menu(sgimgui_t* ctx, const char* title);
 
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_buffers_content(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_images_content(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_samplers_content(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_shaders_content(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_pipelines_content(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_passes_content(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_capture_content(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_capabilities_content(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_frame_stats_content(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_buffer_window_content(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_image_window_content(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_sampler_window_content(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_shader_window_content(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_pipeline_window_content(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_attachments_window_content(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_capture_window_content(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_capabilities_window_content(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_frame_stats_window_content(sgimgui_t* ctx);
 
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_buffers_window(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_images_window(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_samplers_window(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_shaders_window(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_pipelines_window(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_passes_window(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_capture_window(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_capabilities_window(sg_imgui_t* ctx);
-SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_frame_stats_window(sg_imgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_buffer_window(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_image_window(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_sampler_window(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_shader_window(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_pipeline_window(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_attachments_window(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_capture_window(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_capabilities_window(sgimgui_t* ctx);
+SOKOL_GFX_IMGUI_API_DECL void sgimgui_draw_frame_stats_window(sgimgui_t* ctx);
 
 #if defined(__cplusplus)
 } /* extern "C" */
@@ -802,7 +793,7 @@ SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_frame_stats_window(sg_imgui_t* ctx);
 #define SOKOL_GFX_IMGUI_IMPL_INCLUDED (1)
 
 #if defined(SOKOL_MALLOC) || defined(SOKOL_CALLOC) || defined(SOKOL_FREE)
-#error "SOKOL_MALLOC/CALLOC/FREE macros are no longer supported, please use sg_imgui_desc_t.allocator to override memory allocation functions"
+#error "SOKOL_MALLOC/CALLOC/FREE macros are no longer supported, please use sgimgui_desc_t.allocator to override memory allocation functions"
 #endif
 
 #if defined(__cplusplus)
@@ -839,14 +830,14 @@ SOKOL_GFX_IMGUI_API_DECL void sg_imgui_draw_frame_stats_window(sg_imgui_t* ctx);
 #include <stdio.h>      // snprintf
 #include <stdlib.h>     // malloc, free
 
-#define _SG_IMGUI_SLOT_MASK (0xFFFF)
-#define _SG_IMGUI_LIST_WIDTH (192)
-#define _SG_IMGUI_COLOR_OTHER 0xFFCCCCCC
-#define _SG_IMGUI_COLOR_RSRC 0xFF00FFFF
-#define _SG_IMGUI_COLOR_PASS 0xFFFFFF00
-#define _SG_IMGUI_COLOR_APPLY 0xFFCCCC00
-#define _SG_IMGUI_COLOR_DRAW 0xFF00FF00
-#define _SG_IMGUI_COLOR_ERR 0xFF8888FF
+#define _SGIMGUI_SLOT_MASK (0xFFFF)
+#define _SGIMGUI_LIST_WIDTH (192)
+#define _SGIMGUI_COLOR_OTHER 0xFFCCCCCC
+#define _SGIMGUI_COLOR_RSRC 0xFF00FFFF
+#define _SGIMGUI_COLOR_PASS 0xFFFFFF00
+#define _SGIMGUI_COLOR_APPLY 0xFFCCCC00
+#define _SGIMGUI_COLOR_DRAW 0xFF00FF00
+#define _SGIMGUI_COLOR_ERR 0xFF8888FF
 
 /*--- C => C++ layer ---------------------------------------------------------*/
 #if defined(__cplusplus)
@@ -964,12 +955,12 @@ _SOKOL_PRIVATE bool igCheckbox(const char* label, bool* v) {
 #endif
 
 /*--- UTILS ------------------------------------------------------------------*/
-_SOKOL_PRIVATE void _sg_imgui_clear(void* ptr, size_t size) {
+_SOKOL_PRIVATE void _sgimgui_clear(void* ptr, size_t size) {
     SOKOL_ASSERT(ptr && (size > 0));
     memset(ptr, 0, size);
 }
 
-_SOKOL_PRIVATE void* _sg_imgui_malloc(const sg_imgui_allocator_t* allocator, size_t size) {
+_SOKOL_PRIVATE void* _sgimgui_malloc(const sgimgui_allocator_t* allocator, size_t size) {
     SOKOL_ASSERT(allocator && (size > 0));
     void* ptr;
     if (allocator->alloc_fn) {
@@ -981,13 +972,13 @@ _SOKOL_PRIVATE void* _sg_imgui_malloc(const sg_imgui_allocator_t* allocator, siz
     return ptr;
 }
 
-_SOKOL_PRIVATE void* _sg_imgui_malloc_clear(const sg_imgui_allocator_t* allocator, size_t size) {
-    void* ptr = _sg_imgui_malloc(allocator, size);
-    _sg_imgui_clear(ptr, size);
+_SOKOL_PRIVATE void* _sgimgui_malloc_clear(const sgimgui_allocator_t* allocator, size_t size) {
+    void* ptr = _sgimgui_malloc(allocator, size);
+    _sgimgui_clear(ptr, size);
     return ptr;
 }
 
-_SOKOL_PRIVATE void _sg_imgui_free(const sg_imgui_allocator_t* allocator, void* ptr) {
+_SOKOL_PRIVATE void _sgimgui_free(const sgimgui_allocator_t* allocator, void* ptr) {
     SOKOL_ASSERT(allocator);
     if (allocator->free_fn) {
         allocator->free_fn(ptr, allocator->user_data);
@@ -996,30 +987,30 @@ _SOKOL_PRIVATE void _sg_imgui_free(const sg_imgui_allocator_t* allocator, void* 
     }
 }
 
- _SOKOL_PRIVATE void* _sg_imgui_realloc(const sg_imgui_allocator_t* allocator, void* old_ptr, size_t old_size, size_t new_size) {
+ _SOKOL_PRIVATE void* _sgimgui_realloc(const sgimgui_allocator_t* allocator, void* old_ptr, size_t old_size, size_t new_size) {
     SOKOL_ASSERT(allocator && (new_size > 0) && (new_size > old_size));
-    void* new_ptr = _sg_imgui_malloc(allocator, new_size);
+    void* new_ptr = _sgimgui_malloc(allocator, new_size);
     if (old_ptr) {
         if (old_size > 0) {
             memcpy(new_ptr, old_ptr, old_size);
         }
-        _sg_imgui_free(allocator, old_ptr);
+        _sgimgui_free(allocator, old_ptr);
     }
     return new_ptr;
 }
 
-_SOKOL_PRIVATE int _sg_imgui_slot_index(uint32_t id) {
-    int slot_index = (int) (id & _SG_IMGUI_SLOT_MASK);
+_SOKOL_PRIVATE int _sgimgui_slot_index(uint32_t id) {
+    int slot_index = (int) (id & _SGIMGUI_SLOT_MASK);
     SOKOL_ASSERT(0 != slot_index);
     return slot_index;
 }
 
-_SOKOL_PRIVATE uint32_t _sg_imgui_align_u32(uint32_t val, uint32_t align) {
+_SOKOL_PRIVATE uint32_t _sgimgui_align_u32(uint32_t val, uint32_t align) {
     SOKOL_ASSERT((align > 0) && ((align & (align - 1)) == 0));
     return (val + (align - 1)) & ~(align - 1);
 }
 
-_SOKOL_PRIVATE uint32_t _sg_imgui_std140_uniform_alignment(sg_uniform_type type, int array_count) {
+_SOKOL_PRIVATE uint32_t _sgimgui_std140_uniform_alignment(sg_uniform_type type, int array_count) {
     SOKOL_ASSERT(array_count > 0);
     if (array_count == 1) {
         switch (type) {
@@ -1045,7 +1036,7 @@ _SOKOL_PRIVATE uint32_t _sg_imgui_std140_uniform_alignment(sg_uniform_type type,
     }
 }
 
-_SOKOL_PRIVATE uint32_t _sg_imgui_std140_uniform_size(sg_uniform_type type, int array_count) {
+_SOKOL_PRIVATE uint32_t _sgimgui_std140_uniform_size(sg_uniform_type type, int array_count) {
     SOKOL_ASSERT(array_count > 0);
     if (array_count == 1) {
         switch (type) {
@@ -1087,42 +1078,42 @@ _SOKOL_PRIVATE uint32_t _sg_imgui_std140_uniform_size(sg_uniform_type type, int 
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_strcpy(sg_imgui_str_t* dst, const char* src) {
+_SOKOL_PRIVATE void _sgimgui_strcpy(sgimgui_str_t* dst, const char* src) {
     SOKOL_ASSERT(dst);
     if (src) {
         #if defined(_MSC_VER)
-        strncpy_s(dst->buf, SG_IMGUI_STRBUF_LEN, src, (SG_IMGUI_STRBUF_LEN-1));
+        strncpy_s(dst->buf, sgimgui_STRBUF_LEN, src, (sgimgui_STRBUF_LEN-1));
         #else
-        strncpy(dst->buf, src, SG_IMGUI_STRBUF_LEN);
+        strncpy(dst->buf, src, sgimgui_STRBUF_LEN);
         #endif
-        dst->buf[SG_IMGUI_STRBUF_LEN-1] = 0;
+        dst->buf[sgimgui_STRBUF_LEN-1] = 0;
     } else {
-        _sg_imgui_clear(dst->buf, SG_IMGUI_STRBUF_LEN);
+        _sgimgui_clear(dst->buf, sgimgui_STRBUF_LEN);
     }
 }
 
-_SOKOL_PRIVATE sg_imgui_str_t _sg_imgui_make_str(const char* str) {
-    sg_imgui_str_t res;
-    _sg_imgui_strcpy(&res, str);
+_SOKOL_PRIVATE sgimgui_str_t _sgimgui_make_str(const char* str) {
+    sgimgui_str_t res;
+    _sgimgui_strcpy(&res, str);
     return res;
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_str_dup(const sg_imgui_allocator_t* allocator, const char* src) {
+_SOKOL_PRIVATE const char* _sgimgui_str_dup(const sgimgui_allocator_t* allocator, const char* src) {
     SOKOL_ASSERT(allocator && src);
     size_t len = strlen(src) + 1;
-    char* dst = (char*) _sg_imgui_malloc(allocator, len);
+    char* dst = (char*) _sgimgui_malloc(allocator, len);
     memcpy(dst, src, len);
     return (const char*) dst;
 }
 
-_SOKOL_PRIVATE const void* _sg_imgui_bin_dup(const sg_imgui_allocator_t* allocator, const void* src, size_t num_bytes) {
+_SOKOL_PRIVATE const void* _sgimgui_bin_dup(const sgimgui_allocator_t* allocator, const void* src, size_t num_bytes) {
     SOKOL_ASSERT(allocator && src && (num_bytes > 0));
-    void* dst = _sg_imgui_malloc(allocator, num_bytes);
+    void* dst = _sgimgui_malloc(allocator, num_bytes);
     memcpy(dst, src, num_bytes);
     return (const void*) dst;
 }
 
-_SOKOL_PRIVATE void _sg_imgui_snprintf(sg_imgui_str_t* dst, const char* fmt, ...) {
+_SOKOL_PRIVATE void _sgimgui_snprintf(sgimgui_str_t* dst, const char* fmt, ...) {
     SOKOL_ASSERT(dst);
     va_list args;
     va_start(args, fmt);
@@ -1132,7 +1123,7 @@ _SOKOL_PRIVATE void _sg_imgui_snprintf(sg_imgui_str_t* dst, const char* fmt, ...
 }
 
 /*--- STRING CONVERSION ------------------------------------------------------*/
-_SOKOL_PRIVATE const char* _sg_imgui_resourcestate_string(sg_resource_state s) {
+_SOKOL_PRIVATE const char* _sgimgui_resourcestate_string(sg_resource_state s) {
     switch (s) {
         case SG_RESOURCESTATE_INITIAL:  return "SG_RESOURCESTATE_INITIAL";
         case SG_RESOURCESTATE_ALLOC:    return "SG_RESOURCESTATE_ALLOC";
@@ -1142,12 +1133,12 @@ _SOKOL_PRIVATE const char* _sg_imgui_resourcestate_string(sg_resource_state s) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_resource_slot(const sg_slot_info* slot) {
+_SOKOL_PRIVATE void _sgimgui_draw_resource_slot(const sg_slot_info* slot) {
     igText("ResId: %08X", slot->res_id);
-    igText("State: %s", _sg_imgui_resourcestate_string(slot->state));
+    igText("State: %s", _sgimgui_resourcestate_string(slot->state));
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_backend_string(sg_backend b) {
+_SOKOL_PRIVATE const char* _sgimgui_backend_string(sg_backend b) {
     switch (b) {
         case SG_BACKEND_GLCORE33:           return "SG_BACKEND_GLCORE33";
         case SG_BACKEND_GLES3:              return "SG_BACKEND_GLES3";
@@ -1161,7 +1152,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_backend_string(sg_backend b) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_buffertype_string(sg_buffer_type t) {
+_SOKOL_PRIVATE const char* _sgimgui_buffertype_string(sg_buffer_type t) {
     switch (t) {
         case SG_BUFFERTYPE_VERTEXBUFFER:    return "SG_BUFFERTYPE_VERTEXBUFFER";
         case SG_BUFFERTYPE_INDEXBUFFER:     return "SG_BUFFERTYPE_INDEXBUFFER";
@@ -1169,7 +1160,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_buffertype_string(sg_buffer_type t) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_usage_string(sg_usage u) {
+_SOKOL_PRIVATE const char* _sgimgui_usage_string(sg_usage u) {
     switch (u) {
         case SG_USAGE_IMMUTABLE:    return "SG_USAGE_IMMUTABLE";
         case SG_USAGE_DYNAMIC:      return "SG_USAGE_DYNAMIC";
@@ -1178,7 +1169,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_usage_string(sg_usage u) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_imagetype_string(sg_image_type t) {
+_SOKOL_PRIVATE const char* _sgimgui_imagetype_string(sg_image_type t) {
     switch (t) {
         case SG_IMAGETYPE_2D:       return "SG_IMAGETYPE_2D";
         case SG_IMAGETYPE_CUBE:     return "SG_IMAGETYPE_CUBE";
@@ -1188,7 +1179,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_imagetype_string(sg_image_type t) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_imagesampletype_string(sg_image_sample_type t) {
+_SOKOL_PRIVATE const char* _sgimgui_imagesampletype_string(sg_image_sample_type t) {
     switch (t) {
         case SG_IMAGESAMPLETYPE_FLOAT:  return "SG_IMAGESAMPLETYPE_FLOAT";
         case SG_IMAGESAMPLETYPE_DEPTH:  return "SG_IMAGESAMPLETYPE_DEPTH";
@@ -1199,7 +1190,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_imagesampletype_string(sg_image_sample_type
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_samplertype_string(sg_sampler_type t) {
+_SOKOL_PRIVATE const char* _sgimgui_samplertype_string(sg_sampler_type t) {
     switch (t) {
         case SG_SAMPLERTYPE_FILTERING:      return "SG_SAMPLERTYPE_FILTERING";
         case SG_SAMPLERTYPE_COMPARISON:     return "SG_SAMPLERTYPE_COMPARISON";
@@ -1208,7 +1199,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_samplertype_string(sg_sampler_type t) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_uniformlayout_string(sg_uniform_layout l) {
+_SOKOL_PRIVATE const char* _sgimgui_uniformlayout_string(sg_uniform_layout l) {
     switch (l) {
         case SG_UNIFORMLAYOUT_NATIVE:   return "SG_UNIFORMLAYOUT_NATIVE";
         case SG_UNIFORMLAYOUT_STD140:   return "SG_UNIFORMLAYOUT_STD140";
@@ -1216,7 +1207,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_uniformlayout_string(sg_uniform_layout l) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_pixelformat_string(sg_pixel_format fmt) {
+_SOKOL_PRIVATE const char* _sgimgui_pixelformat_string(sg_pixel_format fmt) {
     switch (fmt) {
         case SG_PIXELFORMAT_NONE: return "SG_PIXELFORMAT_NONE";
         case SG_PIXELFORMAT_R8: return "SG_PIXELFORMAT_R8";
@@ -1291,7 +1282,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_pixelformat_string(sg_pixel_format fmt) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_filter_string(sg_filter f) {
+_SOKOL_PRIVATE const char* _sgimgui_filter_string(sg_filter f) {
     switch (f) {
         case SG_FILTER_NONE:    return "SG_FILTER_NONE";
         case SG_FILTER_NEAREST: return "SG_FILTER_NEAREST";
@@ -1300,7 +1291,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_filter_string(sg_filter f) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_wrap_string(sg_wrap w) {
+_SOKOL_PRIVATE const char* _sgimgui_wrap_string(sg_wrap w) {
     switch (w) {
         case SG_WRAP_REPEAT:            return "SG_WRAP_REPEAT";
         case SG_WRAP_CLAMP_TO_EDGE:     return "SG_WRAP_CLAMP_TO_EDGE";
@@ -1310,7 +1301,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_wrap_string(sg_wrap w) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_bordercolor_string(sg_border_color bc) {
+_SOKOL_PRIVATE const char* _sgimgui_bordercolor_string(sg_border_color bc) {
     switch (bc) {
         case SG_BORDERCOLOR_TRANSPARENT_BLACK:  return "SG_BORDERCOLOR_TRANSPARENT_BLACK";
         case SG_BORDERCOLOR_OPAQUE_BLACK:       return "SG_BORDERCOLOR_OPAQUE_BLACK";
@@ -1319,7 +1310,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_bordercolor_string(sg_border_color bc) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_uniformtype_string(sg_uniform_type t) {
+_SOKOL_PRIVATE const char* _sgimgui_uniformtype_string(sg_uniform_type t) {
     switch (t) {
         case SG_UNIFORMTYPE_FLOAT:  return "SG_UNIFORMTYPE_FLOAT";
         case SG_UNIFORMTYPE_FLOAT2: return "SG_UNIFORMTYPE_FLOAT2";
@@ -1334,7 +1325,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_uniformtype_string(sg_uniform_type t) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_vertexstep_string(sg_vertex_step s) {
+_SOKOL_PRIVATE const char* _sgimgui_vertexstep_string(sg_vertex_step s) {
     switch (s) {
         case SG_VERTEXSTEP_PER_VERTEX:      return "SG_VERTEXSTEP_PER_VERTEX";
         case SG_VERTEXSTEP_PER_INSTANCE:    return "SG_VERTEXSTEP_PER_INSTANCE";
@@ -1342,7 +1333,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_vertexstep_string(sg_vertex_step s) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_vertexformat_string(sg_vertex_format f) {
+_SOKOL_PRIVATE const char* _sgimgui_vertexformat_string(sg_vertex_format f) {
     switch (f) {
         case SG_VERTEXFORMAT_FLOAT:     return "SG_VERTEXFORMAT_FLOAT";
         case SG_VERTEXFORMAT_FLOAT2:    return "SG_VERTEXFORMAT_FLOAT2";
@@ -1363,7 +1354,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_vertexformat_string(sg_vertex_format f) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_primitivetype_string(sg_primitive_type t) {
+_SOKOL_PRIVATE const char* _sgimgui_primitivetype_string(sg_primitive_type t) {
     switch (t) {
         case SG_PRIMITIVETYPE_POINTS:           return "SG_PRIMITIVETYPE_POINTS";
         case SG_PRIMITIVETYPE_LINES:            return "SG_PRIMITIVETYPE_LINES";
@@ -1374,7 +1365,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_primitivetype_string(sg_primitive_type t) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_indextype_string(sg_index_type t) {
+_SOKOL_PRIVATE const char* _sgimgui_indextype_string(sg_index_type t) {
     switch (t) {
         case SG_INDEXTYPE_NONE:     return "SG_INDEXTYPE_NONE";
         case SG_INDEXTYPE_UINT16:   return "SG_INDEXTYPE_UINT16";
@@ -1383,7 +1374,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_indextype_string(sg_index_type t) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_stencilop_string(sg_stencil_op op) {
+_SOKOL_PRIVATE const char* _sgimgui_stencilop_string(sg_stencil_op op) {
     switch (op) {
         case SG_STENCILOP_KEEP:         return "SG_STENCILOP_KEEP";
         case SG_STENCILOP_ZERO:         return "SG_STENCILOP_ZERO";
@@ -1397,7 +1388,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_stencilop_string(sg_stencil_op op) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_comparefunc_string(sg_compare_func f) {
+_SOKOL_PRIVATE const char* _sgimgui_comparefunc_string(sg_compare_func f) {
     switch (f) {
         case SG_COMPAREFUNC_NEVER:          return "SG_COMPAREFUNC_NEVER";
         case SG_COMPAREFUNC_LESS:           return "SG_COMPAREFUNC_LESS";
@@ -1411,7 +1402,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_comparefunc_string(sg_compare_func f) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_blendfactor_string(sg_blend_factor f) {
+_SOKOL_PRIVATE const char* _sgimgui_blendfactor_string(sg_blend_factor f) {
     switch (f) {
         case SG_BLENDFACTOR_ZERO:                   return "SG_BLENDFACTOR_ZERO";
         case SG_BLENDFACTOR_ONE:                    return "SG_BLENDFACTOR_ONE";
@@ -1432,7 +1423,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_blendfactor_string(sg_blend_factor f) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_blendop_string(sg_blend_op op) {
+_SOKOL_PRIVATE const char* _sgimgui_blendop_string(sg_blend_op op) {
     switch (op) {
         case SG_BLENDOP_ADD:                return "SG_BLENDOP_ADD";
         case SG_BLENDOP_SUBTRACT:           return "SG_BLENDOP_SUBTRACT";
@@ -1441,7 +1432,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_blendop_string(sg_blend_op op) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_colormask_string(sg_color_mask m) {
+_SOKOL_PRIVATE const char* _sgimgui_colormask_string(sg_color_mask m) {
     static const char* str[] = {
         "NONE",
         "R",
@@ -1463,7 +1454,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_colormask_string(sg_color_mask m) {
     return str[m & 0xF];
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_cullmode_string(sg_cull_mode cm) {
+_SOKOL_PRIVATE const char* _sgimgui_cullmode_string(sg_cull_mode cm) {
     switch (cm) {
         case SG_CULLMODE_NONE:  return "SG_CULLMODE_NONE";
         case SG_CULLMODE_FRONT: return "SG_CULLMODE_FRONT";
@@ -1472,7 +1463,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_cullmode_string(sg_cull_mode cm) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_facewinding_string(sg_face_winding fw) {
+_SOKOL_PRIVATE const char* _sgimgui_facewinding_string(sg_face_winding fw) {
     switch (fw) {
         case SG_FACEWINDING_CCW:    return "SG_FACEWINDING_CCW";
         case SG_FACEWINDING_CW:     return "SG_FACEWINDING_CW";
@@ -1480,7 +1471,7 @@ _SOKOL_PRIVATE const char* _sg_imgui_facewinding_string(sg_face_winding fw) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_shaderstage_string(sg_shader_stage stage) {
+_SOKOL_PRIVATE const char* _sgimgui_shaderstage_string(sg_shader_stage stage) {
     switch (stage) {
         case SG_SHADERSTAGE_VS:     return "SG_SHADERSTAGE_VS";
         case SG_SHADERSTAGE_FS:     return "SG_SHADERSTAGE_FS";
@@ -1488,157 +1479,157 @@ _SOKOL_PRIVATE const char* _sg_imgui_shaderstage_string(sg_shader_stage stage) {
     }
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_bool_string(bool b) {
+_SOKOL_PRIVATE const char* _sgimgui_bool_string(bool b) {
     return b ? "true" : "false";
 }
 
-_SOKOL_PRIVATE const char* _sg_imgui_color_string(sg_imgui_str_t* dst_str, sg_color color) {
-    _sg_imgui_snprintf(dst_str, "%.3f %.3f %.3f %.3f", color.r, color.g, color.b, color.a);
+_SOKOL_PRIVATE const char* _sgimgui_color_string(sgimgui_str_t* dst_str, sg_color color) {
+    _sgimgui_snprintf(dst_str, "%.3f %.3f %.3f %.3f", color.r, color.g, color.b, color.a);
     return dst_str->buf;
 }
 
-_SOKOL_PRIVATE sg_imgui_str_t _sg_imgui_res_id_string(uint32_t res_id, const char* label) {
+_SOKOL_PRIVATE sgimgui_str_t _sgimgui_res_id_string(uint32_t res_id, const char* label) {
     SOKOL_ASSERT(label);
-    sg_imgui_str_t res;
+    sgimgui_str_t res;
     if (label[0]) {
-        _sg_imgui_snprintf(&res, "'%s'", label);
+        _sgimgui_snprintf(&res, "'%s'", label);
     } else {
-        _sg_imgui_snprintf(&res, "0x%08X", res_id);
+        _sgimgui_snprintf(&res, "0x%08X", res_id);
     }
     return res;
 }
 
-_SOKOL_PRIVATE sg_imgui_str_t _sg_imgui_buffer_id_string(sg_imgui_t* ctx, sg_buffer buf_id) {
+_SOKOL_PRIVATE sgimgui_str_t _sgimgui_buffer_id_string(sgimgui_t* ctx, sg_buffer buf_id) {
     if (buf_id.id != SG_INVALID_ID) {
-        const sg_imgui_buffer_t* buf_ui = &ctx->buffers.slots[_sg_imgui_slot_index(buf_id.id)];
-        return _sg_imgui_res_id_string(buf_id.id, buf_ui->label.buf);
+        const sgimgui_buffer_t* buf_ui = &ctx->buffer_window.slots[_sgimgui_slot_index(buf_id.id)];
+        return _sgimgui_res_id_string(buf_id.id, buf_ui->label.buf);
     } else {
-        return _sg_imgui_make_str("<invalid>");
+        return _sgimgui_make_str("<invalid>");
     }
 }
 
-_SOKOL_PRIVATE sg_imgui_str_t _sg_imgui_image_id_string(sg_imgui_t* ctx, sg_image img_id) {
+_SOKOL_PRIVATE sgimgui_str_t _sgimgui_image_id_string(sgimgui_t* ctx, sg_image img_id) {
     if (img_id.id != SG_INVALID_ID) {
-        const sg_imgui_image_t* img_ui = &ctx->images.slots[_sg_imgui_slot_index(img_id.id)];
-        return _sg_imgui_res_id_string(img_id.id, img_ui->label.buf);
+        const sgimgui_image_t* img_ui = &ctx->image_window.slots[_sgimgui_slot_index(img_id.id)];
+        return _sgimgui_res_id_string(img_id.id, img_ui->label.buf);
     } else {
-        return _sg_imgui_make_str("<invalid>");
+        return _sgimgui_make_str("<invalid>");
     }
 }
 
-_SOKOL_PRIVATE sg_imgui_str_t _sg_imgui_sampler_id_string(sg_imgui_t* ctx, sg_sampler smp_id) {
+_SOKOL_PRIVATE sgimgui_str_t _sgimgui_sampler_id_string(sgimgui_t* ctx, sg_sampler smp_id) {
     if (smp_id.id != SG_INVALID_ID) {
-        const sg_imgui_sampler_t* smp_ui = &ctx->samplers.slots[_sg_imgui_slot_index(smp_id.id)];
-        return _sg_imgui_res_id_string(smp_id.id, smp_ui->label.buf);
+        const sgimgui_sampler_t* smp_ui = &ctx->sampler_window.slots[_sgimgui_slot_index(smp_id.id)];
+        return _sgimgui_res_id_string(smp_id.id, smp_ui->label.buf);
     } else {
-        return _sg_imgui_make_str("<invalid>");
+        return _sgimgui_make_str("<invalid>");
     }
 }
 
-_SOKOL_PRIVATE sg_imgui_str_t _sg_imgui_shader_id_string(sg_imgui_t* ctx, sg_shader shd_id) {
+_SOKOL_PRIVATE sgimgui_str_t _sgimgui_shader_id_string(sgimgui_t* ctx, sg_shader shd_id) {
     if (shd_id.id != SG_INVALID_ID) {
-        const sg_imgui_shader_t* shd_ui = &ctx->shaders.slots[_sg_imgui_slot_index(shd_id.id)];
-        return _sg_imgui_res_id_string(shd_id.id, shd_ui->label.buf);
+        const sgimgui_shader_t* shd_ui = &ctx->shader_window.slots[_sgimgui_slot_index(shd_id.id)];
+        return _sgimgui_res_id_string(shd_id.id, shd_ui->label.buf);
     } else {
-        return _sg_imgui_make_str("<invalid>");
+        return _sgimgui_make_str("<invalid>");
     }
 }
 
-_SOKOL_PRIVATE sg_imgui_str_t _sg_imgui_pipeline_id_string(sg_imgui_t* ctx, sg_pipeline pip_id) {
+_SOKOL_PRIVATE sgimgui_str_t _sgimgui_pipeline_id_string(sgimgui_t* ctx, sg_pipeline pip_id) {
     if (pip_id.id != SG_INVALID_ID) {
-        const sg_imgui_pipeline_t* pip_ui = &ctx->pipelines.slots[_sg_imgui_slot_index(pip_id.id)];
-        return _sg_imgui_res_id_string(pip_id.id, pip_ui->label.buf);
+        const sgimgui_pipeline_t* pip_ui = &ctx->pipeline_window.slots[_sgimgui_slot_index(pip_id.id)];
+        return _sgimgui_res_id_string(pip_id.id, pip_ui->label.buf);
     } else {
-        return _sg_imgui_make_str("<invalid>");
+        return _sgimgui_make_str("<invalid>");
     }
 }
 
-_SOKOL_PRIVATE sg_imgui_str_t _sg_imgui_pass_id_string(sg_imgui_t* ctx, sg_pass pass_id) {
-    if (pass_id.id != SG_INVALID_ID) {
-        const sg_imgui_pass_t* pass_ui = &ctx->passes.slots[_sg_imgui_slot_index(pass_id.id)];
-        return _sg_imgui_res_id_string(pass_id.id, pass_ui->label.buf);
+_SOKOL_PRIVATE sgimgui_str_t _sgimgui_attachments_id_string(sgimgui_t* ctx, sg_attachments atts_id) {
+    if (atts_id.id != SG_INVALID_ID) {
+        const sgimgui_attachments_t* atts_ui = &ctx->attachments_window.slots[_sgimgui_slot_index(atts_id.id)];
+        return _sgimgui_res_id_string(atts_id.id, atts_ui->label.buf);
     } else {
-        return _sg_imgui_make_str("<invalid>");
+        return _sgimgui_make_str("<invalid>");
     }
 }
 
 /*--- RESOURCE HELPERS -------------------------------------------------------*/
-_SOKOL_PRIVATE void _sg_imgui_buffer_created(sg_imgui_t* ctx, sg_buffer res_id, int slot_index, const sg_buffer_desc* desc) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->buffers.num_slots));
-    sg_imgui_buffer_t* buf = &ctx->buffers.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_buffer_created(sgimgui_t* ctx, sg_buffer res_id, int slot_index, const sg_buffer_desc* desc) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->buffer_window.num_slots));
+    sgimgui_buffer_t* buf = &ctx->buffer_window.slots[slot_index];
     buf->res_id = res_id;
     buf->desc = *desc;
-    buf->label = _sg_imgui_make_str(desc->label);
+    buf->label = _sgimgui_make_str(desc->label);
 }
 
-_SOKOL_PRIVATE void _sg_imgui_buffer_destroyed(sg_imgui_t* ctx, int slot_index) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->buffers.num_slots));
-    sg_imgui_buffer_t* buf = &ctx->buffers.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_buffer_destroyed(sgimgui_t* ctx, int slot_index) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->buffer_window.num_slots));
+    sgimgui_buffer_t* buf = &ctx->buffer_window.slots[slot_index];
     buf->res_id.id = SG_INVALID_ID;
 }
 
-_SOKOL_PRIVATE void _sg_imgui_image_created(sg_imgui_t* ctx, sg_image res_id, int slot_index, const sg_image_desc* desc) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->images.num_slots));
-    sg_imgui_image_t* img = &ctx->images.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_image_created(sgimgui_t* ctx, sg_image res_id, int slot_index, const sg_image_desc* desc) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->image_window.num_slots));
+    sgimgui_image_t* img = &ctx->image_window.slots[slot_index];
     img->res_id = res_id;
     img->desc = *desc;
     img->ui_scale = 1.0f;
-    img->label = _sg_imgui_make_str(desc->label);
+    img->label = _sgimgui_make_str(desc->label);
     simgui_image_desc_t simgui_img_desc;
-    _sg_imgui_clear(&simgui_img_desc, sizeof(simgui_img_desc));
+    _sgimgui_clear(&simgui_img_desc, sizeof(simgui_img_desc));
     simgui_img_desc.image = res_id;
     // keep sampler at default, which will use sokol_imgui.h's default nearest-filtering sampler
     img->simgui_img = simgui_make_image(&simgui_img_desc);
 }
 
-_SOKOL_PRIVATE void _sg_imgui_image_destroyed(sg_imgui_t* ctx, int slot_index) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->images.num_slots));
-    sg_imgui_image_t* img = &ctx->images.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_image_destroyed(sgimgui_t* ctx, int slot_index) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->image_window.num_slots));
+    sgimgui_image_t* img = &ctx->image_window.slots[slot_index];
     img->res_id.id = SG_INVALID_ID;
     simgui_destroy_image(img->simgui_img);
 }
 
-_SOKOL_PRIVATE void _sg_imgui_sampler_created(sg_imgui_t* ctx, sg_sampler res_id, int slot_index, const sg_sampler_desc* desc) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->samplers.num_slots));
-    sg_imgui_sampler_t* smp = &ctx->samplers.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_sampler_created(sgimgui_t* ctx, sg_sampler res_id, int slot_index, const sg_sampler_desc* desc) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->sampler_window.num_slots));
+    sgimgui_sampler_t* smp = &ctx->sampler_window.slots[slot_index];
     smp->res_id = res_id;
     smp->desc = *desc;
-    smp->label = _sg_imgui_make_str(desc->label);
+    smp->label = _sgimgui_make_str(desc->label);
 }
 
-_SOKOL_PRIVATE void _sg_imgui_sampler_destroyed(sg_imgui_t* ctx, int slot_index) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->samplers.num_slots));
-    sg_imgui_sampler_t* smp = &ctx->samplers.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_sampler_destroyed(sgimgui_t* ctx, int slot_index) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->sampler_window.num_slots));
+    sgimgui_sampler_t* smp = &ctx->sampler_window.slots[slot_index];
     smp->res_id.id = SG_INVALID_ID;
 }
 
-_SOKOL_PRIVATE void _sg_imgui_shader_created(sg_imgui_t* ctx, sg_shader res_id, int slot_index, const sg_shader_desc* desc) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->shaders.num_slots));
-    sg_imgui_shader_t* shd = &ctx->shaders.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_shader_created(sgimgui_t* ctx, sg_shader res_id, int slot_index, const sg_shader_desc* desc) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->shader_window.num_slots));
+    sgimgui_shader_t* shd = &ctx->shader_window.slots[slot_index];
     shd->res_id = res_id;
     shd->desc = *desc;
-    shd->label = _sg_imgui_make_str(desc->label);
+    shd->label = _sgimgui_make_str(desc->label);
     if (shd->desc.vs.entry) {
-        shd->vs_entry = _sg_imgui_make_str(shd->desc.vs.entry);
+        shd->vs_entry = _sgimgui_make_str(shd->desc.vs.entry);
         shd->desc.vs.entry = shd->vs_entry.buf;
     }
     if (shd->desc.fs.entry) {
-        shd->fs_entry = _sg_imgui_make_str(shd->desc.fs.entry);
+        shd->fs_entry = _sgimgui_make_str(shd->desc.fs.entry);
         shd->desc.fs.entry = shd->fs_entry.buf;
     }
     if (shd->desc.vs.d3d11_target) {
-        shd->vs_d3d11_target = _sg_imgui_make_str(shd->desc.vs.d3d11_target);
+        shd->vs_d3d11_target = _sgimgui_make_str(shd->desc.vs.d3d11_target);
         shd->desc.fs.d3d11_target = shd->vs_d3d11_target.buf;
     }
     if (shd->desc.fs.d3d11_target) {
-        shd->fs_d3d11_target = _sg_imgui_make_str(shd->desc.fs.d3d11_target);
+        shd->fs_d3d11_target = _sgimgui_make_str(shd->desc.fs.d3d11_target);
         shd->desc.fs.d3d11_target = shd->fs_d3d11_target.buf;
     }
     for (int i = 0; i < SG_MAX_SHADERSTAGE_UBS; i++) {
         for (int j = 0; j < SG_MAX_UB_MEMBERS; j++) {
             sg_shader_uniform_desc* ud = &shd->desc.vs.uniform_blocks[i].uniforms[j];
             if (ud->name) {
-                shd->vs_uniform_name[i][j] = _sg_imgui_make_str(ud->name);
+                shd->vs_uniform_name[i][j] = _sgimgui_make_str(ud->name);
                 ud->name = shd->vs_uniform_name[i][j].buf;
             }
         }
@@ -1647,173 +1638,173 @@ _SOKOL_PRIVATE void _sg_imgui_shader_created(sg_imgui_t* ctx, sg_shader res_id, 
         for (int j = 0; j < SG_MAX_UB_MEMBERS; j++) {
             sg_shader_uniform_desc* ud = &shd->desc.fs.uniform_blocks[i].uniforms[j];
             if (ud->name) {
-                shd->fs_uniform_name[i][j] = _sg_imgui_make_str(ud->name);
+                shd->fs_uniform_name[i][j] = _sgimgui_make_str(ud->name);
                 ud->name = shd->fs_uniform_name[i][j].buf;
             }
         }
     }
     for (int i = 0; i < SG_MAX_SHADERSTAGE_IMAGESAMPLERPAIRS; i++) {
         if (shd->desc.vs.image_sampler_pairs[i].glsl_name) {
-            shd->vs_image_sampler_name[i] = _sg_imgui_make_str(shd->desc.vs.image_sampler_pairs[i].glsl_name);
+            shd->vs_image_sampler_name[i] = _sgimgui_make_str(shd->desc.vs.image_sampler_pairs[i].glsl_name);
             shd->desc.vs.image_sampler_pairs[i].glsl_name = shd->vs_image_sampler_name[i].buf;
         }
     }
     for (int i = 0; i < SG_MAX_SHADERSTAGE_IMAGESAMPLERPAIRS; i++) {
         if (shd->desc.fs.image_sampler_pairs[i].glsl_name) {
-            shd->fs_image_sampler_name[i] = _sg_imgui_make_str(shd->desc.fs.image_sampler_pairs[i].glsl_name);
+            shd->fs_image_sampler_name[i] = _sgimgui_make_str(shd->desc.fs.image_sampler_pairs[i].glsl_name);
             shd->desc.fs.image_sampler_pairs[i].glsl_name = shd->fs_image_sampler_name[i].buf;
         }
     }
     if (shd->desc.vs.source) {
-        shd->desc.vs.source = _sg_imgui_str_dup(&ctx->desc.allocator, shd->desc.vs.source);
+        shd->desc.vs.source = _sgimgui_str_dup(&ctx->desc.allocator, shd->desc.vs.source);
     }
     if (shd->desc.vs.bytecode.ptr) {
-        shd->desc.vs.bytecode.ptr = _sg_imgui_bin_dup(&ctx->desc.allocator, shd->desc.vs.bytecode.ptr, shd->desc.vs.bytecode.size);
+        shd->desc.vs.bytecode.ptr = _sgimgui_bin_dup(&ctx->desc.allocator, shd->desc.vs.bytecode.ptr, shd->desc.vs.bytecode.size);
     }
     if (shd->desc.fs.source) {
-        shd->desc.fs.source = _sg_imgui_str_dup(&ctx->desc.allocator, shd->desc.fs.source);
+        shd->desc.fs.source = _sgimgui_str_dup(&ctx->desc.allocator, shd->desc.fs.source);
     }
     if (shd->desc.fs.bytecode.ptr) {
-        shd->desc.fs.bytecode.ptr = _sg_imgui_bin_dup(&ctx->desc.allocator, shd->desc.fs.bytecode.ptr, shd->desc.fs.bytecode.size);
+        shd->desc.fs.bytecode.ptr = _sgimgui_bin_dup(&ctx->desc.allocator, shd->desc.fs.bytecode.ptr, shd->desc.fs.bytecode.size);
     }
     for (int i = 0; i < SG_MAX_VERTEX_ATTRIBUTES; i++) {
         sg_shader_attr_desc* ad = &shd->desc.attrs[i];
         if (ad->name) {
-            shd->attr_name[i] = _sg_imgui_make_str(ad->name);
+            shd->attr_name[i] = _sgimgui_make_str(ad->name);
             ad->name = shd->attr_name[i].buf;
         }
         if (ad->sem_name) {
-            shd->attr_sem_name[i] = _sg_imgui_make_str(ad->sem_name);
+            shd->attr_sem_name[i] = _sgimgui_make_str(ad->sem_name);
             ad->sem_name = shd->attr_sem_name[i].buf;
         }
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_shader_destroyed(sg_imgui_t* ctx, int slot_index) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->shaders.num_slots));
-    sg_imgui_shader_t* shd = &ctx->shaders.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_shader_destroyed(sgimgui_t* ctx, int slot_index) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->shader_window.num_slots));
+    sgimgui_shader_t* shd = &ctx->shader_window.slots[slot_index];
     shd->res_id.id = SG_INVALID_ID;
     if (shd->desc.vs.source) {
-        _sg_imgui_free(&ctx->desc.allocator, (void*)shd->desc.vs.source);
+        _sgimgui_free(&ctx->desc.allocator, (void*)shd->desc.vs.source);
         shd->desc.vs.source = 0;
     }
     if (shd->desc.vs.bytecode.ptr) {
-        _sg_imgui_free(&ctx->desc.allocator, (void*)shd->desc.vs.bytecode.ptr);
+        _sgimgui_free(&ctx->desc.allocator, (void*)shd->desc.vs.bytecode.ptr);
         shd->desc.vs.bytecode.ptr = 0;
     }
     if (shd->desc.fs.source) {
-        _sg_imgui_free(&ctx->desc.allocator, (void*)shd->desc.fs.source);
+        _sgimgui_free(&ctx->desc.allocator, (void*)shd->desc.fs.source);
         shd->desc.fs.source = 0;
     }
     if (shd->desc.fs.bytecode.ptr) {
-        _sg_imgui_free(&ctx->desc.allocator, (void*)shd->desc.fs.bytecode.ptr);
+        _sgimgui_free(&ctx->desc.allocator, (void*)shd->desc.fs.bytecode.ptr);
         shd->desc.fs.bytecode.ptr = 0;
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_pipeline_created(sg_imgui_t* ctx, sg_pipeline res_id, int slot_index, const sg_pipeline_desc* desc) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->pipelines.num_slots));
-    sg_imgui_pipeline_t* pip = &ctx->pipelines.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_pipeline_created(sgimgui_t* ctx, sg_pipeline res_id, int slot_index, const sg_pipeline_desc* desc) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->pipeline_window.num_slots));
+    sgimgui_pipeline_t* pip = &ctx->pipeline_window.slots[slot_index];
     pip->res_id = res_id;
-    pip->label = _sg_imgui_make_str(desc->label);
+    pip->label = _sgimgui_make_str(desc->label);
     pip->desc = *desc;
 
 }
 
-_SOKOL_PRIVATE void _sg_imgui_pipeline_destroyed(sg_imgui_t* ctx, int slot_index) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->pipelines.num_slots));
-    sg_imgui_pipeline_t* pip = &ctx->pipelines.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_pipeline_destroyed(sgimgui_t* ctx, int slot_index) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->pipeline_window.num_slots));
+    sgimgui_pipeline_t* pip = &ctx->pipeline_window.slots[slot_index];
     pip->res_id.id = SG_INVALID_ID;
 }
 
-_SOKOL_PRIVATE void _sg_imgui_pass_created(sg_imgui_t* ctx, sg_pass res_id, int slot_index, const sg_pass_desc* desc) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->passes.num_slots));
-    sg_imgui_pass_t* pass = &ctx->passes.slots[slot_index];
-    pass->res_id = res_id;
+_SOKOL_PRIVATE void _sgimgui_attachments_created(sgimgui_t* ctx, sg_attachments res_id, int slot_index, const sg_attachments_desc* desc) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->attachments_window.num_slots));
+    sgimgui_attachments_t* atts = &ctx->attachments_window.slots[slot_index];
+    atts->res_id = res_id;
     for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
-        pass->color_image_scale[i] = 0.25f;
-        pass->resolve_image_scale[i] = 0.25f;
+        atts->color_image_scale[i] = 0.25f;
+        atts->resolve_image_scale[i] = 0.25f;
     }
-    pass->ds_image_scale = 0.25f;
-    pass->label = _sg_imgui_make_str(desc->label);
-    pass->desc = *desc;
+    atts->ds_image_scale = 0.25f;
+    atts->label = _sgimgui_make_str(desc->label);
+    atts->desc = *desc;
 }
 
-_SOKOL_PRIVATE void _sg_imgui_pass_destroyed(sg_imgui_t* ctx, int slot_index) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->passes.num_slots));
-    sg_imgui_pass_t* pass = &ctx->passes.slots[slot_index];
-    pass->res_id.id = SG_INVALID_ID;
+_SOKOL_PRIVATE void _sgimgui_attachments_destroyed(sgimgui_t* ctx, int slot_index) {
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->attachments_window.num_slots));
+    sgimgui_attachments_t* atts = &ctx->attachments_window.slots[slot_index];
+    atts->res_id.id = SG_INVALID_ID;
 }
 
 /*--- COMMAND CAPTURING ------------------------------------------------------*/
-_SOKOL_PRIVATE void _sg_imgui_capture_init(sg_imgui_t* ctx) {
+_SOKOL_PRIVATE void _sgimgui_capture_init(sgimgui_t* ctx) {
     const size_t ubuf_initial_size = 256 * 1024;
     for (int i = 0; i < 2; i++) {
-        sg_imgui_capture_bucket_t* bucket = &ctx->capture.bucket[i];
+        sgimgui_capture_bucket_t* bucket = &ctx->capture_window.bucket[i];
         bucket->ubuf_size = ubuf_initial_size;
-        bucket->ubuf = (uint8_t*) _sg_imgui_malloc(&ctx->desc.allocator, bucket->ubuf_size);
+        bucket->ubuf = (uint8_t*) _sgimgui_malloc(&ctx->desc.allocator, bucket->ubuf_size);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_capture_discard(sg_imgui_t* ctx) {
+_SOKOL_PRIVATE void _sgimgui_capture_discard(sgimgui_t* ctx) {
     for (int i = 0; i < 2; i++) {
-        sg_imgui_capture_bucket_t* bucket = &ctx->capture.bucket[i];
+        sgimgui_capture_bucket_t* bucket = &ctx->capture_window.bucket[i];
         SOKOL_ASSERT(bucket->ubuf);
-        _sg_imgui_free(&ctx->desc.allocator, bucket->ubuf);
+        _sgimgui_free(&ctx->desc.allocator, bucket->ubuf);
         bucket->ubuf = 0;
     }
 }
 
-_SOKOL_PRIVATE sg_imgui_capture_bucket_t* _sg_imgui_capture_get_write_bucket(sg_imgui_t* ctx) {
-    return &ctx->capture.bucket[ctx->capture.bucket_index & 1];
+_SOKOL_PRIVATE sgimgui_capture_bucket_t* _sgimgui_capture_get_write_bucket(sgimgui_t* ctx) {
+    return &ctx->capture_window.bucket[ctx->capture_window.bucket_index & 1];
 }
 
-_SOKOL_PRIVATE sg_imgui_capture_bucket_t* _sg_imgui_capture_get_read_bucket(sg_imgui_t* ctx) {
-    return &ctx->capture.bucket[(ctx->capture.bucket_index + 1) & 1];
+_SOKOL_PRIVATE sgimgui_capture_bucket_t* _sgimgui_capture_get_read_bucket(sgimgui_t* ctx) {
+    return &ctx->capture_window.bucket[(ctx->capture_window.bucket_index + 1) & 1];
 }
 
-_SOKOL_PRIVATE void _sg_imgui_capture_next_frame(sg_imgui_t* ctx) {
-    ctx->capture.bucket_index = (ctx->capture.bucket_index + 1) & 1;
-    sg_imgui_capture_bucket_t* bucket = &ctx->capture.bucket[ctx->capture.bucket_index];
+_SOKOL_PRIVATE void _sgimgui_capture_next_frame(sgimgui_t* ctx) {
+    ctx->capture_window.bucket_index = (ctx->capture_window.bucket_index + 1) & 1;
+    sgimgui_capture_bucket_t* bucket = &ctx->capture_window.bucket[ctx->capture_window.bucket_index];
     bucket->num_items = 0;
     bucket->ubuf_pos = 0;
 }
 
-_SOKOL_PRIVATE void _sg_imgui_capture_grow_ubuf(sg_imgui_t* ctx, size_t required_size) {
-    sg_imgui_capture_bucket_t* bucket = _sg_imgui_capture_get_write_bucket(ctx);
+_SOKOL_PRIVATE void _sgimgui_capture_grow_ubuf(sgimgui_t* ctx, size_t required_size) {
+    sgimgui_capture_bucket_t* bucket = _sgimgui_capture_get_write_bucket(ctx);
     SOKOL_ASSERT(required_size > bucket->ubuf_size);
     size_t old_size = bucket->ubuf_size;
     size_t new_size = required_size + (required_size>>1);  /* allocate a bit ahead */
     bucket->ubuf_size = new_size;
-    bucket->ubuf = (uint8_t*) _sg_imgui_realloc(&ctx->desc.allocator, bucket->ubuf, old_size, new_size);
+    bucket->ubuf = (uint8_t*) _sgimgui_realloc(&ctx->desc.allocator, bucket->ubuf, old_size, new_size);
 }
 
-_SOKOL_PRIVATE sg_imgui_capture_item_t* _sg_imgui_capture_next_write_item(sg_imgui_t* ctx) {
-    sg_imgui_capture_bucket_t* bucket = _sg_imgui_capture_get_write_bucket(ctx);
-    if (bucket->num_items < SG_IMGUI_MAX_FRAMECAPTURE_ITEMS) {
-        sg_imgui_capture_item_t* item = &bucket->items[bucket->num_items++];
+_SOKOL_PRIVATE sgimgui_capture_item_t* _sgimgui_capture_next_write_item(sgimgui_t* ctx) {
+    sgimgui_capture_bucket_t* bucket = _sgimgui_capture_get_write_bucket(ctx);
+    if (bucket->num_items < sgimgui_MAX_FRAMECAPTURE_ITEMS) {
+        sgimgui_capture_item_t* item = &bucket->items[bucket->num_items++];
         return item;
     } else {
         return 0;
     }
 }
 
-_SOKOL_PRIVATE int _sg_imgui_capture_num_read_items(sg_imgui_t* ctx) {
-    sg_imgui_capture_bucket_t* bucket = _sg_imgui_capture_get_read_bucket(ctx);
+_SOKOL_PRIVATE int _sgimgui_capture_num_read_items(sgimgui_t* ctx) {
+    sgimgui_capture_bucket_t* bucket = _sgimgui_capture_get_read_bucket(ctx);
     return bucket->num_items;
 }
 
-_SOKOL_PRIVATE sg_imgui_capture_item_t* _sg_imgui_capture_read_item_at(sg_imgui_t* ctx, int index) {
-    sg_imgui_capture_bucket_t* bucket = _sg_imgui_capture_get_read_bucket(ctx);
+_SOKOL_PRIVATE sgimgui_capture_item_t* _sgimgui_capture_read_item_at(sgimgui_t* ctx, int index) {
+    sgimgui_capture_bucket_t* bucket = _sgimgui_capture_get_read_bucket(ctx);
     SOKOL_ASSERT(index < bucket->num_items);
     return &bucket->items[index];
 }
 
-_SOKOL_PRIVATE size_t _sg_imgui_capture_uniforms(sg_imgui_t* ctx, const sg_range* data) {
-    sg_imgui_capture_bucket_t* bucket = _sg_imgui_capture_get_write_bucket(ctx);
+_SOKOL_PRIVATE size_t _sgimgui_capture_uniforms(sgimgui_t* ctx, const sg_range* data) {
+    sgimgui_capture_bucket_t* bucket = _sgimgui_capture_get_write_bucket(ctx);
     const size_t required_size = bucket->ubuf_pos + data->size;
     if (required_size > bucket->ubuf_size) {
-        _sg_imgui_capture_grow_ubuf(ctx, required_size);
+        _sgimgui_capture_grow_ubuf(ctx, required_size);
     }
     SOKOL_ASSERT(required_size <= bucket->ubuf_size);
     memcpy(bucket->ubuf + bucket->ubuf_pos, data->ptr, data->size);
@@ -1823,642 +1814,634 @@ _SOKOL_PRIVATE size_t _sg_imgui_capture_uniforms(sg_imgui_t* ctx, const sg_range
     return pos;
 }
 
-_SOKOL_PRIVATE sg_imgui_str_t _sg_imgui_capture_item_string(sg_imgui_t* ctx, int index, const sg_imgui_capture_item_t* item) {
-    sg_imgui_str_t str = _sg_imgui_make_str(0);
+_SOKOL_PRIVATE sgimgui_str_t _sgimgui_capture_item_string(sgimgui_t* ctx, int index, const sgimgui_capture_item_t* item) {
+    sgimgui_str_t str = _sgimgui_make_str(0);
     switch (item->cmd) {
-        case SG_IMGUI_CMD_RESET_STATE_CACHE:
-            _sg_imgui_snprintf(&str, "%d: sg_reset_state_cache()", index);
+        case SGIMGUI_CMD_RESET_STATE_CACHE:
+            _sgimgui_snprintf(&str, "%d: sg_reset_state_cache()", index);
             break;
 
-        case SG_IMGUI_CMD_MAKE_BUFFER:
+        case SGIMGUI_CMD_MAKE_BUFFER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_buffer_id_string(ctx, item->args.make_buffer.result);
-                _sg_imgui_snprintf(&str, "%d: sg_make_buffer(desc=..) => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_buffer_id_string(ctx, item->args.make_buffer.result);
+                _sgimgui_snprintf(&str, "%d: sg_make_buffer(desc=..) => %s", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_MAKE_IMAGE:
+        case SGIMGUI_CMD_MAKE_IMAGE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_image_id_string(ctx, item->args.make_image.result);
-                _sg_imgui_snprintf(&str, "%d: sg_make_image(desc=..) => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_image_id_string(ctx, item->args.make_image.result);
+                _sgimgui_snprintf(&str, "%d: sg_make_image(desc=..) => %s", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_MAKE_SAMPLER:
+        case SGIMGUI_CMD_MAKE_SAMPLER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_sampler_id_string(ctx, item->args.make_sampler.result);
-                _sg_imgui_snprintf(&str, "%d: sg_make_sampler(desc=..) => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_sampler_id_string(ctx, item->args.make_sampler.result);
+                _sgimgui_snprintf(&str, "%d: sg_make_sampler(desc=..) => %s", index, res_id.buf);
             }
             break;
-        case SG_IMGUI_CMD_MAKE_SHADER:
+        case SGIMGUI_CMD_MAKE_SHADER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_shader_id_string(ctx, item->args.make_shader.result);
-                _sg_imgui_snprintf(&str, "%d: sg_make_shader(desc=..) => %s", index, res_id.buf);
-            }
-            break;
-
-        case SG_IMGUI_CMD_MAKE_PIPELINE:
-            {
-                sg_imgui_str_t res_id = _sg_imgui_pipeline_id_string(ctx, item->args.make_pipeline.result);
-                _sg_imgui_snprintf(&str, "%d: sg_make_pipeline(desc=..) => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_shader_id_string(ctx, item->args.make_shader.result);
+                _sgimgui_snprintf(&str, "%d: sg_make_shader(desc=..) => %s", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_MAKE_PASS:
+        case SGIMGUI_CMD_MAKE_PIPELINE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_pass_id_string(ctx, item->args.make_pass.result);
-                _sg_imgui_snprintf(&str, "%d: sg_make_pass(desc=..) => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_pipeline_id_string(ctx, item->args.make_pipeline.result);
+                _sgimgui_snprintf(&str, "%d: sg_make_pipeline(desc=..) => %s", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_DESTROY_BUFFER:
+        case SGIMGUI_CMD_MAKE_ATTACHMENTS:
             {
-                sg_imgui_str_t res_id = _sg_imgui_buffer_id_string(ctx, item->args.destroy_buffer.buffer);
-                _sg_imgui_snprintf(&str, "%d: sg_destroy_buffer(buf=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_attachments_id_string(ctx, item->args.make_attachments.result);
+                _sgimgui_snprintf(&str, "%d: sg_make_attachments(desc=..) => %s", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_DESTROY_IMAGE:
+        case SGIMGUI_CMD_DESTROY_BUFFER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_image_id_string(ctx, item->args.destroy_image.image);
-                _sg_imgui_snprintf(&str, "%d: sg_destroy_image(img=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_buffer_id_string(ctx, item->args.destroy_buffer.buffer);
+                _sgimgui_snprintf(&str, "%d: sg_destroy_buffer(buf=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_DESTROY_SAMPLER:
+        case SGIMGUI_CMD_DESTROY_IMAGE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_sampler_id_string(ctx, item->args.destroy_sampler.sampler);
-                _sg_imgui_snprintf(&str, "%d: sg_destroy_sampler(smp=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_image_id_string(ctx, item->args.destroy_image.image);
+                _sgimgui_snprintf(&str, "%d: sg_destroy_image(img=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_DESTROY_SHADER:
+        case SGIMGUI_CMD_DESTROY_SAMPLER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_shader_id_string(ctx, item->args.destroy_shader.shader);
-                _sg_imgui_snprintf(&str, "%d: sg_destroy_shader(shd=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_sampler_id_string(ctx, item->args.destroy_sampler.sampler);
+                _sgimgui_snprintf(&str, "%d: sg_destroy_sampler(smp=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_DESTROY_PIPELINE:
+        case SGIMGUI_CMD_DESTROY_SHADER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_pipeline_id_string(ctx, item->args.destroy_pipeline.pipeline);
-                _sg_imgui_snprintf(&str, "%d: sg_destroy_pipeline(pip=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_shader_id_string(ctx, item->args.destroy_shader.shader);
+                _sgimgui_snprintf(&str, "%d: sg_destroy_shader(shd=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_DESTROY_PASS:
+        case SGIMGUI_CMD_DESTROY_PIPELINE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_pass_id_string(ctx, item->args.destroy_pass.pass);
-                _sg_imgui_snprintf(&str, "%d: sg_destroy_pass(pass=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_pipeline_id_string(ctx, item->args.destroy_pipeline.pipeline);
+                _sgimgui_snprintf(&str, "%d: sg_destroy_pipeline(pip=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_UPDATE_BUFFER:
+        case SGIMGUI_CMD_DESTROY_ATTACHMENTS:
             {
-                sg_imgui_str_t res_id = _sg_imgui_buffer_id_string(ctx, item->args.update_buffer.buffer);
-                _sg_imgui_snprintf(&str, "%d: sg_update_buffer(buf=%s, data.size=%d)",
+                sgimgui_str_t res_id = _sgimgui_attachments_id_string(ctx, item->args.destroy_attachments.attachments);
+                _sgimgui_snprintf(&str, "%d: sg_destroy_attachments(atts=%s)", index, res_id.buf);
+            }
+            break;
+
+        case SGIMGUI_CMD_UPDATE_BUFFER:
+            {
+                sgimgui_str_t res_id = _sgimgui_buffer_id_string(ctx, item->args.update_buffer.buffer);
+                _sgimgui_snprintf(&str, "%d: sg_update_buffer(buf=%s, data.size=%d)",
                     index, res_id.buf,
                     item->args.update_buffer.data_size);
             }
             break;
 
-        case SG_IMGUI_CMD_UPDATE_IMAGE:
+        case SGIMGUI_CMD_UPDATE_IMAGE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_image_id_string(ctx, item->args.update_image.image);
-                _sg_imgui_snprintf(&str, "%d: sg_update_image(img=%s, data=..)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_image_id_string(ctx, item->args.update_image.image);
+                _sgimgui_snprintf(&str, "%d: sg_update_image(img=%s, data=..)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_APPEND_BUFFER:
+        case SGIMGUI_CMD_APPEND_BUFFER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_buffer_id_string(ctx, item->args.append_buffer.buffer);
-                _sg_imgui_snprintf(&str, "%d: sg_append_buffer(buf=%s, data.size=%d) => %d",
+                sgimgui_str_t res_id = _sgimgui_buffer_id_string(ctx, item->args.append_buffer.buffer);
+                _sgimgui_snprintf(&str, "%d: sg_append_buffer(buf=%s, data.size=%d) => %d",
                     index, res_id.buf,
                     item->args.append_buffer.data_size,
                     item->args.append_buffer.result);
             }
             break;
 
-        case SG_IMGUI_CMD_BEGIN_DEFAULT_PASS:
-            _sg_imgui_snprintf(&str, "%d: sg_begin_default_pass(pass_action=.., width=%d, height=%d)",
-                index,
-                item->args.begin_default_pass.width,
-                item->args.begin_default_pass.height);
-            break;
-
-        case SG_IMGUI_CMD_BEGIN_PASS:
+        case SGIMGUI_CMD_BEGIN_PASS:
             {
-                sg_imgui_str_t res_id = _sg_imgui_pass_id_string(ctx, item->args.begin_pass.pass);
-                _sg_imgui_snprintf(&str, "%d: sg_begin_pass(pass=%s, pass_action=..)", index, res_id.buf);
+                _sgimgui_snprintf(&str, "%d: sg_begin_pass(pass=...)", index);
             }
             break;
 
-        case SG_IMGUI_CMD_APPLY_VIEWPORT:
-            _sg_imgui_snprintf(&str, "%d: sg_apply_viewport(x=%d, y=%d, width=%d, height=%d, origin_top_left=%s)",
+        case SGIMGUI_CMD_APPLY_VIEWPORT:
+            _sgimgui_snprintf(&str, "%d: sg_apply_viewport(x=%d, y=%d, width=%d, height=%d, origin_top_left=%s)",
                 index,
                 item->args.apply_viewport.x,
                 item->args.apply_viewport.y,
                 item->args.apply_viewport.width,
                 item->args.apply_viewport.height,
-                _sg_imgui_bool_string(item->args.apply_viewport.origin_top_left));
+                _sgimgui_bool_string(item->args.apply_viewport.origin_top_left));
             break;
 
-        case SG_IMGUI_CMD_APPLY_SCISSOR_RECT:
-            _sg_imgui_snprintf(&str, "%d: sg_apply_scissor_rect(x=%d, y=%d, width=%d, height=%d, origin_top_left=%s)",
+        case SGIMGUI_CMD_APPLY_SCISSOR_RECT:
+            _sgimgui_snprintf(&str, "%d: sg_apply_scissor_rect(x=%d, y=%d, width=%d, height=%d, origin_top_left=%s)",
                 index,
                 item->args.apply_scissor_rect.x,
                 item->args.apply_scissor_rect.y,
                 item->args.apply_scissor_rect.width,
                 item->args.apply_scissor_rect.height,
-                _sg_imgui_bool_string(item->args.apply_scissor_rect.origin_top_left));
+                _sgimgui_bool_string(item->args.apply_scissor_rect.origin_top_left));
             break;
 
-        case SG_IMGUI_CMD_APPLY_PIPELINE:
+        case SGIMGUI_CMD_APPLY_PIPELINE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_pipeline_id_string(ctx, item->args.apply_pipeline.pipeline);
-                _sg_imgui_snprintf(&str, "%d: sg_apply_pipeline(pip=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_pipeline_id_string(ctx, item->args.apply_pipeline.pipeline);
+                _sgimgui_snprintf(&str, "%d: sg_apply_pipeline(pip=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_APPLY_BINDINGS:
-            _sg_imgui_snprintf(&str, "%d: sg_apply_bindings(bindings=..)", index);
+        case SGIMGUI_CMD_APPLY_BINDINGS:
+            _sgimgui_snprintf(&str, "%d: sg_apply_bindings(bindings=..)", index);
             break;
 
-        case SG_IMGUI_CMD_APPLY_UNIFORMS:
-            _sg_imgui_snprintf(&str, "%d: sg_apply_uniforms(stage=%s, ub_index=%d, data.size=%d)",
+        case SGIMGUI_CMD_APPLY_UNIFORMS:
+            _sgimgui_snprintf(&str, "%d: sg_apply_uniforms(stage=%s, ub_index=%d, data.size=%d)",
                 index,
-                _sg_imgui_shaderstage_string(item->args.apply_uniforms.stage),
+                _sgimgui_shaderstage_string(item->args.apply_uniforms.stage),
                 item->args.apply_uniforms.ub_index,
                 item->args.apply_uniforms.data_size);
             break;
 
-        case SG_IMGUI_CMD_DRAW:
-            _sg_imgui_snprintf(&str, "%d: sg_draw(base_element=%d, num_elements=%d, num_instances=%d)",
+        case SGIMGUI_CMD_DRAW:
+            _sgimgui_snprintf(&str, "%d: sg_draw(base_element=%d, num_elements=%d, num_instances=%d)",
                 index,
                 item->args.draw.base_element,
                 item->args.draw.num_elements,
                 item->args.draw.num_instances);
             break;
 
-        case SG_IMGUI_CMD_END_PASS:
-            _sg_imgui_snprintf(&str, "%d: sg_end_pass()", index);
+        case SGIMGUI_CMD_END_PASS:
+            _sgimgui_snprintf(&str, "%d: sg_end_pass()", index);
             break;
 
-        case SG_IMGUI_CMD_COMMIT:
-            _sg_imgui_snprintf(&str, "%d: sg_commit()", index);
+        case SGIMGUI_CMD_COMMIT:
+            _sgimgui_snprintf(&str, "%d: sg_commit()", index);
             break;
 
-        case SG_IMGUI_CMD_ALLOC_BUFFER:
+        case SGIMGUI_CMD_ALLOC_BUFFER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_buffer_id_string(ctx, item->args.alloc_buffer.result);
-                _sg_imgui_snprintf(&str, "%d: sg_alloc_buffer() => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_buffer_id_string(ctx, item->args.alloc_buffer.result);
+                _sgimgui_snprintf(&str, "%d: sg_alloc_buffer() => %s", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_ALLOC_IMAGE:
+        case SGIMGUI_CMD_ALLOC_IMAGE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_image_id_string(ctx, item->args.alloc_image.result);
-                _sg_imgui_snprintf(&str, "%d: sg_alloc_image() => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_image_id_string(ctx, item->args.alloc_image.result);
+                _sgimgui_snprintf(&str, "%d: sg_alloc_image() => %s", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_ALLOC_SAMPLER:
+        case SGIMGUI_CMD_ALLOC_SAMPLER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_sampler_id_string(ctx, item->args.alloc_sampler.result);
-                _sg_imgui_snprintf(&str, "%d: sg_alloc_sampler() => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_sampler_id_string(ctx, item->args.alloc_sampler.result);
+                _sgimgui_snprintf(&str, "%d: sg_alloc_sampler() => %s", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_ALLOC_SHADER:
+        case SGIMGUI_CMD_ALLOC_SHADER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_shader_id_string(ctx, item->args.alloc_shader.result);
-                _sg_imgui_snprintf(&str, "%d: sg_alloc_shader() => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_shader_id_string(ctx, item->args.alloc_shader.result);
+                _sgimgui_snprintf(&str, "%d: sg_alloc_shader() => %s", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_ALLOC_PIPELINE:
+        case SGIMGUI_CMD_ALLOC_PIPELINE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_pipeline_id_string(ctx, item->args.alloc_pipeline.result);
-                _sg_imgui_snprintf(&str, "%d: sg_alloc_pipeline() => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_pipeline_id_string(ctx, item->args.alloc_pipeline.result);
+                _sgimgui_snprintf(&str, "%d: sg_alloc_pipeline() => %s", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_ALLOC_PASS:
+        case SGIMGUI_CMD_ALLOC_ATTACHMENTS:
             {
-                sg_imgui_str_t res_id = _sg_imgui_pass_id_string(ctx, item->args.alloc_pass.result);
-                _sg_imgui_snprintf(&str, "%d: sg_alloc_pass() => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_attachments_id_string(ctx, item->args.alloc_attachments.result);
+                _sgimgui_snprintf(&str, "%d: sg_alloc_attachments() => %s", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_DEALLOC_BUFFER:
+        case SGIMGUI_CMD_DEALLOC_BUFFER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_buffer_id_string(ctx, item->args.dealloc_buffer.buffer);
-                _sg_imgui_snprintf(&str, "%d: sg_dealloc_buffer() => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_buffer_id_string(ctx, item->args.dealloc_buffer.buffer);
+                _sgimgui_snprintf(&str, "%d: sg_dealloc_buffer(buf=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_DEALLOC_IMAGE:
+        case SGIMGUI_CMD_DEALLOC_IMAGE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_image_id_string(ctx, item->args.dealloc_image.image);
-                _sg_imgui_snprintf(&str, "%d: sg_dealloc_image() => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_image_id_string(ctx, item->args.dealloc_image.image);
+                _sgimgui_snprintf(&str, "%d: sg_dealloc_image(img=%d)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_DEALLOC_SAMPLER:
+        case SGIMGUI_CMD_DEALLOC_SAMPLER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_sampler_id_string(ctx, item->args.dealloc_sampler.sampler);
-                _sg_imgui_snprintf(&str, "%d: sg_dealloc_sampler() => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_sampler_id_string(ctx, item->args.dealloc_sampler.sampler);
+                _sgimgui_snprintf(&str, "%d: sg_dealloc_sampler(smp=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_DEALLOC_SHADER:
+        case SGIMGUI_CMD_DEALLOC_SHADER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_shader_id_string(ctx, item->args.dealloc_shader.shader);
-                _sg_imgui_snprintf(&str, "%d: sg_dealloc_shader() => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_shader_id_string(ctx, item->args.dealloc_shader.shader);
+                _sgimgui_snprintf(&str, "%d: sg_dealloc_shader(shd=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_DEALLOC_PIPELINE:
+        case SGIMGUI_CMD_DEALLOC_PIPELINE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_pipeline_id_string(ctx, item->args.dealloc_pipeline.pipeline);
-                _sg_imgui_snprintf(&str, "%d: sg_dealloc_pipeline() => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_pipeline_id_string(ctx, item->args.dealloc_pipeline.pipeline);
+                _sgimgui_snprintf(&str, "%d: sg_dealloc_pipeline(pip=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_DEALLOC_PASS:
+        case SGIMGUI_CMD_DEALLOC_ATTACHMENTS:
             {
-                sg_imgui_str_t res_id = _sg_imgui_pass_id_string(ctx, item->args.dealloc_pass.pass);
-                _sg_imgui_snprintf(&str, "%d: sg_dealloc_pass() => %s", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_attachments_id_string(ctx, item->args.dealloc_attachments.attachments);
+                _sgimgui_snprintf(&str, "%d: sg_dealloc_attachments(atts=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_INIT_BUFFER:
+        case SGIMGUI_CMD_INIT_BUFFER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_buffer_id_string(ctx, item->args.init_buffer.buffer);
-                _sg_imgui_snprintf(&str, "%d: sg_init_buffer(buf=%s, desc=..)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_buffer_id_string(ctx, item->args.init_buffer.buffer);
+                _sgimgui_snprintf(&str, "%d: sg_init_buffer(buf=%s, desc=..)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_INIT_IMAGE:
+        case SGIMGUI_CMD_INIT_IMAGE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_image_id_string(ctx, item->args.init_image.image);
-                _sg_imgui_snprintf(&str, "%d: sg_init_image(img=%s, desc=..)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_image_id_string(ctx, item->args.init_image.image);
+                _sgimgui_snprintf(&str, "%d: sg_init_image(img=%s, desc=..)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_INIT_SAMPLER:
+        case SGIMGUI_CMD_INIT_SAMPLER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_sampler_id_string(ctx, item->args.init_sampler.sampler);
-                _sg_imgui_snprintf(&str, "%d: sg_init_sampler(smp=%s, desc=..)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_sampler_id_string(ctx, item->args.init_sampler.sampler);
+                _sgimgui_snprintf(&str, "%d: sg_init_sampler(smp=%s, desc=..)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_INIT_SHADER:
+        case SGIMGUI_CMD_INIT_SHADER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_shader_id_string(ctx, item->args.init_shader.shader);
-                _sg_imgui_snprintf(&str, "%d: sg_init_shader(shd=%s, desc=..)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_shader_id_string(ctx, item->args.init_shader.shader);
+                _sgimgui_snprintf(&str, "%d: sg_init_shader(shd=%s, desc=..)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_INIT_PIPELINE:
+        case SGIMGUI_CMD_INIT_PIPELINE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_pipeline_id_string(ctx, item->args.init_pipeline.pipeline);
-                _sg_imgui_snprintf(&str, "%d: sg_init_pipeline(pip=%s, desc=..)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_pipeline_id_string(ctx, item->args.init_pipeline.pipeline);
+                _sgimgui_snprintf(&str, "%d: sg_init_pipeline(pip=%s, desc=..)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_INIT_PASS:
+        case SGIMGUI_CMD_INIT_ATTACHMENTS:
             {
-                sg_imgui_str_t res_id = _sg_imgui_pass_id_string(ctx, item->args.init_pass.pass);
-                _sg_imgui_snprintf(&str, "%d: sg_init_pass(pass=%s, desc=..)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_attachments_id_string(ctx, item->args.init_attachments.attachments);
+                _sgimgui_snprintf(&str, "%d: sg_init_attachments(atts=%s, desc=..)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_UNINIT_BUFFER:
+        case SGIMGUI_CMD_UNINIT_BUFFER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_buffer_id_string(ctx, item->args.uninit_buffer.buffer);
-                _sg_imgui_snprintf(&str, "%d: sg_uninit_buffer(buf=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_buffer_id_string(ctx, item->args.uninit_buffer.buffer);
+                _sgimgui_snprintf(&str, "%d: sg_uninit_buffer(buf=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_UNINIT_IMAGE:
+        case SGIMGUI_CMD_UNINIT_IMAGE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_image_id_string(ctx, item->args.uninit_image.image);
-                _sg_imgui_snprintf(&str, "%d: sg_uninit_image(img=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_image_id_string(ctx, item->args.uninit_image.image);
+                _sgimgui_snprintf(&str, "%d: sg_uninit_image(img=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_UNINIT_SAMPLER:
+        case SGIMGUI_CMD_UNINIT_SAMPLER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_sampler_id_string(ctx, item->args.uninit_sampler.sampler);
-                _sg_imgui_snprintf(&str, "%d: sg_uninit_sampler(smp=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_sampler_id_string(ctx, item->args.uninit_sampler.sampler);
+                _sgimgui_snprintf(&str, "%d: sg_uninit_sampler(smp=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_UNINIT_SHADER:
+        case SGIMGUI_CMD_UNINIT_SHADER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_shader_id_string(ctx, item->args.uninit_shader.shader);
-                _sg_imgui_snprintf(&str, "%d: sg_uninit_shader(shd=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_shader_id_string(ctx, item->args.uninit_shader.shader);
+                _sgimgui_snprintf(&str, "%d: sg_uninit_shader(shd=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_UNINIT_PIPELINE:
+        case SGIMGUI_CMD_UNINIT_PIPELINE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_pipeline_id_string(ctx, item->args.uninit_pipeline.pipeline);
-                _sg_imgui_snprintf(&str, "%d: sg_uninit_pipeline(pip=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_pipeline_id_string(ctx, item->args.uninit_pipeline.pipeline);
+                _sgimgui_snprintf(&str, "%d: sg_uninit_pipeline(pip=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_UNINIT_PASS:
+        case SGIMGUI_CMD_UNINIT_ATTACHMENTS:
             {
-                sg_imgui_str_t res_id = _sg_imgui_pass_id_string(ctx, item->args.uninit_pass.pass);
-                _sg_imgui_snprintf(&str, "%d: sg_uninit_pass(pass=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_attachments_id_string(ctx, item->args.uninit_attachments.attachments);
+                _sgimgui_snprintf(&str, "%d: sg_uninit_attachemnts(atts=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_FAIL_BUFFER:
+        case SGIMGUI_CMD_FAIL_BUFFER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_buffer_id_string(ctx, item->args.fail_buffer.buffer);
-                _sg_imgui_snprintf(&str, "%d: sg_fail_buffer(buf=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_buffer_id_string(ctx, item->args.fail_buffer.buffer);
+                _sgimgui_snprintf(&str, "%d: sg_fail_buffer(buf=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_FAIL_IMAGE:
+        case SGIMGUI_CMD_FAIL_IMAGE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_image_id_string(ctx, item->args.fail_image.image);
-                _sg_imgui_snprintf(&str, "%d: sg_fail_image(img=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_image_id_string(ctx, item->args.fail_image.image);
+                _sgimgui_snprintf(&str, "%d: sg_fail_image(img=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_FAIL_SAMPLER:
+        case SGIMGUI_CMD_FAIL_SAMPLER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_sampler_id_string(ctx, item->args.fail_sampler.sampler);
-                _sg_imgui_snprintf(&str, "%d: sg_fail_sampler(smp=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_sampler_id_string(ctx, item->args.fail_sampler.sampler);
+                _sgimgui_snprintf(&str, "%d: sg_fail_sampler(smp=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_FAIL_SHADER:
+        case SGIMGUI_CMD_FAIL_SHADER:
             {
-                sg_imgui_str_t res_id = _sg_imgui_shader_id_string(ctx, item->args.fail_shader.shader);
-                _sg_imgui_snprintf(&str, "%d: sg_fail_shader(shd=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_shader_id_string(ctx, item->args.fail_shader.shader);
+                _sgimgui_snprintf(&str, "%d: sg_fail_shader(shd=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_FAIL_PIPELINE:
+        case SGIMGUI_CMD_FAIL_PIPELINE:
             {
-                sg_imgui_str_t res_id = _sg_imgui_pipeline_id_string(ctx, item->args.fail_pipeline.pipeline);
-                _sg_imgui_snprintf(&str, "%d: sg_fail_pipeline(shd=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_pipeline_id_string(ctx, item->args.fail_pipeline.pipeline);
+                _sgimgui_snprintf(&str, "%d: sg_fail_pipeline(shd=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_FAIL_PASS:
+        case SGIMGUI_CMD_FAIL_ATTACHMENTS:
             {
-                sg_imgui_str_t res_id = _sg_imgui_pass_id_string(ctx, item->args.fail_pass.pass);
-                _sg_imgui_snprintf(&str, "%d: sg_fail_pass(pass=%s)", index, res_id.buf);
+                sgimgui_str_t res_id = _sgimgui_attachments_id_string(ctx, item->args.fail_attachments.attachments);
+                _sgimgui_snprintf(&str, "%d: sg_fail_attachments(atts=%s)", index, res_id.buf);
             }
             break;
 
-        case SG_IMGUI_CMD_PUSH_DEBUG_GROUP:
-            _sg_imgui_snprintf(&str, "%d: sg_push_debug_group(name=%s)", index,
+        case SGIMGUI_CMD_PUSH_DEBUG_GROUP:
+            _sgimgui_snprintf(&str, "%d: sg_push_debug_group(name=%s)", index,
                 item->args.push_debug_group.name.buf);
             break;
 
-        case SG_IMGUI_CMD_POP_DEBUG_GROUP:
-            _sg_imgui_snprintf(&str, "%d: sg_pop_debug_group()", index);
+        case SGIMGUI_CMD_POP_DEBUG_GROUP:
+            _sgimgui_snprintf(&str, "%d: sg_pop_debug_group()", index);
             break;
 
         default:
-            _sg_imgui_snprintf(&str, "%d: ???", index);
+            _sgimgui_snprintf(&str, "%d: ???", index);
             break;
     }
     return str;
 }
 
 /*--- CAPTURE CALLBACKS ------------------------------------------------------*/
-_SOKOL_PRIVATE void _sg_imgui_reset_state_cache(void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_reset_state_cache(void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_RESET_STATE_CACHE;
-        item->color = _SG_IMGUI_COLOR_OTHER;
+        item->cmd = SGIMGUI_CMD_RESET_STATE_CACHE;
+        item->color = _SGIMGUI_COLOR_OTHER;
     }
     if (ctx->hooks.reset_state_cache) {
         ctx->hooks.reset_state_cache(ctx->hooks.user_data);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_make_buffer(const sg_buffer_desc* desc, sg_buffer buf_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_make_buffer(const sg_buffer_desc* desc, sg_buffer buf_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_MAKE_BUFFER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_MAKE_BUFFER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.make_buffer.result = buf_id;
     }
     if (ctx->hooks.make_buffer) {
         ctx->hooks.make_buffer(desc, buf_id, ctx->hooks.user_data);
     }
     if (buf_id.id != SG_INVALID_ID) {
-        _sg_imgui_buffer_created(ctx, buf_id, _sg_imgui_slot_index(buf_id.id), desc);
+        _sgimgui_buffer_created(ctx, buf_id, _sgimgui_slot_index(buf_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_make_image(const sg_image_desc* desc, sg_image img_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_make_image(const sg_image_desc* desc, sg_image img_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_MAKE_IMAGE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_MAKE_IMAGE;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.make_image.result = img_id;
     }
     if (ctx->hooks.make_image) {
         ctx->hooks.make_image(desc, img_id, ctx->hooks.user_data);
     }
     if (img_id.id != SG_INVALID_ID) {
-        _sg_imgui_image_created(ctx, img_id, _sg_imgui_slot_index(img_id.id), desc);
+        _sgimgui_image_created(ctx, img_id, _sgimgui_slot_index(img_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_make_sampler(const sg_sampler_desc* desc, sg_sampler smp_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_make_sampler(const sg_sampler_desc* desc, sg_sampler smp_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_MAKE_SAMPLER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_MAKE_SAMPLER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.make_sampler.result = smp_id;
     }
     if (ctx->hooks.make_sampler) {
         ctx->hooks.make_sampler(desc, smp_id, ctx->hooks.user_data);
     }
     if (smp_id.id != SG_INVALID_ID) {
-        _sg_imgui_sampler_created(ctx, smp_id, _sg_imgui_slot_index(smp_id.id), desc);
+        _sgimgui_sampler_created(ctx, smp_id, _sgimgui_slot_index(smp_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_make_shader(const sg_shader_desc* desc, sg_shader shd_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_make_shader(const sg_shader_desc* desc, sg_shader shd_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_MAKE_SHADER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_MAKE_SHADER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.make_shader.result = shd_id;
     }
     if (ctx->hooks.make_shader) {
         ctx->hooks.make_shader(desc, shd_id, ctx->hooks.user_data);
     }
     if (shd_id.id != SG_INVALID_ID) {
-        _sg_imgui_shader_created(ctx, shd_id, _sg_imgui_slot_index(shd_id.id), desc);
+        _sgimgui_shader_created(ctx, shd_id, _sgimgui_slot_index(shd_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_make_pipeline(const sg_pipeline_desc* desc, sg_pipeline pip_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_make_pipeline(const sg_pipeline_desc* desc, sg_pipeline pip_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_MAKE_PIPELINE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_MAKE_PIPELINE;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.make_pipeline.result = pip_id;
     }
     if (ctx->hooks.make_pipeline) {
         ctx->hooks.make_pipeline(desc, pip_id, ctx->hooks.user_data);
     }
     if (pip_id.id != SG_INVALID_ID) {
-        _sg_imgui_pipeline_created(ctx, pip_id, _sg_imgui_slot_index(pip_id.id), desc);
+        _sgimgui_pipeline_created(ctx, pip_id, _sgimgui_slot_index(pip_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_make_pass(const sg_pass_desc* desc, sg_pass pass_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_make_attachments(const sg_attachments_desc* desc, sg_attachments atts_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_MAKE_PASS;
-        item->color = _SG_IMGUI_COLOR_RSRC;
-        item->args.make_pass.result = pass_id;
+        item->cmd = SGIMGUI_CMD_MAKE_ATTACHMENTS;
+        item->color = _SGIMGUI_COLOR_RSRC;
+        item->args.make_attachments.result = atts_id;
     }
-    if (ctx->hooks.make_pass) {
-        ctx->hooks.make_pass(desc, pass_id, ctx->hooks.user_data);
+    if (ctx->hooks.make_attachments) {
+        ctx->hooks.make_attachments(desc, atts_id, ctx->hooks.user_data);
     }
-    if (pass_id.id != SG_INVALID_ID) {
-        _sg_imgui_pass_created(ctx, pass_id, _sg_imgui_slot_index(pass_id.id), desc);
+    if (atts_id.id != SG_INVALID_ID) {
+        _sgimgui_attachments_created(ctx, atts_id, _sgimgui_slot_index(atts_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_destroy_buffer(sg_buffer buf, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_destroy_buffer(sg_buffer buf, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_DESTROY_BUFFER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_DESTROY_BUFFER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.destroy_buffer.buffer = buf;
     }
     if (ctx->hooks.destroy_buffer) {
         ctx->hooks.destroy_buffer(buf, ctx->hooks.user_data);
     }
     if (buf.id != SG_INVALID_ID) {
-        _sg_imgui_buffer_destroyed(ctx, _sg_imgui_slot_index(buf.id));
+        _sgimgui_buffer_destroyed(ctx, _sgimgui_slot_index(buf.id));
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_destroy_image(sg_image img, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_destroy_image(sg_image img, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_DESTROY_IMAGE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_DESTROY_IMAGE;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.destroy_image.image = img;
     }
     if (ctx->hooks.destroy_image) {
         ctx->hooks.destroy_image(img, ctx->hooks.user_data);
     }
     if (img.id != SG_INVALID_ID) {
-        _sg_imgui_image_destroyed(ctx, _sg_imgui_slot_index(img.id));
+        _sgimgui_image_destroyed(ctx, _sgimgui_slot_index(img.id));
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_destroy_sampler(sg_sampler smp, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_destroy_sampler(sg_sampler smp, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_DESTROY_SAMPLER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_DESTROY_SAMPLER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.destroy_sampler.sampler = smp;
     }
     if (ctx->hooks.destroy_sampler) {
         ctx->hooks.destroy_sampler(smp, ctx->hooks.user_data);
     }
     if (smp.id != SG_INVALID_ID) {
-        _sg_imgui_sampler_destroyed(ctx, _sg_imgui_slot_index(smp.id));
+        _sgimgui_sampler_destroyed(ctx, _sgimgui_slot_index(smp.id));
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_destroy_shader(sg_shader shd, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_destroy_shader(sg_shader shd, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_DESTROY_SHADER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_DESTROY_SHADER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.destroy_shader.shader = shd;
     }
     if (ctx->hooks.destroy_shader) {
         ctx->hooks.destroy_shader(shd, ctx->hooks.user_data);
     }
     if (shd.id != SG_INVALID_ID) {
-        _sg_imgui_shader_destroyed(ctx, _sg_imgui_slot_index(shd.id));
+        _sgimgui_shader_destroyed(ctx, _sgimgui_slot_index(shd.id));
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_destroy_pipeline(sg_pipeline pip, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_destroy_pipeline(sg_pipeline pip, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_DESTROY_PIPELINE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_DESTROY_PIPELINE;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.destroy_pipeline.pipeline = pip;
     }
     if (ctx->hooks.destroy_pipeline) {
         ctx->hooks.destroy_pipeline(pip, ctx->hooks.user_data);
     }
     if (pip.id != SG_INVALID_ID) {
-        _sg_imgui_pipeline_destroyed(ctx, _sg_imgui_slot_index(pip.id));
+        _sgimgui_pipeline_destroyed(ctx, _sgimgui_slot_index(pip.id));
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_destroy_pass(sg_pass pass, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_destroy_attachments(sg_attachments atts, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_DESTROY_PASS;
-        item->color = _SG_IMGUI_COLOR_RSRC;
-        item->args.destroy_pass.pass = pass;
+        item->cmd = SGIMGUI_CMD_DESTROY_ATTACHMENTS;
+        item->color = _SGIMGUI_COLOR_RSRC;
+        item->args.destroy_attachments.attachments = atts;
     }
-    if (ctx->hooks.destroy_pass) {
-        ctx->hooks.destroy_pass(pass, ctx->hooks.user_data);
+    if (ctx->hooks.destroy_attachments) {
+        ctx->hooks.destroy_attachments(atts, ctx->hooks.user_data);
     }
-    if (pass.id != SG_INVALID_ID) {
-        _sg_imgui_pass_destroyed(ctx, _sg_imgui_slot_index(pass.id));
+    if (atts.id != SG_INVALID_ID) {
+        _sgimgui_attachments_destroyed(ctx, _sgimgui_slot_index(atts.id));
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_update_buffer(sg_buffer buf, const sg_range* data, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_update_buffer(sg_buffer buf, const sg_range* data, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_UPDATE_BUFFER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_UPDATE_BUFFER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.update_buffer.buffer = buf;
         item->args.update_buffer.data_size = data->size;
     }
@@ -2467,13 +2450,13 @@ _SOKOL_PRIVATE void _sg_imgui_update_buffer(sg_buffer buf, const sg_range* data,
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_update_image(sg_image img, const sg_image_data* data, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_update_image(sg_image img, const sg_image_data* data, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_UPDATE_IMAGE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_UPDATE_IMAGE;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.update_image.image = img;
     }
     if (ctx->hooks.update_image) {
@@ -2481,13 +2464,13 @@ _SOKOL_PRIVATE void _sg_imgui_update_image(sg_image img, const sg_image_data* da
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_append_buffer(sg_buffer buf, const sg_range* data, int result, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_append_buffer(sg_buffer buf, const sg_range* data, int result, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_APPEND_BUFFER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_APPEND_BUFFER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.append_buffer.buffer = buf;
         item->args.append_buffer.data_size = data->size;
         item->args.append_buffer.result = result;
@@ -2497,46 +2480,28 @@ _SOKOL_PRIVATE void _sg_imgui_append_buffer(sg_buffer buf, const sg_range* data,
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_begin_default_pass(const sg_pass_action* pass_action, int width, int height, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_begin_pass(const sg_pass* pass, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        SOKOL_ASSERT(pass_action);
-        item->cmd = SG_IMGUI_CMD_BEGIN_DEFAULT_PASS;
-        item->color = _SG_IMGUI_COLOR_PASS;
-        item->args.begin_default_pass.action = *pass_action;
-        item->args.begin_default_pass.width = width;
-        item->args.begin_default_pass.height = height;
-    }
-    if (ctx->hooks.begin_default_pass) {
-        ctx->hooks.begin_default_pass(pass_action, width, height, ctx->hooks.user_data);
-    }
-}
-
-_SOKOL_PRIVATE void _sg_imgui_begin_pass(sg_pass pass, const sg_pass_action* pass_action, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
-    SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
-    if (item) {
-        SOKOL_ASSERT(pass_action);
-        item->cmd = SG_IMGUI_CMD_BEGIN_PASS;
-        item->color = _SG_IMGUI_COLOR_PASS;
-        item->args.begin_pass.pass = pass;
-        item->args.begin_pass.action = *pass_action;
+        SOKOL_ASSERT(pass);
+        item->cmd = SGIMGUI_CMD_BEGIN_PASS;
+        item->color = _SGIMGUI_COLOR_PASS;
+        item->args.begin_pass.pass = *pass;
     }
     if (ctx->hooks.begin_pass) {
-        ctx->hooks.begin_pass(pass, pass_action, ctx->hooks.user_data);
+        ctx->hooks.begin_pass(pass, ctx->hooks.user_data);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_apply_viewport(int x, int y, int width, int height, bool origin_top_left, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_apply_viewport(int x, int y, int width, int height, bool origin_top_left, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_APPLY_VIEWPORT;
-        item->color = _SG_IMGUI_COLOR_APPLY;
+        item->cmd = SGIMGUI_CMD_APPLY_VIEWPORT;
+        item->color = _SGIMGUI_COLOR_APPLY;
         item->args.apply_viewport.x = x;
         item->args.apply_viewport.y = y;
         item->args.apply_viewport.width = width;
@@ -2548,13 +2513,13 @@ _SOKOL_PRIVATE void _sg_imgui_apply_viewport(int x, int y, int width, int height
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_apply_scissor_rect(int x, int y, int width, int height, bool origin_top_left, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_apply_scissor_rect(int x, int y, int width, int height, bool origin_top_left, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_APPLY_SCISSOR_RECT;
-        item->color = _SG_IMGUI_COLOR_APPLY;
+        item->cmd = SGIMGUI_CMD_APPLY_SCISSOR_RECT;
+        item->color = _SGIMGUI_COLOR_APPLY;
         item->args.apply_scissor_rect.x = x;
         item->args.apply_scissor_rect.y = y;
         item->args.apply_scissor_rect.width = width;
@@ -2566,14 +2531,14 @@ _SOKOL_PRIVATE void _sg_imgui_apply_scissor_rect(int x, int y, int width, int he
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_apply_pipeline(sg_pipeline pip, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_apply_pipeline(sg_pipeline pip, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    ctx->cur_pipeline = pip;    /* stored for _sg_imgui_apply_uniforms */
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    ctx->cur_pipeline = pip;    /* stored for _sgimgui_apply_uniforms */
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_APPLY_PIPELINE;
-        item->color = _SG_IMGUI_COLOR_APPLY;
+        item->cmd = SGIMGUI_CMD_APPLY_PIPELINE;
+        item->color = _SGIMGUI_COLOR_APPLY;
         item->args.apply_pipeline.pipeline = pip;
     }
     if (ctx->hooks.apply_pipeline) {
@@ -2581,14 +2546,14 @@ _SOKOL_PRIVATE void _sg_imgui_apply_pipeline(sg_pipeline pip, void* user_data) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_apply_bindings(const sg_bindings* bindings, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_apply_bindings(const sg_bindings* bindings, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
         SOKOL_ASSERT(bindings);
-        item->cmd = SG_IMGUI_CMD_APPLY_BINDINGS;
-        item->color = _SG_IMGUI_COLOR_APPLY;
+        item->cmd = SGIMGUI_CMD_APPLY_BINDINGS;
+        item->color = _SGIMGUI_COLOR_APPLY;
         item->args.apply_bindings.bindings = *bindings;
     }
     if (ctx->hooks.apply_bindings) {
@@ -2596,33 +2561,33 @@ _SOKOL_PRIVATE void _sg_imgui_apply_bindings(const sg_bindings* bindings, void* 
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_apply_uniforms(sg_shader_stage stage, int ub_index, const sg_range* data, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_apply_uniforms(sg_shader_stage stage, int ub_index, const sg_range* data, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     SOKOL_ASSERT(data);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_APPLY_UNIFORMS;
-        item->color = _SG_IMGUI_COLOR_APPLY;
-        sg_imgui_args_apply_uniforms_t* args = &item->args.apply_uniforms;
+        item->cmd = SGIMGUI_CMD_APPLY_UNIFORMS;
+        item->color = _SGIMGUI_COLOR_APPLY;
+        sgimgui_args_apply_uniforms_t* args = &item->args.apply_uniforms;
         args->stage = stage;
         args->ub_index = ub_index;
         args->data_size = data->size;
         args->pipeline = ctx->cur_pipeline;
-        args->ubuf_pos = _sg_imgui_capture_uniforms(ctx, data);
+        args->ubuf_pos = _sgimgui_capture_uniforms(ctx, data);
     }
     if (ctx->hooks.apply_uniforms) {
         ctx->hooks.apply_uniforms(stage, ub_index, data, ctx->hooks.user_data);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw(int base_element, int num_elements, int num_instances, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_draw(int base_element, int num_elements, int num_instances, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_DRAW;
-        item->color = _SG_IMGUI_COLOR_DRAW;
+        item->cmd = SGIMGUI_CMD_DRAW;
+        item->color = _SGIMGUI_COLOR_DRAW;
         item->args.draw.base_element = base_element;
         item->args.draw.num_elements = num_elements;
         item->args.draw.num_instances = num_instances;
@@ -2632,41 +2597,41 @@ _SOKOL_PRIVATE void _sg_imgui_draw(int base_element, int num_elements, int num_i
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_end_pass(void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_end_pass(void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     ctx->cur_pipeline.id = SG_INVALID_ID;
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_END_PASS;
-        item->color = _SG_IMGUI_COLOR_PASS;
+        item->cmd = SGIMGUI_CMD_END_PASS;
+        item->color = _SGIMGUI_COLOR_PASS;
     }
     if (ctx->hooks.end_pass) {
         ctx->hooks.end_pass(ctx->hooks.user_data);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_commit(void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_commit(void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_COMMIT;
-        item->color = _SG_IMGUI_COLOR_OTHER;
+        item->cmd = SGIMGUI_CMD_COMMIT;
+        item->color = _SGIMGUI_COLOR_OTHER;
     }
-    _sg_imgui_capture_next_frame(ctx);
+    _sgimgui_capture_next_frame(ctx);
     if (ctx->hooks.commit) {
         ctx->hooks.commit(ctx->hooks.user_data);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_alloc_buffer(sg_buffer result, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_alloc_buffer(sg_buffer result, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_ALLOC_BUFFER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_ALLOC_BUFFER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.alloc_buffer.result = result;
     }
     if (ctx->hooks.alloc_buffer) {
@@ -2674,13 +2639,13 @@ _SOKOL_PRIVATE void _sg_imgui_alloc_buffer(sg_buffer result, void* user_data) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_alloc_image(sg_image result, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_alloc_image(sg_image result, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_ALLOC_IMAGE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_ALLOC_IMAGE;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.alloc_image.result = result;
     }
     if (ctx->hooks.alloc_image) {
@@ -2688,13 +2653,13 @@ _SOKOL_PRIVATE void _sg_imgui_alloc_image(sg_image result, void* user_data) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_alloc_sampler(sg_sampler result, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_alloc_sampler(sg_sampler result, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_ALLOC_SAMPLER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_ALLOC_SAMPLER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.alloc_sampler.result = result;
     }
     if (ctx->hooks.alloc_sampler) {
@@ -2702,13 +2667,13 @@ _SOKOL_PRIVATE void _sg_imgui_alloc_sampler(sg_sampler result, void* user_data) 
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_alloc_shader(sg_shader result, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_alloc_shader(sg_shader result, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_ALLOC_SHADER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_ALLOC_SHADER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.alloc_shader.result = result;
     }
     if (ctx->hooks.alloc_shader) {
@@ -2716,13 +2681,13 @@ _SOKOL_PRIVATE void _sg_imgui_alloc_shader(sg_shader result, void* user_data) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_alloc_pipeline(sg_pipeline result, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_alloc_pipeline(sg_pipeline result, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_ALLOC_PIPELINE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_ALLOC_PIPELINE;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.alloc_pipeline.result = result;
     }
     if (ctx->hooks.alloc_pipeline) {
@@ -2730,27 +2695,27 @@ _SOKOL_PRIVATE void _sg_imgui_alloc_pipeline(sg_pipeline result, void* user_data
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_alloc_pass(sg_pass result, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_alloc_attachments(sg_attachments result, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_ALLOC_PASS;
-        item->color = _SG_IMGUI_COLOR_RSRC;
-        item->args.alloc_pass.result = result;
+        item->cmd = SGIMGUI_CMD_ALLOC_ATTACHMENTS;
+        item->color = _SGIMGUI_COLOR_RSRC;
+        item->args.alloc_attachments.result = result;
     }
-    if (ctx->hooks.alloc_pass) {
-        ctx->hooks.alloc_pass(result, ctx->hooks.user_data);
+    if (ctx->hooks.alloc_attachments) {
+        ctx->hooks.alloc_attachments(result, ctx->hooks.user_data);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_dealloc_buffer(sg_buffer buf_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_dealloc_buffer(sg_buffer buf_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_DEALLOC_BUFFER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_DEALLOC_BUFFER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.dealloc_buffer.buffer = buf_id;
     }
     if (ctx->hooks.dealloc_buffer) {
@@ -2758,13 +2723,13 @@ _SOKOL_PRIVATE void _sg_imgui_dealloc_buffer(sg_buffer buf_id, void* user_data) 
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_dealloc_image(sg_image img_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_dealloc_image(sg_image img_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_DEALLOC_IMAGE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_DEALLOC_IMAGE;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.dealloc_image.image = img_id;
     }
     if (ctx->hooks.dealloc_image) {
@@ -2772,13 +2737,13 @@ _SOKOL_PRIVATE void _sg_imgui_dealloc_image(sg_image img_id, void* user_data) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_dealloc_sampler(sg_sampler smp_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_dealloc_sampler(sg_sampler smp_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_DEALLOC_SAMPLER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_DEALLOC_SAMPLER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.dealloc_sampler.sampler = smp_id;
     }
     if (ctx->hooks.dealloc_sampler) {
@@ -2786,13 +2751,13 @@ _SOKOL_PRIVATE void _sg_imgui_dealloc_sampler(sg_sampler smp_id, void* user_data
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_dealloc_shader(sg_shader shd_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_dealloc_shader(sg_shader shd_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_DEALLOC_SHADER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_DEALLOC_SHADER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.dealloc_shader.shader = shd_id;
     }
     if (ctx->hooks.dealloc_shader) {
@@ -2800,13 +2765,13 @@ _SOKOL_PRIVATE void _sg_imgui_dealloc_shader(sg_shader shd_id, void* user_data) 
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_dealloc_pipeline(sg_pipeline pip_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_dealloc_pipeline(sg_pipeline pip_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_DEALLOC_PIPELINE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_DEALLOC_PIPELINE;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.dealloc_pipeline.pipeline = pip_id;
     }
     if (ctx->hooks.dealloc_pipeline) {
@@ -2814,231 +2779,231 @@ _SOKOL_PRIVATE void _sg_imgui_dealloc_pipeline(sg_pipeline pip_id, void* user_da
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_dealloc_pass(sg_pass pass_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_dealloc_attachments(sg_attachments atts_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_DEALLOC_PASS;
-        item->color = _SG_IMGUI_COLOR_RSRC;
-        item->args.dealloc_pass.pass = pass_id;
+        item->cmd = SGIMGUI_CMD_DEALLOC_ATTACHMENTS;
+        item->color = _SGIMGUI_COLOR_RSRC;
+        item->args.dealloc_attachments.attachments = atts_id;
     }
-    if (ctx->hooks.dealloc_pass) {
-        ctx->hooks.dealloc_pass(pass_id, ctx->hooks.user_data);
+    if (ctx->hooks.dealloc_attachments) {
+        ctx->hooks.dealloc_attachments(atts_id, ctx->hooks.user_data);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_init_buffer(sg_buffer buf_id, const sg_buffer_desc* desc, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_INIT_BUFFER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_INIT_BUFFER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.init_buffer.buffer = buf_id;
     }
     if (ctx->hooks.init_buffer) {
         ctx->hooks.init_buffer(buf_id, desc, ctx->hooks.user_data);
     }
     if (buf_id.id != SG_INVALID_ID) {
-        _sg_imgui_buffer_created(ctx, buf_id, _sg_imgui_slot_index(buf_id.id), desc);
+        _sgimgui_buffer_created(ctx, buf_id, _sgimgui_slot_index(buf_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_init_image(sg_image img_id, const sg_image_desc* desc, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_init_image(sg_image img_id, const sg_image_desc* desc, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_INIT_IMAGE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_INIT_IMAGE;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.init_image.image = img_id;
     }
     if (ctx->hooks.init_image) {
         ctx->hooks.init_image(img_id, desc, ctx->hooks.user_data);
     }
     if (img_id.id != SG_INVALID_ID) {
-        _sg_imgui_image_created(ctx, img_id, _sg_imgui_slot_index(img_id.id), desc);
+        _sgimgui_image_created(ctx, img_id, _sgimgui_slot_index(img_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_init_sampler(sg_sampler smp_id, const sg_sampler_desc* desc, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_init_sampler(sg_sampler smp_id, const sg_sampler_desc* desc, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_INIT_SAMPLER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_INIT_SAMPLER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.init_sampler.sampler = smp_id;
     }
     if (ctx->hooks.init_sampler) {
         ctx->hooks.init_sampler(smp_id, desc, ctx->hooks.user_data);
     }
     if (smp_id.id != SG_INVALID_ID) {
-        _sg_imgui_sampler_created(ctx, smp_id, _sg_imgui_slot_index(smp_id.id), desc);
+        _sgimgui_sampler_created(ctx, smp_id, _sgimgui_slot_index(smp_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_init_shader(sg_shader shd_id, const sg_shader_desc* desc, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_init_shader(sg_shader shd_id, const sg_shader_desc* desc, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_INIT_SHADER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_INIT_SHADER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.init_shader.shader = shd_id;
     }
     if (ctx->hooks.init_shader) {
         ctx->hooks.init_shader(shd_id, desc, ctx->hooks.user_data);
     }
     if (shd_id.id != SG_INVALID_ID) {
-        _sg_imgui_shader_created(ctx, shd_id, _sg_imgui_slot_index(shd_id.id), desc);
+        _sgimgui_shader_created(ctx, shd_id, _sgimgui_slot_index(shd_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_init_pipeline(sg_pipeline pip_id, const sg_pipeline_desc* desc, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_INIT_PIPELINE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_INIT_PIPELINE;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.init_pipeline.pipeline = pip_id;
     }
     if (ctx->hooks.init_pipeline) {
         ctx->hooks.init_pipeline(pip_id, desc, ctx->hooks.user_data);
     }
     if (pip_id.id != SG_INVALID_ID) {
-        _sg_imgui_pipeline_created(ctx, pip_id, _sg_imgui_slot_index(pip_id.id), desc);
+        _sgimgui_pipeline_created(ctx, pip_id, _sgimgui_slot_index(pip_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_init_pass(sg_pass pass_id, const sg_pass_desc* desc, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_init_attachments(sg_attachments atts_id, const sg_attachments_desc* desc, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_INIT_PASS;
-        item->color = _SG_IMGUI_COLOR_RSRC;
-        item->args.init_pass.pass = pass_id;
+        item->cmd = SGIMGUI_CMD_INIT_ATTACHMENTS;
+        item->color = _SGIMGUI_COLOR_RSRC;
+        item->args.init_attachments.attachments = atts_id;
     }
-    if (ctx->hooks.init_pass) {
-        ctx->hooks.init_pass(pass_id, desc, ctx->hooks.user_data);
+    if (ctx->hooks.init_attachments) {
+        ctx->hooks.init_attachments(atts_id, desc, ctx->hooks.user_data);
     }
-    if (pass_id.id != SG_INVALID_ID) {
-        _sg_imgui_pass_created(ctx, pass_id, _sg_imgui_slot_index(pass_id.id), desc);
+    if (atts_id.id != SG_INVALID_ID) {
+        _sgimgui_attachments_created(ctx, atts_id, _sgimgui_slot_index(atts_id.id), desc);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_uninit_buffer(sg_buffer buf, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_uninit_buffer(sg_buffer buf, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_UNINIT_BUFFER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_UNINIT_BUFFER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.uninit_buffer.buffer = buf;
     }
     if (ctx->hooks.uninit_buffer) {
         ctx->hooks.uninit_buffer(buf, ctx->hooks.user_data);
     }
     if (buf.id != SG_INVALID_ID) {
-        _sg_imgui_buffer_destroyed(ctx, _sg_imgui_slot_index(buf.id));
+        _sgimgui_buffer_destroyed(ctx, _sgimgui_slot_index(buf.id));
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_uninit_image(sg_image img, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_uninit_image(sg_image img, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_UNINIT_IMAGE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_UNINIT_IMAGE;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.uninit_image.image = img;
     }
     if (ctx->hooks.uninit_image) {
         ctx->hooks.uninit_image(img, ctx->hooks.user_data);
     }
     if (img.id != SG_INVALID_ID) {
-        _sg_imgui_image_destroyed(ctx, _sg_imgui_slot_index(img.id));
+        _sgimgui_image_destroyed(ctx, _sgimgui_slot_index(img.id));
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_uninit_sampler(sg_sampler smp, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_uninit_sampler(sg_sampler smp, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_UNINIT_SAMPLER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_UNINIT_SAMPLER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.uninit_sampler.sampler = smp;
     }
     if (ctx->hooks.uninit_sampler) {
         ctx->hooks.uninit_sampler(smp, ctx->hooks.user_data);
     }
     if (smp.id != SG_INVALID_ID) {
-        _sg_imgui_sampler_destroyed(ctx, _sg_imgui_slot_index(smp.id));
+        _sgimgui_sampler_destroyed(ctx, _sgimgui_slot_index(smp.id));
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_uninit_shader(sg_shader shd, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_uninit_shader(sg_shader shd, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_UNINIT_SHADER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_UNINIT_SHADER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.uninit_shader.shader = shd;
     }
     if (ctx->hooks.uninit_shader) {
         ctx->hooks.uninit_shader(shd, ctx->hooks.user_data);
     }
     if (shd.id != SG_INVALID_ID) {
-        _sg_imgui_shader_destroyed(ctx, _sg_imgui_slot_index(shd.id));
+        _sgimgui_shader_destroyed(ctx, _sgimgui_slot_index(shd.id));
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_uninit_pipeline(sg_pipeline pip, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_uninit_pipeline(sg_pipeline pip, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_UNINIT_PIPELINE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_UNINIT_PIPELINE;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.uninit_pipeline.pipeline = pip;
     }
     if (ctx->hooks.uninit_pipeline) {
         ctx->hooks.uninit_pipeline(pip, ctx->hooks.user_data);
     }
     if (pip.id != SG_INVALID_ID) {
-        _sg_imgui_pipeline_destroyed(ctx, _sg_imgui_slot_index(pip.id));
+        _sgimgui_pipeline_destroyed(ctx, _sgimgui_slot_index(pip.id));
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_uninit_pass(sg_pass pass, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_uninit_attachments(sg_attachments atts, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_UNINIT_PIPELINE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
-        item->args.uninit_pass.pass = pass;
+        item->cmd = SGIMGUI_CMD_UNINIT_PIPELINE;
+        item->color = _SGIMGUI_COLOR_RSRC;
+        item->args.uninit_attachments.attachments = atts;
     }
-    if (ctx->hooks.uninit_pass) {
-        ctx->hooks.uninit_pass(pass, ctx->hooks.user_data);
+    if (ctx->hooks.uninit_attachments) {
+        ctx->hooks.uninit_attachments(atts, ctx->hooks.user_data);
     }
-    if (pass.id != SG_INVALID_ID) {
-        _sg_imgui_pass_destroyed(ctx, _sg_imgui_slot_index(pass.id));
+    if (atts.id != SG_INVALID_ID) {
+        _sgimgui_attachments_destroyed(ctx, _sgimgui_slot_index(atts.id));
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_fail_buffer(sg_buffer buf_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_fail_buffer(sg_buffer buf_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_FAIL_BUFFER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_FAIL_BUFFER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.fail_buffer.buffer = buf_id;
     }
     if (ctx->hooks.fail_buffer) {
@@ -3046,13 +3011,13 @@ _SOKOL_PRIVATE void _sg_imgui_fail_buffer(sg_buffer buf_id, void* user_data) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_fail_image(sg_image img_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_fail_image(sg_image img_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_FAIL_IMAGE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_FAIL_IMAGE;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.fail_image.image = img_id;
     }
     if (ctx->hooks.fail_image) {
@@ -3060,13 +3025,13 @@ _SOKOL_PRIVATE void _sg_imgui_fail_image(sg_image img_id, void* user_data) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_fail_sampler(sg_sampler smp_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_fail_sampler(sg_sampler smp_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_FAIL_SAMPLER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_FAIL_SAMPLER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.fail_sampler.sampler = smp_id;
     }
     if (ctx->hooks.fail_sampler) {
@@ -3074,13 +3039,13 @@ _SOKOL_PRIVATE void _sg_imgui_fail_sampler(sg_sampler smp_id, void* user_data) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_fail_shader(sg_shader shd_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_fail_shader(sg_shader shd_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_FAIL_SHADER;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_FAIL_SHADER;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.fail_shader.shader = shd_id;
     }
     if (ctx->hooks.fail_shader) {
@@ -3088,13 +3053,13 @@ _SOKOL_PRIVATE void _sg_imgui_fail_shader(sg_shader shd_id, void* user_data) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_fail_pipeline(sg_pipeline pip_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_fail_pipeline(sg_pipeline pip_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_FAIL_PIPELINE;
-        item->color = _SG_IMGUI_COLOR_RSRC;
+        item->cmd = SGIMGUI_CMD_FAIL_PIPELINE;
+        item->color = _SGIMGUI_COLOR_RSRC;
         item->args.fail_pipeline.pipeline = pip_id;
     }
     if (ctx->hooks.fail_pipeline) {
@@ -3102,53 +3067,53 @@ _SOKOL_PRIVATE void _sg_imgui_fail_pipeline(sg_pipeline pip_id, void* user_data)
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_fail_pass(sg_pass pass_id, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_fail_attachments(sg_attachments atts_id, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_FAIL_PASS;
-        item->color = _SG_IMGUI_COLOR_RSRC;
-        item->args.fail_pass.pass = pass_id;
+        item->cmd = SGIMGUI_CMD_FAIL_ATTACHMENTS;
+        item->color = _SGIMGUI_COLOR_RSRC;
+        item->args.fail_attachments.attachments = atts_id;
     }
-    if (ctx->hooks.fail_pass) {
-        ctx->hooks.fail_pass(pass_id, ctx->hooks.user_data);
+    if (ctx->hooks.fail_attachments) {
+        ctx->hooks.fail_attachments(atts_id, ctx->hooks.user_data);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_push_debug_group(const char* name, void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_push_debug_group(const char* name, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     if (0 == strcmp(name, "sokol-imgui")) {
-        ctx->frame_stats.in_sokol_imgui = true;
-        if (ctx->frame_stats.disable_sokol_imgui_stats) {
+        ctx->frame_stats_window.in_sokol_imgui = true;
+        if (ctx->frame_stats_window.disable_sokol_imgui_stats) {
             sg_disable_frame_stats();
         }
     }
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_PUSH_DEBUG_GROUP;
-        item->color = _SG_IMGUI_COLOR_OTHER;
-        item->args.push_debug_group.name = _sg_imgui_make_str(name);
+        item->cmd = SGIMGUI_CMD_PUSH_DEBUG_GROUP;
+        item->color = _SGIMGUI_COLOR_OTHER;
+        item->args.push_debug_group.name = _sgimgui_make_str(name);
     }
     if (ctx->hooks.push_debug_group) {
         ctx->hooks.push_debug_group(name, ctx->hooks.user_data);
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_pop_debug_group(void* user_data) {
-    sg_imgui_t* ctx = (sg_imgui_t*) user_data;
+_SOKOL_PRIVATE void _sgimgui_pop_debug_group(void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
-    if (ctx->frame_stats.in_sokol_imgui) {
-        ctx->frame_stats.in_sokol_imgui = false;
-        if (ctx->frame_stats.disable_sokol_imgui_stats) {
+    if (ctx->frame_stats_window.in_sokol_imgui) {
+        ctx->frame_stats_window.in_sokol_imgui = false;
+        if (ctx->frame_stats_window.disable_sokol_imgui_stats) {
             sg_enable_frame_stats();
         }
     }
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_next_write_item(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
     if (item) {
-        item->cmd = SG_IMGUI_CMD_POP_DEBUG_GROUP;
-        item->color = _SG_IMGUI_COLOR_OTHER;
+        item->cmd = SGIMGUI_CMD_POP_DEBUG_GROUP;
+        item->color = _SGIMGUI_COLOR_OTHER;
     }
     if (ctx->hooks.pop_debug_group) {
         ctx->hooks.pop_debug_group(ctx->hooks.user_data);
@@ -3156,28 +3121,28 @@ _SOKOL_PRIVATE void _sg_imgui_pop_debug_group(void* user_data) {
 }
 
 /*--- IMGUI HELPERS ----------------------------------------------------------*/
-_SOKOL_PRIVATE bool _sg_imgui_draw_resid_list_item(uint32_t res_id, const char* label, bool selected) {
+_SOKOL_PRIVATE bool _sgimgui_draw_resid_list_item(uint32_t res_id, const char* label, bool selected) {
     igPushID_Int((int)res_id);
     bool res;
     if (label[0]) {
         res = igSelectable_Bool(label, selected, 0, IMVEC2(0,0));
     } else {
-        sg_imgui_str_t str;
-        _sg_imgui_snprintf(&str, "0x%08X", res_id);
+        sgimgui_str_t str;
+        _sgimgui_snprintf(&str, "0x%08X", res_id);
         res = igSelectable_Bool(str.buf, selected, 0, IMVEC2(0,0));
     }
     igPopID();
     return res;
 }
 
-_SOKOL_PRIVATE bool _sg_imgui_draw_resid_link(uint32_t res_type, uint32_t res_id, const char* label) {
+_SOKOL_PRIVATE bool _sgimgui_draw_resid_link(uint32_t res_type, uint32_t res_id, const char* label) {
     SOKOL_ASSERT(label);
-    sg_imgui_str_t str_buf;
+    sgimgui_str_t str_buf;
     const char* str;
     if (label[0]) {
         str = label;
     } else {
-        _sg_imgui_snprintf(&str_buf, "0x%08X", res_id);
+        _sgimgui_snprintf(&str_buf, "0x%08X", res_id);
         str = str_buf.buf;
     }
     igPushID_Int((int)((res_type<<24)|res_id));
@@ -3186,162 +3151,162 @@ _SOKOL_PRIVATE bool _sg_imgui_draw_resid_link(uint32_t res_type, uint32_t res_id
     return res;
 }
 
-_SOKOL_PRIVATE bool _sg_imgui_draw_buffer_link(sg_imgui_t* ctx, sg_buffer buf) {
+_SOKOL_PRIVATE bool _sgimgui_draw_buffer_link(sgimgui_t* ctx, sg_buffer buf) {
     bool retval = false;
     if (buf.id != SG_INVALID_ID) {
-        const sg_imgui_buffer_t* buf_ui = &ctx->buffers.slots[_sg_imgui_slot_index(buf.id)];
-        retval = _sg_imgui_draw_resid_link(1, buf.id, buf_ui->label.buf);
+        const sgimgui_buffer_t* buf_ui = &ctx->buffer_window.slots[_sgimgui_slot_index(buf.id)];
+        retval = _sgimgui_draw_resid_link(1, buf.id, buf_ui->label.buf);
     }
     return retval;
 }
 
-_SOKOL_PRIVATE bool _sg_imgui_draw_image_link(sg_imgui_t* ctx, sg_image img) {
+_SOKOL_PRIVATE bool _sgimgui_draw_image_link(sgimgui_t* ctx, sg_image img) {
     bool retval = false;
     if (img.id != SG_INVALID_ID) {
-        const sg_imgui_image_t* img_ui = &ctx->images.slots[_sg_imgui_slot_index(img.id)];
-        retval = _sg_imgui_draw_resid_link(2, img.id, img_ui->label.buf);
+        const sgimgui_image_t* img_ui = &ctx->image_window.slots[_sgimgui_slot_index(img.id)];
+        retval = _sgimgui_draw_resid_link(2, img.id, img_ui->label.buf);
     }
     return retval;
 }
 
-_SOKOL_PRIVATE bool _sg_imgui_draw_sampler_link(sg_imgui_t* ctx, sg_sampler smp) {
+_SOKOL_PRIVATE bool _sgimgui_draw_sampler_link(sgimgui_t* ctx, sg_sampler smp) {
     bool retval = false;
     if (smp.id != SG_INVALID_ID) {
-        const sg_imgui_sampler_t* smp_ui = &ctx->samplers.slots[_sg_imgui_slot_index(smp.id)];
-        retval = _sg_imgui_draw_resid_link(2, smp.id, smp_ui->label.buf);
+        const sgimgui_sampler_t* smp_ui = &ctx->sampler_window.slots[_sgimgui_slot_index(smp.id)];
+        retval = _sgimgui_draw_resid_link(2, smp.id, smp_ui->label.buf);
     }
     return retval;
 }
 
-_SOKOL_PRIVATE bool _sg_imgui_draw_shader_link(sg_imgui_t* ctx, sg_shader shd) {
+_SOKOL_PRIVATE bool _sgimgui_draw_shader_link(sgimgui_t* ctx, sg_shader shd) {
     bool retval = false;
     if (shd.id != SG_INVALID_ID) {
-        const sg_imgui_shader_t* shd_ui = &ctx->shaders.slots[_sg_imgui_slot_index(shd.id)];
-        retval = _sg_imgui_draw_resid_link(3, shd.id, shd_ui->label.buf);
+        const sgimgui_shader_t* shd_ui = &ctx->shader_window.slots[_sgimgui_slot_index(shd.id)];
+        retval = _sgimgui_draw_resid_link(3, shd.id, shd_ui->label.buf);
     }
     return retval;
 }
 
-_SOKOL_PRIVATE void _sg_imgui_show_buffer(sg_imgui_t* ctx, sg_buffer buf) {
-    ctx->buffers.open = true;
-    ctx->buffers.sel_buf = buf;
+_SOKOL_PRIVATE void _sgimgui_show_buffer(sgimgui_t* ctx, sg_buffer buf) {
+    ctx->buffer_window.open = true;
+    ctx->buffer_window.sel_buf = buf;
 }
 
-_SOKOL_PRIVATE void _sg_imgui_show_image(sg_imgui_t* ctx, sg_image img) {
-    ctx->images.open = true;
-    ctx->images.sel_img = img;
+_SOKOL_PRIVATE void _sgimgui_show_image(sgimgui_t* ctx, sg_image img) {
+    ctx->image_window.open = true;
+    ctx->image_window.sel_img = img;
 }
 
-_SOKOL_PRIVATE void _sg_imgui_show_sampler(sg_imgui_t* ctx, sg_sampler smp) {
-    ctx->samplers.open = true;
-    ctx->samplers.sel_smp = smp;
+_SOKOL_PRIVATE void _sgimgui_show_sampler(sgimgui_t* ctx, sg_sampler smp) {
+    ctx->sampler_window.open = true;
+    ctx->sampler_window.sel_smp = smp;
 }
 
-_SOKOL_PRIVATE void _sg_imgui_show_shader(sg_imgui_t* ctx, sg_shader shd) {
-    ctx->shaders.open = true;
-    ctx->shaders.sel_shd = shd;
+_SOKOL_PRIVATE void _sgimgui_show_shader(sgimgui_t* ctx, sg_shader shd) {
+    ctx->shader_window.open = true;
+    ctx->shader_window.sel_shd = shd;
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_buffer_list(sg_imgui_t* ctx) {
-    igBeginChild_Str("buffer_list", IMVEC2(_SG_IMGUI_LIST_WIDTH,0), true, 0);
-    for (int i = 0; i < ctx->buffers.num_slots; i++) {
-        sg_buffer buf = ctx->buffers.slots[i].res_id;
+_SOKOL_PRIVATE void _sgimgui_draw_buffer_list(sgimgui_t* ctx) {
+    igBeginChild_Str("buffer_list", IMVEC2(_SGIMGUI_LIST_WIDTH,0), true, 0);
+    for (int i = 0; i < ctx->buffer_window.num_slots; i++) {
+        sg_buffer buf = ctx->buffer_window.slots[i].res_id;
         sg_resource_state state = sg_query_buffer_state(buf);
         if ((state != SG_RESOURCESTATE_INVALID) && (state != SG_RESOURCESTATE_INITIAL)) {
-            bool selected = ctx->buffers.sel_buf.id == buf.id;
-            if (_sg_imgui_draw_resid_list_item(buf.id, ctx->buffers.slots[i].label.buf, selected)) {
-                ctx->buffers.sel_buf.id = buf.id;
+            bool selected = ctx->buffer_window.sel_buf.id == buf.id;
+            if (_sgimgui_draw_resid_list_item(buf.id, ctx->buffer_window.slots[i].label.buf, selected)) {
+                ctx->buffer_window.sel_buf.id = buf.id;
             }
         }
     }
     igEndChild();
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_image_list(sg_imgui_t* ctx) {
-    igBeginChild_Str("image_list", IMVEC2(_SG_IMGUI_LIST_WIDTH,0), true, 0);
-    for (int i = 0; i < ctx->images.num_slots; i++) {
-        sg_image img = ctx->images.slots[i].res_id;
+_SOKOL_PRIVATE void _sgimgui_draw_image_list(sgimgui_t* ctx) {
+    igBeginChild_Str("image_list", IMVEC2(_SGIMGUI_LIST_WIDTH,0), true, 0);
+    for (int i = 0; i < ctx->image_window.num_slots; i++) {
+        sg_image img = ctx->image_window.slots[i].res_id;
         sg_resource_state state = sg_query_image_state(img);
         if ((state != SG_RESOURCESTATE_INVALID) && (state != SG_RESOURCESTATE_INITIAL)) {
-            bool selected = ctx->images.sel_img.id == img.id;
-            if (_sg_imgui_draw_resid_list_item(img.id, ctx->images.slots[i].label.buf, selected)) {
-                ctx->images.sel_img.id = img.id;
+            bool selected = ctx->image_window.sel_img.id == img.id;
+            if (_sgimgui_draw_resid_list_item(img.id, ctx->image_window.slots[i].label.buf, selected)) {
+                ctx->image_window.sel_img.id = img.id;
             }
         }
     }
     igEndChild();
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_sampler_list(sg_imgui_t* ctx) {
-    igBeginChild_Str("sampler_list", IMVEC2(_SG_IMGUI_LIST_WIDTH,0), true, 0);
-    for (int i = 0; i < ctx->samplers.num_slots; i++) {
-        sg_sampler smp = ctx->samplers.slots[i].res_id;
+_SOKOL_PRIVATE void _sgimgui_draw_sampler_list(sgimgui_t* ctx) {
+    igBeginChild_Str("sampler_list", IMVEC2(_SGIMGUI_LIST_WIDTH,0), true, 0);
+    for (int i = 0; i < ctx->sampler_window.num_slots; i++) {
+        sg_sampler smp = ctx->sampler_window.slots[i].res_id;
         sg_resource_state state = sg_query_sampler_state(smp);
         if ((state != SG_RESOURCESTATE_INVALID) && (state != SG_RESOURCESTATE_INITIAL)) {
-            bool selected = ctx->samplers.sel_smp.id == smp.id;
-            if (_sg_imgui_draw_resid_list_item(smp.id, ctx->samplers.slots[i].label.buf, selected)) {
-                ctx->samplers.sel_smp.id = smp.id;
+            bool selected = ctx->sampler_window.sel_smp.id == smp.id;
+            if (_sgimgui_draw_resid_list_item(smp.id, ctx->sampler_window.slots[i].label.buf, selected)) {
+                ctx->sampler_window.sel_smp.id = smp.id;
             }
         }
     }
     igEndChild();
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_shader_list(sg_imgui_t* ctx) {
-    igBeginChild_Str("shader_list", IMVEC2(_SG_IMGUI_LIST_WIDTH,0), true, 0);
-    for (int i = 0; i < ctx->shaders.num_slots; i++) {
-        sg_shader shd = ctx->shaders.slots[i].res_id;
+_SOKOL_PRIVATE void _sgimgui_draw_shader_list(sgimgui_t* ctx) {
+    igBeginChild_Str("shader_list", IMVEC2(_SGIMGUI_LIST_WIDTH,0), true, 0);
+    for (int i = 0; i < ctx->shader_window.num_slots; i++) {
+        sg_shader shd = ctx->shader_window.slots[i].res_id;
         sg_resource_state state = sg_query_shader_state(shd);
         if ((state != SG_RESOURCESTATE_INVALID) && (state != SG_RESOURCESTATE_INITIAL)) {
-            bool selected = ctx->shaders.sel_shd.id == shd.id;
-            if (_sg_imgui_draw_resid_list_item(shd.id, ctx->shaders.slots[i].label.buf, selected)) {
-                ctx->shaders.sel_shd.id = shd.id;
+            bool selected = ctx->shader_window.sel_shd.id == shd.id;
+            if (_sgimgui_draw_resid_list_item(shd.id, ctx->shader_window.slots[i].label.buf, selected)) {
+                ctx->shader_window.sel_shd.id = shd.id;
             }
         }
     }
     igEndChild();
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_pipeline_list(sg_imgui_t* ctx) {
-    igBeginChild_Str("pipeline_list", IMVEC2(_SG_IMGUI_LIST_WIDTH,0), true, 0);
-    for (int i = 1; i < ctx->pipelines.num_slots; i++) {
-        sg_pipeline pip = ctx->pipelines.slots[i].res_id;
+_SOKOL_PRIVATE void _sgimgui_draw_pipeline_list(sgimgui_t* ctx) {
+    igBeginChild_Str("pipeline_list", IMVEC2(_SGIMGUI_LIST_WIDTH,0), true, 0);
+    for (int i = 1; i < ctx->pipeline_window.num_slots; i++) {
+        sg_pipeline pip = ctx->pipeline_window.slots[i].res_id;
         sg_resource_state state = sg_query_pipeline_state(pip);
         if ((state != SG_RESOURCESTATE_INVALID) && (state != SG_RESOURCESTATE_INITIAL)) {
-            bool selected = ctx->pipelines.sel_pip.id == pip.id;
-            if (_sg_imgui_draw_resid_list_item(pip.id, ctx->pipelines.slots[i].label.buf, selected)) {
-                ctx->pipelines.sel_pip.id = pip.id;
+            bool selected = ctx->pipeline_window.sel_pip.id == pip.id;
+            if (_sgimgui_draw_resid_list_item(pip.id, ctx->pipeline_window.slots[i].label.buf, selected)) {
+                ctx->pipeline_window.sel_pip.id = pip.id;
             }
         }
     }
     igEndChild();
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_pass_list(sg_imgui_t* ctx) {
-    igBeginChild_Str("pass_list", IMVEC2(_SG_IMGUI_LIST_WIDTH,0), true, 0);
-    for (int i = 1; i < ctx->passes.num_slots; i++) {
-        sg_pass pass = ctx->passes.slots[i].res_id;
-        sg_resource_state state = sg_query_pass_state(pass);
+_SOKOL_PRIVATE void _sgimgui_draw_attachments_list(sgimgui_t* ctx) {
+    igBeginChild_Str("pass_list", IMVEC2(_SGIMGUI_LIST_WIDTH,0), true, 0);
+    for (int i = 1; i < ctx->attachments_window.num_slots; i++) {
+        sg_attachments atts = ctx->attachments_window.slots[i].res_id;
+        sg_resource_state state = sg_query_attachments_state(atts);
         if ((state != SG_RESOURCESTATE_INVALID) && (state != SG_RESOURCESTATE_INITIAL)) {
-            bool selected = ctx->passes.sel_pass.id == pass.id;
-            if (_sg_imgui_draw_resid_list_item(pass.id, ctx->passes.slots[i].label.buf, selected)) {
-                ctx->passes.sel_pass.id = pass.id;
+            bool selected = ctx->attachments_window.sel_atts.id == atts.id;
+            if (_sgimgui_draw_resid_list_item(atts.id, ctx->attachments_window.slots[i].label.buf, selected)) {
+                ctx->attachments_window.sel_atts.id = atts.id;
             }
         }
     }
     igEndChild();
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_capture_list(sg_imgui_t* ctx) {
-    igBeginChild_Str("capture_list", IMVEC2(_SG_IMGUI_LIST_WIDTH,0), true, 0);
-    const int num_items = _sg_imgui_capture_num_read_items(ctx);
+_SOKOL_PRIVATE void _sgimgui_draw_capture_list(sgimgui_t* ctx) {
+    igBeginChild_Str("capture_list", IMVEC2(_SGIMGUI_LIST_WIDTH,0), true, 0);
+    const int num_items = _sgimgui_capture_num_read_items(ctx);
     uint64_t group_stack = 1;   /* bit set: group unfolded, cleared: folded */
     for (int i = 0; i < num_items; i++) {
-        const sg_imgui_capture_item_t* item = _sg_imgui_capture_read_item_at(ctx, i);
-        sg_imgui_str_t item_string = _sg_imgui_capture_item_string(ctx, i, item);
+        const sgimgui_capture_item_t* item = _sgimgui_capture_read_item_at(ctx, i);
+        sgimgui_str_t item_string = _sgimgui_capture_item_string(ctx, i, item);
         igPushStyleColor_U32(ImGuiCol_Text, item->color);
         igPushID_Int(i);
-        if (item->cmd == SG_IMGUI_CMD_PUSH_DEBUG_GROUP) {
+        if (item->cmd == SGIMGUI_CMD_PUSH_DEBUG_GROUP) {
             if (group_stack & 1) {
                 group_stack <<= 1;
                 const char* group_name = item->args.push_debug_group.name.buf;
@@ -3351,14 +3316,14 @@ _SOKOL_PRIVATE void _sg_imgui_draw_capture_list(sg_imgui_t* ctx) {
             } else {
                 group_stack <<= 1;
             }
-        } else if (item->cmd == SG_IMGUI_CMD_POP_DEBUG_GROUP) {
+        } else if (item->cmd == SGIMGUI_CMD_POP_DEBUG_GROUP) {
             if (group_stack & 1) {
                 igTreePop();
             }
             group_stack >>= 1;
         } else if (group_stack & 1) {
-            if (igSelectable_Bool(item_string.buf, ctx->capture.sel_item == i, 0, IMVEC2(0,0))) {
-                ctx->capture.sel_item = i;
+            if (igSelectable_Bool(item_string.buf, ctx->capture_window.sel_item == i, 0, IMVEC2(0,0))) {
+                ctx->capture_window.sel_item = i;
             }
             if (igIsItemHovered(0)) {
                 igSetTooltip("%s", item_string.buf);
@@ -3370,17 +3335,17 @@ _SOKOL_PRIVATE void _sg_imgui_draw_capture_list(sg_imgui_t* ctx) {
     igEndChild();
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_buffer_panel(sg_imgui_t* ctx, sg_buffer buf) {
+_SOKOL_PRIVATE void _sgimgui_draw_buffer_panel(sgimgui_t* ctx, sg_buffer buf) {
     if (buf.id != SG_INVALID_ID) {
         igBeginChild_Str("buffer", IMVEC2(0,0), false, 0);
         sg_buffer_info info = sg_query_buffer_info(buf);
         if (info.slot.state == SG_RESOURCESTATE_VALID) {
-            const sg_imgui_buffer_t* buf_ui = &ctx->buffers.slots[_sg_imgui_slot_index(buf.id)];
+            const sgimgui_buffer_t* buf_ui = &ctx->buffer_window.slots[_sgimgui_slot_index(buf.id)];
             igText("Label: %s", buf_ui->label.buf[0] ? buf_ui->label.buf : "---");
-            _sg_imgui_draw_resource_slot(&info.slot);
+            _sgimgui_draw_resource_slot(&info.slot);
             igSeparator();
-            igText("Type:  %s", _sg_imgui_buffertype_string(buf_ui->desc.type));
-            igText("Usage: %s", _sg_imgui_usage_string(buf_ui->desc.usage));
+            igText("Type:  %s", _sgimgui_buffertype_string(buf_ui->desc.type));
+            igText("Usage: %s", _sgimgui_usage_string(buf_ui->desc.usage));
             igText("Size:  %d", buf_ui->desc.size);
             if (buf_ui->desc.usage != SG_USAGE_IMMUTABLE) {
                 igSeparator();
@@ -3389,7 +3354,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_buffer_panel(sg_imgui_t* ctx, sg_buffer buf) 
                 igText("Update Frame Index: %d", info.update_frame_index);
                 igText("Append Frame Index: %d", info.append_frame_index);
                 igText("Append Pos:         %d", info.append_pos);
-                igText("Append Overflow:    %s", _sg_imgui_bool_string(info.append_overflow));
+                igText("Append Overflow:    %s", _sgimgui_bool_string(info.append_overflow));
             }
         } else {
             igText("Buffer 0x%08X not valid.", buf.id);
@@ -3398,16 +3363,16 @@ _SOKOL_PRIVATE void _sg_imgui_draw_buffer_panel(sg_imgui_t* ctx, sg_buffer buf) 
     }
 }
 
-_SOKOL_PRIVATE bool _sg_imgui_image_renderable(sg_image_type type, sg_pixel_format fmt, int sample_count) {
+_SOKOL_PRIVATE bool _sgimgui_image_renderable(sg_image_type type, sg_pixel_format fmt, int sample_count) {
     return (type == SG_IMAGETYPE_2D)
         && sg_query_pixelformat(fmt).sample
         && sample_count == 1;
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_embedded_image(sg_imgui_t* ctx, sg_image img, float* scale) {
+_SOKOL_PRIVATE void _sgimgui_draw_embedded_image(sgimgui_t* ctx, sg_image img, float* scale) {
     if (sg_query_image_state(img) == SG_RESOURCESTATE_VALID) {
-        sg_imgui_image_t* img_ui = &ctx->images.slots[_sg_imgui_slot_index(img.id)];
-        if (_sg_imgui_image_renderable(img_ui->desc.type, img_ui->desc.pixel_format, img_ui->desc.sample_count)) {
+        sgimgui_image_t* img_ui = &ctx->image_window.slots[_sgimgui_slot_index(img.id)];
+        if (_sgimgui_image_renderable(img_ui->desc.type, img_ui->desc.pixel_format, img_ui->desc.sample_count)) {
             igPushID_Int((int)img.id);
             igSliderFloat("Scale", scale, 0.125f, 8.0f, "%.3f", ImGuiSliderFlags_Logarithmic);
             float w = (float)img_ui->desc.width * (*scale);
@@ -3420,26 +3385,26 @@ _SOKOL_PRIVATE void _sg_imgui_draw_embedded_image(sg_imgui_t* ctx, sg_image img,
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_image_panel(sg_imgui_t* ctx, sg_image img) {
+_SOKOL_PRIVATE void _sgimgui_draw_image_panel(sgimgui_t* ctx, sg_image img) {
     if (img.id != SG_INVALID_ID) {
         igBeginChild_Str("image", IMVEC2(0,0), false, 0);
         sg_image_info info = sg_query_image_info(img);
         if (info.slot.state == SG_RESOURCESTATE_VALID) {
-            sg_imgui_image_t* img_ui = &ctx->images.slots[_sg_imgui_slot_index(img.id)];
+            sgimgui_image_t* img_ui = &ctx->image_window.slots[_sgimgui_slot_index(img.id)];
             const sg_image_desc* desc = &img_ui->desc;
             igText("Label: %s", img_ui->label.buf[0] ? img_ui->label.buf : "---");
-            _sg_imgui_draw_resource_slot(&info.slot);
+            _sgimgui_draw_resource_slot(&info.slot);
             igSeparator();
-            _sg_imgui_draw_embedded_image(ctx, img, &img_ui->ui_scale);
+            _sgimgui_draw_embedded_image(ctx, img, &img_ui->ui_scale);
             igSeparator();
-            igText("Type:           %s", _sg_imgui_imagetype_string(desc->type));
-            igText("Usage:          %s", _sg_imgui_usage_string(desc->usage));
-            igText("Render Target:  %s", _sg_imgui_bool_string(desc->render_target));
+            igText("Type:           %s", _sgimgui_imagetype_string(desc->type));
+            igText("Usage:          %s", _sgimgui_usage_string(desc->usage));
+            igText("Render Target:  %s", _sgimgui_bool_string(desc->render_target));
             igText("Width:          %d", desc->width);
             igText("Height:         %d", desc->height);
             igText("Num Slices:     %d", desc->num_slices);
             igText("Num Mipmaps:    %d", desc->num_mipmaps);
-            igText("Pixel Format:   %s", _sg_imgui_pixelformat_string(desc->pixel_format));
+            igText("Pixel Format:   %s", _sgimgui_pixelformat_string(desc->pixel_format));
             igText("Sample Count:   %d", desc->sample_count);
             if (desc->usage != SG_USAGE_IMMUTABLE) {
                 igSeparator();
@@ -3454,26 +3419,26 @@ _SOKOL_PRIVATE void _sg_imgui_draw_image_panel(sg_imgui_t* ctx, sg_image img) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_sampler_panel(sg_imgui_t* ctx, sg_sampler smp) {
+_SOKOL_PRIVATE void _sgimgui_draw_sampler_panel(sgimgui_t* ctx, sg_sampler smp) {
     if (smp.id != SG_INVALID_ID) {
         igBeginChild_Str("sampler", IMVEC2(0,0), false, 0);
         sg_sampler_info info = sg_query_sampler_info(smp);
         if (info.slot.state == SG_RESOURCESTATE_VALID) {
-            sg_imgui_sampler_t* smp_ui = &ctx->samplers.slots[_sg_imgui_slot_index(smp.id)];
+            sgimgui_sampler_t* smp_ui = &ctx->sampler_window.slots[_sgimgui_slot_index(smp.id)];
             const sg_sampler_desc* desc = &smp_ui->desc;
             igText("Label: %s", smp_ui->label.buf[0] ? smp_ui->label.buf : "---");
-            _sg_imgui_draw_resource_slot(&info.slot);
+            _sgimgui_draw_resource_slot(&info.slot);
             igSeparator();
-            igText("Min Filter:     %s", _sg_imgui_filter_string(desc->min_filter));
-            igText("Mag Filter:     %s", _sg_imgui_filter_string(desc->mag_filter));
-            igText("Mipmap Filter:  %s", _sg_imgui_filter_string(desc->mipmap_filter));
-            igText("Wrap U:         %s", _sg_imgui_wrap_string(desc->wrap_u));
-            igText("Wrap V:         %s", _sg_imgui_wrap_string(desc->wrap_v));
-            igText("Wrap W:         %s", _sg_imgui_wrap_string(desc->wrap_w));
+            igText("Min Filter:     %s", _sgimgui_filter_string(desc->min_filter));
+            igText("Mag Filter:     %s", _sgimgui_filter_string(desc->mag_filter));
+            igText("Mipmap Filter:  %s", _sgimgui_filter_string(desc->mipmap_filter));
+            igText("Wrap U:         %s", _sgimgui_wrap_string(desc->wrap_u));
+            igText("Wrap V:         %s", _sgimgui_wrap_string(desc->wrap_v));
+            igText("Wrap W:         %s", _sgimgui_wrap_string(desc->wrap_w));
             igText("Min LOD:        %.3f", desc->min_lod);
             igText("Max LOD:        %.3f", desc->max_lod);
-            igText("Border Color:   %s", _sg_imgui_bordercolor_string(desc->border_color));
-            igText("Compare:        %s", _sg_imgui_comparefunc_string(desc->compare));
+            igText("Border Color:   %s", _sgimgui_bordercolor_string(desc->border_color));
+            igText("Compare:        %s", _sgimgui_comparefunc_string(desc->compare));
             igText("Max Anisotropy: %d", desc->max_anisotropy);
         } else {
             igText("Sampler 0x%08X not valid.", smp.id);
@@ -3482,7 +3447,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_sampler_panel(sg_imgui_t* ctx, sg_sampler smp
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_shader_stage(const sg_shader_stage_desc* stage) {
+_SOKOL_PRIVATE void _sgimgui_draw_shader_stage(const sg_shader_stage_desc* stage) {
     int num_valid_ubs = 0;
     for (int i = 0; i < SG_MAX_SHADERSTAGE_UBS; i++) {
         const sg_shader_uniform_block_desc* ub = &stage->uniform_blocks[i];
@@ -3522,14 +3487,14 @@ _SOKOL_PRIVATE void _sg_imgui_draw_shader_stage(const sg_shader_stage_desc* stag
         if (igTreeNode_Str("Uniform Blocks")) {
             for (int i = 0; i < num_valid_ubs; i++) {
                 const sg_shader_uniform_block_desc* ub = &stage->uniform_blocks[i];
-                igText("#%d: (size: %d layout: %s)\n", i, ub->size, _sg_imgui_uniformlayout_string(ub->layout));
+                igText("#%d: (size: %d layout: %s)\n", i, ub->size, _sgimgui_uniformlayout_string(ub->layout));
                 for (int j = 0; j < SG_MAX_UB_MEMBERS; j++) {
                     const sg_shader_uniform_desc* u = &ub->uniforms[j];
                     if (SG_UNIFORMTYPE_INVALID != u->type) {
                         if (u->array_count <= 1) {
-                            igText("  %s %s", _sg_imgui_uniformtype_string(u->type), u->name ? u->name : "");
+                            igText("  %s %s", _sgimgui_uniformtype_string(u->type), u->name ? u->name : "");
                         } else {
-                            igText("  %s[%d] %s", _sg_imgui_uniformtype_string(u->type), u->array_count, u->name ? u->name : "");
+                            igText("  %s[%d] %s", _sgimgui_uniformtype_string(u->type), u->array_count, u->name ? u->name : "");
                         }
                     }
                 }
@@ -3544,8 +3509,8 @@ _SOKOL_PRIVATE void _sg_imgui_draw_shader_stage(const sg_shader_stage_desc* stag
                 igText("slot: %d\n  multisampled: %s\n  image_type: %s\n  sample_type: %s",
                     i,
                     sid->multisampled ? "true" : "false",
-                    _sg_imgui_imagetype_string(sid->image_type),
-                    _sg_imgui_imagesampletype_string(sid->sample_type));
+                    _sgimgui_imagetype_string(sid->image_type),
+                    _sgimgui_imagesampletype_string(sid->sample_type));
             }
             igTreePop();
         }
@@ -3554,7 +3519,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_shader_stage(const sg_shader_stage_desc* stag
         if (igTreeNode_Str("Samplers")) {
             for (int i = 0; i < num_valid_samplers; i++) {
                 const sg_shader_sampler_desc* ssd = &stage->samplers[i];
-                igText("slot: %d\n  sampler_type: %s", i, _sg_imgui_samplertype_string(ssd->sampler_type));
+                igText("slot: %d\n  sampler_type: %s", i, _sgimgui_samplertype_string(ssd->sampler_type));
             }
             igTreePop();
         }
@@ -3591,14 +3556,14 @@ _SOKOL_PRIVATE void _sg_imgui_draw_shader_stage(const sg_shader_stage_desc* stag
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_shader_panel(sg_imgui_t* ctx, sg_shader shd) {
+_SOKOL_PRIVATE void _sgimgui_draw_shader_panel(sgimgui_t* ctx, sg_shader shd) {
     if (shd.id != SG_INVALID_ID) {
         igBeginChild_Str("shader", IMVEC2(0,0), false, ImGuiWindowFlags_HorizontalScrollbar);
         sg_shader_info info = sg_query_shader_info(shd);
         if (info.slot.state == SG_RESOURCESTATE_VALID) {
-            const sg_imgui_shader_t* shd_ui = &ctx->shaders.slots[_sg_imgui_slot_index(shd.id)];
+            const sgimgui_shader_t* shd_ui = &ctx->shader_window.slots[_sgimgui_slot_index(shd.id)];
             igText("Label: %s", shd_ui->label.buf[0] ? shd_ui->label.buf : "---");
-            _sg_imgui_draw_resource_slot(&info.slot);
+            _sgimgui_draw_resource_slot(&info.slot);
             igSeparator();
             if (igTreeNode_Str("Attrs")) {
                 for (int i = 0; i < SG_MAX_VERTEX_ATTRIBUTES; i++) {
@@ -3613,11 +3578,11 @@ _SOKOL_PRIVATE void _sg_imgui_draw_shader_panel(sg_imgui_t* ctx, sg_shader shd) 
                 igTreePop();
             }
             if (igTreeNode_Str("Vertex Shader Stage")) {
-                _sg_imgui_draw_shader_stage(&shd_ui->desc.vs);
+                _sgimgui_draw_shader_stage(&shd_ui->desc.vs);
                 igTreePop();
             }
             if (igTreeNode_Str("Fragment Shader Stage")) {
-                _sg_imgui_draw_shader_stage(&shd_ui->desc.fs);
+                _sgimgui_draw_shader_stage(&shd_ui->desc.fs);
                 igTreePop();
             }
         } else {
@@ -3627,14 +3592,14 @@ _SOKOL_PRIVATE void _sg_imgui_draw_shader_panel(sg_imgui_t* ctx, sg_shader shd) 
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_vertex_layout_state(const sg_vertex_layout_state* layout) {
+_SOKOL_PRIVATE void _sgimgui_draw_vertex_layout_state(const sg_vertex_layout_state* layout) {
     if (igTreeNode_Str("Buffers")) {
         for (int i = 0; i < SG_MAX_VERTEX_BUFFERS; i++) {
             const sg_vertex_buffer_layout_state* l_state = &layout->buffers[i];
             if (l_state->stride > 0) {
                 igText("#%d:", i);
                 igText("  Stride:    %d", l_state->stride);
-                igText("  Step Func: %s", _sg_imgui_vertexstep_string(l_state->step_func));
+                igText("  Step Func: %s", _sgimgui_vertexstep_string(l_state->step_func));
                 igText("  Step Rate: %d", l_state->step_rate);
             }
         }
@@ -3645,7 +3610,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_vertex_layout_state(const sg_vertex_layout_st
             const sg_vertex_attr_state* a_state = &layout->attrs[i];
             if (a_state->format != SG_VERTEXFORMAT_INVALID) {
                 igText("#%d:", i);
-                igText("  Format:       %s", _sg_imgui_vertexformat_string(a_state->format));
+                igText("  Format:       %s", _sgimgui_vertexformat_string(a_state->format));
                 igText("  Offset:       %d", a_state->offset);
                 igText("  Buffer Index: %d", a_state->buffer_index);
             }
@@ -3654,98 +3619,98 @@ _SOKOL_PRIVATE void _sg_imgui_draw_vertex_layout_state(const sg_vertex_layout_st
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_stencil_face_state(const sg_stencil_face_state* sfs) {
-    igText("Fail Op:       %s", _sg_imgui_stencilop_string(sfs->fail_op));
-    igText("Depth Fail Op: %s", _sg_imgui_stencilop_string(sfs->depth_fail_op));
-    igText("Pass Op:       %s", _sg_imgui_stencilop_string(sfs->pass_op));
-    igText("Compare:       %s", _sg_imgui_comparefunc_string(sfs->compare));
+_SOKOL_PRIVATE void _sgimgui_draw_stencil_face_state(const sg_stencil_face_state* sfs) {
+    igText("Fail Op:       %s", _sgimgui_stencilop_string(sfs->fail_op));
+    igText("Depth Fail Op: %s", _sgimgui_stencilop_string(sfs->depth_fail_op));
+    igText("Pass Op:       %s", _sgimgui_stencilop_string(sfs->pass_op));
+    igText("Compare:       %s", _sgimgui_comparefunc_string(sfs->compare));
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_stencil_state(const sg_stencil_state* ss) {
-    igText("Enabled:    %s", _sg_imgui_bool_string(ss->enabled));
+_SOKOL_PRIVATE void _sgimgui_draw_stencil_state(const sg_stencil_state* ss) {
+    igText("Enabled:    %s", _sgimgui_bool_string(ss->enabled));
     igText("Read Mask:  0x%02X", ss->read_mask);
     igText("Write Mask: 0x%02X", ss->write_mask);
     igText("Ref:        0x%02X", ss->ref);
     if (igTreeNode_Str("Front")) {
-        _sg_imgui_draw_stencil_face_state(&ss->front);
+        _sgimgui_draw_stencil_face_state(&ss->front);
         igTreePop();
     }
     if (igTreeNode_Str("Back")) {
-        _sg_imgui_draw_stencil_face_state(&ss->back);
+        _sgimgui_draw_stencil_face_state(&ss->back);
         igTreePop();
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_depth_state(const sg_depth_state* ds) {
-    igText("Pixel Format:  %s", _sg_imgui_pixelformat_string(ds->pixel_format));
-    igText("Compare:       %s", _sg_imgui_comparefunc_string(ds->compare));
-    igText("Write Enabled: %s", _sg_imgui_bool_string(ds->write_enabled));
+_SOKOL_PRIVATE void _sgimgui_draw_depth_state(const sg_depth_state* ds) {
+    igText("Pixel Format:  %s", _sgimgui_pixelformat_string(ds->pixel_format));
+    igText("Compare:       %s", _sgimgui_comparefunc_string(ds->compare));
+    igText("Write Enabled: %s", _sgimgui_bool_string(ds->write_enabled));
     igText("Bias:          %f", ds->bias);
     igText("Bias Slope:    %f", ds->bias_slope_scale);
     igText("Bias Clamp:    %f", ds->bias_clamp);
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_blend_state(const sg_blend_state* bs) {
-    igText("Blend Enabled:    %s", _sg_imgui_bool_string(bs->enabled));
-    igText("Src Factor RGB:   %s", _sg_imgui_blendfactor_string(bs->src_factor_rgb));
-    igText("Dst Factor RGB:   %s", _sg_imgui_blendfactor_string(bs->dst_factor_rgb));
-    igText("Op RGB:           %s", _sg_imgui_blendop_string(bs->op_rgb));
-    igText("Src Factor Alpha: %s", _sg_imgui_blendfactor_string(bs->src_factor_alpha));
-    igText("Dst Factor Alpha: %s", _sg_imgui_blendfactor_string(bs->dst_factor_alpha));
-    igText("Op Alpha:         %s", _sg_imgui_blendop_string(bs->op_alpha));
+_SOKOL_PRIVATE void _sgimgui_draw_blend_state(const sg_blend_state* bs) {
+    igText("Blend Enabled:    %s", _sgimgui_bool_string(bs->enabled));
+    igText("Src Factor RGB:   %s", _sgimgui_blendfactor_string(bs->src_factor_rgb));
+    igText("Dst Factor RGB:   %s", _sgimgui_blendfactor_string(bs->dst_factor_rgb));
+    igText("Op RGB:           %s", _sgimgui_blendop_string(bs->op_rgb));
+    igText("Src Factor Alpha: %s", _sgimgui_blendfactor_string(bs->src_factor_alpha));
+    igText("Dst Factor Alpha: %s", _sgimgui_blendfactor_string(bs->dst_factor_alpha));
+    igText("Op Alpha:         %s", _sgimgui_blendop_string(bs->op_alpha));
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_color_target_state(const sg_color_target_state* cs) {
-    igText("Pixel Format:     %s", _sg_imgui_pixelformat_string(cs->pixel_format));
-    igText("Write Mask:       %s", _sg_imgui_colormask_string(cs->write_mask));
+_SOKOL_PRIVATE void _sgimgui_draw_color_target_state(const sg_color_target_state* cs) {
+    igText("Pixel Format:     %s", _sgimgui_pixelformat_string(cs->pixel_format));
+    igText("Write Mask:       %s", _sgimgui_colormask_string(cs->write_mask));
     if (igTreeNode_Str("Blend State:")) {
-        _sg_imgui_draw_blend_state(&cs->blend);
+        _sgimgui_draw_blend_state(&cs->blend);
         igTreePop();
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_pipeline_panel(sg_imgui_t* ctx, sg_pipeline pip) {
+_SOKOL_PRIVATE void _sgimgui_draw_pipeline_panel(sgimgui_t* ctx, sg_pipeline pip) {
     if (pip.id != SG_INVALID_ID) {
         igBeginChild_Str("pipeline", IMVEC2(0,0), false, 0);
         sg_pipeline_info info = sg_query_pipeline_info(pip);
         if (info.slot.state == SG_RESOURCESTATE_VALID) {
-            const sg_imgui_pipeline_t* pip_ui = &ctx->pipelines.slots[_sg_imgui_slot_index(pip.id)];
+            const sgimgui_pipeline_t* pip_ui = &ctx->pipeline_window.slots[_sgimgui_slot_index(pip.id)];
             igText("Label: %s", pip_ui->label.buf[0] ? pip_ui->label.buf : "---");
-            _sg_imgui_draw_resource_slot(&info.slot);
+            _sgimgui_draw_resource_slot(&info.slot);
             igSeparator();
             igText("Shader:    "); igSameLine(0,-1);
-            if (_sg_imgui_draw_shader_link(ctx, pip_ui->desc.shader)) {
-                _sg_imgui_show_shader(ctx, pip_ui->desc.shader);
+            if (_sgimgui_draw_shader_link(ctx, pip_ui->desc.shader)) {
+                _sgimgui_show_shader(ctx, pip_ui->desc.shader);
             }
             if (igTreeNode_Str("Vertex Layout State")) {
-                _sg_imgui_draw_vertex_layout_state(&pip_ui->desc.layout);
+                _sgimgui_draw_vertex_layout_state(&pip_ui->desc.layout);
                 igTreePop();
             }
             if (igTreeNode_Str("Depth State")) {
-                _sg_imgui_draw_depth_state(&pip_ui->desc.depth);
+                _sgimgui_draw_depth_state(&pip_ui->desc.depth);
                 igTreePop();
             }
             if (igTreeNode_Str("Stencil State")) {
-                _sg_imgui_draw_stencil_state(&pip_ui->desc.stencil);
+                _sgimgui_draw_stencil_state(&pip_ui->desc.stencil);
                 igTreePop();
             }
             igText("Color Count: %d", pip_ui->desc.color_count);
             for (int i = 0; i < pip_ui->desc.color_count; i++) {
-                sg_imgui_str_t str;
-                _sg_imgui_snprintf(&str, "Color Target %d", i);
+                sgimgui_str_t str;
+                _sgimgui_snprintf(&str, "Color Target %d", i);
                 if (igTreeNode_Str(str.buf)) {
-                    _sg_imgui_draw_color_target_state(&pip_ui->desc.colors[i]);
+                    _sgimgui_draw_color_target_state(&pip_ui->desc.colors[i]);
                     igTreePop();
                 }
             }
-            igText("Prim Type:      %s", _sg_imgui_primitivetype_string(pip_ui->desc.primitive_type));
-            igText("Index Type:     %s", _sg_imgui_indextype_string(pip_ui->desc.index_type));
-            igText("Cull Mode:      %s", _sg_imgui_cullmode_string(pip_ui->desc.cull_mode));
-            igText("Face Winding:   %s", _sg_imgui_facewinding_string(pip_ui->desc.face_winding));
+            igText("Prim Type:      %s", _sgimgui_primitivetype_string(pip_ui->desc.primitive_type));
+            igText("Index Type:     %s", _sgimgui_indextype_string(pip_ui->desc.index_type));
+            igText("Cull Mode:      %s", _sgimgui_cullmode_string(pip_ui->desc.cull_mode));
+            igText("Face Winding:   %s", _sgimgui_facewinding_string(pip_ui->desc.face_winding));
             igText("Sample Count:   %d", pip_ui->desc.sample_count);
-            sg_imgui_str_t blend_color_str;
-            igText("Blend Color:    %.3f %.3f %.3f %.3f", _sg_imgui_color_string(&blend_color_str, pip_ui->desc.blend_color));
-            igText("Alpha To Coverage: %s", _sg_imgui_bool_string(pip_ui->desc.alpha_to_coverage_enabled));
+            sgimgui_str_t blend_color_str;
+            igText("Blend Color:    %.3f %.3f %.3f %.3f", _sgimgui_color_string(&blend_color_str, pip_ui->desc.blend_color));
+            igText("Alpha To Coverage: %s", _sgimgui_bool_string(pip_ui->desc.alpha_to_coverage_enabled));
         } else {
             igText("Pipeline 0x%08X not valid.", pip.id);
         }
@@ -3753,61 +3718,61 @@ _SOKOL_PRIVATE void _sg_imgui_draw_pipeline_panel(sg_imgui_t* ctx, sg_pipeline p
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_pass_attachment(sg_imgui_t* ctx, const sg_pass_attachment_desc* att, float* img_scale) {
+_SOKOL_PRIVATE void _sgimgui_draw_attachment(sgimgui_t* ctx, const sg_attachment_desc* att, float* img_scale) {
     igText("  Image: "); igSameLine(0,-1);
-    if (_sg_imgui_draw_image_link(ctx, att->image)) {
-        _sg_imgui_show_image(ctx, att->image);
+    if (_sgimgui_draw_image_link(ctx, att->image)) {
+        _sgimgui_show_image(ctx, att->image);
     }
     igText("  Mip Level: %d", att->mip_level);
     igText("  Slice: %d", att->slice);
-    _sg_imgui_draw_embedded_image(ctx, att->image, img_scale);
+    _sgimgui_draw_embedded_image(ctx, att->image, img_scale);
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_pass_panel(sg_imgui_t* ctx, sg_pass pass) {
-    if (pass.id != SG_INVALID_ID) {
-        igBeginChild_Str("pass", IMVEC2(0,0), false, 0);
-        sg_pass_info info = sg_query_pass_info(pass);
+_SOKOL_PRIVATE void _sgimgui_draw_attachments_panel(sgimgui_t* ctx, sg_attachments atts) {
+    if (atts.id != SG_INVALID_ID) {
+        igBeginChild_Str("attachments", IMVEC2(0,0), false, 0);
+        sg_attachments_info info = sg_query_attachments_info(atts);
         if (info.slot.state == SG_RESOURCESTATE_VALID) {
-            sg_imgui_pass_t* pass_ui = &ctx->passes.slots[_sg_imgui_slot_index(pass.id)];
-            igText("Label: %s", pass_ui->label.buf[0] ? pass_ui->label.buf : "---");
-            _sg_imgui_draw_resource_slot(&info.slot);
+            sgimgui_attachments_t* atts_ui = &ctx->attachments_window.slots[_sgimgui_slot_index(atts.id)];
+            igText("Label: %s", atts_ui->label.buf[0] ? atts_ui->label.buf : "---");
+            _sgimgui_draw_resource_slot(&info.slot);
             for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
-                if (pass_ui->desc.color_attachments[i].image.id == SG_INVALID_ID) {
+                if (atts_ui->desc.colors[i].image.id == SG_INVALID_ID) {
                     break;
                 }
                 igSeparator();
-                igText("Color Attachment #%d:", i);
-                _sg_imgui_draw_pass_attachment(ctx, &pass_ui->desc.color_attachments[i], &pass_ui->color_image_scale[i]);
+                igText("Color Image #%d:", i);
+                _sgimgui_draw_attachment(ctx, &atts_ui->desc.colors[i], &atts_ui->color_image_scale[i]);
             }
             for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
-                if (pass_ui->desc.resolve_attachments[i].image.id == SG_INVALID_ID) {
+                if (atts_ui->desc.resolves[i].image.id == SG_INVALID_ID) {
                     break;
                 }
                 igSeparator();
-                igText("Resolve Attachment #%d:", i);
-                _sg_imgui_draw_pass_attachment(ctx, &pass_ui->desc.resolve_attachments[i], &pass_ui->resolve_image_scale[i]);
+                igText("Resolve Image #%d:", i);
+                _sgimgui_draw_attachment(ctx, &atts_ui->desc.resolves[i], &atts_ui->resolve_image_scale[i]);
             }
-            if (pass_ui->desc.depth_stencil_attachment.image.id != SG_INVALID_ID) {
+            if (atts_ui->desc.depth_stencil.image.id != SG_INVALID_ID) {
                 igSeparator();
-                igText("Depth-Stencil Attachment:");
-                _sg_imgui_draw_pass_attachment(ctx, &pass_ui->desc.depth_stencil_attachment, &pass_ui->ds_image_scale);
+                igText("Depth-Stencil Image:");
+                _sgimgui_draw_attachment(ctx, &atts_ui->desc.depth_stencil, &atts_ui->ds_image_scale);
             }
         } else {
-            igText("Pass 0x%08X not valid.", pass.id);
+            igText("Attachments 0x%08X not valid.", atts.id);
         }
         igEndChild();
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_bindings_panel(sg_imgui_t* ctx, const sg_bindings* bnd) {
+_SOKOL_PRIVATE void _sgimgui_draw_bindings_panel(sgimgui_t* ctx, const sg_bindings* bnd) {
     for (int i = 0; i < SG_MAX_VERTEX_BUFFERS; i++) {
         sg_buffer buf = bnd->vertex_buffers[i];
         if (buf.id != SG_INVALID_ID) {
             igSeparator();
             igText("Vertex Buffer Slot #%d:", i);
             igText("  Buffer: "); igSameLine(0,-1);
-            if (_sg_imgui_draw_buffer_link(ctx, buf)) {
-                _sg_imgui_show_buffer(ctx, buf);
+            if (_sgimgui_draw_buffer_link(ctx, buf)) {
+                _sgimgui_show_buffer(ctx, buf);
             }
             igText("  Offset: %d", bnd->vertex_buffer_offsets[i]);
         } else {
@@ -3820,8 +3785,8 @@ _SOKOL_PRIVATE void _sg_imgui_draw_bindings_panel(sg_imgui_t* ctx, const sg_bind
             igSeparator();
             igText("Index Buffer Slot:");
             igText("  Buffer: "); igSameLine(0,-1);
-            if (_sg_imgui_draw_buffer_link(ctx, buf)) {
-                _sg_imgui_show_buffer(ctx, buf);
+            if (_sgimgui_draw_buffer_link(ctx, buf)) {
+                _sgimgui_show_buffer(ctx, buf);
             }
             igText("  Offset: %d", bnd->index_buffer_offset);
         }
@@ -3832,8 +3797,8 @@ _SOKOL_PRIVATE void _sg_imgui_draw_bindings_panel(sg_imgui_t* ctx, const sg_bind
             igSeparator();
             igText("Vertex Stage Image Slot #%d:", i);
             igText("  Image: "); igSameLine(0,-1);
-            if (_sg_imgui_draw_image_link(ctx, img)) {
-                _sg_imgui_show_image(ctx, img);
+            if (_sgimgui_draw_image_link(ctx, img)) {
+                _sgimgui_show_image(ctx, img);
             }
         } else {
             break;
@@ -3845,8 +3810,8 @@ _SOKOL_PRIVATE void _sg_imgui_draw_bindings_panel(sg_imgui_t* ctx, const sg_bind
             igSeparator();
             igText("Vertex Stage Sampler Slot #%d:", i);
             igText("  Sampler: "); igSameLine(0,-1);
-            if (_sg_imgui_draw_sampler_link(ctx, smp)) {
-                _sg_imgui_show_sampler(ctx, smp);
+            if (_sgimgui_draw_sampler_link(ctx, smp)) {
+                _sgimgui_show_sampler(ctx, smp);
             }
         } else {
             break;
@@ -3858,8 +3823,8 @@ _SOKOL_PRIVATE void _sg_imgui_draw_bindings_panel(sg_imgui_t* ctx, const sg_bind
             igSeparator();
             igText("Fragment Stage Image Slot #%d:", i);
             igText("  Image: "); igSameLine(0,-1);
-            if (_sg_imgui_draw_image_link(ctx, img)) {
-                _sg_imgui_show_image(ctx, img);
+            if (_sgimgui_draw_image_link(ctx, img)) {
+                _sgimgui_show_image(ctx, img);
             }
         }
     }
@@ -3869,14 +3834,14 @@ _SOKOL_PRIVATE void _sg_imgui_draw_bindings_panel(sg_imgui_t* ctx, const sg_bind
             igSeparator();
             igText("Fragment Stage Sampler Slot #%d:", i);
             igText("  Sampler: "); igSameLine(0,-1);
-            if (_sg_imgui_draw_sampler_link(ctx, smp)) {
-                _sg_imgui_show_sampler(ctx, smp);
+            if (_sgimgui_draw_sampler_link(ctx, smp)) {
+                _sgimgui_show_sampler(ctx, smp);
             }
         }
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_uniforms_panel(sg_imgui_t* ctx, const sg_imgui_args_apply_uniforms_t* args) {
+_SOKOL_PRIVATE void _sgimgui_draw_uniforms_panel(sgimgui_t* ctx, const sgimgui_args_apply_uniforms_t* args) {
     SOKOL_ASSERT(args->ub_index < SG_MAX_VERTEX_BUFFERS);
 
     /* check if all the required information for drawing the structured uniform block content
@@ -3886,12 +3851,12 @@ _SOKOL_PRIVATE void _sg_imgui_draw_uniforms_panel(sg_imgui_t* ctx, const sg_imgu
         igText("Pipeline object not valid!");
         return;
    }
-    sg_imgui_pipeline_t* pip_ui = &ctx->pipelines.slots[_sg_imgui_slot_index(args->pipeline.id)];
+    sgimgui_pipeline_t* pip_ui = &ctx->pipeline_window.slots[_sgimgui_slot_index(args->pipeline.id)];
     if (sg_query_shader_state(pip_ui->desc.shader) != SG_RESOURCESTATE_VALID) {
         igText("Shader object not valid!");
         return;
     }
-    sg_imgui_shader_t* shd_ui = &ctx->shaders.slots[_sg_imgui_slot_index(pip_ui->desc.shader.id)];
+    sgimgui_shader_t* shd_ui = &ctx->shader_window.slots[_sgimgui_slot_index(pip_ui->desc.shader.id)];
     SOKOL_ASSERT(shd_ui->res_id.id == pip_ui->desc.shader.id);
     const sg_shader_uniform_block_desc* ub_desc = (args->stage == SG_SHADERSTAGE_VS) ?
         &shd_ui->desc.vs.uniform_blocks[args->ub_index] :
@@ -3902,7 +3867,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_uniforms_panel(sg_imgui_t* ctx, const sg_imgu
         draw_dump = true;
     }
 
-    sg_imgui_capture_bucket_t* bucket = _sg_imgui_capture_get_read_bucket(ctx);
+    sgimgui_capture_bucket_t* bucket = _sgimgui_capture_get_read_bucket(ctx);
     SOKOL_ASSERT((args->ubuf_pos + args->data_size) <= bucket->ubuf_size);
     const float* uptrf = (const float*) (bucket->ubuf + args->ubuf_pos);
     const int32_t* uptri32 = (const int32_t*) uptrf;
@@ -3915,14 +3880,14 @@ _SOKOL_PRIVATE void _sg_imgui_draw_uniforms_panel(sg_imgui_t* ctx, const sg_imgu
             }
             int num_items = (ud->array_count > 1) ? ud->array_count : 1;
             if (num_items > 1) {
-                igText("%d: %s %s[%d] =", i, _sg_imgui_uniformtype_string(ud->type), ud->name?ud->name:"", ud->array_count);
+                igText("%d: %s %s[%d] =", i, _sgimgui_uniformtype_string(ud->type), ud->name?ud->name:"", ud->array_count);
             } else {
-                igText("%d: %s %s =", i, _sg_imgui_uniformtype_string(ud->type), ud->name?ud->name:"");
+                igText("%d: %s %s =", i, _sgimgui_uniformtype_string(ud->type), ud->name?ud->name:"");
             }
             for (int item_index = 0; item_index < num_items; item_index++) {
-                const uint32_t u_size = _sg_imgui_std140_uniform_size(ud->type, ud->array_count) / 4;
-                const uint32_t u_align = _sg_imgui_std140_uniform_alignment(ud->type, ud->array_count) / 4;
-                u_off = _sg_imgui_align_u32(u_off, u_align);
+                const uint32_t u_size = _sgimgui_std140_uniform_size(ud->type, ud->array_count) / 4;
+                const uint32_t u_align = _sgimgui_std140_uniform_alignment(ud->type, ud->array_count) / 4;
+                u_off = _sgimgui_align_u32(u_off, u_align);
                 switch (ud->type) {
                     case SG_UNIFORMTYPE_FLOAT:
                         igText("    %.3f", uptrf[u_off]);
@@ -3977,16 +3942,16 @@ _SOKOL_PRIVATE void _sg_imgui_draw_uniforms_panel(sg_imgui_t* ctx, const sg_imgu
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_passaction_panel(sg_imgui_t* ctx, sg_pass pass, const sg_pass_action* action) {
-    /* determine number of valid color attachments in the pass */
+_SOKOL_PRIVATE void _sgimgui_draw_passaction_panel(sgimgui_t* ctx, sg_attachments atts, const sg_pass_action* action) {
+    /* determine number of valid color attachments */
     int num_color_atts = 0;
-    if (SG_INVALID_ID == pass.id) {
-        /* default pass: one color attachment */
+    if (SG_INVALID_ID == atts.id) {
+        /* a swapchain pass: one color attachment */
         num_color_atts = 1;
     } else {
-        const sg_imgui_pass_t* pass_ui = &ctx->passes.slots[_sg_imgui_slot_index(pass.id)];
+        const sgimgui_attachments_t* atts_ui = &ctx->attachments_window.slots[_sgimgui_slot_index(atts.id)];
         for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
-            if (pass_ui->desc.color_attachments[i].image.id != SG_INVALID_ID) {
+            if (atts_ui->desc.colors[i].image.id != SG_INVALID_ID) {
                 num_color_atts++;
             }
         }
@@ -3996,12 +3961,12 @@ _SOKOL_PRIVATE void _sg_imgui_draw_passaction_panel(sg_imgui_t* ctx, sg_pass pas
     for (int i = 0; i < num_color_atts; i++) {
         const sg_color_attachment_action* c_att = &action->colors[i];
         igText("  Color Attachment %d:", i);
-        sg_imgui_str_t color_str;
+        sgimgui_str_t color_str;
         switch (c_att->load_action) {
             case SG_LOADACTION_LOAD: igText("    SG_LOADACTION_LOAD"); break;
             case SG_LOADACTION_DONTCARE: igText("    SG_LOADACTION_DONTCARE"); break;
             case SG_LOADACTION_CLEAR:
-                igText("    SG_LOADACTION_CLEAR: %s", _sg_imgui_color_string(&color_str, c_att->clear_value));
+                igText("    SG_LOADACTION_CLEAR: %s", _sgimgui_color_string(&color_str, c_att->clear_value));
                 break;
             default: igText("    ???"); break;
         }
@@ -4039,145 +4004,140 @@ _SOKOL_PRIVATE void _sg_imgui_draw_passaction_panel(sg_imgui_t* ctx, sg_pass pas
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_capture_panel(sg_imgui_t* ctx) {
-    int sel_item_index = ctx->capture.sel_item;
-    if (sel_item_index >= _sg_imgui_capture_num_read_items(ctx)) {
+_SOKOL_PRIVATE void _sgimgui_draw_capture_panel(sgimgui_t* ctx) {
+    int sel_item_index = ctx->capture_window.sel_item;
+    if (sel_item_index >= _sgimgui_capture_num_read_items(ctx)) {
         return;
     }
-    sg_imgui_capture_item_t* item = _sg_imgui_capture_read_item_at(ctx, sel_item_index);
+    sgimgui_capture_item_t* item = _sgimgui_capture_read_item_at(ctx, sel_item_index);
     igBeginChild_Str("capture_item", IMVEC2(0, 0), false, 0);
     igPushStyleColor_U32(ImGuiCol_Text, item->color);
-    igText("%s", _sg_imgui_capture_item_string(ctx, sel_item_index, item).buf);
+    igText("%s", _sgimgui_capture_item_string(ctx, sel_item_index, item).buf);
     igPopStyleColor(1);
     igSeparator();
     switch (item->cmd) {
-        case SG_IMGUI_CMD_RESET_STATE_CACHE:
+        case SGIMGUI_CMD_RESET_STATE_CACHE:
             break;
-        case SG_IMGUI_CMD_MAKE_BUFFER:
-            _sg_imgui_draw_buffer_panel(ctx, item->args.make_buffer.result);
+        case SGIMGUI_CMD_MAKE_BUFFER:
+            _sgimgui_draw_buffer_panel(ctx, item->args.make_buffer.result);
             break;
-        case SG_IMGUI_CMD_MAKE_IMAGE:
-            _sg_imgui_draw_image_panel(ctx, item->args.make_image.result);
+        case SGIMGUI_CMD_MAKE_IMAGE:
+            _sgimgui_draw_image_panel(ctx, item->args.make_image.result);
             break;
-        case SG_IMGUI_CMD_MAKE_SAMPLER:
-            _sg_imgui_draw_sampler_panel(ctx, item->args.make_sampler.result);
+        case SGIMGUI_CMD_MAKE_SAMPLER:
+            _sgimgui_draw_sampler_panel(ctx, item->args.make_sampler.result);
             break;
-        case SG_IMGUI_CMD_MAKE_SHADER:
-            _sg_imgui_draw_shader_panel(ctx, item->args.make_shader.result);
+        case SGIMGUI_CMD_MAKE_SHADER:
+            _sgimgui_draw_shader_panel(ctx, item->args.make_shader.result);
             break;
-        case SG_IMGUI_CMD_MAKE_PIPELINE:
-            _sg_imgui_draw_pipeline_panel(ctx, item->args.make_pipeline.result);
+        case SGIMGUI_CMD_MAKE_PIPELINE:
+            _sgimgui_draw_pipeline_panel(ctx, item->args.make_pipeline.result);
             break;
-        case SG_IMGUI_CMD_MAKE_PASS:
-            _sg_imgui_draw_pass_panel(ctx, item->args.make_pass.result);
+        case SGIMGUI_CMD_MAKE_ATTACHMENTS:
+            _sgimgui_draw_attachments_panel(ctx, item->args.make_attachments.result);
             break;
-        case SG_IMGUI_CMD_DESTROY_BUFFER:
-            _sg_imgui_draw_buffer_panel(ctx, item->args.destroy_buffer.buffer);
+        case SGIMGUI_CMD_DESTROY_BUFFER:
+            _sgimgui_draw_buffer_panel(ctx, item->args.destroy_buffer.buffer);
             break;
-        case SG_IMGUI_CMD_DESTROY_IMAGE:
-            _sg_imgui_draw_image_panel(ctx, item->args.destroy_image.image);
+        case SGIMGUI_CMD_DESTROY_IMAGE:
+            _sgimgui_draw_image_panel(ctx, item->args.destroy_image.image);
             break;
-        case SG_IMGUI_CMD_DESTROY_SAMPLER:
-            _sg_imgui_draw_sampler_panel(ctx, item->args.destroy_sampler.sampler);
+        case SGIMGUI_CMD_DESTROY_SAMPLER:
+            _sgimgui_draw_sampler_panel(ctx, item->args.destroy_sampler.sampler);
             break;
-        case SG_IMGUI_CMD_DESTROY_SHADER:
-            _sg_imgui_draw_shader_panel(ctx, item->args.destroy_shader.shader);
+        case SGIMGUI_CMD_DESTROY_SHADER:
+            _sgimgui_draw_shader_panel(ctx, item->args.destroy_shader.shader);
             break;
-        case SG_IMGUI_CMD_DESTROY_PIPELINE:
-            _sg_imgui_draw_pipeline_panel(ctx, item->args.destroy_pipeline.pipeline);
+        case SGIMGUI_CMD_DESTROY_PIPELINE:
+            _sgimgui_draw_pipeline_panel(ctx, item->args.destroy_pipeline.pipeline);
             break;
-        case SG_IMGUI_CMD_DESTROY_PASS:
-            _sg_imgui_draw_pass_panel(ctx, item->args.destroy_pass.pass);
+        case SGIMGUI_CMD_DESTROY_ATTACHMENTS:
+            _sgimgui_draw_attachments_panel(ctx, item->args.destroy_attachments.attachments);
             break;
-        case SG_IMGUI_CMD_UPDATE_BUFFER:
-            _sg_imgui_draw_buffer_panel(ctx, item->args.update_buffer.buffer);
+        case SGIMGUI_CMD_UPDATE_BUFFER:
+            _sgimgui_draw_buffer_panel(ctx, item->args.update_buffer.buffer);
             break;
-        case SG_IMGUI_CMD_UPDATE_IMAGE:
-            _sg_imgui_draw_image_panel(ctx, item->args.update_image.image);
+        case SGIMGUI_CMD_UPDATE_IMAGE:
+            _sgimgui_draw_image_panel(ctx, item->args.update_image.image);
             break;
-        case SG_IMGUI_CMD_APPEND_BUFFER:
-            _sg_imgui_draw_buffer_panel(ctx, item->args.update_buffer.buffer);
+        case SGIMGUI_CMD_APPEND_BUFFER:
+            _sgimgui_draw_buffer_panel(ctx, item->args.update_buffer.buffer);
             break;
-        case SG_IMGUI_CMD_BEGIN_DEFAULT_PASS:
-            {
-                sg_pass inv_pass = { SG_INVALID_ID };
-                _sg_imgui_draw_passaction_panel(ctx, inv_pass, &item->args.begin_default_pass.action);
-            }
-            break;
-        case SG_IMGUI_CMD_BEGIN_PASS:
-            _sg_imgui_draw_passaction_panel(ctx, item->args.begin_pass.pass, &item->args.begin_pass.action);
+        case SGIMGUI_CMD_BEGIN_PASS:
+            _sgimgui_draw_passaction_panel(ctx, item->args.begin_pass.pass.attachments, &item->args.begin_pass.pass.action);
             igSeparator();
-            _sg_imgui_draw_pass_panel(ctx, item->args.begin_pass.pass);
+            _sgimgui_draw_attachments_panel(ctx, item->args.begin_pass.pass.attachments);
+            // FIXME: swapchain panel
             break;
-        case SG_IMGUI_CMD_APPLY_VIEWPORT:
-        case SG_IMGUI_CMD_APPLY_SCISSOR_RECT:
+        case SGIMGUI_CMD_APPLY_VIEWPORT:
+        case SGIMGUI_CMD_APPLY_SCISSOR_RECT:
             break;
-        case SG_IMGUI_CMD_APPLY_PIPELINE:
-            _sg_imgui_draw_pipeline_panel(ctx, item->args.apply_pipeline.pipeline);
+        case SGIMGUI_CMD_APPLY_PIPELINE:
+            _sgimgui_draw_pipeline_panel(ctx, item->args.apply_pipeline.pipeline);
             break;
-        case SG_IMGUI_CMD_APPLY_BINDINGS:
-            _sg_imgui_draw_bindings_panel(ctx, &item->args.apply_bindings.bindings);
+        case SGIMGUI_CMD_APPLY_BINDINGS:
+            _sgimgui_draw_bindings_panel(ctx, &item->args.apply_bindings.bindings);
             break;
-        case SG_IMGUI_CMD_APPLY_UNIFORMS:
-            _sg_imgui_draw_uniforms_panel(ctx, &item->args.apply_uniforms);
+        case SGIMGUI_CMD_APPLY_UNIFORMS:
+            _sgimgui_draw_uniforms_panel(ctx, &item->args.apply_uniforms);
             break;
-        case SG_IMGUI_CMD_DRAW:
-        case SG_IMGUI_CMD_END_PASS:
-        case SG_IMGUI_CMD_COMMIT:
+        case SGIMGUI_CMD_DRAW:
+        case SGIMGUI_CMD_END_PASS:
+        case SGIMGUI_CMD_COMMIT:
             break;
-        case SG_IMGUI_CMD_ALLOC_BUFFER:
-            _sg_imgui_draw_buffer_panel(ctx, item->args.alloc_buffer.result);
+        case SGIMGUI_CMD_ALLOC_BUFFER:
+            _sgimgui_draw_buffer_panel(ctx, item->args.alloc_buffer.result);
             break;
-        case SG_IMGUI_CMD_ALLOC_IMAGE:
-            _sg_imgui_draw_image_panel(ctx, item->args.alloc_image.result);
+        case SGIMGUI_CMD_ALLOC_IMAGE:
+            _sgimgui_draw_image_panel(ctx, item->args.alloc_image.result);
             break;
-        case SG_IMGUI_CMD_ALLOC_SAMPLER:
-            _sg_imgui_draw_sampler_panel(ctx, item->args.alloc_sampler.result);
+        case SGIMGUI_CMD_ALLOC_SAMPLER:
+            _sgimgui_draw_sampler_panel(ctx, item->args.alloc_sampler.result);
             break;
-        case SG_IMGUI_CMD_ALLOC_SHADER:
-            _sg_imgui_draw_shader_panel(ctx, item->args.alloc_shader.result);
+        case SGIMGUI_CMD_ALLOC_SHADER:
+            _sgimgui_draw_shader_panel(ctx, item->args.alloc_shader.result);
             break;
-        case SG_IMGUI_CMD_ALLOC_PIPELINE:
-            _sg_imgui_draw_pipeline_panel(ctx, item->args.alloc_pipeline.result);
+        case SGIMGUI_CMD_ALLOC_PIPELINE:
+            _sgimgui_draw_pipeline_panel(ctx, item->args.alloc_pipeline.result);
             break;
-        case SG_IMGUI_CMD_ALLOC_PASS:
-            _sg_imgui_draw_pass_panel(ctx, item->args.alloc_pass.result);
+        case SGIMGUI_CMD_ALLOC_ATTACHMENTS:
+            _sgimgui_draw_attachments_panel(ctx, item->args.alloc_attachments.result);
             break;
-        case SG_IMGUI_CMD_INIT_BUFFER:
-            _sg_imgui_draw_buffer_panel(ctx, item->args.init_buffer.buffer);
+        case SGIMGUI_CMD_INIT_BUFFER:
+            _sgimgui_draw_buffer_panel(ctx, item->args.init_buffer.buffer);
             break;
-        case SG_IMGUI_CMD_INIT_IMAGE:
-            _sg_imgui_draw_image_panel(ctx, item->args.init_image.image);
+        case SGIMGUI_CMD_INIT_IMAGE:
+            _sgimgui_draw_image_panel(ctx, item->args.init_image.image);
             break;
-        case SG_IMGUI_CMD_INIT_SAMPLER:
-            _sg_imgui_draw_sampler_panel(ctx, item->args.init_sampler.sampler);
+        case SGIMGUI_CMD_INIT_SAMPLER:
+            _sgimgui_draw_sampler_panel(ctx, item->args.init_sampler.sampler);
             break;
-        case SG_IMGUI_CMD_INIT_SHADER:
-            _sg_imgui_draw_shader_panel(ctx, item->args.init_shader.shader);
+        case SGIMGUI_CMD_INIT_SHADER:
+            _sgimgui_draw_shader_panel(ctx, item->args.init_shader.shader);
             break;
-        case SG_IMGUI_CMD_INIT_PIPELINE:
-            _sg_imgui_draw_pipeline_panel(ctx, item->args.init_pipeline.pipeline);
+        case SGIMGUI_CMD_INIT_PIPELINE:
+            _sgimgui_draw_pipeline_panel(ctx, item->args.init_pipeline.pipeline);
             break;
-        case SG_IMGUI_CMD_INIT_PASS:
-            _sg_imgui_draw_pass_panel(ctx, item->args.init_pass.pass);
+        case SGIMGUI_CMD_INIT_ATTACHMENTS:
+            _sgimgui_draw_attachments_panel(ctx, item->args.init_attachments.attachments);
             break;
-        case SG_IMGUI_CMD_FAIL_BUFFER:
-            _sg_imgui_draw_buffer_panel(ctx, item->args.fail_buffer.buffer);
+        case SGIMGUI_CMD_FAIL_BUFFER:
+            _sgimgui_draw_buffer_panel(ctx, item->args.fail_buffer.buffer);
             break;
-        case SG_IMGUI_CMD_FAIL_IMAGE:
-            _sg_imgui_draw_image_panel(ctx, item->args.fail_image.image);
+        case SGIMGUI_CMD_FAIL_IMAGE:
+            _sgimgui_draw_image_panel(ctx, item->args.fail_image.image);
             break;
-        case SG_IMGUI_CMD_FAIL_SAMPLER:
-            _sg_imgui_draw_sampler_panel(ctx, item->args.fail_sampler.sampler);
+        case SGIMGUI_CMD_FAIL_SAMPLER:
+            _sgimgui_draw_sampler_panel(ctx, item->args.fail_sampler.sampler);
             break;
-        case SG_IMGUI_CMD_FAIL_SHADER:
-            _sg_imgui_draw_shader_panel(ctx, item->args.fail_shader.shader);
+        case SGIMGUI_CMD_FAIL_SHADER:
+            _sgimgui_draw_shader_panel(ctx, item->args.fail_shader.shader);
             break;
-        case SG_IMGUI_CMD_FAIL_PIPELINE:
-            _sg_imgui_draw_pipeline_panel(ctx, item->args.fail_pipeline.pipeline);
+        case SGIMGUI_CMD_FAIL_PIPELINE:
+            _sgimgui_draw_pipeline_panel(ctx, item->args.fail_pipeline.pipeline);
             break;
-        case SG_IMGUI_CMD_FAIL_PASS:
-            _sg_imgui_draw_pass_panel(ctx, item->args.fail_pass.pass);
+        case SGIMGUI_CMD_FAIL_ATTACHMENTS:
+            _sgimgui_draw_attachments_panel(ctx, item->args.fail_attachments.attachments);
             break;
         default:
             break;
@@ -4185,14 +4145,14 @@ _SOKOL_PRIVATE void _sg_imgui_draw_capture_panel(sg_imgui_t* ctx) {
     igEndChild();
 }
 
-_SOKOL_PRIVATE void _sg_imgui_draw_caps_panel(void) {
-    igText("Backend: %s\n\n", _sg_imgui_backend_string(sg_query_backend()));
+_SOKOL_PRIVATE void _sgimgui_draw_caps_panel(void) {
+    igText("Backend: %s\n\n", _sgimgui_backend_string(sg_query_backend()));
     sg_features f = sg_query_features();
     igText("Features:");
-    igText("    origin_top_left: %s", _sg_imgui_bool_string(f.origin_top_left));
-    igText("    image_clamp_to_border: %s", _sg_imgui_bool_string(f.image_clamp_to_border));
-    igText("    mrt_independent_blend_state: %s", _sg_imgui_bool_string(f.mrt_independent_blend_state));
-    igText("    mrt_independent_write_mask: %s", _sg_imgui_bool_string(f.mrt_independent_write_mask));
+    igText("    origin_top_left: %s", _sgimgui_bool_string(f.origin_top_left));
+    igText("    image_clamp_to_border: %s", _sgimgui_bool_string(f.image_clamp_to_border));
+    igText("    mrt_independent_blend_state: %s", _sgimgui_bool_string(f.mrt_independent_blend_state));
+    igText("    mrt_independent_write_mask: %s", _sgimgui_bool_string(f.mrt_independent_write_mask));
     sg_limits l = sg_query_limits();
     igText("\nLimits:\n");
     igText("    max_image_size_2d: %d", l.max_image_size_2d);
@@ -4209,7 +4169,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_caps_panel(void) {
         sg_pixelformat_info info = sg_query_pixelformat(fmt);
         if (info.sample) {
             igText("  %s: %s%s%s%s%s%s",
-                _sg_imgui_pixelformat_string(fmt),
+                _sgimgui_pixelformat_string(fmt),
                 info.sample ? "SAMPLE ":"",
                 info.filter ? "FILTER ":"",
                 info.blend ? "BLEND ":"",
@@ -4220,7 +4180,7 @@ _SOKOL_PRIVATE void _sg_imgui_draw_caps_panel(void) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_imgui_frame_add_stats_row(const char* key, uint32_t value) {
+_SOKOL_PRIVATE void _sgimgui_frame_add_stats_row(const char* key, uint32_t value) {
     igTableNextRow(0, 0.0f);
     igTableSetColumnIndex(0);
     igText(key);
@@ -4228,12 +4188,12 @@ _SOKOL_PRIVATE void _sg_imgui_frame_add_stats_row(const char* key, uint32_t valu
     igText("%d", value);
 }
 
-#define _sg_imgui_frame_stats(key) _sg_imgui_frame_add_stats_row(#key, stats->key)
+#define _sgimgui_frame_stats(key) _sgimgui_frame_add_stats_row(#key, stats->key)
 
-_SOKOL_PRIVATE void _sg_imgui_draw_frame_stats_panel(sg_imgui_t* ctx) {
+_SOKOL_PRIVATE void _sgimgui_draw_frame_stats_panel(sgimgui_t* ctx) {
     _SOKOL_UNUSED(ctx);
-    igCheckbox("Ignore sokol_imgui.h", &ctx->frame_stats.disable_sokol_imgui_stats);
-    const sg_frame_stats* stats = &ctx->frame_stats.stats;
+    igCheckbox("Ignore sokol_imgui.h", &ctx->frame_stats_window.disable_sokol_imgui_stats);
+    const sg_frame_stats* stats = &ctx->frame_stats_window.stats;
     const ImGuiTableFlags flags =
         ImGuiTableFlags_Resizable |
         ImGuiTableFlags_ScrollY |
@@ -4244,100 +4204,100 @@ _SOKOL_PRIVATE void _sg_imgui_draw_frame_stats_panel(sg_imgui_t* ctx) {
         igTableSetupColumn("key", ImGuiTableColumnFlags_None, 0, 0);
         igTableSetupColumn("value", ImGuiTableColumnFlags_None, 0, 0);
         igTableHeadersRow();
-        _sg_imgui_frame_stats(frame_index);
-        _sg_imgui_frame_stats(num_passes);
-        _sg_imgui_frame_stats(num_apply_viewport);
-        _sg_imgui_frame_stats(num_apply_scissor_rect);
-        _sg_imgui_frame_stats(num_apply_pipeline);
-        _sg_imgui_frame_stats(num_apply_bindings);
-        _sg_imgui_frame_stats(num_apply_uniforms);
-        _sg_imgui_frame_stats(num_draw);
-        _sg_imgui_frame_stats(num_update_buffer);
-        _sg_imgui_frame_stats(num_append_buffer);
-        _sg_imgui_frame_stats(num_update_image);
-        _sg_imgui_frame_stats(size_apply_uniforms);
-        _sg_imgui_frame_stats(size_update_buffer);
-        _sg_imgui_frame_stats(size_append_buffer);
-        _sg_imgui_frame_stats(size_update_image);
+        _sgimgui_frame_stats(frame_index);
+        _sgimgui_frame_stats(num_passes);
+        _sgimgui_frame_stats(num_apply_viewport);
+        _sgimgui_frame_stats(num_apply_scissor_rect);
+        _sgimgui_frame_stats(num_apply_pipeline);
+        _sgimgui_frame_stats(num_apply_bindings);
+        _sgimgui_frame_stats(num_apply_uniforms);
+        _sgimgui_frame_stats(num_draw);
+        _sgimgui_frame_stats(num_update_buffer);
+        _sgimgui_frame_stats(num_append_buffer);
+        _sgimgui_frame_stats(num_update_image);
+        _sgimgui_frame_stats(size_apply_uniforms);
+        _sgimgui_frame_stats(size_update_buffer);
+        _sgimgui_frame_stats(size_append_buffer);
+        _sgimgui_frame_stats(size_update_image);
         switch (sg_query_backend()) {
             case SG_BACKEND_GLCORE33:
             case SG_BACKEND_GLES3:
-                _sg_imgui_frame_stats(gl.num_bind_buffer);
-                _sg_imgui_frame_stats(gl.num_active_texture);
-                _sg_imgui_frame_stats(gl.num_bind_texture);
-                _sg_imgui_frame_stats(gl.num_bind_sampler);
-                _sg_imgui_frame_stats(gl.num_use_program);
-                _sg_imgui_frame_stats(gl.num_render_state);
-                _sg_imgui_frame_stats(gl.num_vertex_attrib_pointer);
-                _sg_imgui_frame_stats(gl.num_vertex_attrib_divisor);
-                _sg_imgui_frame_stats(gl.num_enable_vertex_attrib_array);
-                _sg_imgui_frame_stats(gl.num_disable_vertex_attrib_array);
-                _sg_imgui_frame_stats(gl.num_uniform);
+                _sgimgui_frame_stats(gl.num_bind_buffer);
+                _sgimgui_frame_stats(gl.num_active_texture);
+                _sgimgui_frame_stats(gl.num_bind_texture);
+                _sgimgui_frame_stats(gl.num_bind_sampler);
+                _sgimgui_frame_stats(gl.num_use_program);
+                _sgimgui_frame_stats(gl.num_render_state);
+                _sgimgui_frame_stats(gl.num_vertex_attrib_pointer);
+                _sgimgui_frame_stats(gl.num_vertex_attrib_divisor);
+                _sgimgui_frame_stats(gl.num_enable_vertex_attrib_array);
+                _sgimgui_frame_stats(gl.num_disable_vertex_attrib_array);
+                _sgimgui_frame_stats(gl.num_uniform);
                 break;
             case SG_BACKEND_WGPU:
-                _sg_imgui_frame_stats(wgpu.uniforms.num_set_bindgroup);
-                _sg_imgui_frame_stats(wgpu.uniforms.size_write_buffer);
-                _sg_imgui_frame_stats(wgpu.bindings.num_set_vertex_buffer);
-                _sg_imgui_frame_stats(wgpu.bindings.num_skip_redundant_vertex_buffer);
-                _sg_imgui_frame_stats(wgpu.bindings.num_set_index_buffer);
-                _sg_imgui_frame_stats(wgpu.bindings.num_skip_redundant_index_buffer);
-                _sg_imgui_frame_stats(wgpu.bindings.num_create_bindgroup);
-                _sg_imgui_frame_stats(wgpu.bindings.num_discard_bindgroup);
-                _sg_imgui_frame_stats(wgpu.bindings.num_set_bindgroup);
-                _sg_imgui_frame_stats(wgpu.bindings.num_skip_redundant_bindgroup);
-                _sg_imgui_frame_stats(wgpu.bindings.num_bindgroup_cache_hits);
-                _sg_imgui_frame_stats(wgpu.bindings.num_bindgroup_cache_misses);
-                _sg_imgui_frame_stats(wgpu.bindings.num_bindgroup_cache_collisions);
-                _sg_imgui_frame_stats(wgpu.bindings.num_bindgroup_cache_hash_vs_key_mismatch);
+                _sgimgui_frame_stats(wgpu.uniforms.num_set_bindgroup);
+                _sgimgui_frame_stats(wgpu.uniforms.size_write_buffer);
+                _sgimgui_frame_stats(wgpu.bindings.num_set_vertex_buffer);
+                _sgimgui_frame_stats(wgpu.bindings.num_skip_redundant_vertex_buffer);
+                _sgimgui_frame_stats(wgpu.bindings.num_set_index_buffer);
+                _sgimgui_frame_stats(wgpu.bindings.num_skip_redundant_index_buffer);
+                _sgimgui_frame_stats(wgpu.bindings.num_create_bindgroup);
+                _sgimgui_frame_stats(wgpu.bindings.num_discard_bindgroup);
+                _sgimgui_frame_stats(wgpu.bindings.num_set_bindgroup);
+                _sgimgui_frame_stats(wgpu.bindings.num_skip_redundant_bindgroup);
+                _sgimgui_frame_stats(wgpu.bindings.num_bindgroup_cache_hits);
+                _sgimgui_frame_stats(wgpu.bindings.num_bindgroup_cache_misses);
+                _sgimgui_frame_stats(wgpu.bindings.num_bindgroup_cache_collisions);
+                _sgimgui_frame_stats(wgpu.bindings.num_bindgroup_cache_hash_vs_key_mismatch);
                 break;
             case SG_BACKEND_METAL_MACOS:
             case SG_BACKEND_METAL_IOS:
             case SG_BACKEND_METAL_SIMULATOR:
-                _sg_imgui_frame_stats(metal.idpool.num_added);
-                _sg_imgui_frame_stats(metal.idpool.num_released);
-                _sg_imgui_frame_stats(metal.idpool.num_garbage_collected);
-                _sg_imgui_frame_stats(metal.pipeline.num_set_blend_color);
-                _sg_imgui_frame_stats(metal.pipeline.num_set_cull_mode);
-                _sg_imgui_frame_stats(metal.pipeline.num_set_front_facing_winding);
-                _sg_imgui_frame_stats(metal.pipeline.num_set_stencil_reference_value);
-                _sg_imgui_frame_stats(metal.pipeline.num_set_depth_bias);
-                _sg_imgui_frame_stats(metal.pipeline.num_set_render_pipeline_state);
-                _sg_imgui_frame_stats(metal.pipeline.num_set_depth_stencil_state);
-                _sg_imgui_frame_stats(metal.bindings.num_set_vertex_buffer);
-                _sg_imgui_frame_stats(metal.bindings.num_set_vertex_texture);
-                _sg_imgui_frame_stats(metal.bindings.num_set_vertex_sampler_state);
-                _sg_imgui_frame_stats(metal.bindings.num_set_fragment_texture);
-                _sg_imgui_frame_stats(metal.bindings.num_set_fragment_sampler_state);
-                _sg_imgui_frame_stats(metal.uniforms.num_set_vertex_buffer_offset);
-                _sg_imgui_frame_stats(metal.uniforms.num_set_fragment_buffer_offset);
+                _sgimgui_frame_stats(metal.idpool.num_added);
+                _sgimgui_frame_stats(metal.idpool.num_released);
+                _sgimgui_frame_stats(metal.idpool.num_garbage_collected);
+                _sgimgui_frame_stats(metal.pipeline.num_set_blend_color);
+                _sgimgui_frame_stats(metal.pipeline.num_set_cull_mode);
+                _sgimgui_frame_stats(metal.pipeline.num_set_front_facing_winding);
+                _sgimgui_frame_stats(metal.pipeline.num_set_stencil_reference_value);
+                _sgimgui_frame_stats(metal.pipeline.num_set_depth_bias);
+                _sgimgui_frame_stats(metal.pipeline.num_set_render_pipeline_state);
+                _sgimgui_frame_stats(metal.pipeline.num_set_depth_stencil_state);
+                _sgimgui_frame_stats(metal.bindings.num_set_vertex_buffer);
+                _sgimgui_frame_stats(metal.bindings.num_set_vertex_texture);
+                _sgimgui_frame_stats(metal.bindings.num_set_vertex_sampler_state);
+                _sgimgui_frame_stats(metal.bindings.num_set_fragment_texture);
+                _sgimgui_frame_stats(metal.bindings.num_set_fragment_sampler_state);
+                _sgimgui_frame_stats(metal.uniforms.num_set_vertex_buffer_offset);
+                _sgimgui_frame_stats(metal.uniforms.num_set_fragment_buffer_offset);
                 break;
             case SG_BACKEND_D3D11:
-                _sg_imgui_frame_stats(d3d11.pass.num_om_set_render_targets);
-                _sg_imgui_frame_stats(d3d11.pass.num_clear_render_target_view);
-                _sg_imgui_frame_stats(d3d11.pass.num_clear_depth_stencil_view);
-                _sg_imgui_frame_stats(d3d11.pass.num_resolve_subresource);
-                _sg_imgui_frame_stats(d3d11.pipeline.num_rs_set_state);
-                _sg_imgui_frame_stats(d3d11.pipeline.num_om_set_depth_stencil_state);
-                _sg_imgui_frame_stats(d3d11.pipeline.num_om_set_blend_state);
-                _sg_imgui_frame_stats(d3d11.pipeline.num_ia_set_primitive_topology);
-                _sg_imgui_frame_stats(d3d11.pipeline.num_ia_set_input_layout);
-                _sg_imgui_frame_stats(d3d11.pipeline.num_vs_set_shader);
-                _sg_imgui_frame_stats(d3d11.pipeline.num_vs_set_constant_buffers);
-                _sg_imgui_frame_stats(d3d11.pipeline.num_ps_set_shader);
-                _sg_imgui_frame_stats(d3d11.pipeline.num_ps_set_constant_buffers);
-                _sg_imgui_frame_stats(d3d11.bindings.num_ia_set_vertex_buffers);
-                _sg_imgui_frame_stats(d3d11.bindings.num_ia_set_index_buffer);
-                _sg_imgui_frame_stats(d3d11.bindings.num_vs_set_shader_resources);
-                _sg_imgui_frame_stats(d3d11.bindings.num_ps_set_shader_resources);
-                _sg_imgui_frame_stats(d3d11.bindings.num_vs_set_samplers);
-                _sg_imgui_frame_stats(d3d11.bindings.num_ps_set_samplers);
-                _sg_imgui_frame_stats(d3d11.uniforms.num_update_subresource);
-                _sg_imgui_frame_stats(d3d11.draw.num_draw_indexed_instanced);
-                _sg_imgui_frame_stats(d3d11.draw.num_draw_indexed);
-                _sg_imgui_frame_stats(d3d11.draw.num_draw_instanced);
-                _sg_imgui_frame_stats(d3d11.draw.num_draw);
-                _sg_imgui_frame_stats(d3d11.num_map);
-                _sg_imgui_frame_stats(d3d11.num_unmap);
+                _sgimgui_frame_stats(d3d11.pass.num_om_set_render_targets);
+                _sgimgui_frame_stats(d3d11.pass.num_clear_render_target_view);
+                _sgimgui_frame_stats(d3d11.pass.num_clear_depth_stencil_view);
+                _sgimgui_frame_stats(d3d11.pass.num_resolve_subresource);
+                _sgimgui_frame_stats(d3d11.pipeline.num_rs_set_state);
+                _sgimgui_frame_stats(d3d11.pipeline.num_om_set_depth_stencil_state);
+                _sgimgui_frame_stats(d3d11.pipeline.num_om_set_blend_state);
+                _sgimgui_frame_stats(d3d11.pipeline.num_ia_set_primitive_topology);
+                _sgimgui_frame_stats(d3d11.pipeline.num_ia_set_input_layout);
+                _sgimgui_frame_stats(d3d11.pipeline.num_vs_set_shader);
+                _sgimgui_frame_stats(d3d11.pipeline.num_vs_set_constant_buffers);
+                _sgimgui_frame_stats(d3d11.pipeline.num_ps_set_shader);
+                _sgimgui_frame_stats(d3d11.pipeline.num_ps_set_constant_buffers);
+                _sgimgui_frame_stats(d3d11.bindings.num_ia_set_vertex_buffers);
+                _sgimgui_frame_stats(d3d11.bindings.num_ia_set_index_buffer);
+                _sgimgui_frame_stats(d3d11.bindings.num_vs_set_shader_resources);
+                _sgimgui_frame_stats(d3d11.bindings.num_ps_set_shader_resources);
+                _sgimgui_frame_stats(d3d11.bindings.num_vs_set_samplers);
+                _sgimgui_frame_stats(d3d11.bindings.num_ps_set_samplers);
+                _sgimgui_frame_stats(d3d11.uniforms.num_update_subresource);
+                _sgimgui_frame_stats(d3d11.draw.num_draw_indexed_instanced);
+                _sgimgui_frame_stats(d3d11.draw.num_draw_indexed);
+                _sgimgui_frame_stats(d3d11.draw.num_draw_instanced);
+                _sgimgui_frame_stats(d3d11.draw.num_draw);
+                _sgimgui_frame_stats(d3d11.num_map);
+                _sgimgui_frame_stats(d3d11.num_unmap);
                 break;
             default: break;
         }
@@ -4345,374 +4305,373 @@ _SOKOL_PRIVATE void _sg_imgui_draw_frame_stats_panel(sg_imgui_t* ctx) {
     }
 }
 
-#define _sg_imgui_def(val, def) (((val) == 0) ? (def) : (val))
+#define _sgimgui_def(val, def) (((val) == 0) ? (def) : (val))
 
-_SOKOL_PRIVATE sg_imgui_desc_t _sg_imgui_desc_defaults(const sg_imgui_desc_t* desc) {
+_SOKOL_PRIVATE sgimgui_desc_t _sgimgui_desc_defaults(const sgimgui_desc_t* desc) {
     SOKOL_ASSERT((desc->allocator.alloc_fn && desc->allocator.free_fn) || (!desc->allocator.alloc_fn && !desc->allocator.free_fn));
-    sg_imgui_desc_t res = *desc;
+    sgimgui_desc_t res = *desc;
     // FIXME: any additional default overrides would go here
     return res;
 }
 
 /*--- PUBLIC FUNCTIONS -------------------------------------------------------*/
-SOKOL_API_IMPL void sg_imgui_init(sg_imgui_t* ctx, const sg_imgui_desc_t* desc) {
+SOKOL_API_IMPL void sgimgui_init(sgimgui_t* ctx, const sgimgui_desc_t* desc) {
     SOKOL_ASSERT(ctx && desc);
-    _sg_imgui_clear(ctx, sizeof(sg_imgui_t));
+    _sgimgui_clear(ctx, sizeof(sgimgui_t));
     ctx->init_tag = 0xABCDABCD;
-    ctx->desc = _sg_imgui_desc_defaults(desc);
-    _sg_imgui_capture_init(ctx);
+    ctx->desc = _sgimgui_desc_defaults(desc);
+    _sgimgui_capture_init(ctx);
 
     /* hook into sokol_gfx functions */
     sg_trace_hooks hooks;
-    _sg_imgui_clear(&hooks, sizeof(hooks));
+    _sgimgui_clear(&hooks, sizeof(hooks));
     hooks.user_data = (void*) ctx;
-    hooks.reset_state_cache = _sg_imgui_reset_state_cache;
-    hooks.make_buffer = _sg_imgui_make_buffer;
-    hooks.make_image = _sg_imgui_make_image;
-    hooks.make_sampler = _sg_imgui_make_sampler;
-    hooks.make_shader = _sg_imgui_make_shader;
-    hooks.make_pipeline = _sg_imgui_make_pipeline;
-    hooks.make_pass = _sg_imgui_make_pass;
-    hooks.destroy_buffer = _sg_imgui_destroy_buffer;
-    hooks.destroy_image = _sg_imgui_destroy_image;
-    hooks.destroy_sampler = _sg_imgui_destroy_sampler;
-    hooks.destroy_shader = _sg_imgui_destroy_shader;
-    hooks.destroy_pipeline = _sg_imgui_destroy_pipeline;
-    hooks.destroy_pass = _sg_imgui_destroy_pass;
-    hooks.update_buffer = _sg_imgui_update_buffer;
-    hooks.update_image = _sg_imgui_update_image;
-    hooks.append_buffer = _sg_imgui_append_buffer;
-    hooks.begin_default_pass = _sg_imgui_begin_default_pass;
-    hooks.begin_pass = _sg_imgui_begin_pass;
-    hooks.apply_viewport = _sg_imgui_apply_viewport;
-    hooks.apply_scissor_rect = _sg_imgui_apply_scissor_rect;
-    hooks.apply_pipeline = _sg_imgui_apply_pipeline;
-    hooks.apply_bindings = _sg_imgui_apply_bindings;
-    hooks.apply_uniforms = _sg_imgui_apply_uniforms;
-    hooks.draw = _sg_imgui_draw;
-    hooks.end_pass = _sg_imgui_end_pass;
-    hooks.commit = _sg_imgui_commit;
-    hooks.alloc_buffer = _sg_imgui_alloc_buffer;
-    hooks.alloc_image = _sg_imgui_alloc_image;
-    hooks.alloc_sampler = _sg_imgui_alloc_sampler;
-    hooks.alloc_shader = _sg_imgui_alloc_shader;
-    hooks.alloc_pipeline = _sg_imgui_alloc_pipeline;
-    hooks.alloc_pass = _sg_imgui_alloc_pass;
-    hooks.dealloc_buffer = _sg_imgui_dealloc_buffer;
-    hooks.dealloc_image = _sg_imgui_dealloc_image;
-    hooks.dealloc_sampler = _sg_imgui_dealloc_sampler;
-    hooks.dealloc_shader = _sg_imgui_dealloc_shader;
-    hooks.dealloc_pipeline = _sg_imgui_dealloc_pipeline;
-    hooks.dealloc_pass = _sg_imgui_dealloc_pass;
-    hooks.init_buffer = _sg_imgui_init_buffer;
-    hooks.init_image = _sg_imgui_init_image;
-    hooks.init_sampler = _sg_imgui_init_sampler;
-    hooks.init_shader = _sg_imgui_init_shader;
-    hooks.init_pipeline = _sg_imgui_init_pipeline;
-    hooks.init_pass = _sg_imgui_init_pass;
-    hooks.uninit_buffer = _sg_imgui_uninit_buffer;
-    hooks.uninit_image = _sg_imgui_uninit_image;
-    hooks.uninit_sampler = _sg_imgui_uninit_sampler;
-    hooks.uninit_shader = _sg_imgui_uninit_shader;
-    hooks.uninit_pipeline = _sg_imgui_uninit_pipeline;
-    hooks.uninit_pass = _sg_imgui_uninit_pass;
-    hooks.fail_buffer = _sg_imgui_fail_buffer;
-    hooks.fail_image = _sg_imgui_fail_image;
-    hooks.fail_sampler = _sg_imgui_fail_sampler;
-    hooks.fail_shader = _sg_imgui_fail_shader;
-    hooks.fail_pipeline = _sg_imgui_fail_pipeline;
-    hooks.fail_pass = _sg_imgui_fail_pass;
-    hooks.push_debug_group = _sg_imgui_push_debug_group;
-    hooks.pop_debug_group = _sg_imgui_pop_debug_group;
+    hooks.reset_state_cache = _sgimgui_reset_state_cache;
+    hooks.make_buffer = _sgimgui_make_buffer;
+    hooks.make_image = _sgimgui_make_image;
+    hooks.make_sampler = _sgimgui_make_sampler;
+    hooks.make_shader = _sgimgui_make_shader;
+    hooks.make_pipeline = _sgimgui_make_pipeline;
+    hooks.make_attachments = _sgimgui_make_attachments;
+    hooks.destroy_buffer = _sgimgui_destroy_buffer;
+    hooks.destroy_image = _sgimgui_destroy_image;
+    hooks.destroy_sampler = _sgimgui_destroy_sampler;
+    hooks.destroy_shader = _sgimgui_destroy_shader;
+    hooks.destroy_pipeline = _sgimgui_destroy_pipeline;
+    hooks.destroy_attachments = _sgimgui_destroy_attachments;
+    hooks.update_buffer = _sgimgui_update_buffer;
+    hooks.update_image = _sgimgui_update_image;
+    hooks.append_buffer = _sgimgui_append_buffer;
+    hooks.begin_pass = _sgimgui_begin_pass;
+    hooks.apply_viewport = _sgimgui_apply_viewport;
+    hooks.apply_scissor_rect = _sgimgui_apply_scissor_rect;
+    hooks.apply_pipeline = _sgimgui_apply_pipeline;
+    hooks.apply_bindings = _sgimgui_apply_bindings;
+    hooks.apply_uniforms = _sgimgui_apply_uniforms;
+    hooks.draw = _sgimgui_draw;
+    hooks.end_pass = _sgimgui_end_pass;
+    hooks.commit = _sgimgui_commit;
+    hooks.alloc_buffer = _sgimgui_alloc_buffer;
+    hooks.alloc_image = _sgimgui_alloc_image;
+    hooks.alloc_sampler = _sgimgui_alloc_sampler;
+    hooks.alloc_shader = _sgimgui_alloc_shader;
+    hooks.alloc_pipeline = _sgimgui_alloc_pipeline;
+    hooks.alloc_attachments = _sgimgui_alloc_attachments;
+    hooks.dealloc_buffer = _sgimgui_dealloc_buffer;
+    hooks.dealloc_image = _sgimgui_dealloc_image;
+    hooks.dealloc_sampler = _sgimgui_dealloc_sampler;
+    hooks.dealloc_shader = _sgimgui_dealloc_shader;
+    hooks.dealloc_pipeline = _sgimgui_dealloc_pipeline;
+    hooks.dealloc_attachments = _sgimgui_dealloc_attachments;
+    hooks.init_buffer = _sgimgui_init_buffer;
+    hooks.init_image = _sgimgui_init_image;
+    hooks.init_sampler = _sgimgui_init_sampler;
+    hooks.init_shader = _sgimgui_init_shader;
+    hooks.init_pipeline = _sgimgui_init_pipeline;
+    hooks.init_attachments = _sgimgui_init_attachments;
+    hooks.uninit_buffer = _sgimgui_uninit_buffer;
+    hooks.uninit_image = _sgimgui_uninit_image;
+    hooks.uninit_sampler = _sgimgui_uninit_sampler;
+    hooks.uninit_shader = _sgimgui_uninit_shader;
+    hooks.uninit_pipeline = _sgimgui_uninit_pipeline;
+    hooks.uninit_attachments = _sgimgui_uninit_attachments;
+    hooks.fail_buffer = _sgimgui_fail_buffer;
+    hooks.fail_image = _sgimgui_fail_image;
+    hooks.fail_sampler = _sgimgui_fail_sampler;
+    hooks.fail_shader = _sgimgui_fail_shader;
+    hooks.fail_pipeline = _sgimgui_fail_pipeline;
+    hooks.fail_attachments = _sgimgui_fail_attachments;
+    hooks.push_debug_group = _sgimgui_push_debug_group;
+    hooks.pop_debug_group = _sgimgui_pop_debug_group;
     ctx->hooks = sg_install_trace_hooks(&hooks);
 
     /* allocate resource debug-info slots */
     const sg_desc sgdesc = sg_query_desc();
-    ctx->buffers.num_slots = sgdesc.buffer_pool_size;
-    ctx->images.num_slots = sgdesc.image_pool_size;
-    ctx->samplers.num_slots = sgdesc.sampler_pool_size;
-    ctx->shaders.num_slots = sgdesc.shader_pool_size;
-    ctx->pipelines.num_slots = sgdesc.pipeline_pool_size;
-    ctx->passes.num_slots = sgdesc.pass_pool_size;
+    ctx->buffer_window.num_slots = sgdesc.buffer_pool_size;
+    ctx->image_window.num_slots = sgdesc.image_pool_size;
+    ctx->sampler_window.num_slots = sgdesc.sampler_pool_size;
+    ctx->shader_window.num_slots = sgdesc.shader_pool_size;
+    ctx->pipeline_window.num_slots = sgdesc.pipeline_pool_size;
+    ctx->attachments_window.num_slots = sgdesc.attachments_pool_size;
 
-    const size_t buffer_pool_size = (size_t)ctx->buffers.num_slots * sizeof(sg_imgui_buffer_t);
-    ctx->buffers.slots = (sg_imgui_buffer_t*) _sg_imgui_malloc_clear(&ctx->desc.allocator, buffer_pool_size);
+    const size_t buffer_pool_size = (size_t)ctx->buffer_window.num_slots * sizeof(sgimgui_buffer_t);
+    ctx->buffer_window.slots = (sgimgui_buffer_t*) _sgimgui_malloc_clear(&ctx->desc.allocator, buffer_pool_size);
 
-    const size_t image_pool_size = (size_t)ctx->images.num_slots * sizeof(sg_imgui_image_t);
-    ctx->images.slots = (sg_imgui_image_t*) _sg_imgui_malloc_clear(&ctx->desc.allocator, image_pool_size);
+    const size_t image_pool_size = (size_t)ctx->image_window.num_slots * sizeof(sgimgui_image_t);
+    ctx->image_window.slots = (sgimgui_image_t*) _sgimgui_malloc_clear(&ctx->desc.allocator, image_pool_size);
 
-    const size_t sampler_pool_size = (size_t)ctx->samplers.num_slots * sizeof(sg_imgui_sampler_t);
-    ctx->samplers.slots = (sg_imgui_sampler_t*) _sg_imgui_malloc_clear(&ctx->desc.allocator, sampler_pool_size);
+    const size_t sampler_pool_size = (size_t)ctx->sampler_window.num_slots * sizeof(sgimgui_sampler_t);
+    ctx->sampler_window.slots = (sgimgui_sampler_t*) _sgimgui_malloc_clear(&ctx->desc.allocator, sampler_pool_size);
 
-    const size_t shader_pool_size = (size_t)ctx->shaders.num_slots * sizeof(sg_imgui_shader_t);
-    ctx->shaders.slots = (sg_imgui_shader_t*) _sg_imgui_malloc_clear(&ctx->desc.allocator, shader_pool_size);
+    const size_t shader_pool_size = (size_t)ctx->shader_window.num_slots * sizeof(sgimgui_shader_t);
+    ctx->shader_window.slots = (sgimgui_shader_t*) _sgimgui_malloc_clear(&ctx->desc.allocator, shader_pool_size);
 
-    const size_t pipeline_pool_size = (size_t)ctx->pipelines.num_slots * sizeof(sg_imgui_pipeline_t);
-    ctx->pipelines.slots = (sg_imgui_pipeline_t*) _sg_imgui_malloc_clear(&ctx->desc.allocator, pipeline_pool_size);
+    const size_t pipeline_pool_size = (size_t)ctx->pipeline_window.num_slots * sizeof(sgimgui_pipeline_t);
+    ctx->pipeline_window.slots = (sgimgui_pipeline_t*) _sgimgui_malloc_clear(&ctx->desc.allocator, pipeline_pool_size);
 
-    const size_t pass_pool_size = (size_t)ctx->passes.num_slots * sizeof(sg_imgui_pass_t);
-    ctx->passes.slots = (sg_imgui_pass_t*) _sg_imgui_malloc_clear(&ctx->desc.allocator, pass_pool_size);
+    const size_t attachments_pool_size = (size_t)ctx->attachments_window.num_slots * sizeof(sgimgui_attachments_t);
+    ctx->attachments_window.slots = (sgimgui_attachments_t*) _sgimgui_malloc_clear(&ctx->desc.allocator, attachments_pool_size);
 }
 
-SOKOL_API_IMPL void sg_imgui_discard(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_discard(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
     /* restore original trace hooks */
     sg_install_trace_hooks(&ctx->hooks);
     ctx->init_tag = 0;
-    _sg_imgui_capture_discard(ctx);
-    if (ctx->buffers.slots) {
-        for (int i = 0; i < ctx->buffers.num_slots; i++) {
-            if (ctx->buffers.slots[i].res_id.id != SG_INVALID_ID) {
-                _sg_imgui_buffer_destroyed(ctx, i);
+    _sgimgui_capture_discard(ctx);
+    if (ctx->buffer_window.slots) {
+        for (int i = 0; i < ctx->buffer_window.num_slots; i++) {
+            if (ctx->buffer_window.slots[i].res_id.id != SG_INVALID_ID) {
+                _sgimgui_buffer_destroyed(ctx, i);
             }
         }
-        _sg_imgui_free(&ctx->desc.allocator, (void*)ctx->buffers.slots);
-        ctx->buffers.slots = 0;
+        _sgimgui_free(&ctx->desc.allocator, (void*)ctx->buffer_window.slots);
+        ctx->buffer_window.slots = 0;
     }
-    if (ctx->images.slots) {
-        for (int i = 0; i < ctx->images.num_slots; i++) {
-            if (ctx->images.slots[i].res_id.id != SG_INVALID_ID) {
-                _sg_imgui_image_destroyed(ctx, i);
+    if (ctx->image_window.slots) {
+        for (int i = 0; i < ctx->image_window.num_slots; i++) {
+            if (ctx->image_window.slots[i].res_id.id != SG_INVALID_ID) {
+                _sgimgui_image_destroyed(ctx, i);
             }
         }
-        _sg_imgui_free(&ctx->desc.allocator, (void*)ctx->images.slots);
-        ctx->images.slots = 0;
+        _sgimgui_free(&ctx->desc.allocator, (void*)ctx->image_window.slots);
+        ctx->image_window.slots = 0;
     }
-    if (ctx->samplers.slots) {
-        for (int i = 0; i < ctx->samplers.num_slots; i++) {
-            if (ctx->samplers.slots[i].res_id.id != SG_INVALID_ID) {
-                _sg_imgui_sampler_destroyed(ctx, i);
+    if (ctx->sampler_window.slots) {
+        for (int i = 0; i < ctx->sampler_window.num_slots; i++) {
+            if (ctx->sampler_window.slots[i].res_id.id != SG_INVALID_ID) {
+                _sgimgui_sampler_destroyed(ctx, i);
             }
         }
-        _sg_imgui_free(&ctx->desc.allocator, (void*)ctx->samplers.slots);
-        ctx->samplers.slots = 0;
+        _sgimgui_free(&ctx->desc.allocator, (void*)ctx->sampler_window.slots);
+        ctx->sampler_window.slots = 0;
     }
-    if (ctx->shaders.slots) {
-        for (int i = 0; i < ctx->shaders.num_slots; i++) {
-            if (ctx->shaders.slots[i].res_id.id != SG_INVALID_ID) {
-                _sg_imgui_shader_destroyed(ctx, i);
+    if (ctx->shader_window.slots) {
+        for (int i = 0; i < ctx->shader_window.num_slots; i++) {
+            if (ctx->shader_window.slots[i].res_id.id != SG_INVALID_ID) {
+                _sgimgui_shader_destroyed(ctx, i);
             }
         }
-        _sg_imgui_free(&ctx->desc.allocator, (void*)ctx->shaders.slots);
-        ctx->shaders.slots = 0;
+        _sgimgui_free(&ctx->desc.allocator, (void*)ctx->shader_window.slots);
+        ctx->shader_window.slots = 0;
     }
-    if (ctx->pipelines.slots) {
-        for (int i = 0; i < ctx->pipelines.num_slots; i++) {
-            if (ctx->pipelines.slots[i].res_id.id != SG_INVALID_ID) {
-                _sg_imgui_pipeline_destroyed(ctx, i);
+    if (ctx->pipeline_window.slots) {
+        for (int i = 0; i < ctx->pipeline_window.num_slots; i++) {
+            if (ctx->pipeline_window.slots[i].res_id.id != SG_INVALID_ID) {
+                _sgimgui_pipeline_destroyed(ctx, i);
             }
         }
-        _sg_imgui_free(&ctx->desc.allocator, (void*)ctx->pipelines.slots);
-        ctx->pipelines.slots = 0;
+        _sgimgui_free(&ctx->desc.allocator, (void*)ctx->pipeline_window.slots);
+        ctx->pipeline_window.slots = 0;
     }
-    if (ctx->passes.slots) {
-        for (int i = 0; i < ctx->passes.num_slots; i++) {
-            if (ctx->passes.slots[i].res_id.id != SG_INVALID_ID) {
-                _sg_imgui_pass_destroyed(ctx, i);
+    if (ctx->attachments_window.slots) {
+        for (int i = 0; i < ctx->attachments_window.num_slots; i++) {
+            if (ctx->attachments_window.slots[i].res_id.id != SG_INVALID_ID) {
+                _sgimgui_attachments_destroyed(ctx, i);
             }
         }
-        _sg_imgui_free(&ctx->desc.allocator, (void*)ctx->passes.slots);
-        ctx->passes.slots = 0;
+        _sgimgui_free(&ctx->desc.allocator, (void*)ctx->attachments_window.slots);
+        ctx->attachments_window.slots = 0;
     }
 }
 
-SOKOL_API_IMPL void sg_imgui_draw(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    sg_imgui_draw_buffers_window(ctx);
-    sg_imgui_draw_images_window(ctx);
-    sg_imgui_draw_samplers_window(ctx);
-    sg_imgui_draw_shaders_window(ctx);
-    sg_imgui_draw_pipelines_window(ctx);
-    sg_imgui_draw_passes_window(ctx);
-    sg_imgui_draw_capture_window(ctx);
-    sg_imgui_draw_capabilities_window(ctx);
-    sg_imgui_draw_frame_stats_window(ctx);
+    sgimgui_draw_buffer_window(ctx);
+    sgimgui_draw_image_window(ctx);
+    sgimgui_draw_sampler_window(ctx);
+    sgimgui_draw_shader_window(ctx);
+    sgimgui_draw_pipeline_window(ctx);
+    sgimgui_draw_attachments_window(ctx);
+    sgimgui_draw_capture_window(ctx);
+    sgimgui_draw_capabilities_window(ctx);
+    sgimgui_draw_frame_stats_window(ctx);
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_menu(sg_imgui_t* ctx, const char* title) {
+SOKOL_API_IMPL void sgimgui_draw_menu(sgimgui_t* ctx, const char* title) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
     SOKOL_ASSERT(title);
     if (igBeginMenu(title, true)) {
-        igMenuItem_BoolPtr("Capabilities", 0, &ctx->caps.open, true);
-        igMenuItem_BoolPtr("Frame Stats", 0, &ctx->frame_stats.open, true);
-        igMenuItem_BoolPtr("Buffers", 0, &ctx->buffers.open, true);
-        igMenuItem_BoolPtr("Images", 0, &ctx->images.open, true);
-        igMenuItem_BoolPtr("Samplers", 0, &ctx->samplers.open, true);
-        igMenuItem_BoolPtr("Shaders", 0, &ctx->shaders.open, true);
-        igMenuItem_BoolPtr("Pipelines", 0, &ctx->pipelines.open, true);
-        igMenuItem_BoolPtr("Passes", 0, &ctx->passes.open, true);
-        igMenuItem_BoolPtr("Calls", 0, &ctx->capture.open, true);
+        igMenuItem_BoolPtr("Capabilities", 0, &ctx->caps_window.open, true);
+        igMenuItem_BoolPtr("Frame Stats", 0, &ctx->frame_stats_window.open, true);
+        igMenuItem_BoolPtr("Buffers", 0, &ctx->buffer_window.open, true);
+        igMenuItem_BoolPtr("Images", 0, &ctx->image_window.open, true);
+        igMenuItem_BoolPtr("Samplers", 0, &ctx->sampler_window.open, true);
+        igMenuItem_BoolPtr("Shaders", 0, &ctx->shader_window.open, true);
+        igMenuItem_BoolPtr("Pipelines", 0, &ctx->pipeline_window.open, true);
+        igMenuItem_BoolPtr("Attachments", 0, &ctx->attachments_window.open, true);
+        igMenuItem_BoolPtr("Calls", 0, &ctx->capture_window.open, true);
         igEndMenu();
     }
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_buffers_window(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_buffer_window(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    if (!ctx->buffers.open) {
+    if (!ctx->buffer_window.open) {
         return;
     }
     igSetNextWindowSize(IMVEC2(440, 280), ImGuiCond_Once);
-    if (igBegin("Buffers", &ctx->buffers.open, 0)) {
-        sg_imgui_draw_buffers_content(ctx);
+    if (igBegin("Buffers", &ctx->buffer_window.open, 0)) {
+        sgimgui_draw_buffer_window_content(ctx);
     }
     igEnd();
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_images_window(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_image_window(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    if (!ctx->images.open) {
+    if (!ctx->image_window.open) {
         return;
     }
     igSetNextWindowSize(IMVEC2(440, 400), ImGuiCond_Once);
-    if (igBegin("Images", &ctx->images.open, 0)) {
-        sg_imgui_draw_images_content(ctx);
+    if (igBegin("Images", &ctx->image_window.open, 0)) {
+        sgimgui_draw_image_window_content(ctx);
     }
     igEnd();
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_samplers_window(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_sampler_window(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    if (!ctx->samplers.open) {
+    if (!ctx->sampler_window.open) {
         return;
     }
     igSetNextWindowSize(IMVEC2(440, 400), ImGuiCond_Once);
-    if (igBegin("Samplers", &ctx->samplers.open, 0)) {
-        sg_imgui_draw_samplers_content(ctx);
+    if (igBegin("Samplers", &ctx->sampler_window.open, 0)) {
+        sgimgui_draw_sampler_window_content(ctx);
     }
     igEnd();
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_shaders_window(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_shader_window(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    if (!ctx->shaders.open) {
+    if (!ctx->shader_window.open) {
         return;
     }
     igSetNextWindowSize(IMVEC2(440, 400), ImGuiCond_Once);
-    if (igBegin("Shaders", &ctx->shaders.open, 0)) {
-        sg_imgui_draw_shaders_content(ctx);
+    if (igBegin("Shaders", &ctx->shader_window.open, 0)) {
+        sgimgui_draw_shader_window_content(ctx);
     }
     igEnd();
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_pipelines_window(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_pipeline_window(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    if (!ctx->pipelines.open) {
+    if (!ctx->pipeline_window.open) {
         return;
     }
     igSetNextWindowSize(IMVEC2(540, 400), ImGuiCond_Once);
-    if (igBegin("Pipelines", &ctx->pipelines.open, 0)) {
-        sg_imgui_draw_pipelines_content(ctx);
+    if (igBegin("Pipelines", &ctx->pipeline_window.open, 0)) {
+        sgimgui_draw_pipeline_window_content(ctx);
     }
     igEnd();
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_passes_window(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_attachments_window(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    if (!ctx->passes.open) {
+    if (!ctx->attachments_window.open) {
         return;
     }
     igSetNextWindowSize(IMVEC2(440, 400), ImGuiCond_Once);
-    if (igBegin("Passes", &ctx->passes.open, 0)) {
-        sg_imgui_draw_passes_content(ctx);
+    if (igBegin("Attachments", &ctx->attachments_window.open, 0)) {
+        sgimgui_draw_attachments_window_content(ctx);
     }
     igEnd();
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_capture_window(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_capture_window(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    if (!ctx->capture.open) {
+    if (!ctx->capture_window.open) {
         return;
     }
     igSetNextWindowSize(IMVEC2(640, 400), ImGuiCond_Once);
-    if (igBegin("Frame Capture", &ctx->capture.open, 0)) {
-        sg_imgui_draw_capture_content(ctx);
+    if (igBegin("Frame Capture", &ctx->capture_window.open, 0)) {
+        sgimgui_draw_capture_window_content(ctx);
     }
     igEnd();
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_capabilities_window(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_capabilities_window(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    if (!ctx->caps.open) {
+    if (!ctx->caps_window.open) {
         return;
     }
     igSetNextWindowSize(IMVEC2(440, 400), ImGuiCond_Once);
-    if (igBegin("Capabilities", &ctx->caps.open, 0)) {
-        sg_imgui_draw_capabilities_content(ctx);
+    if (igBegin("Capabilities", &ctx->caps_window.open, 0)) {
+        sgimgui_draw_capabilities_window_content(ctx);
     }
     igEnd();
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_frame_stats_window(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_frame_stats_window(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    if (!ctx->frame_stats.open) {
+    if (!ctx->frame_stats_window.open) {
         return;
     }
     igSetNextWindowSize(IMVEC2(512, 400), ImGuiCond_Once);
-    if (igBegin("Frame Stats", &ctx->frame_stats.open, 0)) {
-        sg_imgui_draw_frame_stats_content(ctx);
+    if (igBegin("Frame Stats", &ctx->frame_stats_window.open, 0)) {
+        sgimgui_draw_frame_stats_window_content(ctx);
     }
     igEnd();
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_buffers_content(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_buffer_window_content(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    _sg_imgui_draw_buffer_list(ctx);
+    _sgimgui_draw_buffer_list(ctx);
     igSameLine(0,-1);
-    _sg_imgui_draw_buffer_panel(ctx, ctx->buffers.sel_buf);
+    _sgimgui_draw_buffer_panel(ctx, ctx->buffer_window.sel_buf);
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_images_content(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_image_window_content(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    _sg_imgui_draw_image_list(ctx);
+    _sgimgui_draw_image_list(ctx);
     igSameLine(0,-1);
-    _sg_imgui_draw_image_panel(ctx, ctx->images.sel_img);
+    _sgimgui_draw_image_panel(ctx, ctx->image_window.sel_img);
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_samplers_content(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_sampler_window_content(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    _sg_imgui_draw_sampler_list(ctx);
+    _sgimgui_draw_sampler_list(ctx);
     igSameLine(0,-1);
-    _sg_imgui_draw_sampler_panel(ctx, ctx->samplers.sel_smp);
+    _sgimgui_draw_sampler_panel(ctx, ctx->sampler_window.sel_smp);
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_shaders_content(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_shader_window_content(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    _sg_imgui_draw_shader_list(ctx);
+    _sgimgui_draw_shader_list(ctx);
     igSameLine(0,-1);
-    _sg_imgui_draw_shader_panel(ctx, ctx->shaders.sel_shd);
+    _sgimgui_draw_shader_panel(ctx, ctx->shader_window.sel_shd);
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_pipelines_content(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_pipeline_window_content(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    _sg_imgui_draw_pipeline_list(ctx);
+    _sgimgui_draw_pipeline_list(ctx);
     igSameLine(0,-1);
-    _sg_imgui_draw_pipeline_panel(ctx, ctx->pipelines.sel_pip);
+    _sgimgui_draw_pipeline_panel(ctx, ctx->pipeline_window.sel_pip);
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_passes_content(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_attachments_window_content(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    _sg_imgui_draw_pass_list(ctx);
+    _sgimgui_draw_attachments_list(ctx);
     igSameLine(0,-1);
-    _sg_imgui_draw_pass_panel(ctx, ctx->passes.sel_pass);
+    _sgimgui_draw_attachments_panel(ctx, ctx->attachments_window.sel_atts);
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_capture_content(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_capture_window_content(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    _sg_imgui_draw_capture_list(ctx);
+    _sgimgui_draw_capture_list(ctx);
     igSameLine(0,-1);
-    _sg_imgui_draw_capture_panel(ctx);
+    _sgimgui_draw_capture_panel(ctx);
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_capabilities_content(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_capabilities_window_content(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
     _SOKOL_UNUSED(ctx);
-    _sg_imgui_draw_caps_panel();
+    _sgimgui_draw_caps_panel();
 }
 
-SOKOL_API_IMPL void sg_imgui_draw_frame_stats_content(sg_imgui_t* ctx) {
+SOKOL_API_IMPL void sgimgui_draw_frame_stats_window_content(sgimgui_t* ctx) {
     SOKOL_ASSERT(ctx && (ctx->init_tag == 0xABCDABCD));
-    ctx->frame_stats.stats = sg_query_frame_stats();
-    _sg_imgui_draw_frame_stats_panel(ctx);
+    ctx->frame_stats_window.stats = sg_query_frame_stats();
+    _sgimgui_draw_frame_stats_panel(ctx);
 }
 
 #endif /* SOKOL_GFX_IMGUI_IMPL */

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -2480,7 +2480,7 @@ _SOKOL_PRIVATE void _sgimgui_append_buffer(sg_buffer buf, const sg_range* data, 
     }
 }
 
-_SOKOL_PRIVATE void _sgimgui_begin_pass(const sg_pass* pass, const sg_pass_action* resolved_pass_action, void* user_data) {
+_SOKOL_PRIVATE void _sgimgui_begin_pass(const sg_pass* pass, void* user_data) {
     sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
@@ -2489,10 +2489,9 @@ _SOKOL_PRIVATE void _sgimgui_begin_pass(const sg_pass* pass, const sg_pass_actio
         item->cmd = SGIMGUI_CMD_BEGIN_PASS;
         item->color = _SGIMGUI_COLOR_PASS;
         item->args.begin_pass.pass = *pass;
-        item->args.begin_pass.pass.action = *resolved_pass_action;
     }
     if (ctx->hooks.begin_pass) {
-        ctx->hooks.begin_pass(pass, resolved_pass_action, ctx->hooks.user_data);
+        ctx->hooks.begin_pass(pass, ctx->hooks.user_data);
     }
 }
 

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -4005,6 +4005,46 @@ _SOKOL_PRIVATE void _sgimgui_draw_passaction_panel(sgimgui_t* ctx, sg_attachment
     }
 }
 
+_SOKOL_PRIVATE void _sgimgui_draw_swapchain_panel(sg_swapchain* swapchain) {
+    igText("Swapchain");
+    igText("  Width: %d", swapchain->width);
+    igText("  Height: %d", swapchain->height);
+    igText("  Sample Count: %d", swapchain->sample_count);
+    igText("  Color Format: %s", _sgimgui_pixelformat_string(swapchain->color_format));
+    igText("  Depth Format: %s", _sgimgui_pixelformat_string(swapchain->depth_format));
+    igSeparator();
+    switch (sg_query_backend()) {
+        case SG_BACKEND_D3D11:
+            igText("D3D11 Objects:");
+            igText("  Render View: %p", swapchain->d3d11.render_view);
+            igText("  Resolve View: %p", swapchain->d3d11.resolve_view);
+            igText("  Depth Stencil View: %p", swapchain->d3d11.depth_stencil_view);
+            break;
+        case SG_BACKEND_WGPU:
+            igText("WGPU Objects:");
+            igText("  Render View: %p", swapchain->wgpu.render_view);
+            igText("  Resolve View: %p", swapchain->wgpu.resolve_view);
+            igText("  Depth Stencil View: %p", swapchain->wgpu.depth_stencil_view);
+            break;
+        case SG_BACKEND_METAL_MACOS:
+        case SG_BACKEND_METAL_IOS:
+        case SG_BACKEND_METAL_SIMULATOR:
+            igText("Metal Objects:");
+            igText("  Current Drawable: %p", swapchain->metal.current_drawable);
+            igText("  Depth Stencil Texture: %p", swapchain->metal.depth_stencil_texture);
+            igText("  MSAA Color Texture: %p", swapchain->metal.msaa_color_texture);
+            break;
+        case SG_BACKEND_GLCORE33:
+        case SG_BACKEND_GLES3:
+            igText("GL Objects:");
+            igText("  Framebuffer: %d", swapchain->gl.framebuffer);
+            break;
+        default:
+            igText("  UNKNOWN BACKEND!");
+            break;
+    }
+}
+
 _SOKOL_PRIVATE void _sgimgui_draw_capture_panel(sgimgui_t* ctx) {
     int sel_item_index = ctx->capture_window.sel_item;
     if (sel_item_index >= _sgimgui_capture_num_read_items(ctx)) {
@@ -4067,8 +4107,11 @@ _SOKOL_PRIVATE void _sgimgui_draw_capture_panel(sgimgui_t* ctx) {
         case SGIMGUI_CMD_BEGIN_PASS:
             _sgimgui_draw_passaction_panel(ctx, item->args.begin_pass.pass.attachments, &item->args.begin_pass.pass.action);
             igSeparator();
-            _sgimgui_draw_attachments_panel(ctx, item->args.begin_pass.pass.attachments);
-            // FIXME: swapchain panel
+            if (item->args.begin_pass.pass.attachments.id != SG_INVALID_ID) {
+                _sgimgui_draw_attachments_panel(ctx, item->args.begin_pass.pass.attachments);
+            } else {
+                _sgimgui_draw_swapchain_panel(&item->args.begin_pass.pass.swapchain);
+            }
             break;
         case SGIMGUI_CMD_APPLY_VIEWPORT:
         case SGIMGUI_CMD_APPLY_SCISSOR_RECT:

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -4205,7 +4205,7 @@ _SOKOL_PRIVATE void _sgimgui_draw_caps_panel(void) {
     igText("    max_image_size_array: %d", l.max_image_size_array);
     igText("    max_image_array_layers: %d", l.max_image_array_layers);
     igText("    max_vertex_attrs: %d", l.max_vertex_attrs);
-    igText("    gl_max_vertex_uniform_vectors: %d", l.gl_max_vertex_uniform_vectors);
+    igText("    gl_max_vertex_uniform_components: %d", l.gl_max_vertex_uniform_components);
     igText("    gl_max_combined_texture_image_units: %d", l.gl_max_combined_texture_image_units);
     igText("\nUsable Pixelformats:");
     for (int i = (int)(SG_PIXELFORMAT_NONE+1); i < (int)_SG_PIXELFORMAT_NUM; i++) {

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -2480,7 +2480,7 @@ _SOKOL_PRIVATE void _sgimgui_append_buffer(sg_buffer buf, const sg_range* data, 
     }
 }
 
-_SOKOL_PRIVATE void _sgimgui_begin_pass(const sg_pass* pass, void* user_data) {
+_SOKOL_PRIVATE void _sgimgui_begin_pass(const sg_pass* pass, const sg_pass_action* resolved_pass_action, void* user_data) {
     sgimgui_t* ctx = (sgimgui_t*) user_data;
     SOKOL_ASSERT(ctx);
     sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
@@ -2489,9 +2489,10 @@ _SOKOL_PRIVATE void _sgimgui_begin_pass(const sg_pass* pass, void* user_data) {
         item->cmd = SGIMGUI_CMD_BEGIN_PASS;
         item->color = _SGIMGUI_COLOR_PASS;
         item->args.begin_pass.pass = *pass;
+        item->args.begin_pass.pass.action = *resolved_pass_action;
     }
     if (ctx->hooks.begin_pass) {
-        ctx->hooks.begin_pass(pass, ctx->hooks.user_data);
+        ctx->hooks.begin_pass(pass, resolved_pass_action, ctx->hooks.user_data);
     }
 }
 


### PR DESCRIPTION
- [x] change recipe blog post: https://floooh.github.io/2024/02/26/sokol-spring-cleaning-2024.html
- [x] remove contexts
- [x] rename sg_pass to sg_attachments, sg_make_pass() => sg_make_attachments() (and use 
- [x] drive-by fix for #714: change GL_MAX_VERTEX_UNIFORM_VECTORS to GL_MAX_VERTEX_UNIFORM_COMPONENTS (a minor breaking change in sg_limits).
- [x] sg_pass for the all-in-one param going into the new unified sg_begin_pass()
    - [x] dummy backend
    - [x] gl backend
    - [x] metal backend
    - [x] d3d11 backend
    - [x] wgpu backend
- [x] new sg_pass struct with sg_pass_action and sg_attachments
- [x] change sg_begin_pass() to take const sg_pass*
- [x] new sg_swapchain struct which contains backend-specific swapchain surfaces (etc...)
- [x] integrate sg_swapchain into sg_begin_pass()
    - [x] dummy backend
    - [x] metal backend
    - [x] gl backend
    - [x] d3d11 backend
    - [x] wgpu backend
- [x] fix _sg_validate_begin_pass() to also check swapchain arguments (and make sure they are mutually exclusive with sg_attachments)
    - [x] metal backend
    - [x] gl backend
    - [x] d3d11 backend
    - [x] wgpu backend
- [x] remove sg_begin_default_pass()
- [x] remove swapchain attributes from sg_context_desc
- [x] _sg.cur_pass related cleanup
    - [x] metal
    - [x] d3d11
    - [x] gl
    - [x] wgpu
- [x] implement sapp_gl_get_framebuffer()
    - [x] macOS
    - [x] iOS
    - [x] Android
    - [x] Emscripten
    - [x] Windows
    - [x] Linux/GLX
    - [x] Linux/EGL
- [x] find a better name for sg_context_desc  ( => sg_environment)
- [x] change semantics of pixel formats and sample count in sg_context_desc to mean "default pipeline attributes"
- [x] ~~replace granular getter functions in sokol_app.h with `sapp_swapchain sapp_get_swapchain(void)` and this must fail when called outside the frame callback (to enforce correct usage)~~
- [x] Q: should the Metal swapchain description have the 'raw' surfaces instead of an MTLRenderPassDescriptor object? Would be more in line with the other platform, and less 'hardwired' to MTKView.
- [x] Metal: label the Metal render pass (also WGPU)
- [x] Metal: optionally support commandBuffer with retained references (via new config item `sg_desc.mtl_use_command_buffer_with_retained_references`, fixes https://github.com/floooh/sokol/issues/981)
- [x] D3D11: move swapchain MSAA resolve into sokol_gfx.h _sg_d3d11_end_pass() (like in the other backends)
- [x] fix related code-cleanup fixmes
- [x] fix tests
- [x] ~~move `backend.cur_pipeline` up into generic state~~ (maybe at a later time)
- [x] change sokol_glue.h prefix to sglue_, and remove the 'clever' included prepreocessor checks
- [x] make sokol_glue.h a regular bindings header(?)
- [x] fix sokol_gfx_imgui.h
- [x] fix sg_swapchain defaults to use the default values from sg_environment
- [x] fix all samples
    - [x] sapp
    - [x] metal
    - [x] d3d11
    - [x] glfw    
        - [x] glfw+metal example
        - [x] multi-window example
        - [x] ...all other glfw examles
    - [x] html5
    - [x] wgpu
- [x] make swapchain depth buffer optional
    - [x] metal
    - [x] d3d11
    - [x] gl
    - [x] webgpu
- [x] allow defaults for color_format, depth_format and sample_count in sg_environment and sg_swapchain.
- [x] ~~sokol_app.h: sapp_pixelformat, and allow to configure depth-buffer (none, depth-only, depth-stencil)~~ move this into a later update
- [x] fix all bindings
    - [x] zig (https://github.com/floooh/sokol-zig/pull/57)
    - [x] odin (https://github.com/floooh/sokol-odin/pull/8)
    - [x] nim (https://github.com/floooh/sokol-nim/pull/28)
    - [x] rust (https://github.com/floooh/sokol-rust/pull/22)
- [x] fix dependent projects
    - [x] pacman.c (https://github.com/floooh/pacman.c/pull/12)
    - [x] chips (https://github.com/floooh/chips-test/pull/33)
    - [x] v6502r (https://github.com/floooh/v6502r/pull/24)
    - [x] pacman.zig (https://github.com/floooh/pacman.zig/pull/23)
    - [x] kc85.zig (https://github.com/floooh/kc85.zig/pull/4)
    - [x] doom (https://github.com/floooh/doom-sokol/pull/1)
    - [x] cimgui-starter-kit (https://github.com/floooh/cimgui-sokol-starterkit/pull/18)
    - [x] qoiview (https://github.com/floooh/qoiview/pull/10)
- [x] fix sokol_app.h documentation
- [x] fix sokol_gfx_imgui.h documentation
- [x] fix sokol_gfx.h documentation
    - [x] sg_setup() + sokol_glue.h()
    - [x] sg_swapchain
    - [x] sg_environment
    - [x] sg_attachments
    - [x] sg_attachments_desc
    - [x] rewrite render passes section
- [x] test
    - [x] macOS + Metal
    - [x] macOS + GL
    - [x] iOS + Metal
    - [x] iOS + GL
    - [x] Android
    - [x] Windows + D3D11
    - [x] Windows + GL
    - [x] Web + WebGL2
    - [x] Web + WebGPU
- [x] update changelog
- [x] update readme
    - [x] merge sokol_gfx.h and sokol_app.h section and change the hello-triangle to use sokol_app.h

Merged:

- [x] sokol-zig
- [x] sokol-odin
- [x] sokol-nim
- [x] sokol-rust
- [ ] pacman.c
- [ ] pacman.zig
- [ ] kc85.zig
- [ ] doom
- [ ] cimgui-starter-kit
- [ ] v6502r
- [ ] chips-test
- [ ] qoiview