### PR TITLE
sokol_app.h html5: cleanup canvas lookup handling (see #1154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 ## Updates
 
+### 23-Nov-2024
+
+- sokol_app.h html5: Merged PR https://github.com/floooh/sokol/pull/1159 (related
+  issue https://github.com/floooh/sokol/issues/1154).
+
+  This cleans up code that is concerned about finding the HTML canvas to
+  render to by:
+
+    - removing any leftover hacks from the time when Emscripten moved
+      from `document.getElementById()` to `document.querySelector()` for
+      looking up the canvas object
+    - adding two options for canvas objects that can't be looked up via
+      `document.querySelector()`
+
+  If you don't provide a custom canvas name to sokol_app.h this change
+  is non-breaking. Otherwise:
+
+    - in sokol_main(): change `.html5_canvas_name` to `.html5_canvas_selector`
+    - change the canvas name string to a CSS selector string (e.g.
+    from `"my_canvas"` to `"#my_canvas"`)
+
+  For more options to communicate the HTML canvas object to sokol_app.h,
+  please read the new doc section `SETTING THE CANVAS OBJECT ON THE WEB PLATFORM` in sokol_app.h.
+
+  Many thanks to @konsumer for kicking off the feature and the following
+  discussion :)
+
+
 ### 19-Nov-2024
 
 - Merged PR https://github.com/floooh/sokol/pull/1155, this allows to use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@
   For more options to communicate the HTML canvas object to sokol_app.h,
   please read the new doc section `SETTING THE CANVAS OBJECT ON THE WEB PLATFORM` in sokol_app.h.
 
+  Additionally, please also note the simplified `shell.html` in the
+  sokol-samples repository (some outdated cruft has been removed):
+
+  https://github.com/floooh/sokol-samples/blob/master/webpage/shell.html
+
   Many thanks to @konsumer for kicking off the feature and the following
   discussion :)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 - sokol_app.h html5: Merged PR https://github.com/floooh/sokol/pull/1159 (related
   issue https://github.com/floooh/sokol/issues/1154).
 
-  This cleans up code that is concerned about finding the HTML canvas to
-  render to by:
+  This cleans up code that is concerned about finding the WebGL/WebGPU HTML canvas by:
 
     - removing any leftover hacks from the time when Emscripten moved
       from `document.getElementById()` to `document.querySelector()` for

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -5095,8 +5095,6 @@ EM_JS(void, sapp_js_remove_dragndrop_listeners, (void), {
 
 EM_JS(void, sapp_js_init, (const char* c_str_target_selector), {
     const target_selector_str = UTF8ToString(c_str_target_selector);
-    // Special way to lookup the canvas by setting Module['canvas'] outside
-    // the WASM, this may be useful when the canvas can't be setup via document.querySelector()
     if (Module['canvas'] !== undefined) {
         if (typeof Module['canvas'] === 'object') {
             specialHTMLTargets[target_selector_str] = Module['canvas'];

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4931,7 +4931,6 @@ _SOKOL_PRIVATE void _sapp_emsc_set_clipboard_string(const char* str) {
 
 EM_JS(void, sapp_js_add_dragndrop_listeners, (void), {
     Module.sokol_drop_files = [];
-    const canvas = Module.sapp_emsc_target;
     Module.sokol_dragenter = (event) => {
         event.stopPropagation();
         event.preventDefault();
@@ -4964,6 +4963,8 @@ EM_JS(void, sapp_js_add_dragndrop_listeners, (void), {
         // FIXME? see computation of targetX/targetY in emscripten via getClientBoundingRect
         __sapp_emsc_end_drop(event.clientX, event.clientY, mods);
     };
+    \x2F\x2A\x2A @suppress {missingProperties} \x2A\x2F
+    const canvas = Module.sapp_emsc_target;
     canvas.addEventListener('dragenter', Module.sokol_dragenter, false);
     canvas.addEventListener('dragleave', Module.sokol_dragleave, false);
     canvas.addEventListener('dragover',  Module.sokol_dragover, false);
@@ -5004,6 +5005,7 @@ EM_JS(void, sapp_js_fetch_dropped_file, (int index, _sapp_html5_fetch_callback c
 });
 
 EM_JS(void, sapp_js_remove_dragndrop_listeners, (void), {
+    \x2F\x2A\x2A @suppress {missingProperties} \x2A\x2F
     const canvas = Module.sapp_emsc_target;
     canvas.removeEventListener('dragenter', Module.sokol_dragenter);
     canvas.removeEventListener('dragleave', Module.sokol_dragleave);
@@ -5012,14 +5014,13 @@ EM_JS(void, sapp_js_remove_dragndrop_listeners, (void), {
 });
 
 EM_JS(void, sapp_js_init, (const char* c_str_target_selector), {
-    // lookup and store canvas object by name
     const target_selector_str = UTF8ToString(c_str_target_selector);
     Module.sapp_emsc_target = findCanvasEventTarget(target_selector_str);
     if (!Module.sapp_emsc_target) {
-        console.log("sokol_app.h: invalid target selector:" + target_str);
+        console.log("sokol_app.h: invalid target selector:" + target_selector_str);
     }
     if (!Module.sapp_emsc_target.requestPointerLock) {
-        console.log("sokol_app.h: target doesn't support requestPointerLock:" + target_str);
+        console.log("sokol_app.h: target doesn't support requestPointerLock:" + target_selector_str);
     }
 });
 

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -5015,6 +5015,12 @@ EM_JS(void, sapp_js_remove_dragndrop_listeners, (void), {
 
 EM_JS(void, sapp_js_init, (const char* c_str_target_selector), {
     const target_selector_str = UTF8ToString(c_str_target_selector);
+    // check if canvas is provided via Module['canvas'], if yes make it visible
+    // in specialHTMLTargets[], this is an additional way to inject a canvas into
+    // sokol_app.h when it can't be found via document.querySelector()
+    if (Module['canvas']) {
+        specialHTMLTargets[target_selector_str] = Module['canvas'];
+    }
     Module.sapp_emsc_target = findCanvasEventTarget(target_selector_str);
     if (!Module.sapp_emsc_target) {
         console.log("sokol_app.h: invalid target selector:" + target_selector_str);


### PR DESCRIPTION
Proposal for #1154:

- change `sapp_desc.html5_canvas_name` to `.html5_canvas_selector`
- remove the canvas-id vs canvas-selector hack (instead sokol-app now expects a 'css selector string' to be passed in.
- uses the Emscripten helper function `findCanvasEventTarget()` to lookup the JS canvas name by canvas selector (which also considers `Module['canvas']` and `specialHMTLTargets[]`)

TODO:
- [x] test with custom canvas selectors (e.g. `<canvas id="bla">` => `.html5_canvas_selector="#bla"`
- [x] ~~test with setting canvas in index.html via `Module['canvas']`~~ this doesn't actually work any longer
- [x] test with adding canvases to `specialHTMLTargets[]` in index.html (see below)
- [x] in sokol-samples shell.html, remove the Module.canvas() and Module.postRun() functions (those are not actually called anymore)

To register canvases that can't be looked up via `document.querySelector()`, add them to the `specialHTMLTargets[]` array after the Emscripten environment is setup but before the WASM is started. For instance via `Module.preRun()` in index.html:

```js
        preRun: [
          () => {
            specialHTMLTargets['my_canvas'] = my_canvas;
          },
        ],
```

...then in sokol_main() use `.html5_canvas_selector = "my_canvas"`