### PR TITLE
sokol_app.h: add native WebGPU backends

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -16788,7 +16788,7 @@ _SOKOL_PRIVATE void _sg_wgpu_bindings_cache_bg_update(const _sg_wgpu_bindgroup_t
     }
 }
 
-_SOKOL_PRIVATE void _sg_wgpu_set_bindgroup(size_t bg_idx, _sg_wgpu_bindgroup_t* bg) {
+_SOKOL_PRIVATE void _sg_wgpu_set_bindgroup(uint32_t bg_idx, _sg_wgpu_bindgroup_t* bg) {
     if (_sg_wgpu_bindings_cache_bg_dirty(bg)) {
         _sg_wgpu_bindings_cache_bg_update(bg);
         _sg_stats_add(wgpu.bindings.num_set_bindgroup, 1);


### PR DESCRIPTION
Add native WebGPU backends to sokol_app.h on the desktop platforms, so that WebGPU can also be used outside the web via libdawn.

In the beginning the main intent is debuggability and benchmarking.

A nice side effect of the macOS code is also that is a testbed for the removal of MTKView.

TODO:

- [x] macos + webgpu
- [ ] windows + webgpu
- [ ] linux + webgpu
- [ ] documentation
- [ ] changelog