### PR TITLE
[nuklear] Added command to enable cursors with default font.

### DIFF
--- a/util/sokol_nuklear.h
+++ b/util/sokol_nuklear.h
@@ -2152,6 +2152,8 @@ SOKOL_API_IMPL void snk_setup(const snk_desc_t* desc) {
         nk_font_atlas_cleanup(&_snuklear.atlas);
         if (_snuklear.atlas.default_font) {
             nk_style_set_font(&_snuklear.ctx, &_snuklear.atlas.default_font->handle);
+            // This adds the default cursors into the nuklear overlay for use.
+            nk_style_load_all_cursors(&_snuklear.ctx, &_snuklear.atlas.cursors);
         }
     }
 

--- a/util/sokol_nuklear.h
+++ b/util/sokol_nuklear.h
@@ -2153,7 +2153,7 @@ SOKOL_API_IMPL void snk_setup(const snk_desc_t* desc) {
         if (_snuklear.atlas.default_font) {
             nk_style_set_font(&_snuklear.ctx, &_snuklear.atlas.default_font->handle);
             // This adds the default cursors into the nuklear overlay for use.
-            nk_style_load_all_cursors(&_snuklear.ctx, &_snuklear.atlas.cursors);
+            nk_style_load_all_cursors(&_snuklear.ctx, &_snuklear.atlas.cursors[0]);
         }
     }
 


### PR DESCRIPTION
This adds the cursor to be available for use when using the default font. 

To enable cursors in a sokol application:
- First hide the native mouse: ```sapp_show_mouse(false);```
- Then show the nuklear mouse: ```nk_style_show_cursor(ctx);```
The nuklear show must be called with a valid context.

If not using the default font, then after a font is initialized and added manually call:
```nk_style_load_all_cursors(ctx, &your_font_atlas);```
And then use the above operations to show the nuklear cursor.