### PR TITLE
Allow SG_PIXELFORMAT_RG11B10F to be a render target on SOKOL_GLCORE

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -7494,7 +7494,6 @@ _SOKOL_PRIVATE void _sg_gl_init_pixelformats(bool has_bgra) {
         _sg_pixelformat_all(&_sg.formats[SG_PIXELFORMAT_BGRA8]);
     }
     _sg_pixelformat_all(&_sg.formats[SG_PIXELFORMAT_RGB10A2]);
-    _sg_pixelformat_sf(&_sg.formats[SG_PIXELFORMAT_RG11B10F]);
     _sg_pixelformat_sf(&_sg.formats[SG_PIXELFORMAT_RGB9E5]);
     _sg_pixelformat_srm(&_sg.formats[SG_PIXELFORMAT_RG32UI]);
     _sg_pixelformat_srm(&_sg.formats[SG_PIXELFORMAT_RG32SI]);
@@ -7535,20 +7534,24 @@ _SOKOL_PRIVATE void _sg_gl_init_pixelformats_float(bool has_colorbuffer_float, b
                 _sg_pixelformat_sfrm(&_sg.formats[SG_PIXELFORMAT_RG32F]);
                 _sg_pixelformat_sfrm(&_sg.formats[SG_PIXELFORMAT_RGBA32F]);
             }
+            _sg_pixelformat_sfrm(&_sg.formats[SG_PIXELFORMAT_RG11B10F]);
         } else {
             _sg_pixelformat_sf(&_sg.formats[SG_PIXELFORMAT_R32F]);
             _sg_pixelformat_sf(&_sg.formats[SG_PIXELFORMAT_RG32F]);
             _sg_pixelformat_sf(&_sg.formats[SG_PIXELFORMAT_RGBA32F]);
+            _sg_pixelformat_sf(&_sg.formats[SG_PIXELFORMAT_RG11B10F]);
         }
     } else {
         if (has_colorbuffer_float) {
             _sg_pixelformat_sbrm(&_sg.formats[SG_PIXELFORMAT_R32F]);
             _sg_pixelformat_sbrm(&_sg.formats[SG_PIXELFORMAT_RG32F]);
             _sg_pixelformat_sbrm(&_sg.formats[SG_PIXELFORMAT_RGBA32F]);
+            _sg_pixelformat_srm(&_sg.formats[SG_PIXELFORMAT_RG11B10F]);
         } else {
             _sg_pixelformat_s(&_sg.formats[SG_PIXELFORMAT_R32F]);
             _sg_pixelformat_s(&_sg.formats[SG_PIXELFORMAT_RG32F]);
             _sg_pixelformat_s(&_sg.formats[SG_PIXELFORMAT_RGBA32F]);
+            _sg_pixelformat_s(&_sg.formats[SG_PIXELFORMAT_RG11B10F]);
         }
     }
 }


### PR DESCRIPTION
Page 209 of https://registry.khronos.org/OpenGL/specs/gl/glspec46.core.pdf (and page 181 of https://registry.khronos.org/OpenGL/specs/gl/glspec43.core.pdf for 4.3) show `R11F_G11F_B10F` as color renderable.