### PR TITLE
win32: Prioritize attaching console, otherwise create

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -8557,11 +8557,12 @@ _SOKOL_PRIVATE void _sapp_win32_destroy_icons(void) {
 _SOKOL_PRIVATE void _sapp_win32_init_console(void) {
     if (_sapp.desc.win32_console_create || _sapp.desc.win32_console_attach) {
         BOOL con_valid = FALSE;
-        if (_sapp.desc.win32_console_create) {
-            con_valid = AllocConsole();
-        } else if (_sapp.desc.win32_console_attach) {
+        if (_sapp.desc.win32_console_attach) {
             con_valid = AttachConsole(ATTACH_PARENT_PROCESS);
         }
+        if (!con_valid && _sapp.desc.win32_console_create) {
+            con_valid = AllocConsole();
+        }  
         if (con_valid) {
             FILE* res_fp = 0;
             errno_t err;


### PR DESCRIPTION
This change makes it possible to get good console behavior regardless of if the app was launched via double-click or from the console. To get the new improved behavior, set both `sapp_desc.win32_console_attach` and `sapp_desc.win32_console_create` to `true`

The previous behavior had these issues:

- Console launch +`sapp_desc.win32_console_create=true` + `sapp_desc.win32_console_attach=false`
-> app-created console would disappear on crash and you can't see error logs.

- Double-click launch + `sapp_desc.win32_console_attach=true` 
-> you can't see console output


New behavior when both `sapp_desc.win32_console_create` and `sapp_desc.win32_console_attach` are true:
- Console launch: outputs to console.
- Double-click launch: creates new console
