### PR TITLE
sokol_gfx.h linux: window positioning and size fixes.

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -10830,27 +10830,18 @@ _SOKOL_PRIVATE void _sapp_x11_create_window(Visual* visual, int depth) {
 
     int display_width = DisplayWidth(_sapp.x11.display, _sapp.x11.screen);
     int display_height = DisplayHeight(_sapp.x11.display, _sapp.x11.screen);
-    int window_width = _sapp.window_width;
-    int window_height = _sapp.window_height;
+    int window_width = (int)(_sapp.window_width * _sapp.dpi_scale);
+    int window_height = (int)(_sapp.window_height * _sapp.dpi_scale);
     if (0 == window_width) {
         window_width = (display_width * 4) / 5;
     }
     if (0 == window_height) {
         window_height = (display_height * 4) / 5;
     }
-    int window_xpos = (display_width - window_width) / 2;
-    int window_ypos = (display_height - window_height) / 2;
-    if (window_xpos < 0) {
-        window_xpos = 0;
-    }
-    if (window_ypos < 0) {
-        window_ypos = 0;
-    }
     _sapp_x11_grab_error_handler();
     _sapp.x11.window = XCreateWindow(_sapp.x11.display,
                                      _sapp.x11.root,
-                                     window_xpos,
-                                     window_ypos,
+                                     0, 0,
                                      (uint32_t)window_width,
                                      (uint32_t)window_height,
                                      0,     /* border width */
@@ -10868,17 +10859,14 @@ _SOKOL_PRIVATE void _sapp_x11_create_window(Visual* visual, int depth) {
     };
     XSetWMProtocols(_sapp.x11.display, _sapp.x11.window, protocols, 1);
 
+    // NOTE: PPosition and PSize are obsolete and ignored
     XSizeHints* hints = XAllocSizeHints();
-    hints->flags = (PWinGravity | PPosition | PSize);
-    hints->win_gravity = StaticGravity;
-    hints->x = window_xpos;
-    hints->y = window_ypos;
-    hints->width = window_width;
-    hints->height = window_height;
+    hints->flags = PWinGravity;
+    hints->win_gravity = CenterGravity;
     XSetWMNormalHints(_sapp.x11.display, _sapp.x11.window, hints);
     XFree(hints);
 
-    /* announce support for drag'n'drop */
+    // announce support for drag'n'drop
     if (_sapp.drop.enabled) {
         const Atom version = _SAPP_X11_XDND_VERSION;
         XChangeProperty(_sapp.x11.display, _sapp.x11.window, _sapp.x11.xdnd.XdndAware, XA_ATOM, 32, PropModeReplace, (unsigned char*) &version, 1);


### PR DESCRIPTION
- generally let X11 pick the window position (with a hint to center the window)
- scale the window size by `dpi_scale`
