### PR TITLE
sokol_app.h: fix empty struct warning on Emscripten

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2565,7 +2565,7 @@ typedef struct {
             uint64_t start;
         } mach;
     #elif defined(_SAPP_EMSCRIPTEN)
-        // empty
+        int _dummy;
     #elif defined(_SAPP_WIN32)
         struct {
             LARGE_INTEGER freq;


### PR DESCRIPTION
The `_sapp_timestamp_t` struct has no members in the `_SAPP_EMSCRIPTEN` branch, which triggers `-Wgnu-empty-struct` when building with `-Wpedantic`.

Fix: add a dummy `int` member.