### PR TITLE
fix(gl): detach unused FBO attachments in _sg_gl_begin_pass

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -10909,6 +10909,11 @@ _SOKOL_PRIVATE void _sg_gl_begin_pass(const sg_pass* pass, const _sg_attachments
                 _sg_gl_fb_attach_texture(view, gl_att_type);
             }
         }
+        // explicitly detach unused color attachments
+        for (int i = atts->num_color_views; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
+            const GLenum gl_att_type = (GLenum)(GL_COLOR_ATTACHMENT0 + i);
+            glFramebufferTexture2D(GL_FRAMEBUFFER, gl_att_type, GL_TEXTURE_2D, 0, 0);
+        }
         if (atts->ds_view) {
             const _sg_view_t* view = atts->ds_view;
             const _sg_image_t* img = _sg_image_ref_ptr(&view->cmn.img.ref);
@@ -10918,6 +10923,9 @@ _SOKOL_PRIVATE void _sg_gl_begin_pass(const sg_pass* pass, const _sg_attachments
             } else {
                 _sg_gl_fb_attach_texture(view, gl_att_type);
             }
+        } else {
+            // explicitly detach depth-stencil attachment if not used in this pass
+            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
         }
         if (!_sg_gl_check_framebuffer_status()) {
             _sg.cur_pass.valid = false;


### PR DESCRIPTION
## Summary

Fixes rendering clipping when mixing render targets with and without depth-stencil attachments in the same frame.

## Problem

The GL backend uses a single shared FBO (`_sg.gl.fb`) for all offscreen passes. When switching from a pass **with** depth-stencil to one **without**, the old depth-stencil attachment remained bound. Since OpenGL FBOs are constrained by their smallest attachment, this caused rendering to be clipped to the smaller attachment's dimensions—even though `glViewport`/`glScissor` were set correctly.

## Solution

Explicitly detach unused attachments in `_sg_gl_begin_pass()`:
- Unused color attachment slots (beyond `num_color_views`)
- Depth-stencil attachment when not used in the current pass

## Reproduction

Minimal repro with before/after verification:
https://github.com/etherbound-dev/sokol-depth-stencil-bug

```bash
git clone https://github.com/etherbound-dev/sokol-depth-stencil-bug
cd sokol-depth-stencil-bug
make && ./repro      # Bug: ~1% coverage (clipped to 200x200)
make fixed           # Fix: 100% coverage (full gradient)
```

## Test Environment

- AMD Radeon 860M (RDNA 3.5), Mesa 25.2.7, OpenGL 4.6
- Linux (Fedora 43, kernel 6.17.8)