### PR TITLE
Update bindgen url for sokol-d

### DIFF
--- a/bindgen/README.md
+++ b/bindgen/README.md
@@ -24,7 +24,7 @@ To update the Zig bindings:
 > git clone https://github.com/floooh/sokol-nim
 > git clone https://github.com/floooh/sokol-odin
 > git clone https://github.com/floooh/sokol-rust
-> git clone https://github.com/floooh/sokol-d
+> git clone https://github.com/kassane/sokol-d
 > git clone https://github.com/colinbellino/sokol-jai
 > git clone https://github.com/floooh/sokol-c3
 > python3 gen_all.py


### PR DESCRIPTION
It looks like the path was never updated in the bindgen readme