### PR TITLE
remove references to sg_begin_default_pass

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -254,8 +254,8 @@
         Both sg_apply_viewport() and sg_apply_scissor_rect() must be called
         inside a rendering pass (e.g. not in a compute pass, or outside a pass)
 
-        Note that sg_begin_default_pass() and sg_begin_pass() will reset both the
-        viewport and scissor rectangles to cover the entire framebuffer.
+        Note that sg_begin_pass() will reset both the viewport and scissor
+        rectangles to cover the entire framebuffer.
 
     --- to update (overwrite) the content of buffer and image resources, call:
 

--- a/util/sokol_spine.h
+++ b/util/sokol_spine.h
@@ -383,7 +383,7 @@
 
         const sspine_layer_transform tform = { ... };
 
-        sg_begin_default_pass(...);
+        sg_begin_pass(...);
         sspine_draw_layer(0, tform);
         sg_end_pass();
         sg_commit();


### PR DESCRIPTION
Was looking at some old code I had and noticed the sg_begin_default_pass had been [removed](https://floooh.github.io/2024/02/26/sokol-spring-cleaning-2024.html#detailed-change-list), but there are still a few references to it in the docs.