### PR TITLE
sokol_args: Fix Emscripten extra semi-colon

### DIFF
--- a/sokol_args.h
+++ b/sokol_args.h
@@ -685,7 +685,7 @@ extern "C" {
 #endif
 
 #if defined(EM_JS_DEPS)
-EM_JS_DEPS(sokol_audio, "$withStackSave,$stringToUTF8OnStack");
+EM_JS_DEPS(sokol_audio, "$withStackSave,$stringToUTF8OnStack")
 #endif
 
 EMSCRIPTEN_KEEPALIVE void _sargs_add_kvp(const char* key, const char* val) {
@@ -729,7 +729,7 @@ EM_JS(void, sargs_js_parse_url, (void), {
             __sargs_add_kvp(key_cstr, val_cstr)
         });
     }
-});
+})
 
 #endif // EMSCRIPTEN
 


### PR DESCRIPTION
In Emscripten, the `EM_JS` function should not end with a `;`. This change fixes that for both instances.

This is the error that you get when using the `;`...
```
sokol_args.h:688:63: error: extra ';' outside of a function [-Werror,-Wextra-semi]
  688 | EM_JS_DEPS(sokol_audio, "$withStackSave,$stringToUTF8OnStack");
      |                                                               ^
sokol_args.h:732:3: error: extra ';' outside of a function [-Werror,-Wextra-semi]
  732 | });
      |   ^
2 errors generated.
```