### PR TITLE
Fix Jai bindings for Metal on MacOS

### DIFF
--- a/bindgen/gen_jai.py
+++ b/bindgen/gen_jai.py
@@ -30,7 +30,7 @@ system_libs = {
             'gl': '#system_library,link_always "gdi32"; #system_library,link_always "dxguid"; #system_library,link_always "user32"; #system_library,link_always "shell32";',
         },
         'macos': {
-            'metal': '#library "../../libclang_rt.osx"; #system_library,link_always "Cocoa"; #system_library,link_always "QuartzCore"; #system_library,link_always "Metal"; #system_library,link_always "MetalKit";',
+            'metal': '#library,link_always "../../libclang_rt.osx"; #system_library,link_always "Cocoa"; #system_library,link_always "QuartzCore"; #system_library,link_always "Metal"; #system_library,link_always "MetalKit";',
             'gl': '#system_library,link_always "Cocoa"; #system_library,link_always "QuartzCore"; #system_library,link_always "OpenGL";',
         },
         'linux': {


### PR DESCRIPTION
Added missing `,link_always` when using the Metal backend on MacOS, which caused linker issues on some versions of MacOS.

This should fix the following linker error when using Metal:
```console
lld-macos: error: undefined symbol: ___isPlatformVersionAtLeast
```