### PR TITLE
sokol_app: support for custom mouse cursor images

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -10914,12 +10914,12 @@ _SOKOL_PRIVATE sapp_mouse_cursor_image _sapp_x11_make_mouse_cursor_image(sapp_im
     img->yhot = (XcursorDim) hotspot_y;
     const size_t dest_num_bytes = (size_t)(img->width * img->height) * sizeof(XcursorPixel);
     SOKOL_ASSERT(dest_num_bytes == desc->pixels.size);
-    // Convert RGBA -> ARGB
+    // Copy RGBA -> BGRA
     for (size_t i = 0; i < dest_num_bytes; i += 4) {
-        ((uint8_t*) img->pixels)[i+3] = ((uint8_t*) desc->pixels.ptr)[i+0];
-        ((uint8_t*) img->pixels)[i+2] = ((uint8_t*) desc->pixels.ptr)[i+3];
-        ((uint8_t*) img->pixels)[i+1] = ((uint8_t*) desc->pixels.ptr)[i+2];
-        ((uint8_t*) img->pixels)[i+0] = ((uint8_t*) desc->pixels.ptr)[i+1];
+        ((uint8_t*) img->pixels)[i+0] = ((uint8_t*) desc->pixels.ptr)[i+2];
+        ((uint8_t*) img->pixels)[i+1] = ((uint8_t*) desc->pixels.ptr)[i+1];
+        ((uint8_t*) img->pixels)[i+2] = ((uint8_t*) desc->pixels.ptr)[i+0];
+        ((uint8_t*) img->pixels)[i+3] = ((uint8_t*) desc->pixels.ptr)[i+3];
     }
     Cursor cursor = XcursorImageLoadCursor(_sapp.x11.display, img);
     ret.opaque = (uint64_t) cursor;

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4258,7 +4258,7 @@ _SOKOL_PRIVATE sapp_mouse_cursor_image _sapp_macos_make_mouse_cursor_image(sapp_
         bitsPerPixel:32];
     
     if (rep != nil) {
-        memcpy([rep bitmapData], desc->pixels.ptr, desc->width * desc->height * 4);
+        memcpy([rep bitmapData], desc->pixels.ptr, (size_t) (desc->width * desc->height * 4));
 
         NSImage* native = [[NSImage alloc] initWithSize:NSMakeSize(desc->width, desc->height)];
         [native addRepresentation:rep];
@@ -10906,13 +10906,13 @@ _SOKOL_PRIVATE void _sapp_x11_destroy_cursors(void) {
 _SOKOL_PRIVATE sapp_mouse_cursor_image _sapp_x11_make_mouse_cursor_image(sapp_image_desc* desc, int hotspot_x, int hotspot_y) {
     sapp_mouse_cursor_image ret = {};
     XcursorImage* img = XcursorImageCreate(desc->width, desc->height);
-    SOKOL_ASSERT(img && (img->width == desc->width) && (img->height == desc->height) && img->pixels);
-    img->xhot = hotspot_x;
-    img->yhot = hotspot_y;
+    SOKOL_ASSERT(img && ((int) img->width == desc->width) && ((int) img->height == desc->height) && img->pixels);
+    img->xhot = (XcursorDim) hotspot_x;
+    img->yhot = (XcursorDim) hotspot_y;
     const size_t dest_num_bytes = (size_t)(img->width * img->height) * sizeof(XcursorPixel);
     SOKOL_ASSERT(dest_num_bytes == desc->pixels.size);
     // Convert RGBA -> ARGB
-    for (int i = 0; i < dest_num_bytes; i += 4) {
+    for (size_t i = 0; i < dest_num_bytes; i += 4) {
         ((uint8_t*) img->pixels)[i+3] = ((uint8_t*) desc->pixels.ptr)[i+0];
         ((uint8_t*) img->pixels)[i+2] = ((uint8_t*) desc->pixels.ptr)[i+3];
         ((uint8_t*) img->pixels)[i+1] = ((uint8_t*) desc->pixels.ptr)[i+2];
@@ -12322,7 +12322,7 @@ SOKOL_API_IMPL void sapp_set_mouse_cursor(sapp_mouse_cursor cursor) {
     SOKOL_ASSERT((cursor >= 0) && (cursor < _SAPP_MOUSECURSOR_NUM));
     SOKOL_ASSERT(cursor != SAPP_MOUSECURSOR_CUSTOM_IMAGE); // call sapp_make_mouse_cursor_image instead.
     if (_sapp.mouse.current_cursor != cursor) {
-        _sapp_update_cursor(cursor, (sapp_mouse_cursor_image) {}, _sapp.mouse.shown);
+        _sapp_update_cursor(cursor, (sapp_mouse_cursor_image) {0}, _sapp.mouse.shown);
     }
 }
 

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -5608,7 +5608,6 @@ EM_JS(int, sapp_js_make_mouse_cursor_image, (uint8_t* bmp_ptr, int bmp_size, int
 })
 
 // Only used by the emscriten backend right now. Returned memory must be freed by caller.
-// Only used by the emscriten backend right now. Returned memory must be freed by caller.
 sapp_range _sapp_bitmap_from_image_desc(sapp_image_desc* desc) {
     SOKOL_ASSERT(desc->width * desc->height * 4 == (int) desc->pixels.size);
     size_t bmp_header_size = 14;
@@ -5634,6 +5633,7 @@ sapp_range _sapp_bitmap_from_image_desc(sapp_image_desc* desc) {
     write_int32(0); // reserved
     write_int32(bmp_header_size+dib_header_size); // offset to pixel data
     SOKOL_ASSERT((size_t)(bmp_write - bmp_header_start) == bmp_header_size);
+    SOKOL_UNUSED(bmp_header_start);
     // DIB Header
     uint8_t* dib_header_start = bmp_write;
     write_int32(dib_header_size); // header size
@@ -5654,12 +5654,14 @@ sapp_range _sapp_bitmap_from_image_desc(sapp_image_desc* desc) {
     write_int32('sRGB'); // color space type 'Win ' 'sRGB' or 0 for RGB
     bmp_write += 64; // color space stuff, unused for 'Win ' or 'sRGB'
     SOKOL_ASSERT((size_t)(bmp_write - dib_header_start) == dib_header_size);
+    SOKOL_UNUSED(dib_header_start)
     #undef write_byte
     #undef write_int16
     #undef write_int32
     // copy the pixel data row by row (bmp is bottom to top)
     ptrdiff_t remain = (bmp_data + bmp_size) - bmp_write;
     SOKOL_ASSERT(remain == (int) desc->pixels.size);
+    SOKOL_UNUSED(remain);
     size_t row_size = (size_t)desc->width * 4;
     for (int y = 0; y < desc->height; y++) {
         memcpy(bmp_write + (size_t)(desc->height - y - 1) * row_size, (uint8_t*)desc->pixels.ptr + (size_t)y * row_size, row_size);

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -8548,7 +8548,7 @@ _SOKOL_PRIVATE char** _sapp_win32_command_line_to_utf8_argv(LPWSTR w_command_lin
 
 _SOKOL_PRIVATE sapp_mouse_cursor_image _sapp_win32_make_mouse_cursor_image(sapp_image_desc* desc, int hotspot_x, int hotspot_y) {
     HCURSOR cursor_handle = _sapp_win32_create_icon_from_image(desc, true, hotspot_x, hotspot_y);
-    sapp_mouse_cursor_image ret = {};
+    sapp_mouse_cursor_image ret = {0};
     ret.opaque = (uint64_t) cursor_handle;
     return ret;
 }
@@ -12349,7 +12349,7 @@ SOKOL_API_IMPL sapp_mouse_cursor_image sapp_make_mouse_cursor_image(sapp_image_d
     //       the behaviour consistent.
     SOKOL_ASSERT(hotspot_x < desc->width - 1 && hotspot_y < desc->height - 1);
     SOKOL_ASSERT(desc->width * desc->height * 4 == (int) desc->pixels.size);
-    sapp_mouse_cursor_image ret = {};
+    sapp_mouse_cursor_image ret = {0};
     #if defined(_SAPP_MACOS)
     ret = _sapp_macos_make_mouse_cursor_image(desc, hotspot_x, hotspot_y);
     #elif defined(_SAPP_EMSCRIPTEN)

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -12335,6 +12335,7 @@ SOKOL_API_IMPL sapp_mouse_cursor sapp_get_mouse_cursor(void) {
 }
 
 SOKOL_API_IMPL void sapp_set_mouse_cursor_image(sapp_mouse_cursor_image cursor_image) {
+    SOKOL_ASSERT(cursor_image.opaque != 0);
     if (_sapp.mouse.current_cursor != SAPP_MOUSECURSOR_CUSTOM_IMAGE || _sapp.mouse.current_cursor_image.opaque != cursor_image.opaque) {
         _sapp_update_cursor(SAPP_MOUSECURSOR_CUSTOM_IMAGE, cursor_image, _sapp.mouse.shown);
     }

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4275,6 +4275,7 @@ _SOKOL_PRIVATE sapp_mouse_cursor_image _sapp_macos_make_mouse_cursor_image(sapp_
 
 _SOKOL_PRIVATE void _sapp_macos_destroy_mouse_cursor_image(sapp_mouse_cursor_image cursor_image) {
     NSCursor* cursor = (__bridge NSCursor*) (void*) cursor_image.opaque;
+    _SOKOL_UNUSED(cursor);
     _SAPP_OBJC_RELEASE(cursor);
 }
 

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -5654,7 +5654,7 @@ sapp_range _sapp_bitmap_from_image_desc(sapp_image_desc* desc) {
     write_int32('sRGB'); // color space type 'Win ' 'sRGB' or 0 for RGB
     bmp_write += 64; // color space stuff, unused for 'Win ' or 'sRGB'
     SOKOL_ASSERT((size_t)(bmp_write - dib_header_start) == dib_header_size);
-    SOKOL_UNUSED(dib_header_start)
+    SOKOL_UNUSED(dib_header_start);
     #undef write_byte
     #undef write_int16
     #undef write_int32

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4267,15 +4267,15 @@ _SOKOL_PRIVATE sapp_mouse_cursor_image _sapp_macos_make_mouse_cursor_image(sapp_
             initWithImage:native
             hotSpot:NSMakePoint(hotspot_x, hotspot_y)];
         
-        [native release];
-        [rep release];
+        _SAPP_OBJC_RELEASE(native);
+        _SAPP_OBJC_RELEASE(rep);
     }
     return ret;
 }
 
 _SOKOL_PRIVATE void _sapp_macos_destroy_mouse_cursor_image(sapp_mouse_cursor_image cursor_image) {
     NSCursor* cursor = (__bridge NSCursor*) (void*) cursor_image.opaque;
-    [cursor release];
+    _SAPP_OBJC_RELEASE(cursor);
 }
 
 _SOKOL_PRIVATE void _sapp_macos_set_icon(const sapp_icon_desc* icon_desc, int num_images) {
@@ -12322,7 +12322,8 @@ SOKOL_API_IMPL void sapp_set_mouse_cursor(sapp_mouse_cursor cursor) {
     SOKOL_ASSERT((cursor >= 0) && (cursor < _SAPP_MOUSECURSOR_NUM));
     SOKOL_ASSERT(cursor != SAPP_MOUSECURSOR_CUSTOM_IMAGE); // call sapp_make_mouse_cursor_image instead.
     if (_sapp.mouse.current_cursor != cursor) {
-        _sapp_update_cursor(cursor, (sapp_mouse_cursor_image) {0}, _sapp.mouse.shown);
+        sapp_mouse_cursor_image img = {0};
+        _sapp_update_cursor(cursor, img, _sapp.mouse.shown);
     }
 }
 

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -5605,7 +5605,7 @@ EM_JS(int, sapp_js_make_mouse_cursor_image, (uint8_t* bmp_ptr, int bmp_size, int
     const handle = Module.__sapp_cursor_images.length;
     Module.__sapp_cursor_images.push(cursor);
     return handle;
-});
+})
 
 // Only used by the emscriten backend right now. Returned memory must be freed by caller.
 // Only used by the emscriten backend right now. Returned memory must be freed by caller.
@@ -12355,6 +12355,10 @@ SOKOL_API_IMPL sapp_mouse_cursor_image sapp_make_mouse_cursor_image(sapp_image_d
     ret = _sapp_win32_make_mouse_cursor_image(desc, hotspot_x, hotspot_y);
     #elif defined(_SAPP_LINUX)
     ret = _sapp_x11_make_mouse_cursor_image(desc, hotspot_x, hotspot_y);
+    #else
+    _SOKOL_UNUSED(desc);
+    _SOKOL_UNUSED(hotspot_x);
+    _SOKOL_UNUSED(hotspot_y);
     #endif
     return ret;
 }
@@ -12368,6 +12372,8 @@ SOKOL_API_IMPL void sapp_destroy_mouse_cursor_image(sapp_mouse_cursor_image curs
     _sapp_win32_destroy_mouse_cursor_image(cursor_image);
     #elif defined(_SAPP_LINUX)
     _sapp_x11_destroy_mouse_cursor_image(cursor_image);
+    #else
+    _SOKOL_UNUSED(cursor_image);
     #endif
 }
 

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -5633,7 +5633,7 @@ sapp_range _sapp_bitmap_from_image_desc(sapp_image_desc* desc) {
     write_int32(0); // reserved
     write_int32(bmp_header_size+dib_header_size); // offset to pixel data
     SOKOL_ASSERT((size_t)(bmp_write - bmp_header_start) == bmp_header_size);
-    SOKOL_UNUSED(bmp_header_start);
+    _SOKOL_UNUSED(bmp_header_start);
     // DIB Header
     uint8_t* dib_header_start = bmp_write;
     write_int32(dib_header_size); // header size
@@ -5654,14 +5654,14 @@ sapp_range _sapp_bitmap_from_image_desc(sapp_image_desc* desc) {
     write_int32('sRGB'); // color space type 'Win ' 'sRGB' or 0 for RGB
     bmp_write += 64; // color space stuff, unused for 'Win ' or 'sRGB'
     SOKOL_ASSERT((size_t)(bmp_write - dib_header_start) == dib_header_size);
-    SOKOL_UNUSED(dib_header_start);
+    _SOKOL_UNUSED(dib_header_start);
     #undef write_byte
     #undef write_int16
     #undef write_int32
     // copy the pixel data row by row (bmp is bottom to top)
     ptrdiff_t remain = (bmp_data + bmp_size) - bmp_write;
     SOKOL_ASSERT(remain == (int) desc->pixels.size);
-    SOKOL_UNUSED(remain);
+    _SOKOL_UNUSED(remain);
     size_t row_size = (size_t)desc->width * 4;
     for (int y = 0; y < desc->height; y++) {
         memcpy(bmp_write + (size_t)(desc->height - y - 1) * row_size, (uint8_t*)desc->pixels.ptr + (size_t)y * row_size, row_size);


### PR DESCRIPTION
This PR adds custom cursor images for macos, windows, linux and macos.

Two new functions are added to make and destroy cursor images:

```c
/* returns a custom cursor image for use with sapp_set_mouse_cursor_image */
sapp_mouse_cursor_image sapp_make_mouse_cursor_image(sapp_image_desc* desc, int hotspot_x, int hotspot_y);
/* frees resource associated with the cursor image */
void sapp_destroy_mouse_cursor_image(sapp_mouse_cursor_image image);
```

`sapp_mouse_cursor_image` is just an opaque handle to the platform's cursor representation. I deliberately choose not to use a pool and generational handles because I think the typical use case for custom cursor images is pretty trivial – just make a bunch of cursors in setup() and optionaly destroy them in shutdown() – and it makes the cost of added code not worth it imo.

It does mean that the user should be careful not to destroy a cursor image and then pass it to sapp_set_mouse_cursor_image, of course.

To set a custom cursor, `sapp_set_mouse_cursor_image()` can be called instead of `sapp_set_mouse_cursor()`. Calling `sapp_set_mouse_cursor` will reset the cursor to the specified "system" cursor. `sapp_set_mouse_cursor_image()` and `sapp_set_mouse_cursor()` therefore work as "sibling" functions, both overriding the internal cursor state. This is the simplest api I could think of that doesn't break existing code.

Note that after calling `sapp_set_mouse_cursor_image()`, `sapp_get_mouse_cursor()` returns a new `sapp_mouse_cursor` enum value: `SAPP_MOUSECURSOR_CUSTOM_IMAGE`. This was done to simplify the tracking of the cursor stat in sokol_app, and also so external code that uses `sapp_get_mouse_cursor()` to check if `sapp_set_mouse_cursor_image()` should be called continues to work.

Implementation was rather straightforward on all platforms except the web which was quite a bit more thrilling!
To make a cursor, sokol_app will first take the raw rgba pixels and write them to a bmp image in memory. I picked bmp because it seemed to be the simplest format to write that browser support. Transparency is poorly specified in the bmp format, and different browser understand different versions, but after some experimentation I found a format that works on safari, chromium and firefox (for the record, it's the version that has a bip header of 124bytes). The bmp is then passed to the JS side (along with hotspot coordinates), put into a blob, which itself is made into a URL. The url is then stored in a global array, along with the hotspot coordinates. The index into this array is stuffed in the sapp_mouse_cursor_image opaque handle, which can be used later to retrive the JS object and update the CSS with the proper url and hotspot. The array will never shrink, but again I think this is not a concern with reasonable usage of the api.

Finally, I also made a new sample to test the behaviour on different platforms. I'll do a separate PR on sokol-samples. It doesn't have to be merged, but will be useful to test this PR.

I hope this is a helpful PR, happy to do any required changes of course!