### PR TITLE
sokol_gl.h: don't skip rendering completely in case of errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ A small behaviour update for sokol_gl.h (may be breaking if you call `sgl_error(
     - `int sgl_num_vertices(void)`
     - `int sgl_num_commands(void)`
 
-Also see ticket #1092 and PR (fixme) for details!
+Also see ticket #1092 and PR #1096 for details!
 
 ### 14-Aug-2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 ## Updates
 
+### 26-Aug-2024
+
+A small behaviour update for sokol_gl.h (may be breaking if you call `sgl_error()`):
+
+- Instead of skipping rendering completely for the current frame if an error is encountered
+  (for instance the vertex- or command-buffer running full), sokol-gl will now
+  render all successfully recorded draw commands before the error was recorded.
+- Minor breaking change: `sgl_error` has been changed from an error code enum to
+  a struct with a boolean flag per error type, that way no error information is
+  lost if multiple error happen in the same frame.
+- Two new functions to query the current number of recorded vertices and commands
+  in the current frame:
+    - `int sgl_num_vertices(void)`
+    - `int sgl_num_commands(void)`
+
+Also see ticket #1092 and PR (fixme) for details!
+
 ### 14-Aug-2024
 
 The previously 'inofficial' Jai bindings at https://github.com/colinbellino/sokol-jai


### PR DESCRIPTION
Also:

- more detailed error tracking
- two new functions to query number of recorded vertices and commands

Fixes #1092 