### PR TITLE
sokol_app.h macos: move activationPolicy before window creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## Updates
 
+### 01-May-2026
+
+- sokol_app.h macos: Move `activationPolicy` in front of window
+  creation. This fixes the edge case that when the app is built as 'bare'
+  cmdline executable (e.g. not as a macOS app bundle with Info.plist file),
+  and the exe is started from a fullscreen terminal, the application window
+  would be opened on the same screen as the fullscreen app before visibility
+  and control switches to the desktop screen (but leaving the app window
+  on the now hidden terminal screen). Moving activationPolicy before
+  window creation fixes the behaviour and makes it identical with app bundles
+  (visibility and focus switch to the desktop screen first, then the window
+  is opened on the desktop screen).
+
+  Many thanks to @johannesmono for reporting the issue and suggesting the
+  correct solution!
+
+  Issue: https://github.com/floooh/sokol/issues/1500
+  PR: https://github.com/floooh/sokol/pull/1501
+
 ### 26-Apr-2026
 
 A new code-generation script has been added which compiles and injects the embedded

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -5842,6 +5842,8 @@ _SOKOL_PRIVATE void _sapp_macos_frame(void) {
 @implementation _sapp_macos_app_delegate
 - (void)applicationDidFinishLaunching:(NSNotification*)aNotification {
     _SOKOL_UNUSED(aNotification);
+    // NOTE: keep activationPolicy in front of window creation (see https://github.com/floooh/sokol/issues/1500)
+    NSApp.activationPolicy = NSApplicationActivationPolicyRegular;
     _sapp_macos_init_cursors();
     if ((_sapp.window_width == 0) || (_sapp.window_height == 0)) {
         _sapp_macos_init_default_dimensions();
@@ -5875,7 +5877,6 @@ _SOKOL_PRIVATE void _sapp_macos_frame(void) {
     [_sapp.macos.window makeFirstResponder:_sapp.macos.view];
     [_sapp.macos.window center];
     _sapp.valid = true;
-    NSApp.activationPolicy = NSApplicationActivationPolicyRegular;
     if (_sapp.fullscreen) {
         /* ^^^ on GL, this already toggles a rendered frame, so set the valid flag before */
         [_sapp.macos.window toggleFullScreen:self];


### PR DESCRIPTION
Fixes #1500.