### PR TITLE
Fix missalign sokol app

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2053,7 +2053,6 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 #include <stdlib.h> // malloc, free
 #include <string.h> // memset, strncmp
 #include <stddef.h> // size_t
-#include <stdalign.h> //alignas
 #include <math.h>   // roundf
 
 // helper macros

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2053,6 +2053,7 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 #include <stdlib.h> // malloc, free
 #include <string.h> // memset, strncmp
 #include <stddef.h> // size_t
+#include <stdalign.h> //alignas
 #include <math.h>   // roundf
 
 // helper macros
@@ -2675,7 +2676,7 @@ typedef struct {
         bool tracked;
         uint8_t capture_mask;
     } mouse;
-    uint8_t raw_input_data[256];
+    RAWINPUT raw_input_data;
 } _sapp_win32_t;
 
 #if defined(SOKOL_GLCORE)
@@ -7674,7 +7675,7 @@ _SOKOL_PRIVATE LRESULT CALLBACK _sapp_win32_wndproc(HWND hWnd, UINT uMsg, WPARAM
                         _SAPP_ERROR(WIN32_GET_RAW_INPUT_DATA_FAILED);
                         break;
                     }
-                    const RAWINPUT* raw_mouse_data = (const RAWINPUT*) &_sapp.win32.raw_input_data;
+                    const RAWINPUT* raw_mouse_data = &_sapp.win32.raw_input_data;
                     if (raw_mouse_data->data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE) {
                         /* mouse only reports absolute position
                            NOTE: This code is untested and will most likely behave wrong in Remote Desktop sessions.


### PR DESCRIPTION
This fix solves the issue I was having about a missalignment crash when dereferencing raw_input_data.
I don't know why you used an uint8_t array so maybe I'm missing something here.

