### PR TITLE
sokol_gfx.h: Adapt SG_MAX_COLOR_ATTACHMENTS per backend.

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -1965,7 +1965,11 @@ typedef struct sg_range {
 enum {
     SG_INVALID_ID = 0,
     SG_NUM_INFLIGHT_FRAMES = 2,
+#if defined(SOKOL_GLES3) || defined(SOKOL_WGPU)
     SG_MAX_COLOR_ATTACHMENTS = 4,
+#else
+    SG_MAX_COLOR_ATTACHMENTS = 8,
+#endif
     SG_MAX_STORAGE_ATTACHMENTS = 4,
     SG_MAX_UNIFORMBLOCK_MEMBERS = 16,
     SG_MAX_VERTEX_ATTRIBUTES = 16,


### PR DESCRIPTION
I noticed when using Sokol that the maximums for a lot of things were limited to the web capabilities, which is fine for most applications, but if you want to use more unique buffers outside the usual color, position, normal, etc. You need more than 4 color buffers which is supported in all the other OpenGL, DX, and Metal backends.

I added a small check to see if it is GLES/WGPU, I did not research to see limits on the other buffer objects and samplers, but I would assume SG_MAX_STORAGE_ATTACHMENTS can also be 8 for the other backends.

I am using OpenGL 4.1 and tested it on MacOS 26, Arch Linux, and Windows 11 23H2. It should be tested with the other backends.

Thanks!