### PR TITLE
sokol_imgui.h: workaround ImDrawCallback_ResetRenderState deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Updates
 
+### 21-May-2026
+
+- sokol_imgui.h: fix for removal of the deprecated `ImDrawCallback_ResetRenderState`
+  magic value (only an issue when building with `IMGUI_DISABLE_OBSOLETE_FUNCTIONS`).
+
+  Original issue which introduced the magic value check: https://github.com/floooh/sokol/issues/1000
+  New issue with the breakage report: https://github.com/floooh/sokol/issues/1514
+  Fix PR: https://github.com/floooh/sokol/pull/1515
+
 ### 11-May-2026
 
 - A new header `sokol_framebuffer.h` has been added which provides a 'CPU framebuffer'

--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -2812,8 +2812,10 @@ SOKOL_API_IMPL void simgui_render(void) {
             ImDrawCmd* pcmd = &cl->CmdBuffer.Data[cmd_index];
             if (pcmd->UserCallback != 0) {
                 // User callback, registered via ImDrawList::AddCallback()
-                // (ImDrawCallback_ResetRenderState is a special callback value used by the user to request the renderer to reset render state.)
-                if (pcmd->UserCallback != ImDrawCallback_ResetRenderState) {
+                // NOTE: once the deprecated ImDrawCallback_ResetRenderState define has
+                // been completely removed from Dear ImGui the below magic value can be removed too
+                const intptr_t deprecated_ImDrawCallback_ResetRenderState_magic_value = (-8);
+                if ((intptr_t)pcmd->UserCallback != deprecated_ImDrawCallback_ResetRenderState_magic_value) {
                     pcmd->UserCallback(cl, pcmd);
                     // need to re-apply all state after calling a user callback
                     sg_reset_state_cache();


### PR DESCRIPTION
Replaces the (deprecated in Dear ImGui 1.92.8) `ImDrawCallback_ResetRenderState` magic value with our own magic value. This is necessary at least until Dear ImGui fully removes the magic value completely (currently it's still supported unless `IMGUI_DISABLE_OBSOLETE_FUNCTIONS` is enabled).

Fixes: https://github.com/floooh/sokol/issues/1514

Originally introduced in: https://github.com/floooh/sokol/issues/1000