### PR TITLE
Add explicit cast to convert void* to ImTextureID to fix a Clang C++ compile time error.

### DIFF
--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -2431,7 +2431,7 @@ SOKOL_API_IMPL void simgui_create_fonts_texture(const simgui_font_tex_desc_t* de
     img_desc.image = _simgui.font_img;
     img_desc.sampler = _simgui.font_smp;
     _simgui.default_font = simgui_make_image(&img_desc);
-    io->Fonts->TexID = simgui_imtextureid(_simgui.default_font);
+    io->Fonts->TexID = (ImTextureID)simgui_imtextureid(_simgui.default_font);
 }
 
 SOKOL_API_IMPL void simgui_destroy_fonts_texture(void) {


### PR DESCRIPTION
Fixes the following compiler error when using Sokol headers in a C++ project.

```shell
In file included from src/application.cpp:12:
libs/sokol/util/sokol_imgui.h:2434:24: error: incompatible pointer to integer conversion assigning to 'ImTextureID' (aka 'unsigned long long') from 'void *'
 2434 |     io->Fonts->TexID = simgui_imtextureid(_simgui.default_font);
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

This fix is similar to #1134 however, it passes the tests.