### PR TITLE
center window on windows to match macOS and linux

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -9863,11 +9863,9 @@ _SOKOL_PRIVATE void _sapp_win32_create_window(void) {
         int monitor_width = info.rcMonitor.right - info.rcMonitor.left;
         int monitor_height = info.rcMonitor.bottom - info.rcMonitor.top;
 
-        int width = _sapp.framebuffer_width;
-        int height = _sapp.framebuffer_height;
-        int center_x = (monitor_width - width) / 2;
-        int center_y = (monitor_height - height) / 2;
-        SetWindowPos(_sapp.win32.hwnd, HWND_TOP, center_x, center_y, width, height, SWP_NOOWNERZORDER);
+        int center_x = (monitor_width - win_width) / 2;
+        int center_y = (monitor_height - win_height) / 2;
+        SetWindowPos(_sapp.win32.hwnd, HWND_TOP, center_x, center_y, win_width, win_height, SWP_NOOWNERZORDER);
     }
     ShowWindow(_sapp.win32.hwnd, SW_SHOW);
     DragAcceptFiles(_sapp.win32.hwnd, 1);


### PR DESCRIPTION
If you like, I'm also happy to implement centering as an option instead. As in something like this:

```c
    sapp_run(&(sapp_desc){
        .init_cb = init,
        .frame_cb = frame,
        .cleanup_cb = cleanup,
        .event_cb = event,
        .width = 1280,
        .height = 720,
        .high_dpi = true,
        .center = true,
        .sample_count = 4,
        .logger.func = slog_func,
    });

```