### PR TITLE
skip framebuffer invalidation when possible

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -8679,10 +8679,10 @@ _SOKOL_PRIVATE void _sg_gl_end_pass(void) {
                 invalidate_atts[att_index++] = (GLenum)(GL_COLOR_ATTACHMENT0 + i);
             }
         }
-        if (_sg.gl.depth_store_action == SG_STOREACTION_DONTCARE) {
+        if (_sg.gl.depth_store_action == SG_STOREACTION_DONTCARE && _sg.gl.cur_pass->cmn.ds_att.image_id.id != 0) {
             invalidate_atts[att_index++] = GL_DEPTH_ATTACHMENT;
         }
-        if (_sg.gl.stencil_store_action == SG_STOREACTION_DONTCARE) {
+        if (_sg.gl.stencil_store_action == SG_STOREACTION_DONTCARE && _sg.gl.cur_pass->cmn.ds_att.image_id.id != 0) {
             invalidate_atts[att_index++] = GL_STENCIL_ATTACHMENT;
         }
         if (att_index > 0) {


### PR DESCRIPTION
sokol was invalidating the depth/stencil attachment when there was none attached. Because of this, we were seeing webGL's gl.InvalidateFramebuffer in performance profiles when the call wasn't needed at all.

This PR only clears the depth or stencil attachments if the pass has a depth/stencil attachment.