### PR TITLE
sokol_gfx: validate that sg_image_desc.usage.color_attachment and .depth_stencil_attachment

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4547,6 +4547,7 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDATA_DATA_SIZE, "sg_image_data: data size doesn't match expected surface size") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_CANARY, "sg_image_desc not initialized") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_IMMUTABLE_DYNAMIC_STREAM, "sg_image_desc.usage: only one of .immutable, .dynamic_update, .stream_update can be true") \
+    _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_ATTACHMENT_COLOR_DEPTH_STENCIL, "sg_image_desc.usage: only one of .color_attachment and .depth_stencil_attachment can be true") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_IMAGETYPE_2D_NUMSLICES, "sg_image_desc.num_slices must be exactly 1 for SG_IMAGETYPE_2D") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_IMAGETYPE_CUBE_NUMSLICES, "sg_image_desc.num_slices must be exactly 6 for SG_IMAGETYPE_CUBE") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_IMAGETYPE_ARRAY_NUMSLICES, "sg_image_desc.num_slices must be ((>= 1) && (<= sg_limits.max_image_array_layers)) for SG_IMAGETYPE_ARRAY") \
@@ -22490,6 +22491,7 @@ _SOKOL_PRIVATE bool _sg_validate_image_desc(const sg_image_desc* desc) {
         _SG_VALIDATE(desc->_start_canary == 0, VALIDATE_IMAGEDESC_CANARY);
         _SG_VALIDATE(desc->_end_canary == 0, VALIDATE_IMAGEDESC_CANARY);
         _SG_VALIDATE(_sg_one(usg->immutable, usg->dynamic_update, usg->stream_update), VALIDATE_IMAGEDESC_IMMUTABLE_DYNAMIC_STREAM);
+        _SG_VALIDATE(!(usg->color_attachment && usg->depth_stencil_attachment), VALIDATE_IMAGEDESC_ATTACHMENT_COLOR_DEPTH_STENCIL);
         switch (desc->type) {
             case SG_IMAGETYPE_2D:
                 _SG_VALIDATE(desc->num_slices == 1, VALIDATE_IMAGEDESC_IMAGETYPE_2D_NUMSLICES);


### PR DESCRIPTION
When .color_attachment and .depth_stencil_attachment are both set, D3D11 fails to create the texture with this validation layer error:

```
D3D11 ERROR: ID3D11Device::CreateTexture2D: D3D11_BIND_RENDER_TARGET and D3D11_BIND_DEPTH_STENCIL can't both be used together. [ STATE_CREATION ERROR #99: CREATETEXTURE2D_INVALIDBINDFLAGS]
D3D11 ERROR: ID3D11Device::CreateTexture2D: Returning E_INVALIDARG, meaning invalid parameters were passed. [ STATE_CREATION ERROR #104: CREATETEXTURE2D_INVALIDARG_RETURN]
```

It doesn't seem to be a problem on other backends I tried: Metal and WebGL. Since it's explicitly forbidden on D3D11 I think it should be picked up by sokol.

I encountered this situation after modifying some code similar to the offscreen-sapp.c sample:
```c
sg_image_desc img_desc = {
    .usage = { .color_attachment = true },
    .width = 256,
    .height = 256,
    .pixel_format = OFFSCREEN_PIXEL_FORMAT,
    .sample_count = OFFSCREEN_SAMPLE_COUNT,
    .label = "color-image"
};
sg_image color_img = sg_make_image(&img_desc);
img_desc.pixel_format = SG_PIXELFORMAT_DEPTH;
img_desc.usage.depth_stencil_attachment = true; // <---- my mistake here, not initializing the entire usage struct and leaving .color_attachment to true.
img_desc.label = "depth-image";
sg_image depth_img = sg_make_image(&img_desc);
```
But since I was testing on Metal I didn't notice the problem until later.

I considered whether we should validate that only one of .color_attachment, .depth_stencil_attachment or .resolve_attachment is true, but it seems other combinations of flags worked fine. Only color && depth_stencil causes CreateTexture to fail on D3D11.
