### PR TITLE
fix: GLES3 FBO depth attachment switching

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -11365,16 +11365,14 @@ _SOKOL_PRIVATE void _sg_gl_begin_pass(const sg_pass* pass, const _sg_attachments
             glFramebufferTexture2D(GL_FRAMEBUFFER, gl_att_type, GL_TEXTURE_2D, 0, 0);
         }
         if (atts->ds_view) {
-            // GLES3 FBO fix: When switching between depth-only and depth-stencil attachments,
-            // explicitly detach BOTH attachment types first. Some GLES3 drivers (e.g., Pixel 8 Pro)
-            // fail with GL_FRAMEBUFFER_UNSUPPORTED if both attachment types are bound to the same FBO,
-            // even if one is bound to a different texture.
-            #if defined(SOKOL_GLES3)
+            // When switching between depth-only and depth-stencil attachments,
+            // explicitly detach BOTH attachment types first. Some GL drivers
+            // fail with GL_FRAMEBUFFER_UNSUPPORTED if both attachment types
+            // are bound to the same FBO.
             glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, 0);
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
             glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, 0);
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
-            #endif
             const _sg_view_t* view = atts->ds_view;
             const _sg_image_t* img = _sg_image_ref_ptr(&view->cmn.img.ref);
             const GLenum gl_att_type = _sg_gl_depth_stencil_attachment_type(img);


### PR DESCRIPTION
On some GLES3 drivers (tested on Pixel 8 Pro with Mali GPU), switching between GL_DEPTH_ATTACHMENT and GL_DEPTH_STENCIL_ATTACHMENT on the same FBO causes GL_FRAMEBUFFER_UNSUPPORTED, even when attaching valid textures.

When sokol attaches a new depth/depth-stencil texture, it doesn't first detach the other attachment type. Some GLES3 drivers fail if both attachment points have ever been used on the same FBO.