### PR TITLE
Implement sg_draw_ex(base_element, num_elements, num_instances, base_vertex, base_instance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ On GLES3 platforms the feature availability is as follows:
 
 On desktop GL the feature availability is as follows:
 
-- `base_vertex` is generally supported (technically since GL 3.2, but that's the
-  minimum version expected by the sokol_gfx.h GL backend)
+- `base_vertex` is generally supported (technically since GL 3.2, but that's below
+  the minimum version supported by the sokol_gfx.h GL backend)
 - `base_instance` is only supported since GL 4.2 (this basically means that
   it can't be used on macOS, but anywhere else)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 ## Updates
 
+### 04-Oct-2025
+
+sokol_gfx.h: a new function `sg_draw_ex()` has been added with additional parameters
+`base_vertex` and `base_instance`. This allows to render from different vertex
+buffer sections without re-binding the vertex buffers with different offsets.
+
+I know, I know... the name `sg_draw_ex()` isn't exactly creative, but at some point in
+the future I expect that `sg_draw_ex()` will become the regular `sg_draw()`
+function.
+
+Note that support for rendering with `base_vertex` and/or `base_instance` is
+not portable (but only the GL backend has restrictions). To check for feature
+availabality at runtime, two new `sg_feature` flags have been added:
+
+- `sg_features.draw_base_vertex`: rendering with `base_vertex != 0` is supported
+- `sg_features.draw_base_instance`: rendering with `base_instance > 0` is supported
+
+On GLES3 platforms the feature availability is as follows:
+
+- on WebGL2 both `base_vertex` and `base_instance` must be zero
+- on all GLES3 versions, `base_instance` must be zero
+- `base_vertex` is only supported in GLES3.2 (technically, the required functions
+  seem to be part of the GLES3.1 standard, but at least on Linux the functions
+  are only declared in the GLES3.2 headers)
+
+On desktop GL the feature availability is as follows:
+
+- `base_vertex` is generally supported (technically since GL 3.2, but that's the
+  minimum version expected by the sokol_gfx.h GL backend)
+- `base_instance` is only supported since GL 4.2 (this basically means that
+  it can't be used on macOS, but anywhere else)
+
+A new sample [drawex-sapp](https://floooh.github.io/sokol-webgpu/drawex-sapp-ui.html)
+has been added (note that this requires a WebGPU capable browser).
+
+Related PR: https://github.com/floooh/sokol/pull/1339
+
 ### 29-Sep-2025
 
 The 'flexible resource binding limits' update: sokol_gfx.h now allows more render pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ has been added (note that this requires a WebGPU capable browser).
 
 Related PR: https://github.com/floooh/sokol/pull/1339
 
+Unrelated bugfix in the GL backend: in the internal function `_sg_pipeline_common_init()`
+a loop over the pipeline's vertex attribute declarations was using
+`SG_MAX_VERTEXBUFFER_BINDSLOTS` as loop limit instead of `SG_MAX_VERTEX_ATTRIBUTES`.
+This means that the max number of vertex attributes was effectively limited to
+8 instead of 16. This bug slipped in via commit https://github.com/floooh/sokol/commit/73385924cfe98d482462f7064a6621e166441a0a
+on 26-Oct-2024.
+
 ### 29-Sep-2025
 
 The 'flexible resource binding limits' update: sokol_gfx.h now allows more render pass

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Sokol
 
-[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**29-Sep-2025**: the 'flexible resource binding limits' update)
+[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**04-Oct-2025**: new sokol_gfx.h function sg_draw_ex() added)
 
 [![Build](/../../actions/workflows/main.yml/badge.svg)](/../../actions/workflows/main.yml) [![Bindings](/../../actions/workflows/gen_bindings.yml/badge.svg)](/../../actions/workflows/gen_bindings.yml) [![build](https://github.com/floooh/sokol-zig/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-zig/actions/workflows/main.yml) [![build](https://github.com/floooh/sokol-nim/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-nim/actions/workflows/main.yml) [![Odin](https://github.com/floooh/sokol-odin/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-odin/actions/workflows/main.yml)[![Rust](https://github.com/floooh/sokol-rust/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-rust/actions/workflows/main.yml)[![Dlang](https://github.com/kassane/sokol-d/actions/workflows/build.yml/badge.svg)](https://github.com/kassane/sokol-d/actions/workflows/build.yml)[![C3](https://github.com/floooh/sokol-c3/actions/workflows/build.yml/badge.svg)](https://github.com/floooh/sokol-c3/actions/workflows/build.yml)
 

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -5393,6 +5393,8 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
                 #define _SOKOL_GL_HAS_COMPUTE (1)
                 #define _SOKOL_GL_HAS_TEXSTORAGE (1)
                 #define _SOKOL_GL_HAS_TEXVIEWS (1)
+                #define _SOKOL_GL_HAS_BASEVERTEX (1)
+                #define _SOKOL_GL_HAS_BASEINSTANCE (1)
             #endif
         #elif defined(__APPLE__)
             #include <TargetConditionals.h>
@@ -5401,6 +5403,7 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
             #endif
             #if defined(TARGET_OS_IPHONE) && !TARGET_OS_IPHONE
                 #include <OpenGL/gl3.h>
+                #define _SOKOL_GL_HAS_BASEVERTEX (1)
             #else
                 #include <OpenGLES/ES3/gl.h>
                 #include <OpenGLES/ES3/glext.h>
@@ -5415,17 +5418,20 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
             #include <GLES3/gl31.h>
             #define _SOKOL_GL_HAS_COMPUTE (1)
             #define _SOKOL_GL_HAS_TEXSTORAGE (1)
+            #define _SOKOL_GL_HAS_BASEVERTEX (1)
         #elif defined(__linux__) || defined(__unix__)
+            #define _SOKOL_GL_HAS_BASEVERTEX (1)
+            #define _SOKOL_GL_HAS_COMPUTE (1)
+            #define _SOKOL_GL_HAS_TEXSTORAGE (1)
             #if defined(SOKOL_GLCORE)
                 #define GL_GLEXT_PROTOTYPES
                 #include <GL/gl.h>
                 #define _SOKOL_GL_HAS_TEXVIEWS (1)
+                #define _SOKOL_GL_HAS_BASEINSTANCE (1)
             #else
                 #include <GLES3/gl31.h>
                 #include <GLES3/gl3ext.h>
             #endif
-            #define _SOKOL_GL_HAS_COMPUTE (1)
-            #define _SOKOL_GL_HAS_TEXSTORAGE (1)
         #endif
     #endif
 
@@ -11488,17 +11494,25 @@ _SOKOL_PRIVATE void _sg_gl_draw(int base_element, int num_elements, int num_inst
             if ((base_vertex == 0) && (base_instance == 0)) {
                 glDrawElementsInstanced(p_type, num_elements, i_type, indices, num_instances);
             } else if ((base_vertex != 0) && (base_instance == 0) && _sg.features.draw_base_vertex) {
+                #if defined(_SOKOL_GL_HAS_BASEVERTEX)
                 glDrawElementsInstancedBaseVertex(p_type, num_elements, i_type, indices, num_instances, base_vertex);
+                #endif
             } else if ((base_vertex == 0) && (base_instance != 0) && _sg.features.draw_base_instance) {
+                #if defined(_SOKOL_GL_HAS_BASEINSTANCE)
                 glDrawElementsInstancedBaseInstance(p_type, num_elements, i_type, indices, num_instances, (GLuint)base_instance);
+                #endif
             } else if ((base_vertex != 0) && (base_instance != 0) && _sg.features.draw_base_vertex_base_instance) {
+                #if defined(_SOKOL_GL_HAS_BASEINSTANCE)
                 glDrawElementsInstancedBaseVertexBaseInstance(p_type, num_elements, i_type, indices, num_instances, base_vertex, (GLuint)base_instance);
+                #endif
             }
         } else {
             if (base_vertex == 0) {
                 glDrawElements(p_type, num_elements, i_type, indices);
             } else if (_sg.features.draw_base_vertex) {
+                #if defined(_SOKOL_GL_HAS_BASEVERTEX)
                 glDrawElementsBaseVertex(p_type, num_elements, i_type, indices, base_vertex);
+                #endif
             }
         }
     } else {
@@ -11507,7 +11521,9 @@ _SOKOL_PRIVATE void _sg_gl_draw(int base_element, int num_elements, int num_inst
             if (base_instance == 0) {
                 glDrawArraysInstanced(p_type, base_element, num_elements, num_instances);
             } else if (_sg.features.draw_base_instance) {
+                #if defined(_SOKOL_GL_HAS_BASEINSTANCE)
                 glDrawArraysInstancedBaseInstance(p_type, base_element, num_elements, num_instances, (GLuint)base_instance);
+                #endif
             }
         } else {
             glDrawArrays(p_type, base_element, num_elements);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -12449,6 +12449,9 @@ _SOKOL_PRIVATE void _sg_d3d11_init_caps(void) {
     _sg.features.mrt_independent_write_mask = true;
     _sg.features.compute = true;
     _sg.features.msaa_texture_bindings = true;
+    _sg.features.draw_base_vertex = true;
+    _sg.features.draw_base_instance = true;
+    _sg.features.draw_base_vertex_base_instance = true;
 
     _sg.limits.max_image_size_2d = 16 * 1024;
     _sg.limits.max_image_size_cube = 16 * 1024;
@@ -13774,19 +13777,28 @@ _SOKOL_PRIVATE void _sg_d3d11_apply_uniforms(int ub_slot, const sg_range* data) 
     _sg_stats_add(d3d11.uniforms.num_update_subresource, 1);
 }
 
-_SOKOL_PRIVATE void _sg_d3d11_draw(int base_element, int num_elements, int num_instances) {
+_SOKOL_PRIVATE void _sg_d3d11_draw(int base_element, int num_elements, int num_instances, int base_vertex, int base_instance) {
     const bool use_instanced_draw = (num_instances > 1) || (_sg.use_instanced_draw);
     if (_sg.use_indexed_draw) {
         if (use_instanced_draw) {
-            _sg_d3d11_DrawIndexedInstanced(_sg.d3d11.ctx, (UINT)num_elements, (UINT)num_instances, (UINT)base_element, 0, 0);
+            _sg_d3d11_DrawIndexedInstanced(_sg.d3d11.ctx,
+                (UINT)num_elements,
+                (UINT)num_instances,
+                (UINT)base_element,
+                base_vertex,
+                (UINT)base_instance);
             _sg_stats_add(d3d11.draw.num_draw_indexed_instanced, 1);
         } else {
-            _sg_d3d11_DrawIndexed(_sg.d3d11.ctx, (UINT)num_elements, (UINT)base_element, 0);
+            _sg_d3d11_DrawIndexed(_sg.d3d11.ctx, (UINT)num_elements, (UINT)base_element, base_vertex);
             _sg_stats_add(d3d11.draw.num_draw_indexed, 1);
         }
     } else {
         if (use_instanced_draw) {
-            _sg_d3d11_DrawInstanced(_sg.d3d11.ctx, (UINT)num_elements, (UINT)num_instances, (UINT)base_element, 0);
+            _sg_d3d11_DrawInstanced(_sg.d3d11.ctx,
+                (UINT)num_elements,
+                (UINT)num_instances,
+                (UINT)base_element,
+                (UINT)base_instance);
             _sg_stats_add(d3d11.draw.num_draw_instanced, 1);
         } else {
             _sg_d3d11_Draw(_sg.d3d11.ctx, (UINT)num_elements, (UINT)base_element);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -14415,6 +14415,9 @@ _SOKOL_PRIVATE void _sg_mtl_init_caps(void) {
     _sg.features.mrt_independent_write_mask = true;
     _sg.features.compute = true;
     _sg.features.msaa_texture_bindings = true;
+    _sg.features.draw_base_vertex = true;
+    _sg.features.draw_base_instance = true;
+    _sg.features.draw_base_vertex_base_instance = true;
 
     _sg.features.image_clamp_to_border = false;
     #if (MAC_OS_X_VERSION_MAX_ALLOWED >= 120000) || (__IPHONE_OS_VERSION_MAX_ALLOWED >= 140000)

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -11490,9 +11490,9 @@ _SOKOL_PRIVATE void _sg_gl_draw(int base_element, int num_elements, int num_inst
             } else if ((base_vertex != 0) && (base_instance == 0) && _sg.features.draw_base_vertex) {
                 glDrawElementsInstancedBaseVertex(p_type, num_elements, i_type, indices, num_instances, base_vertex);
             } else if ((base_vertex == 0) && (base_instance != 0) && _sg.features.draw_base_instance) {
-                glDrawElementsInstancedBaseInstance(p_type, num_elements, i_type, indices, num_instances, base_instance);
+                glDrawElementsInstancedBaseInstance(p_type, num_elements, i_type, indices, num_instances, (GLuint)base_instance);
             } else if ((base_vertex != 0) && (base_instance != 0) && _sg.features.draw_base_vertex_base_instance) {
-                glDrawElementsInstancedBaseVertexBaseInstance(p_type, num_elements, i_type, indices, num_instances, base_vertex, base_instance);
+                glDrawElementsInstancedBaseVertexBaseInstance(p_type, num_elements, i_type, indices, num_instances, base_vertex, (GLuint)base_instance);
             }
         } else {
             if (base_vertex == 0) {
@@ -11507,7 +11507,7 @@ _SOKOL_PRIVATE void _sg_gl_draw(int base_element, int num_elements, int num_inst
             if (base_instance == 0) {
                 glDrawArraysInstanced(p_type, base_element, num_elements, num_instances);
             } else if (_sg.features.draw_base_instance) {
-                glDrawArraysInstancedBaseInstance(p_type, base_element, num_elements, num_instances, base_instance);
+                glDrawArraysInstancedBaseInstance(p_type, base_element, num_elements, num_instances, (GLuint)base_instance);
             }
         } else {
             glDrawArrays(p_type, base_element, num_elements);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -8426,10 +8426,12 @@ _SOKOL_PRIVATE void _sg_dummy_apply_uniforms(int ub_slot, const sg_range* data) 
     _SOKOL_UNUSED(data);
 }
 
-_SOKOL_PRIVATE void _sg_dummy_draw(int base_element, int num_elements, int num_instances) {
+_SOKOL_PRIVATE void _sg_dummy_draw(int base_element, int num_elements, int num_instances, int base_vertex, int base_instance) {
     _SOKOL_UNUSED(base_element);
     _SOKOL_UNUSED(num_elements);
     _SOKOL_UNUSED(num_instances);
+    _SOKOL_UNUSED(base_vertex);
+    _SOKOL_UNUSED(base_instance);
 }
 
 _SOKOL_PRIVATE void _sg_dummy_dispatch(int num_groups_x, int num_groups_y, int num_groups_z) {
@@ -15904,7 +15906,7 @@ _SOKOL_PRIVATE void _sg_mtl_apply_uniforms(int ub_slot, const sg_range* data) {
     _sg.mtl.cur_ub_offset = _sg_roundup(_sg.mtl.cur_ub_offset + (int)data->size, _SG_MTL_UB_ALIGN);
 }
 
-_SOKOL_PRIVATE void _sg_mtl_draw(int base_element, int num_elements, int num_instances) {
+_SOKOL_PRIVATE void _sg_mtl_draw(int base_element, int num_elements, int num_instances, int base_vertex, int base_instance) {
     SOKOL_ASSERT(nil != _sg.mtl.render_cmd_encoder);
     const _sg_pipeline_t* pip = _sg_pipeline_ref_ptr(&_sg.cur_pip);
     SOKOL_ASSERT(pip);
@@ -15918,13 +15920,16 @@ _SOKOL_PRIVATE void _sg_mtl_draw(int base_element, int num_elements, int num_ins
             indexType:pip->mtl.index_type
             indexBuffer:_sg_mtl_id(ib->mtl.buf[ib->cmn.active_slot])
             indexBufferOffset:index_buffer_offset
-            instanceCount:(NSUInteger)num_instances];
+            instanceCount:(NSUInteger)num_instances
+            baseVertex:base_vertex
+            baseInstance:(NSUInteger)base_instance];
     } else {
         // non-indexed rendering
         [_sg.mtl.render_cmd_encoder drawPrimitives:pip->mtl.prim_type
             vertexStart:(NSUInteger)base_element
             vertexCount:(NSUInteger)num_elements
-            instanceCount:(NSUInteger)num_instances];
+            instanceCount:(NSUInteger)num_instances
+            baseInstance:(NSUInteger)base_instance];
     }
 }
 
@@ -18436,15 +18441,15 @@ static inline void _sg_apply_uniforms(int ub_slot, const sg_range* data) {
 
 static inline void _sg_draw(int base_element, int num_elements, int num_instances, int base_vertex, int base_index) {
     #if defined(_SOKOL_ANY_GL)
-    _sg_gl_draw(base_element, num_elements, num_instances);
+    _sg_gl_draw(base_element, num_elements, num_instances, base_vertex, base_index);
     #elif defined(SOKOL_METAL)
-    _sg_mtl_draw(base_element, num_elements, num_instances);
+    _sg_mtl_draw(base_element, num_elements, num_instances, base_vertex, base_index);
     #elif defined(SOKOL_D3D11)
-    _sg_d3d11_draw(base_element, num_elements, num_instances);
+    _sg_d3d11_draw(base_element, num_elements, num_instances, base_vertex, base_index);
     #elif defined(SOKOL_WGPU)
-    _sg_wgpu_draw(base_element, num_elements, num_instances);
+    _sg_wgpu_draw(base_element, num_elements, num_instances, base_vertex, base_index);
     #elif defined(SOKOL_DUMMY_BACKEND)
-    _sg_dummy_draw(base_element, num_elements, num_instances);
+    _sg_dummy_draw(base_element, num_elements, num_instances, base_vertex, base_index);
     #else
     #error("INVALID BACKEND");
     #endif

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4685,7 +4685,7 @@ typedef struct sg_frame_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_DRAW_EX_BASEINSTANCE_GE_ZERO, "sg_draw_ex: base_instance cannot be < 0") \
     _SG_LOGITEM_XMACRO(VALIDATE_DRAW_EX_BASEVERTEX_VS_INDEXED, "sg_draw_ex(): base_vertex must be == 0 for non-indexed rendering") \
     _SG_LOGITEM_XMACRO(VALIDATE_DRAW_EX_BASEINSTANCE_VS_INSTANCED, "sg_draw_ex(): base_instance must be == 0 for non-instanced rendering") \
-    _SG_LOGITEM_XMACRO(VALIDATE_DRAW_EX_BASEVERTEX_NOT_SUPPORTED, "sg_draw_ex(): base_vertex > 0 not supported on this backend (sg_features.draw_base_vertex)") \
+    _SG_LOGITEM_XMACRO(VALIDATE_DRAW_EX_BASEVERTEX_NOT_SUPPORTED, "sg_draw_ex(): base_vertex != 0 not supported on this backend (sg_features.draw_base_vertex)") \
     _SG_LOGITEM_XMACRO(VALIDATE_DRAW_EX_BASEINSTANCE_NOT_SUPPORTED, "sg_draw_ex(): base_instance > 0 not supported on this backend (sg_features.draw_base_instance)") \
     _SG_LOGITEM_XMACRO(VALIDATE_DRAW_REQUIRED_BINDINGS_OR_UNIFORMS_MISSING, "sg_draw: call to sg_apply_bindings() and/or sg_apply_uniforms() missing after sg_apply_pipeline()") \
     _SG_LOGITEM_XMACRO(VALIDATE_DISPATCH_COMPUTEPASS_EXPECTED, "sg_dispatch: must be called in a compute pass") \
@@ -19972,7 +19972,7 @@ _SOKOL_PRIVATE bool _sg_validate_draw_ex(int base_element, int num_elements, int
         _SG_VALIDATE(num_elements >= 0, VALIDATE_DRAW_EX_NUMELEMENTS_GE_ZERO);
         _SG_VALIDATE(num_instances >= 0, VALIDATE_DRAW_EX_NUMINSTANCES_GE_ZERO);
         _SG_VALIDATE(base_instance >= 0, VALIDATE_DRAW_EX_BASEINSTANCE_GE_ZERO);
-        if (base_vertex > 0) {
+        if (base_vertex != 0) {
             _SG_VALIDATE(_sg.features.draw_base_vertex, VALIDATE_DRAW_EX_BASEVERTEX_NOT_SUPPORTED);
         }
         if (base_instance > 0) {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -5418,18 +5418,17 @@ inline int sg_append_buffer(sg_buffer buf_id, const sg_range& data) { return sg_
             #include <GLES3/gl31.h>
             #define _SOKOL_GL_HAS_COMPUTE (1)
             #define _SOKOL_GL_HAS_TEXSTORAGE (1)
-            #define _SOKOL_GL_HAS_BASEVERTEX (1)
         #elif defined(__linux__) || defined(__unix__)
-            #define _SOKOL_GL_HAS_BASEVERTEX (1)
             #define _SOKOL_GL_HAS_COMPUTE (1)
             #define _SOKOL_GL_HAS_TEXSTORAGE (1)
+            #define _SOKOL_GL_HAS_BASEVERTEX (1)
             #if defined(SOKOL_GLCORE)
                 #define GL_GLEXT_PROTOTYPES
                 #include <GL/gl.h>
                 #define _SOKOL_GL_HAS_TEXVIEWS (1)
                 #define _SOKOL_GL_HAS_BASEINSTANCE (1)
             #else
-                #include <GLES3/gl31.h>
+                #include <GLES3/gl32.h>
                 #include <GLES3/gl3ext.h>
             #endif
         #endif
@@ -9512,6 +9511,9 @@ _SOKOL_PRIVATE void _sg_gl_init_caps_gles3(void) {
     #else
     _sg.features.separate_buffer_types = false;
     #endif
+    _sg.features.draw_base_vertex = version >= 320;
+    _sg.features.draw_base_instance = false;
+    _sg.features.draw_base_vertex_base_instance = false;
 
     bool has_s3tc = false;  // BC1..BC3
     bool has_rgtc = false;  // BC4 and BC5

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -4519,6 +4519,7 @@ _SOKOL_PRIVATE void _sgimgui_draw_frame_stats_panel(sgimgui_t* ctx) {
         _sgimgui_frame_stats(num_apply_bindings);
         _sgimgui_frame_stats(num_apply_uniforms);
         _sgimgui_frame_stats(num_draw);
+        _sgimgui_frame_stats(num_draw_ex);
         _sgimgui_frame_stats(num_dispatch);
         _sgimgui_frame_stats(num_update_buffer);
         _sgimgui_frame_stats(num_append_buffer);

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -4755,6 +4755,7 @@ SOKOL_API_IMPL void sgimgui_init(sgimgui_t* ctx, const sgimgui_desc_t* desc) {
     hooks.apply_bindings = _sgimgui_apply_bindings;
     hooks.apply_uniforms = _sgimgui_apply_uniforms;
     hooks.draw = _sgimgui_draw;
+    hooks.draw_ex = _sgimgui_draw_ex;
     hooks.dispatch = _sgimgui_dispatch;
     hooks.end_pass = _sgimgui_end_pass;
     hooks.commit = _sgimgui_commit;

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -4481,6 +4481,9 @@ _SOKOL_PRIVATE void _sgimgui_draw_caps_panel(void) {
     _sgimgui_igtext("    compute: %s", _sgimgui_bool_string(f.compute));
     _sgimgui_igtext("    msaa_texture_bindings: %s", _sgimgui_bool_string(f.msaa_texture_bindings));
     _sgimgui_igtext("    separate_buffer_types: %s", _sgimgui_bool_string(f.separate_buffer_types));
+    _sgimgui_igtext("    draw_base_vertex: %s", _sgimgui_bool_string(f.draw_base_vertex));
+    _sgimgui_igtext("    draw_base_instance: %s", _sgimgui_bool_string(f.draw_base_instance));
+    _sgimgui_igtext("    draw_base_vertex_base_instance: %s", _sgimgui_bool_string(f.draw_base_vertex_base_instance));
     sg_limits l = sg_query_limits();
     _sgimgui_igtext("\nLimits:\n");
     _sgimgui_igtext("    max_image_size_2d: %d", l.max_image_size_2d);

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -362,6 +362,7 @@ typedef enum sgimgui_cmd_t {
     SGIMGUI_CMD_APPLY_BINDINGS,
     SGIMGUI_CMD_APPLY_UNIFORMS,
     SGIMGUI_CMD_DRAW,
+    SGIMGUI_CMD_DRAW_EX,
     SGIMGUI_CMD_DISPATCH,
     SGIMGUI_CMD_END_PASS,
     SGIMGUI_CMD_COMMIT,
@@ -496,6 +497,14 @@ typedef struct sgimgui_args_draw_t {
     int num_elements;
     int num_instances;
 } sgimgui_args_draw_t;
+
+typedef struct sgimgui_args_draw_ex_t {
+    int base_element;
+    int num_elements;
+    int num_instances;
+    int base_vertex;
+    int base_instance;
+} sgimgui_args_draw_ex_t;
 
 typedef struct sgimgui_args_dispatch_t {
     int num_groups_x;
@@ -650,6 +659,7 @@ typedef union sgimgui_args_t {
     sgimgui_args_apply_bindings_t apply_bindings;
     sgimgui_args_apply_uniforms_t apply_uniforms;
     sgimgui_args_draw_t draw;
+    sgimgui_args_draw_ex_t draw_ex;
     sgimgui_args_dispatch_t dispatch;
     sgimgui_args_alloc_buffer_t alloc_buffer;
     sgimgui_args_alloc_image_t alloc_image;
@@ -2044,6 +2054,16 @@ _SOKOL_PRIVATE sgimgui_str_t _sgimgui_capture_item_string(sgimgui_t* ctx, int in
                 item->args.draw.num_instances);
             break;
 
+        case SGIMGUI_CMD_DRAW_EX:
+            _sgimgui_snprintf(&str, "%d: sg_draw_ex(base_element=%d, num_elements=%d, num_instances=%d, base_vertex=%d, base_instance=%d)",
+                index,
+                item->args.draw_ex.base_element,
+                item->args.draw_ex.num_elements,
+                item->args.draw_ex.num_instances,
+                item->args.draw_ex.base_vertex,
+                item->args.draw_ex.base_instance);
+            break;
+
         case SGIMGUI_CMD_DISPATCH:
             _sgimgui_snprintf(&str, "%d: sg_dispatch(num_groups_x=%d, num_groups_y=%d, num_groups_z=%d)",
                 index,
@@ -2662,6 +2682,24 @@ _SOKOL_PRIVATE void _sgimgui_draw(int base_element, int num_elements, int num_in
     }
     if (ctx->hooks.draw) {
         ctx->hooks.draw(base_element, num_elements, num_instances, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sgimgui_draw_ex(int base_element, int num_elements, int num_instances, int base_vertex, int base_instance, void* user_data) {
+    sgimgui_t* ctx = (sgimgui_t*)user_data;
+    SOKOL_ASSERT(ctx);
+    sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = SGIMGUI_CMD_DRAW_EX;
+        item->color = _SGIMGUI_COLOR_DRAW;
+        item->args.draw_ex.base_element = base_element;
+        item->args.draw_ex.num_elements = num_elements;
+        item->args.draw_ex.num_instances = num_instances;
+        item->args.draw_ex.base_vertex = base_vertex;
+        item->args.draw_ex.base_instance = base_instance;
+    }
+    if (ctx->hooks.draw_ex) {
+        ctx->hooks.draw_ex(base_element, num_elements, num_instances, base_vertex, base_instance, ctx->hooks.user_data);
     }
 }
 
@@ -4367,6 +4405,7 @@ _SOKOL_PRIVATE void _sgimgui_draw_capture_panel(sgimgui_t* ctx) {
             _sgimgui_draw_uniforms_panel(ctx, &item->args.apply_uniforms);
             break;
         case SGIMGUI_CMD_DRAW:
+        case SGIMGUI_CMD_DRAW_EX:
         case SGIMGUI_CMD_DISPATCH:
         case SGIMGUI_CMD_END_PASS:
         case SGIMGUI_CMD_COMMIT:

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -4483,7 +4483,6 @@ _SOKOL_PRIVATE void _sgimgui_draw_caps_panel(void) {
     _sgimgui_igtext("    separate_buffer_types: %s", _sgimgui_bool_string(f.separate_buffer_types));
     _sgimgui_igtext("    draw_base_vertex: %s", _sgimgui_bool_string(f.draw_base_vertex));
     _sgimgui_igtext("    draw_base_instance: %s", _sgimgui_bool_string(f.draw_base_instance));
-    _sgimgui_igtext("    draw_base_vertex_base_instance: %s", _sgimgui_bool_string(f.draw_base_vertex_base_instance));
     sg_limits l = sg_query_limits();
     _sgimgui_igtext("\nLimits:\n");
     _sgimgui_igtext("    max_image_size_2d: %d", l.max_image_size_2d);


### PR DESCRIPTION
- [x] changelog
- [x] add new sample to sample webpage
- [x] inline docs
- [x] new sample: https://github.com/floooh/sokol-samples/pull/184
- [x] important: bugfix wrong index in sg_pipeline_common_init() (SG_MAX_VERTEXBUFFER_BINDSLOTS vs SG_MAX_VERTEX_ATTRIBUTES) (was introduced in https://github.com/floooh/sokol/commit/73385924cfe98d482462f7064a6621e166441a0a)
- [x] move `use_indexed_draw` and `use_instanced_draw` into `_sg_state_t`
- [x] move initialization of `use_instanced_draw` into` _sg_pipeline_common_init()`
- [x] sg_features (all true except on WebGL2 vs GLES3 vs GL 4.1/4.3):
    - [x] draw_base_vertex
    - [x] draw_base_instance
    - [x] ~~draw_base_vertex_base_instance~~ (redundant with `draw_base_instance`)
- [x] backends:
    - [x] dummy
    - [x] metal
    - [x] d3d11
    - [x] gl:
        - [x] gles3
        - [x] gl 4.1
        - [x] gl 4.3
    - [x] wgpu
- [x] sokol_gfx_imgui.h:
    - [x] add new `sg_feature` items
    - [x] track `sg_draw_ex()`
- [x] new drawex-sapp sample:
    - [x] only vertex_base
    - [x] only instance_base
    - [x] both vertex_base and instance_base