### PR TITLE
sokol_gfx.h: allow multisampled images as resource bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## Updates
 
+### 19-Nov-2024
+
+- Merged PR https://github.com/floooh/sokol/pull/1155, this allows to use
+  MSAA textures as resource bindings to load individual MSAA samples in
+  shaders. This is an optional feature and isn't supported on the following
+  platform/backend combos:
+
+  - macOS+GL
+  - iOS+GLES3
+  - WebGL2
+  - Android
+
+  You can also check the new feature flag `sg_features.msaa_image_bindings`
+  for support at runtime.
+
+  There's also a new sample https://floooh.github.io/sokol-webgpu/customresolve-sapp.html
+  which demonstrates how to access multisampled textures and the MSAA coverage mask
+  (requires a browser with WebGPU support).
+
 ### 13-Nov-2024
 
 - sokol_nuklear.h: merge PR https://github.com/floooh/sokol/pull/1150, this allows to connect the

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -7841,7 +7841,11 @@ _SOKOL_PRIVATE void _sg_gl_init_caps_glcore(void) {
     _sg.features.mrt_independent_blend_state = false;
     _sg.features.mrt_independent_write_mask = true;
     _sg.features.storage_buffer = version >= 430;
+    #if defined(__APPLE__)
+    _sg.features.msaa_image_bindings = false;
+    #else
     _sg.features.msaa_image_bindings = true;
+    #endif
 
     // scan extensions
     bool has_s3tc = false;  // BC1..BC3
@@ -8465,9 +8469,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_image(_sg_image_t* img, const sg_
     }
     const GLenum gl_internal_format = _sg_gl_teximage_internal_format(img->cmn.pixel_format);
 
-    // GLES3/WebGL2 doesn't have support for multisampled textures, so create a render buffer object instead
-    // on GLES3, if this is a MSAA render target, a render buffer object will be created instead of a regular texture
-    // (since GLES3 has no multisampled texture objects)
+    // GLES3/WebGL2/macOS doesn't have support for multisampled textures, so create a render buffer object instead
     if (!_sg.features.msaa_image_bindings && img->cmn.render_target && msaa) {
         glGenRenderbuffers(1, &img->gl.msaa_render_buffer);
         glBindRenderbuffer(GL_RENDERBUFFER, img->gl.msaa_render_buffer);
@@ -8529,7 +8531,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_image(_sg_image_t* img, const sg_
                                     mip_width, mip_height, 0, data_size, data_ptr);
                             } else {
                                 const GLenum gl_type = _sg_gl_teximage_type(img->cmn.pixel_format);
-                                #if defined(SOKOL_GLCORE)
+                                #if defined(SOKOL_GLCORE) && !defined(__APPLE__)
                                     if (msaa) {
                                         glTexImage2DMultisample(gl_img_target, img->cmn.sample_count, gl_internal_format,
                                             mip_width, mip_height, GL_TRUE);
@@ -8555,7 +8557,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_image(_sg_image_t* img, const sg_
                                     mip_width, mip_height, mip_depth, 0, data_size, data_ptr);
                             } else {
                                 const GLenum gl_type = _sg_gl_teximage_type(img->cmn.pixel_format);
-                                #if defined(SOKOL_GLCORE)
+                                #if defined(SOKOL_GLCORE) && !defined(__APPLE__)
                                     if (msaa) {
                                         // NOTE: only for array textures, not actual 3D textures!
                                         glTexImage3DMultisample(gl_img_target, img->cmn.sample_count, gl_internal_format,

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3948,6 +3948,7 @@ typedef struct sg_frame_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECTED_IMAGE_BINDING, "sg_apply_bindings: image binding is missing or the image handle is invalid") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_IMG_EXISTS, "sg_apply_bindings: bound image no longer alive") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_IMAGE_TYPE_MISMATCH, "sg_apply_bindings: type of bound image doesn't match shader desc") \
+    _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECTED_MULTISAMPLED_IMAGE, "sg_apply_bindings: expected image with sample_count > 1") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_IMAGE_MSAA, "sg_apply_bindings: cannot bind image with sample_count>1") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECTED_FILTERABLE_IMAGE, "sg_apply_bindings: filterable image expected") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECTED_DEPTH_IMAGE, "sg_apply_bindings: depth image expected") \
@@ -12607,7 +12608,7 @@ _SOKOL_PRIVATE void _sg_mtl_init_texdesc_rt(MTLTextureDescriptor* mtl_desc, _sg_
 // initialize MTLTextureDescriptor with MSAA attributes
 _SOKOL_PRIVATE void _sg_mtl_init_texdesc_rt_msaa(MTLTextureDescriptor* mtl_desc, _sg_image_t* img) {
     SOKOL_ASSERT(img->cmn.sample_count > 1);
-    mtl_desc.usage = MTLTextureUsageRenderTarget;
+    mtl_desc.usage = MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget;
     mtl_desc.resourceOptions = MTLResourceStorageModePrivate;
     mtl_desc.textureType = MTLTextureType2DMultisample;
     mtl_desc.sampleCount = (NSUInteger)img->cmn.sample_count;
@@ -17238,7 +17239,10 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bindings) {
                     _SG_VALIDATE(img != 0, VALIDATE_ABND_IMG_EXISTS);
                     if (img && img->slot.state == SG_RESOURCESTATE_VALID) {
                         _SG_VALIDATE(img->cmn.type == shd->cmn.images[i].image_type, VALIDATE_ABND_IMAGE_TYPE_MISMATCH);
-                        _SG_VALIDATE(img->cmn.sample_count == 1, VALIDATE_ABND_IMAGE_MSAA);
+//                        _SG_VALIDATE(img->cmn.sample_count == 1, VALIDATE_ABND_IMAGE_MSAA);
+                        if (shd->cmn.images[0].multisampled) {
+                            _SG_VALIDATE(img->cmn.sample_count > 1, VALIDATE_ABND_EXPECTED_MULTISAMPLED_IMAGE);
+                        }
                         const _sg_pixelformat_info_t* info = &_sg.formats[img->cmn.pixel_format];
                         switch (shd->cmn.images[i].sample_type) {
                             case SG_IMAGESAMPLETYPE_FLOAT:

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -8531,7 +8531,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_image(_sg_image_t* img, const sg_
                                 const GLenum gl_type = _sg_gl_teximage_type(img->cmn.pixel_format);
                                 #if defined(SOKOL_GLCORE)
                                     if (msaa) {
-                                        glTexImage2DMultisample(gl_img_target, img->cmn.sample_count, (GLint)gl_internal_format,
+                                        glTexImage2DMultisample(gl_img_target, img->cmn.sample_count, gl_internal_format,
                                             mip_width, mip_height, GL_TRUE);
                                     } else {
                                         glTexImage2D(gl_img_target, mip_index, (GLint)gl_internal_format,
@@ -8558,7 +8558,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_gl_create_image(_sg_image_t* img, const sg_
                                 #if defined(SOKOL_GLCORE)
                                     if (msaa) {
                                         // NOTE: only for array textures, not actual 3D textures!
-                                        glTexImage3DMultisample(gl_img_target, img->cmn.sample_count, (GLint)gl_internal_format,
+                                        glTexImage3DMultisample(gl_img_target, img->cmn.sample_count, gl_internal_format,
                                             mip_width, mip_height, mip_depth, GL_TRUE);
                                     } else {
                                         glTexImage3D(gl_img_target, mip_index, (GLint)gl_internal_format,

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -4212,6 +4212,7 @@ _SOKOL_PRIVATE void _sgimgui_draw_caps_panel(void) {
     igText("    mrt_independent_blend_state: %s", _sgimgui_bool_string(f.mrt_independent_blend_state));
     igText("    mrt_independent_write_mask: %s", _sgimgui_bool_string(f.mrt_independent_write_mask));
     igText("    storage_buffer: %s", _sgimgui_bool_string(f.storage_buffer));
+    igText("    msaa_image_bindings: %s", _sgimgui_bool_string(f.msaa_image_bindings));
     sg_limits l = sg_query_limits();
     igText("\nLimits:\n");
     igText("    max_image_size_2d: %d", l.max_image_size_2d);


### PR DESCRIPTION
Allows to fetch samples in shader from multisampled textures (for instance to allow custom-resolve render passes).

Not supported on WebGL2/GLES3 because no of missing support for multisampled texture objects, and also not on macOS because it just doesn't seem to work (even though the required function exist, but only in gl3ext.h, not in gl3.h).

Related ticket: https://github.com/floooh/sokol/issues/1142

- [x] changelog entry
- [x] integrate new custom resolve sample into sample webpage
- [x] update docs (sg_features.msaa_image_bindings)
- [x] add a coverage visualization to the custom resolve sample
- [x] test:
    - [x] macOS + Metal
    - [x] macOS + GL
        - [x] ~~crash: `Assertion failed: (glGetError() == 0), function _sg_gl_cache_bind_texture_sampler, file sokol_gfx.h, line 8195.`~~ simply disable msaa texture code path on macOS+GL, not worth the hassle
    - [x] iOS + Metal
    - [x] iOS + GLES3 (not supported)
    - [x] Windows + D3D11
    - [x] Windows + GL
    - [x] Linux + GL
    - [x] WebGL2 (not supported)
    - [x] WebGPU
    - [x] Android (not supported)
