### PR TITLE
Fix _saudio_backend_shutdown for _SAUDIO_APPLE

### DIFF
--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -2473,7 +2473,7 @@ void _saudio_backend_shutdown(void) {
     #elif defined(SAUDIO_ANDROID_SLES)
         _saudio_sles_backend_shutdown();
     #elif defined(_SAUDIO_APPLE)
-        return _saudio_coreaudio_backend_shutdown();
+        _saudio_coreaudio_backend_shutdown();
     #else
     #error "unknown platform"
     #endif


### PR DESCRIPTION
The code path tries to return void. Does not compile for obvious reasons.