### PR TITLE
Expose X11 Window and Display

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -12388,7 +12388,7 @@ SOKOL_API_IMPL int sapp_gl_get_minor_version(void) {
 }
 
 SOKOL_API_IMPL const void* sapp_x11_get_window(void) {
-    #if defined(_SAPP_LINUX)
+    #if defined(_SAPP_LINUX) && defined(_SAPP_GLX)
         return (void*)_sapp.x11.window;
     #else
         return 0;
@@ -12396,7 +12396,7 @@ SOKOL_API_IMPL const void* sapp_x11_get_window(void) {
 }
 
 SOKOL_API_IMPL const void* sapp_x11_get_display(void) {
-    #if defined(_SAPP_LINUX)
+    #if defined(_SAPP_LINUX) && defined(_SAPP_GLX)
         return (void*)_sapp.x11.display;
     #else
         return 0;

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -310,6 +310,16 @@
             HWND has been cast to a void pointer in order to be tunneled
             through code which doesn't include Windows.h.
 
+        const void* sapp_x11_get_window(void)
+            On Linux, get the X11 Window, otherwise a null pointer. The
+            Window has been cast to a void pointer in order to be tunneled
+            through code which doesn't include X11/Xlib.h.
+
+        const void* sapp_x11_get_display(void)
+            On Linux, get the X11 Display, otherwise a null pointer. The
+            Display has been cast to a void pointer in order to be tunneled
+            through code which doesn't include X11/Xlib.h.
+
         const void* sapp_wgpu_get_device(void)
         const void* sapp_wgpu_get_render_view(void)
         const void* sapp_wgpu_get_resolve_view(void)
@@ -2004,6 +2014,11 @@ SOKOL_APP_API_DECL uint32_t sapp_gl_get_framebuffer(void);
 SOKOL_APP_API_DECL int sapp_gl_get_major_version(void);
 /* GL: get minor version (only valid for desktop GL) */
 SOKOL_APP_API_DECL int sapp_gl_get_minor_version(void);
+
+/* X11: get Window */
+SOKOL_APP_API_DECL const void* sapp_x11_get_window(void);
+/* X11: get Display */
+SOKOL_APP_API_DECL const void* sapp_x11_get_display(void);
 
 /* Android: get native activity handle */
 SOKOL_APP_API_DECL const void* sapp_android_get_native_activity(void);
@@ -12367,6 +12382,22 @@ SOKOL_API_IMPL int sapp_gl_get_minor_version(void) {
     SOKOL_ASSERT(_sapp.valid);
     #if defined(SOKOL_GLCORE)
         return _sapp.desc.gl_minor_version;
+    #else
+        return 0;
+    #endif
+}
+
+SOKOL_API_IMPL const void* sapp_x11_get_window(void) {
+    #if defined(_SAPP_LINUX)
+        return (void*)_sapp.x11.window;
+    #else
+        return 0;
+    #endif
+}
+
+SOKOL_API_IMPL const void* sapp_x11_get_display(void) {
+    #if defined(_SAPP_LINUX)
+        return (void*)_sapp.x11.display;
     #else
         return 0;
     #endif


### PR DESCRIPTION
The handle of X11 Window and Display should be exposed to the end user like every other platform.

This allows doing platform-specific operations such as resizing or setting attributes.