### PR TITLE
Set activation policy before making window fullscreen

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4097,11 +4097,11 @@ _SOKOL_PRIVATE void _sapp_macos_frame(void) {
     #endif
     [_sapp.macos.window center];
     _sapp.valid = true;
+    NSApp.activationPolicy = NSApplicationActivationPolicyRegular;
     if (_sapp.fullscreen) {
         /* ^^^ on GL, this already toggles a rendered frame, so set the valid flag before */
         [_sapp.macos.window toggleFullScreen:self];
     }
-    NSApp.activationPolicy = NSApplicationActivationPolicyRegular;
     [NSApp activateIgnoringOtherApps:YES];
     [_sapp.macos.window makeKeyAndOrderFront:nil];
     _sapp_macos_update_dimensions();


### PR DESCRIPTION
On macOS 15.4.1 `sapp_desc.fullscreen = true` didn't work because `NSWindow -toggleFullScreen:` doesn't seem to work when the `NSApp.activationPolicy` is still `NSApplicationActivationPolicyProhibited`. Setting the activationPolicy earlier fixes the issue. 

(noticed the bug on macOS 15.4.1 (24E263), with SOKOL_METAL, in a command line app, not an app bundle)

Side note: this exposed a bug in `sapp_is_fullscreen` where its internal state could differ from the real window state. To eliminate the possibility of that bug on macOS it could be implemented as 
```c
SOKOL_API_IMPL bool sapp_is_fullscreen(void) {
    #if defined(_SAPP_MACOS)
    return (_sapp.macos.window.styleMask & NSWindowStyleMaskFullScreen) != 0;
    #else
    return _sapp.fullscreen;
    #endif
}
```