### PR TITLE
sokol_app.h macos: fix for Ctrl-Tab key down event not sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Updates
 
+### 20-Mar-2025
+
+- sokol_app.h macOS: A small fix for Ctrl-Tab key down. So far this wasn't forwarded
+  as an SAPP_EVENTTYPE_KEY_DOWN, presumably because Ctrl-Tab is the macOS
+  system hotkey for switching between application windows. The workaround
+  hooks into the Cocoa `performKeyEquivalent` callback to catch
+  Ctrl-Tab key-down events and forward them to sokol-app. Note that there are some
+  other special key combinations which cannot be intercepted the same way
+  (for instance Ctrl-F1 - which probably is a good thing because it enables
+  some critical accessibility features).
+
+  Relates issue: https://github.com/floooh/sokol/issues/1227
+  ...and PR: https://github.com/floooh/sokol/pull/1228
+
 ### 17-Mar-2025
 
 - sokol_fetch.h web: replace XMLHttpRequest with the more modern fetch API,

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4482,6 +4482,14 @@ static void _sapp_gl_make_current(void) {
         }
     }
 }
+
+- (BOOL)performKeyEquivalent:(NSEvent*)event {
+    // FIXME: need to forward only specific events here (like Ctrl-Tab)
+    // since performKeyEquivalent is called for *all* key combos with Ctrl or Cmd
+    [_sapp.macos.view keyDown:event];
+    return YES;
+}
+
 - (void)keyUp:(NSEvent*)event {
     _sapp_gl_make_current();
     _sapp_macos_key_event(SAPP_EVENTTYPE_KEY_UP,

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4485,12 +4485,8 @@ static void _sapp_gl_make_current(void) {
 
 - (BOOL)performKeyEquivalent:(NSEvent*)event {
     // fixes Ctrl-Tab keydown not triggering a keyDown event
-    // NOTE: some other (function-) keys have the same behaviour, but we're
-    // not generally intercepting those because they may trigger important
-    // macOS accessibility features. If Ctrl+Fx is desired for all function keys,
-    // new options should be added to sapp_desc, similar to the HTML5 event bubbling
-    // options.
-    // NOTE 2: it seems that Ctrl-F1 cannot be intercepted the same way, but since
+    //
+    // NOTE: it seems that Ctrl-F1 cannot be intercepted the same way, but since
     // this enabled critical accessibility features that's probably a good thing.
     switch (_sapp_translate_key(event.keyCode)) {
         case SAPP_KEYCODE_TAB:

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4489,7 +4489,9 @@ static void _sapp_gl_make_current(void) {
     // not generally intercepting those because they may trigger important
     // macOS accessibility features. If Ctrl+Fx is desired for all function keys,
     // new options should be added to sapp_desc, similar to the HTML5 event bubbling
-    // options. It seems like Ctrl-F1 is always off-limits for applications(?)
+    // options.
+    // NOTE 2: it seems that Ctrl-F1 cannot be intercepted the same way, but since
+    // this enabled critical accessibility features that's probably a good thing.
     switch (_sapp_translate_key(event.keyCode)) {
         case SAPP_KEYCODE_TAB:
             [_sapp.macos.view keyDown:event];

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4484,10 +4484,19 @@ static void _sapp_gl_make_current(void) {
 }
 
 - (BOOL)performKeyEquivalent:(NSEvent*)event {
-    // FIXME: need to forward only specific events here (like Ctrl-Tab)
-    // since performKeyEquivalent is called for *all* key combos with Ctrl or Cmd
-    [_sapp.macos.view keyDown:event];
-    return YES;
+    // fixes Ctrl-Tab keydown not triggering a keyDown event
+    // NOTE: some other (function-) keys have the same behaviour, but we're
+    // not generally intercepting those because they may trigger important
+    // macOS accessibility features. If Ctrl+Fx is desired for all function keys,
+    // new options should be added to sapp_desc, similar to the HTML5 event bubbling
+    // options. It seems like Ctrl-F1 is always off-limits for applications(?)
+    switch (_sapp_translate_key(event.keyCode)) {
+        case SAPP_KEYCODE_TAB:
+            [_sapp.macos.view keyDown:event];
+            return YES;
+        default:
+            return NO;
+    }
 }
 
 - (void)keyUp:(NSEvent*)event {


### PR DESCRIPTION
See https://github.com/floooh/sokol/issues/1227

- [x] only consider specific key-combos (like Ctrl-Tab) since all keys with Ctrl/Cmd pressed arrive at `performKeyEquivalent`