### PR TITLE
[odin bindings] Exclude 'NUM' enum values

### DIFF
--- a/bindgen/gen_odin.py
+++ b/bindgen/gen_odin.py
@@ -421,7 +421,7 @@ def gen_enum(decl, prefix):
     l(f'{as_struct_or_enum_type(enum_name, prefix)} :: enum i32 {{')
     for item in decl['items']:
         item_name = as_enum_item_name(check_override(item['name']))
-        if item_name != 'FORCE_U32':
+        if item_name != 'FORCE_U32' and item_name != 'NUM':
             if 'value' in item:
                 l(f"    {item_name} = {item['value']},")
             else:


### PR DESCRIPTION
There is no reason to have a `NUM` field at the end of an enum in Odin. Because unlike in C, Odin supports `len(My_Enum)`. And the additional enum field also interferes with things like enumerated arrays and bit_sets.