### PR TITLE
bindgen: add option to use tiger style for zig

### DIFF
--- a/bindgen/gen_all.py
+++ b/bindgen/gen_all.py
@@ -1,4 +1,8 @@
-import os, gen_nim, gen_zig, gen_odin, gen_rust, gen_d, gen_jai, gen_c3
+import os, argparse, gen_nim, gen_zig, gen_odin, gen_rust, gen_d, gen_jai, gen_c3
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--zig-tiger-style", action="store_true", help="Enable zig tiger style mode.")
+args = parser.parse_args()
 
 tasks = [
     [ '../sokol_log.h',            'slog_',     [] ],
@@ -39,7 +43,7 @@ zig_tasks = [
 gen_zig.prepare()
 for task in zig_tasks:
     [c_header_path, main_prefix, dep_prefixes] = task
-    gen_zig.gen(c_header_path, main_prefix, dep_prefixes)
+    gen_zig.gen(c_header_path, main_prefix, dep_prefixes, {"tiger-style": args.zig_tiger_style})
 
 # D
 d_tasks = [


### PR DESCRIPTION
This commit adds an option to generate function names using `snake_case` instead of `camel_case`, per Tiger Style.

I don't mind maintaining this in my own fork if this is too niche for your taste, but figured I would offer it up. Thanks for all your work!


-- Commit Message:

Tiger Style comes from TigerBeetle's Zig style guide that they used for their popular database (same name).

"Use snake_case for function, variable, and file names. The underscore is the closest thing we have as programmers to a space, and helps to separate words and encourage descriptive names."

https://github.com/tigerbeetle/tigerbeetle/blob/main/docs/TIGER_STYLE.md