### PR TITLE
[sokol_imgui] add  the optional backend interface for font management

### DIFF
--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -543,6 +543,8 @@ SOKOL_IMGUI_API_DECL bool simgui_handle_event(const sapp_event* ev);
 SOKOL_IMGUI_API_DECL int simgui_map_keycode(sapp_keycode keycode);  // returns ImGuiKey_*
 #endif
 SOKOL_IMGUI_API_DECL void simgui_shutdown(void);
+SOKOL_IMGUI_API_DECL void simgui_create_fonts_texture(void);
+SOKOL_IMGUI_API_DECL void simgui_destroy_fonts_texture(void);
 
 #ifdef __cplusplus
 } // extern "C"
@@ -2368,33 +2370,49 @@ SOKOL_API_IMPL void simgui_setup(const simgui_desc_t* desc) {
 
     // default font texture
     if (!_simgui.desc.no_default_font) {
-        unsigned char* font_pixels;
-        int font_width, font_height;
-        #if defined(__cplusplus)
-            io->Fonts->GetTexDataAsRGBA32(&font_pixels, &font_width, &font_height);
-        #else
-            int bytes_per_pixel;
-            ImFontAtlas_GetTexDataAsRGBA32(io->Fonts, &font_pixels, &font_width, &font_height, &bytes_per_pixel);
-        #endif
-        sg_image_desc font_img_desc;
-        _simgui_clear(&font_img_desc, sizeof(font_img_desc));
-        font_img_desc.width = font_width;
-        font_img_desc.height = font_height;
-        font_img_desc.pixel_format = SG_PIXELFORMAT_RGBA8;
-        font_img_desc.data.subimage[0][0].ptr = font_pixels;
-        font_img_desc.data.subimage[0][0].size = (size_t)(font_width * font_height) * sizeof(uint32_t);
-        font_img_desc.label = "sokol-imgui-font-image";
-        _simgui.font_img = sg_make_image(&font_img_desc);
-
-        simgui_image_desc_t img_desc;
-        _simgui_clear(&img_desc, sizeof(img_desc));
-        img_desc.image = _simgui.font_img;
-        img_desc.sampler = _simgui.font_smp;
-        _simgui.default_font = simgui_make_image(&img_desc);
-        io->Fonts->TexID = simgui_imtextureid(_simgui.default_font);
+        simgui_create_fonts_texture();
     }
 
     sg_pop_debug_group();
+}
+
+SOKOL_API_IMPL void simgui_create_fonts_texture(void) {
+    #if defined(__cplusplus)
+        ImGuiIO* io = &ImGui::GetIO();
+    #else
+        ImGuiIO* io = igGetIO();
+    #endif
+
+    unsigned char* font_pixels;
+    int font_width, font_height;
+    #if defined(__cplusplus)
+        io->Fonts->GetTexDataAsRGBA32(&font_pixels, &font_width, &font_height);
+    #else
+        int bytes_per_pixel;
+        ImFontAtlas_GetTexDataAsRGBA32(io->Fonts, &font_pixels, &font_width, &font_height, &bytes_per_pixel);
+    #endif
+    sg_image_desc font_img_desc;
+    _simgui_clear(&font_img_desc, sizeof(font_img_desc));
+    font_img_desc.width = font_width;
+    font_img_desc.height = font_height;
+    font_img_desc.pixel_format = SG_PIXELFORMAT_RGBA8;
+    font_img_desc.data.subimage[0][0].ptr = font_pixels;
+    font_img_desc.data.subimage[0][0].size = (size_t)(font_width * font_height) * sizeof(uint32_t);
+    font_img_desc.label = "sokol-imgui-font-image";
+    _simgui.font_img = sg_make_image(&font_img_desc);
+
+    simgui_image_desc_t img_desc;
+    _simgui_clear(&img_desc, sizeof(img_desc));
+    img_desc.image = _simgui.font_img;
+    img_desc.sampler = _simgui.font_smp;
+    _simgui.default_font = simgui_make_image(&img_desc);
+    io->Fonts->TexID = simgui_imtextureid(_simgui.default_font);
+}
+
+SOKOL_API_IMPL void simgui_destroy_fonts_texture(void) {
+    // NOTE: it's valid to call the destroy funcs with SG_INVALID_ID
+    sg_destroy_image(_simgui.font_img);
+    simgui_destroy_image(_simgui.default_font);
 }
 
 SOKOL_API_IMPL void simgui_shutdown(void) {


### PR DESCRIPTION
As a happy sokol_imgui user, I am humbling proposing this PR. It splits the font texture creation in a API function and add a function for the font texture destruction. Those functions are  considered optional function of the imgui backends.

For instance they are implemented for opengl3 on the main imgui repo:

https://github.com/ocornut/imgui/blob/659fb41d0a23efbb9ea6cf74f51ecae0a51575b5/backends/imgui_impl_opengl3.h#L39C1-L42C3

I find those functions are useful in two cases:
- when testing different fonts raterization config,  it is convenient to recreate the texture dynamically. The imgui's author provides an example of such application: https://gist.github.com/ocornut/b3a9ecf13502fd818799a452969649ad
- when creating non default font, this allows to remove the boilerplate of uploading the font on GPU for the user of sokol_imgui.

Does this proposal make sense?