### PR TITLE
[sokol_app] add an option html5_use_emsc_set_main_loop

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1711,6 +1711,7 @@ typedef struct sapp_desc {
     bool html5_bubble_wheel_events;     // same for wheel events
     bool html5_bubble_key_events;       // if true, bubble up *all* key events to browser, not just key events that represent characters
     bool html5_bubble_char_events;      // if true, bubble up character events to browser
+    bool html5_use_emsc_set_main_loop;  // if true, use set_main_loop instead of request_animation_frame_loop
     bool ios_keyboard_resizes_canvas;   // if true, showing the iOS keyboard shrinks the canvas
 } sapp_desc;
 
@@ -5806,7 +5807,7 @@ _SOKOL_PRIVATE void _sapp_emsc_unregister_eventhandlers(void) {
     #endif
 }
 
-_SOKOL_PRIVATE EM_BOOL _sapp_emsc_frame(double time, void* userData) {
+_SOKOL_PRIVATE EM_BOOL _sapp_emsc_frame_animation_loop(double time, void* userData) {
     _SOKOL_UNUSED(userData);
     _sapp_timing_external(&_sapp.timing, time / 1000.0);
 
@@ -5831,6 +5832,13 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_frame(double time, void* userData) {
         return EM_FALSE;
     }
     return EM_TRUE;
+}
+
+_SOKOL_PRIVATE void _sapp_emsc_frame_main_loop(void) {
+    const double time = emscripten_performance_now();
+    if(!_sapp_emsc_frame_animation_loop(time, NULL)) {
+        emscripten_cancel_main_loop();
+    }
 }
 
 _SOKOL_PRIVATE void _sapp_emsc_run(const sapp_desc* desc) {
@@ -5863,8 +5871,11 @@ _SOKOL_PRIVATE void _sapp_emsc_run(const sapp_desc* desc) {
     sapp_set_icon(&desc->icon);
 
     // start the frame loop
-    emscripten_request_animation_frame_loop(_sapp_emsc_frame, 0);
-
+    if (_sapp.desc.html5_use_emsc_set_main_loop) {
+        emscripten_set_main_loop(_sapp_emsc_frame_main_loop, 0, false);
+    } else {
+        emscripten_request_animation_frame_loop(_sapp_emsc_frame_animation_loop, 0);
+    }
     // NOT A BUG: do not call _sapp_discard_state() here, instead this is
     // called in _sapp_emsc_frame() when the application is ordered to quit
 }


### PR DESCRIPTION
Implementation of the idea suggested in https://github.com/floooh/sokol/issues/843#issuecomment-1959114136

`emscripten_set_main_loop` is a higher level function compared to `emscripten_request_animation_frame_loop` and seems to play nicer with various `emcc` options (EXIT_RUNTIME or PROXY_TO_PTHREAD). The downside is that we have to compute the timestamp on our side and hence it might be less accurate than the one the browser returns with `[requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame)`.

I tested both implementation on a test app. Not sure if we need more testing and how to test.

In particular for my use case, only the version `SOKOL_EMSC_USE_SET_MAIN_LOOP` works when `PROXY_TO_PTHREAD` is enabled. But A few more changes are needed for this case in sokol_app which will be for another PR.