### PR TITLE
sapp: emsc: fix permanent loss of focus in iframe

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -7208,6 +7208,14 @@ EM_JS(void, sapp_js_init, (const char* c_str_target_selector, const char* c_str_
     }
 })
 
+EM_JS(void, sapp_js_focus, (void), {
+    if (window) {
+        if (window.focus) {
+            window.focus();
+        }
+    }
+})
+
 _SOKOL_PRIVATE EM_BOOL _sapp_emsc_pointerlockchange_cb(int emsc_type, const EmscriptenPointerlockChangeEvent* emsc_event, void* user_data) {
     _SOKOL_UNUSED(emsc_type);
     _SOKOL_UNUSED(user_data);
@@ -7628,6 +7636,10 @@ _SOKOL_PRIVATE EM_BOOL _sapp_emsc_mouse_cb(int emsc_type, const EmscriptenMouseE
         // mouse lock can only be activated in mouse button events (not in move, enter or leave)
         if (is_button_event) {
             _sapp_emsc_update_mouse_lock_state();
+            if (consume_event) {
+                // always grab focus on click, in case we are in an iframe
+                sapp_js_focus();
+            }
         }
     }
     return consume_event;


### PR DESCRIPTION
As described in issue #1224, a sokol game running in an iframe (eg. on itch.io) will not receive keyboard events unless the iframe is focused. Since by default mouse events do not bubble up to the page, it's not possible to re-focus the iframe when the canvas takes up the entire iframe. Enabling html5_bubble_mouse_events does fix this, but I think it makes more sense to maintain the window focus behavior even when you don't want all mouse events bubbled up.

I verified that this patch fixes keyboard events on itch.io, but my project is way back on version 85ec51b13f72d211be3fcf5604623a539041987a so it wasn't an ideal test. [Before patch](https://nkorth.itch.io/project-sable-20260305?secret=dMiNe1YjYJ5kJcYN9il5kDfnDNk), [after patch](https://nkorth.itch.io/project-sable-20260306?secret=kbihjpeg71pPMJwVrHWNUnaoXs). I looked briefly at commit history and couldn't find any changes to this code path since then.