### PR TITLE
Fix Odin bindgen type mappings

### DIFF
--- a/bindgen/gen_odin.py
+++ b/bindgen/gen_odin.py
@@ -105,9 +105,9 @@ prim_types = {
     'uint64_t':     'u64',
     'float':        'f32',
     'double':       'f64',
-    'uintptr_t':    'u64',
-    'intptr_t':     'i64',
-    'size_t':       'u64'
+    'uintptr_t':    'c.uintptr_t',
+    'intptr_t':     'c.intptr_t',
+    'size_t':       'c.size_t'
 }
 
 prim_defaults = {


### PR DESCRIPTION
This affects `intptr_t`, `uintptr_t`, and `size_t`, which are variable-sized. The previous mappings were mapped directly to 64-bit values, and they've been changed to use the corresponding `core:c` aliases.

This closes #1157. An additional fix is required in `sokol-odin` itself to correct `helpers.Allocator.alloc_fn`, which uses `u64` for a `size_t` argument.