### PR TITLE
Attempt to fix #1384 (glDrawBuffers call when used without color attachments)

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -10927,7 +10927,7 @@ _SOKOL_PRIVATE void _sg_gl_begin_pass(const sg_pass* pass, const _sg_attachments
         SOKOL_ASSERT(_sg.limits.max_color_attachments <= SG_MAX_COLOR_ATTACHMENTS);
         for (int i = 0; i < _sg.limits.max_color_attachments; i++) {
             if (i < atts->num_color_views) {
-                gl_draw_bufs[i] = GL_COLOR_ATTACHMENT0 + i;
+                gl_draw_bufs[i] = (GLenum)(GL_COLOR_ATTACHMENT0 + i);
             } else {
                 gl_draw_bufs[i] = GL_NONE;
             }


### PR DESCRIPTION
> NOTE: this change shouldn't actually make any difference, because the glDrawBuffers() implementation is also supposed to set any unused color attachments slots to `GL_NONE`:

https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDrawBuffers.xhtml

...the code is still fixing the issue that the old behaviour wasn't updated for the bumped GL_MAX_COLOR_ATTACHMENTS (from 4 to 8), so in any case it's an improvement.