### PR TITLE
[sokol_gfx] add unorm10-10-10-2 vertex format

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -13502,8 +13502,7 @@ _SOKOL_PRIVATE WGPUVertexFormat _sg_wgpu_vertexformat(sg_vertex_format f) {
         case SG_VERTEXFORMAT_USHORT4N:      return WGPUVertexFormat_Unorm16x4;
         case SG_VERTEXFORMAT_HALF2:         return WGPUVertexFormat_Float16x2;
         case SG_VERTEXFORMAT_HALF4:         return WGPUVertexFormat_Float16x4;
-        // FIXME! UINT10_N2 (see https://github.com/gpuweb/gpuweb/issues/4275)
-        case SG_VERTEXFORMAT_UINT10_N2:     return WGPUVertexFormat_Undefined;
+        case SG_VERTEXFORMAT_UINT10_N2:     return WGPUVertexFormat_Unorm10_10_10_2;
         default:
             SOKOL_UNREACHABLE;
             return WGPUVertexFormat_Force32;


### PR DESCRIPTION
According to PR: https://github.com/webgpu-native/webgpu-headers/pull/324

This can be merged later, when webgpu.h will be updated everywhere.
