### PR TITLE
sokol_app, macos: fix not showing the correct cursor sometimes

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4857,6 +4857,9 @@ static void _sapp_gl_make_current(void) {
             _sapp_macos_mods(event));
     }
 }
+- (void)cursorUpdate:(NSEvent *)event {
+    _sapp_macos_update_cursor(_sapp.mouse.current_cursor, _sapp.mouse.shown);
+}
 @end
 
 #endif // macOS


### PR DESCRIPTION
e.g when hovering the frame of the window (which changes the cursor), then coming back inside the window, the cursor will be incorrect.

I suppose this issue wasn't caught earlier because most apps that change the cursor will frequently change it when hovering different things, which calls _sapp_macos_update_cursor. However, if you set the cursor once in init, or even if you repeatedly set the same cursor every frame, the proper cursor will never be shown. 

Calling _sapp_macos_update_cursor() in `- (void)cursorUpdate` fixes it.

Loosely related to https://github.com/floooh/sokol/pull/1309 since showing a single custom cursor is a usecase that would be hit by this bug.