### PR TITLE
sokol_gl.h: set default write_mask to RGBA

### DIFF
--- a/util/sokol_gl.h
+++ b/util/sokol_gl.h
@@ -3148,7 +3148,7 @@ static void _sgl_init_pipeline(sgl_pipeline pip_id, const sg_pipeline_desc* in_d
     }
     desc.colors[0].pixel_format = ctx_desc->color_format;
     if (desc.colors[0].write_mask == _SG_COLORMASK_DEFAULT) {
-        desc.colors[0].write_mask = SG_COLORMASK_RGB;
+        desc.colors[0].write_mask = SG_COLORMASK_RGBA;
     }
 
     _sgl_pipeline_t* pip = _sgl_lookup_pipeline(pip_id.id);


### PR DESCRIPTION
Setting the write_mask from RGB to RGBA allows for using sokol_gl to draw to a render target (when creating a pipeline with make_context_pipeline), and retain alpha values. 

Without this change,  render textures written to with sokol_gl will truncate the alpha information, and will appear invisible when blending is enabled.