### PR TITLE
[sokol_gfx] Increase _SG_STRING_SIZE from 16 to 32

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4756,7 +4756,7 @@ _SOKOL_PRIVATE int _sg_slot_index(uint32_t id);
 
 // constants
 enum {
-    _SG_STRING_SIZE = 16,
+    _SG_STRING_SIZE = 32,
     _SG_SLOT_SHIFT = 16,
     _SG_SLOT_MASK = (1<<_SG_SLOT_SHIFT)-1,
     _SG_MAX_POOL_SIZE = (1<<_SG_SLOT_SHIFT),


### PR DESCRIPTION
I'm not sure why the static string size limit was so low, since it's used for vertex attribute names. I ran into issues where a regular variable name of a shader vertex vertex/instance attribute would trigger this limit.

So I changed it to 32 which seems like a more reasonable limit for variable names...