### PR TITLE
fix font loading to work with more fonts than default one

### DIFF
--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -2369,13 +2369,6 @@ SOKOL_API_IMPL void simgui_setup(const simgui_desc_t* desc) {
     def_image_desc.label = "sokol-imgui-default-image";
     _simgui.def_img = sg_make_image(&def_image_desc);
 
-    // default font texture
-    if (!_simgui.desc.no_default_font) {
-        simgui_font_tex_desc_t simgui_font_smp_desc;
-        _simgui_clear(&simgui_font_smp_desc, sizeof(simgui_font_smp_desc));
-        simgui_create_fonts_texture(&simgui_font_smp_desc);
-    }
-
     sg_pop_debug_group();
 }
 
@@ -2515,6 +2508,11 @@ SOKOL_API_IMPL void simgui_new_frame(const simgui_frame_desc_t* desc) {
     #else
         ImGuiIO* io = igGetIO();
     #endif
+    if (!io->Fonts->TexReady) {
+        simgui_font_tex_desc_t simgui_font_smp_desc;
+        _simgui_clear(&simgui_font_smp_desc, sizeof(simgui_font_smp_desc));
+        simgui_create_fonts_texture(&simgui_font_smp_desc);
+    }
     io->DisplaySize.x = ((float)desc->width) / _simgui.cur_dpi_scale;
     io->DisplaySize.y = ((float)desc->height) / _simgui.cur_dpi_scale;
     io->DeltaTime = (float)desc->delta_time;

--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -2369,6 +2369,13 @@ SOKOL_API_IMPL void simgui_setup(const simgui_desc_t* desc) {
     def_image_desc.label = "sokol-imgui-default-image";
     _simgui.def_img = sg_make_image(&def_image_desc);
 
+    // default font texture
+    if (!_simgui.desc.no_default_font) {
+        simgui_font_tex_desc_t simgui_font_smp_desc;
+        _simgui_clear(&simgui_font_smp_desc, sizeof(simgui_font_smp_desc));
+        simgui_create_fonts_texture(&simgui_font_smp_desc);
+    }
+
     sg_pop_debug_group();
 }
 
@@ -2509,6 +2516,7 @@ SOKOL_API_IMPL void simgui_new_frame(const simgui_frame_desc_t* desc) {
         ImGuiIO* io = igGetIO();
     #endif
     if (!io->Fonts->TexReady) {
+        simgui_destroy_fonts_texture();
         simgui_font_tex_desc_t simgui_font_smp_desc;
         _simgui_clear(&simgui_font_smp_desc, sizeof(simgui_font_smp_desc));
         simgui_create_fonts_texture(&simgui_font_smp_desc);


### PR DESCRIPTION
Every time you invoke the io->AddFontXXX functions, imgui invalidates the default atlas texture, as it rebuilds the texture packer and needs to reload the new atlas on the GPU.