### PR TITLE
Avoid warnings in mingw

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2220,6 +2220,12 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #include <windows.h>
     #include <windowsx.h>
     #include <shellapi.h>
+
+    #if defined(__GNUC__)
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wunknown-pragmas"
+    #endif
+
     #if !defined(SOKOL_NO_ENTRY)    // if SOKOL_NO_ENTRY is defined, it's the application's responsibility to use the right subsystem
 
         #if defined(SOKOL_WIN32_FORCE_MAIN) && defined(SOKOL_WIN32_FORCE_WINMAIN)
@@ -2240,6 +2246,10 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
     #if defined(SOKOL_D3D11)
         #pragma comment (lib, "dxgi")
         #pragma comment (lib, "d3d11")
+    #endif
+
+    #if defined(__GNUC__)
+        #pragma GCC diagnostic pop
     #endif
 
     #if defined(SOKOL_D3D11)

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2224,22 +2224,26 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 
         #if defined(SOKOL_WIN32_FORCE_MAIN) && defined(SOKOL_WIN32_FORCE_WINMAIN)
             // If both are defined, it's the application's responsibility to use the right subsystem
-        #elif defined(SOKOL_WIN32_FORCE_MAIN)
-            #pragma comment (linker, "/subsystem:console")
-        #else
-            #pragma comment (linker, "/subsystem:windows")
+        #elif defined(_MSC_VER)
+            #if defined(SOKOL_WIN32_FORCE_MAIN)
+                #pragma comment (linker, "/subsystem:console")
+            #else
+                #pragma comment (linker, "/subsystem:windows")
+            #endif
         #endif
     #endif
     #include <stdio.h>  /* freopen_s() */
     #include <wchar.h>  /* wcslen() */
 
-    #pragma comment (lib, "kernel32")
-    #pragma comment (lib, "user32")
-    #pragma comment (lib, "shell32")    /* CommandLineToArgvW, DragQueryFileW, DragFinished */
-    #pragma comment (lib, "gdi32")
-    #if defined(SOKOL_D3D11)
-        #pragma comment (lib, "dxgi")
-        #pragma comment (lib, "d3d11")
+	#ifdef _MSC_VER
+        #pragma comment (lib, "kernel32")
+        #pragma comment (lib, "user32")
+        #pragma comment (lib, "shell32")    /* CommandLineToArgvW, DragQueryFileW, DragFinished */
+        #pragma comment (lib, "gdi32")
+        #if defined(SOKOL_D3D11)
+            #pragma comment (lib, "dxgi")
+            #pragma comment (lib, "d3d11")
+        #endif
     #endif
 
     #if defined(SOKOL_D3D11)

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2224,26 +2224,22 @@ inline void sapp_run(const sapp_desc& desc) { return sapp_run(&desc); }
 
         #if defined(SOKOL_WIN32_FORCE_MAIN) && defined(SOKOL_WIN32_FORCE_WINMAIN)
             // If both are defined, it's the application's responsibility to use the right subsystem
-        #elif defined(_MSC_VER)
-            #if defined(SOKOL_WIN32_FORCE_MAIN)
-                #pragma comment (linker, "/subsystem:console")
-            #else
-                #pragma comment (linker, "/subsystem:windows")
-            #endif
+        #elif defined(SOKOL_WIN32_FORCE_MAIN)
+            #pragma comment (linker, "/subsystem:console")
+        #else
+            #pragma comment (linker, "/subsystem:windows")
         #endif
     #endif
     #include <stdio.h>  /* freopen_s() */
     #include <wchar.h>  /* wcslen() */
 
-	#ifdef _MSC_VER
-        #pragma comment (lib, "kernel32")
-        #pragma comment (lib, "user32")
-        #pragma comment (lib, "shell32")    /* CommandLineToArgvW, DragQueryFileW, DragFinished */
-        #pragma comment (lib, "gdi32")
-        #if defined(SOKOL_D3D11)
-            #pragma comment (lib, "dxgi")
-            #pragma comment (lib, "d3d11")
-        #endif
+    #pragma comment (lib, "kernel32")
+    #pragma comment (lib, "user32")
+    #pragma comment (lib, "shell32")    /* CommandLineToArgvW, DragQueryFileW, DragFinished */
+    #pragma comment (lib, "gdi32")
+    #if defined(SOKOL_D3D11)
+        #pragma comment (lib, "dxgi")
+        #pragma comment (lib, "d3d11")
     #endif
 
     #if defined(SOKOL_D3D11)


### PR DESCRIPTION
mingw gcc don't accept `#pragma comment`, and some warnings would be generated.
```
3rd/sokol/sokol_app.h:2230: warning: ignoring '#pragma comment ' [-Wunknown-pragmas]
 2230 |             #pragma comment (linker, "/subsystem:windows")
      |
3rd/sokol/sokol_app.h:2236: warning: ignoring '#pragma comment ' [-Wunknown-pragmas]
 2236 |     #pragma comment (lib, "kernel32")
      |
3rd/sokol/sokol_app.h:2237: warning: ignoring '#pragma comment ' [-Wunknown-pragmas]
 2237 |     #pragma comment (lib, "user32")
      |
3rd/sokol/sokol_app.h:2238: warning: ignoring '#pragma comment ' [-Wunknown-pragmas]
 2238 |     #pragma comment (lib, "shell32")    /* CommandLineToArgvW, DragQueryFileW, DragFinished */
      |
3rd/sokol/sokol_app.h:2239: warning: ignoring '#pragma comment ' [-Wunknown-pragmas]
 2239 |     #pragma comment (lib, "gdi32")
      |
3rd/sokol/sokol_app.h:2241: warning: ignoring '#pragma comment ' [-Wunknown-pragmas]
 2241 |         #pragma comment (lib, "dxgi")
      |
3rd/sokol/sokol_app.h:2242: warning: ignoring '#pragma comment ' [-Wunknown-pragmas]
 2242 |         #pragma comment (lib, "d3d11")`
```

There doesn't seem to be any mention of any equivalent pragmas https://gcc.gnu.org/onlinedocs/gcc/Pragmas.html
This patch checks the macro `_MSC_VER` to turn on these progama comment, but I'm not sure if this is exclusive to msvc.