### PR TITLE
sokol_imgui.h: changed ImTextureID type from void* to uint64_t

### DIFF
--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -530,8 +530,8 @@ SOKOL_IMGUI_API_DECL void simgui_render(void);
 SOKOL_IMGUI_API_DECL simgui_image_t simgui_make_image(const simgui_image_desc_t* desc);
 SOKOL_IMGUI_API_DECL void simgui_destroy_image(simgui_image_t img);
 SOKOL_IMGUI_API_DECL simgui_image_desc_t simgui_query_image_desc(simgui_image_t img);
-SOKOL_IMGUI_API_DECL void* simgui_imtextureid(simgui_image_t img);
-SOKOL_IMGUI_API_DECL simgui_image_t simgui_image_from_imtextureid(void* im_texture_id);
+SOKOL_IMGUI_API_DECL uint64_t simgui_imtextureid(simgui_image_t img);
+SOKOL_IMGUI_API_DECL simgui_image_t simgui_image_from_imtextureid(uint64_t im_texture_id);
 SOKOL_IMGUI_API_DECL void simgui_add_focus_event(bool focus);
 SOKOL_IMGUI_API_DECL void simgui_add_mouse_pos_event(float x, float y);
 SOKOL_IMGUI_API_DECL void simgui_add_touch_pos_event(float x, float y);
@@ -2505,14 +2505,14 @@ SOKOL_API_IMPL simgui_image_desc_t simgui_query_image_desc(simgui_image_t img_id
     return desc;
 }
 
-SOKOL_API_IMPL void* simgui_imtextureid(simgui_image_t img) {
+SOKOL_API_IMPL uint64_t simgui_imtextureid(simgui_image_t img) {
     SOKOL_ASSERT(_SIMGUI_INIT_COOKIE == _simgui.init_cookie);
-    return (void*)(uintptr_t)img.id;
+    return (uint64_t)(uintptr_t)img.id;
 }
 
-SOKOL_API_IMPL simgui_image_t simgui_image_from_imtextureid(void* im_texture_id) {
+SOKOL_API_IMPL simgui_image_t simgui_image_from_imtextureid(uint64_t im_texture_id) {
     SOKOL_ASSERT(_SIMGUI_INIT_COOKIE == _simgui.init_cookie);
-    simgui_image_t img = { (uint32_t)(uintptr_t) im_texture_id };
+    simgui_image_t img = { (uint32_t)im_texture_id };
     return img;
 }
 


### PR DESCRIPTION
This PR brings `sokol_imgui.h` up to date with Dear ImGui v1.91.4 which changes the type of `ImTextureID` from `void*` to `uint64_t`.