### PR TITLE
sokol_audio.h: remove extra semicolons

### DIFF
--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -1480,7 +1480,7 @@ error:
         _saudio.backend.device = 0;
     }
     return false;
-};
+}
 
 _SOKOL_PRIVATE void _saudio_alsa_backend_shutdown(void) {
     SOKOL_ASSERT(_saudio.backend.device);
@@ -1489,7 +1489,7 @@ _SOKOL_PRIVATE void _saudio_alsa_backend_shutdown(void) {
     snd_pcm_drain(_saudio.backend.device);
     snd_pcm_close(_saudio.backend.device);
     _saudio_free(_saudio.backend.buffer);
-};
+}
 
 // ██     ██  █████  ███████  █████  ██████  ██
 // ██     ██ ██   ██ ██      ██   ██ ██   ██ ██


### PR DESCRIPTION
These trigger `-Werror,-Wextra-semi` with clang 19 when building `tests/CMakeLists.txt`:

```
In file included from /home/user/sokol/tests/compile/sokol_audio.c:2:
/home/user/sokol/tests/compile/../../sokol_audio.h:1483:2: error: extra ';' outside of a function [-Werror,-Wextra-semi]
 1483 | };
      |  ^
/home/user/sokol/tests/compile/../../sokol_audio.h:1492:2: error: extra ';' outside of a function [-Werror,-Wextra-semi]
 1492 | };
      |  ^
```