### PR TITLE
[audio] fixed issue in 3ds shutdown

### DIFF
--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -2473,9 +2473,10 @@ _SOKOL_PRIVATE void _saudio_n3ds_backend_shutdown(void) {
 
     if (_saudio.backend.n3ds_desc.channel_id >= 0) {
         ndspChnWaveBufClear(_saudio.backend.n3ds_desc.channel_id);
-        ndspExit();
         _saudio.backend.n3ds_desc.channel_id = -1;
     }
+
+    ndspExit();
 
     _saudio_free(_saudio.backend.queue_n3ds);
     _saudio_free(_saudio.backend.buffer_n3ds);


### PR DESCRIPTION
The original code worked 99% of the time, but I did have 1 strange test case where it would crash. Changing it to always exit the ndsp solved the problem and 100% of my tests are fine now

Sorry about that :sweat_smile: i only recently got the hardware and have been testing more thoroughly