### PR TITLE
[sokol_gfx] Assign labels as debug names to D3D11 resources

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -10014,9 +10014,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_buffer(_sg_buffer_t* buf, cons
             _SG_ERROR(D3D11_CREATE_BUFFER_FAILED);
             return SG_RESOURCESTATE_FAILED;
         }
-        #if defined(SOKOL_DEBUG)
         _sg_d3d11_setlabel(buf->d3d11.buf, desc->label);
-        #endif
     }
     return SG_RESOURCESTATE_VALID;
 }

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -9238,6 +9238,13 @@ _SOKOL_PRIVATE void _sg_gl_update_image(_sg_image_t* img, const sg_image_data* d
 
 static const GUID _sg_d3d11_WKPDID_D3DDebugObjectName = { 0x429b8c22,0x9188,0x4b0c, {0x87,0x42,0xac,0xb0,0xbf,0x85,0xc2,0x00} };
 
+#if defined(SOKOL_DEBUG)
+#define _sg_d3d11_setlabel(self, label) _sg_d3d11_SetPrivateData(self, _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), label ? (UINT)strlen(label) : 0, label)
+#else
+#define _sg_d3d11_setlabel(self, label)
+#endif
+
+
 //-- D3D11 C/C++ wrappers ------------------------------------------------------
 static inline HRESULT _sg_d3d11_CheckFormatSupport(ID3D11Device* self, DXGI_FORMAT Format, UINT* pFormatSupport) {
     #if defined(__cplusplus)
@@ -10008,7 +10015,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_buffer(_sg_buffer_t* buf, cons
             return SG_RESOURCESTATE_FAILED;
         }
         #if defined(SOKOL_DEBUG)
-        _sg_d3d11_SetPrivateData(buf->d3d11.buf, _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), (UINT)strlen(desc->label), desc->label);
+        _sg_d3d11_setlabel(buf->d3d11.buf, desc->label);
         #endif
     }
     return SG_RESOURCESTATE_VALID;
@@ -10116,9 +10123,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
                 _SG_ERROR(D3D11_CREATE_2D_TEXTURE_FAILED);
                 return SG_RESOURCESTATE_FAILED;
             }
-            #if defined(SOKOL_DEBUG)
-            _sg_d3d11_SetPrivateData(img->d3d11.tex2d, _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), (UINT)strlen(desc->label), desc->label);
-            #endif
+            _sg_d3d11_setlabel(img->d3d11.tex2d, desc->label);
 
             // create shader-resource-view for 2D texture
             // FIXME: currently we don't support setting MSAA texture as shader resource
@@ -10148,9 +10153,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
                     _SG_ERROR(D3D11_CREATE_2D_SRV_FAILED);
                     return SG_RESOURCESTATE_FAILED;
                 }
-                #if defined(SOKOL_DEBUG)
-                _sg_d3d11_SetPrivateData(img->d3d11.srv, _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), (UINT)strlen(desc->label), desc->label);
-                #endif
+                _sg_d3d11_setlabel(img->d3d11.srv, desc->label);
             }
         }
         SOKOL_ASSERT(img->d3d11.tex2d);
@@ -10192,9 +10195,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
                 _SG_ERROR(D3D11_CREATE_3D_TEXTURE_FAILED);
                 return SG_RESOURCESTATE_FAILED;
             }
-            #if defined(SOKOL_DEBUG)
-            _sg_d3d11_SetPrivateData(img->d3d11.tex3d, _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), (UINT)strlen(desc->label), desc->label);
-            #endif
+            _sg_d3d11_setlabel(img->d3d11.tex3d, desc->label);
 
             // create shader-resource-view for 3D texture
             if (!msaa) {
@@ -10208,9 +10209,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_image(_sg_image_t* img, const 
                     _SG_ERROR(D3D11_CREATE_3D_SRV_FAILED);
                     return SG_RESOURCESTATE_FAILED;
                 }
-                #if defined(SOKOL_DEBUG)
-                _sg_d3d11_SetPrivateData(img->d3d11.srv, _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), (UINT)strlen(desc->label), desc->label);
-                #endif
+                _sg_d3d11_setlabel(img->d3d11.srv, desc->label);
             }
         }
         SOKOL_ASSERT(img->d3d11.tex3d);
@@ -10274,9 +10273,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_sampler(_sg_sampler_t* smp, co
             _SG_ERROR(D3D11_CREATE_SAMPLER_STATE_FAILED);
             return SG_RESOURCESTATE_FAILED;
         }
-        #if defined(SOKOL_DEBUG)
-        _sg_d3d11_SetPrivateData(smp->d3d11.smp, _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), (UINT)strlen(desc->label), desc->label);
-        #endif
+        _sg_d3d11_setlabel(smp->d3d11.smp, desc->label);
     }
     return SG_RESOURCESTATE_VALID;
 }
@@ -10371,9 +10368,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_shader(_sg_shader_t* shd, cons
                 _SG_ERROR(D3D11_CREATE_CONSTANT_BUFFER_FAILED);
                 return SG_RESOURCESTATE_FAILED;
             }
-            #if defined(SOKOL_DEBUG)
-            _sg_d3d11_SetPrivateData(d3d11_stage->cbufs[ub_index], _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), (UINT)strlen(desc->label), desc->label);
-            #endif
+            _sg_d3d11_setlabel(d3d11_stage->cbufs[ub_index], desc->label);
         }
     }
 
@@ -10412,10 +10407,8 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_shader(_sg_shader_t* shd, cons
             SOKOL_ASSERT(shd->d3d11.vs_blob);
             memcpy(shd->d3d11.vs_blob, vs_ptr, vs_length);
             result = SG_RESOURCESTATE_VALID;
-            #if defined(SOKOL_DEBUG)
-            _sg_d3d11_SetPrivateData(shd->d3d11.vs, _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), (UINT)strlen(desc->label), desc->label);
-            _sg_d3d11_SetPrivateData(shd->d3d11.fs, _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), (UINT)strlen(desc->label), desc->label);
-            #endif
+            _sg_d3d11_setlabel(shd->d3d11.vs, desc->label);
+            _sg_d3d11_setlabel(shd->d3d11.fs, desc->label);
         }
     }
     if (vs_blob) {
@@ -10507,9 +10500,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_pipeline(_sg_pipeline_t* pip, 
         _SG_ERROR(D3D11_CREATE_INPUT_LAYOUT_FAILED);
         return SG_RESOURCESTATE_FAILED;
     }
-    #if defined(SOKOL_DEBUG)
-    _sg_d3d11_SetPrivateData(pip->d3d11.il, _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), (UINT)strlen(desc->label), desc->label);
-    #endif
+    _sg_d3d11_setlabel(pip->d3d11.il, desc->label);
 
     // create rasterizer state
     D3D11_RASTERIZER_DESC rs_desc;
@@ -10529,9 +10520,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_pipeline(_sg_pipeline_t* pip, 
         _SG_ERROR(D3D11_CREATE_RASTERIZER_STATE_FAILED);
         return SG_RESOURCESTATE_FAILED;
     }
-    #if defined(SOKOL_DEBUG)
-    _sg_d3d11_SetPrivateData(pip->d3d11.rs, _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), (UINT)strlen(desc->label), desc->label);
-    #endif
+    _sg_d3d11_setlabel(pip->d3d11.rs, desc->label);
 
     // create depth-stencil state
     D3D11_DEPTH_STENCIL_DESC dss_desc;
@@ -10557,9 +10546,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_pipeline(_sg_pipeline_t* pip, 
         _SG_ERROR(D3D11_CREATE_DEPTH_STENCIL_STATE_FAILED);
         return SG_RESOURCESTATE_FAILED;
     }
-    #if defined(SOKOL_DEBUG)
-    _sg_d3d11_SetPrivateData(pip->d3d11.dss, _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), (UINT)strlen(desc->label), desc->label);
-    #endif
+    _sg_d3d11_setlabel(pip->d3d11.dss, desc->label);
 
     // create blend state
     D3D11_BLEND_DESC bs_desc;
@@ -10594,9 +10581,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_pipeline(_sg_pipeline_t* pip, 
         _SG_ERROR(D3D11_CREATE_BLEND_STATE_FAILED);
         return SG_RESOURCESTATE_FAILED;
     }
-    #if defined(SOKOL_DEBUG)
-    _sg_d3d11_SetPrivateData(pip->d3d11.bs, _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), (UINT)strlen(desc->label), desc->label);
-    #endif
+    _sg_d3d11_setlabel(pip->d3d11.bs, desc->label);
     return SG_RESOURCESTATE_VALID;
 }
 
@@ -10692,9 +10677,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_attachments(_sg_attachments_t*
             _SG_ERROR(D3D11_CREATE_RTV_FAILED);
             return SG_RESOURCESTATE_FAILED;
         }
-        #if defined(SOKOL_DEBUG)
-        _sg_d3d11_SetPrivateData(atts->d3d11.colors[i].view.rtv, _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), (UINT)strlen(desc->label), desc->label);
-        #endif
+        _sg_d3d11_setlabel(atts->d3d11.colors[i].view.rtv, desc->label);
     }
     SOKOL_ASSERT(0 == atts->d3d11.depth_stencil.view.dsv);
     if (ds_desc->image.id != SG_INVALID_ID) {
@@ -10729,9 +10712,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_d3d11_create_attachments(_sg_attachments_t*
             _SG_ERROR(D3D11_CREATE_DSV_FAILED);
             return SG_RESOURCESTATE_FAILED;
         }
-        #if defined(SOKOL_DEBUG)
-        _sg_d3d11_SetPrivateData(atts->d3d11.depth_stencil.view.dsv, _sg_win32_refguid(_sg_d3d11_WKPDID_D3DDebugObjectName), (UINT)strlen(desc->label), desc->label);
-        #endif
+        _sg_d3d11_setlabel(atts->d3d11.depth_stencil.view.dsv, desc->label);
     }
     return SG_RESOURCESTATE_VALID;
 }


### PR DESCRIPTION
This change assigns the "label" field form resource desc structs to D3D11 resource objects, using 
`SetPrivateData` with `WKPDID_D3DDebugObjectName`. This code is enabled only when `SOKOL_DEBUG` is defined.

Note: this requires sokol_gfx to also link with `dxguid.lib`.

Note: some resources have multiple "sub-resources", e.g. a shader has a vertex and a fragment shader resource. In those cases the label is the same for all sub-resources.

This is useful especially in RenderDoc ([docs](https://renderdoc.org/docs/how/how_annotate_capture.html#:~:text=tex2d%2D%3ESetPrivateData(WKPDID_D3DDebugObjectName%2C%20sizeof(%22Example%20Texture%22)%2C%20%22Example%20Texture%22)%3B)) and in D3D11 debugging messages.