### PR TITLE
Merge branch for #1322 (web fullscreen support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@
   restored when moving the mouse outside a window and then back in. Again, many thanks to @Seb-degraff
   for identifying the issue and providing a fix via PR https://github.com/floooh/sokol/pull/1323!
 
+- ...and another sokol_app.h update: `sapp_toggle_fullscreen()` now works on the web
+  (with the usual web platform caveats: the function needs to be called within
+  or 'near' an input event, and the user may leave fullscreen mode at any time,
+  and Safari on iOS doesn't support fullscreen mode at all).
+
+  Many thanks again to @Seb-degraff for kicking this off! Original PR:
+  https://github.com/floooh/sokol/pull/1322, merge branch PR with additional
+  fixes: https://github.com/floooh/sokol/pull/1324
 
 ### 29-Aug-2025
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Sokol
 
-[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**01-Sep-2025**: custom mouse cursors in sokol_app.h)
+[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**01-Sep-2025**: custom mouse cursors in and web fullscreen support in sokol_app.h)
 
 [![Build](/../../actions/workflows/main.yml/badge.svg)](/../../actions/workflows/main.yml) [![Bindings](/../../actions/workflows/gen_bindings.yml/badge.svg)](/../../actions/workflows/gen_bindings.yml) [![build](https://github.com/floooh/sokol-zig/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-zig/actions/workflows/main.yml) [![build](https://github.com/floooh/sokol-nim/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-nim/actions/workflows/main.yml) [![Odin](https://github.com/floooh/sokol-odin/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-odin/actions/workflows/main.yml)[![Rust](https://github.com/floooh/sokol-rust/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-rust/actions/workflows/main.yml)[![Dlang](https://github.com/kassane/sokol-d/actions/workflows/build.yml/badge.svg)](https://github.com/kassane/sokol-d/actions/workflows/build.yml)[![C3](https://github.com/floooh/sokol-c3/actions/workflows/build.yml/badge.svg)](https://github.com/floooh/sokol-c3/actions/workflows/build.yml)
 

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -866,8 +866,13 @@
     call sapp_is_fullscreen().
 
     On the web, sapp_desc.fullscreen will have no effect, and the application
-    will always start in non-fullscreen mode. Call sapp_toggle_fullscreen() to
-    switch to fullscreen programatically, if the user allows it.
+    will always start in non-fullscreen mode. Call sapp_toggle_fullscreen()
+    from within or 'near' an input event to switch to fullscreen programatically.
+    Note that on the web, the fullscreen state may change back to windowed at
+    any time (either because the browser had rejected switching into fullscreen,
+    or the user leaves fullscreen via Esc), this means that the result
+    of sapp_is_fullscreen() may change also without calling sapp_toggle_fullscreen()!
+
 
     WINDOW ICON SUPPORT
     ===================
@@ -5726,8 +5731,8 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_fullscreenchange_cb(int emsc_type, const Emscr
     return true;
 }
 
-// will be called after the request/exitFullscreen promise resolves or rejects
-// to set the actual state of fullscreen mode
+// will be called after the request/exitFullscreen promise rejects
+// to restore the _sapp.fullscreen flag to the actual fullscreen state
 EMSCRIPTEN_KEEPALIVE void _sapp_emsc_set_fullscreen_flag(int f) {
     _sapp.fullscreen = (bool)f;
 }

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -5391,6 +5391,12 @@ EMSCRIPTEN_KEEPALIVE void _sapp_emsc_invoke_fetch_cb(int index, int success, int
     callback(&response);
 }
 
+// will be called after the request/exitFullscreen promise rejects
+// to restore the _sapp.fullscreen flag to the actual fullscreen state
+EMSCRIPTEN_KEEPALIVE void _sapp_emsc_set_fullscreen_flag(int f) {
+    _sapp.fullscreen = (bool)f;
+}
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
@@ -5729,12 +5735,6 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_fullscreenchange_cb(int emsc_type, const Emscr
     _SOKOL_UNUSED(user_data);
     _sapp.fullscreen = emsc_event->isFullscreen;
     return true;
-}
-
-// will be called after the request/exitFullscreen promise rejects
-// to restore the _sapp.fullscreen flag to the actual fullscreen state
-EMSCRIPTEN_KEEPALIVE void _sapp_emsc_set_fullscreen_flag(int f) {
-    _sapp.fullscreen = (bool)f;
 }
 
 EM_JS(void, sapp_js_toggle_fullscreen, (void), {

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -5766,7 +5766,7 @@ EM_JS(void, sapp_js_toggle_fullscreen, (void), {
             if (p) {
                 p.catch((err) => {
                     console.warn('sapp_js_toggle_fullscreen(): failed to exit fullscreen mode with', err);
-                    _sapp_emsc_set_fullscreen_flag(1);
+                    __sapp_emsc_set_fullscreen_flag(1);
                 });
             } else {
                 console.warn('sapp_js_toggle_fullscreen(): browser has no [wekbit|moz]exitFullscreen')

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -5774,7 +5774,7 @@ EM_JS(void, sapp_js_toggle_fullscreen, (void), {
                     __sapp_emsc_set_fullscreen_flag(1);
                 });
             } else {
-                console.warn('sapp_js_toggle_fullscreen(): browser has no [wekbit|moz]exitFullscreen')
+                console.warn('sapp_js_toggle_fullscreen(): browser has no [wekbit|moz]exitFullscreen');
                 // NOTE: don't need to explicitly set the fullscreen flag here
             }
         }


### PR DESCRIPTION
Merge branch with followup fixes for https://github.com/floooh/sokol/pull/1322:

- catch rejected promise when attempting to switch in and out of fullscreen and reset the `_sapp.fullscreen` flag accordingly
- some console.warn() warnings when switching in and out of fullscreen is rejected
- fixed moz/webkit prefixed names