### PR TITLE
sokol-audio webaudio: handle 'interrupted' state (Safari specific)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### 13-Apr-2026
 
+- sokol_audio.h emscripten: added handling for the WebAudio 'interrupted'
+  state (Safari specific behaviour). The sokol_audio.h code which handled
+  WebAudio suspend/resume could be confused if the audio context goes into
+  the so far unknown state 'interrupted'.
+
+  More details in the PR: https://github.com/floooh/sokol/pull/1479
+
 - sokol_gfx.h: update pixel format cababilities for most backends:
   - GL 4.3+: the pixel format compute read/write flags have been updated
     according the table in the glBindImageTexture documentation:

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -1903,6 +1903,9 @@ EM_JS(int, saudio_js_suspended, (void), {
         else {
             return 0;
         }
+    } else {
+        // shouldn't actually happen since caller makes sure that setup has been called
+        return 0;
     }
 })
 

--- a/sokol_audio.h
+++ b/sokol_audio.h
@@ -1845,11 +1845,20 @@ EM_JS(int, saudio_js_init, (int sample_rate, int num_channels, int buffer_size),
         // in some browsers, WebAudio needs to be activated on a user action
         const resume_webaudio = () => {
             if (Module._saudio_context) {
-                if (Module._saudio_context.state === 'suspended') {
-                    Module._saudio_context.resume();
+                const state = Module._saudio_context.state;
+                if ((state === 'suspended') || (state === 'interrupted')) {
+                    Module._saudio_context.resume().catch((err) => {
+                        console.warn('sokol_audio.h: webaudio resume failed');
+                    });
                 }
             }
         };
+        Module._saudio_context.onstatechange = resume_webaudio;
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'visible') {
+                resume_webaudio();
+            }
+        });
         document.addEventListener('click', resume_webaudio, {once:true});
         document.addEventListener('touchend', resume_webaudio, {once:true});
         document.addEventListener('keydown', resume_webaudio, {once:true});
@@ -1894,13 +1903,13 @@ EM_JS(int, saudio_js_buffer_frames, (void), {
     }
 })
 
-/* return 1 if the WebAudio context is currently suspended, else 0 */
+/* return 1 if the WebAudio context is currently suspended (or interrupted), else 0 */
 EM_JS(int, saudio_js_suspended, (void), {
     if (Module._saudio_context) {
-        if (Module._saudio_context.state === 'suspended') {
+        const state = Module._saudio_context.state;
+        if ((state === 'suspended') || (state === 'interrupted')) {
             return 1;
-        }
-        else {
+        } else {
             return 0;
         }
     } else {


### PR DESCRIPTION
macOS Safari has a webaudio context state 'interrupted', and that may throw off sokol_audio.h's suspended testing and handling.

In the PR:
- `saudio_suspended()` also returns true when the audio context is in interrupted state
- a state change listener on the webaudio context attempts to resume from interruptes state (which may be delayed until the interrupted state is actually over)
- a visibilitychange listener has been added which also generally resumes the audio context from suspended or interrupted state when the tab becomes visible again
- better robustness: added a .catch() to the webaudio resume() method to swallow any exception being thrown out of the method

Drive-by fix: the EM_JS function `_saudio_js_suspended` didn't return a value when sokol audio wasn't initialized. This should never have been triggered because this situation is also caught on the C side before calling the JS function.