### PR TITLE
sokol_app.h vk: handle invalid swapchain during window minimized state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## Updates
 
+### 24-May-2026
+
+- sokol_app.h vulkan: Properly fix the situation when
+  `vkGetPhysicalDeviceSurfaceCapabilitiesKHR` returns a width and height of zero.
+  This is for instance the case when minimizing the application window on Windows.
+  The Intel Vulkan driver refuses to create a swapchain object in that case
+  (previously resulting in a triggert assert), while the Nvidia Vulkan driver
+  happily creates a zero-sized swapchain object and image objects (there are
+  validation layer errors though). In this situation, sokol_app.h will now go into
+  an 'invalid swapchain state' until the window is deminimized. Thos builds on top
+  of the recent introduction of 'invalid swapchain passes' in sokol-gfx (such an
+  invalid swapchain pass silently skips all rendering operations).
+
+  Please note that the Vulkan backend should still be considered 'experimental'
+  (especially on Windows).
+
+  PR: https://github.com/floooh/sokol/pull/1518
+
 ### 21-May-2026
 
 - sokol_imgui.h: fix for removal of the deprecated `ImDrawCallback_ResetRenderState`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Sokol
 
-[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**11-May-2026**: new header: sokol_framebuffer.h)
+[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**24-May-2026**: properly handle window minimized state in sokol_app.h vulkan backend)
 
 [![Build](/../../actions/workflows/main.yml/badge.svg)](/../../actions/workflows/main.yml) [![Bindings](/../../actions/workflows/gen_bindings.yml/badge.svg)](/../../actions/workflows/gen_bindings.yml) [![build](https://github.com/floooh/sokol-zig/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-zig/actions/workflows/main.yml) [![build](https://github.com/floooh/sokol-nim/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-nim/actions/workflows/main.yml) [![Odin](https://github.com/floooh/sokol-odin/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-odin/actions/workflows/main.yml)[![Rust](https://github.com/floooh/sokol-rust/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-rust/actions/workflows/main.yml)[![Dlang](https://github.com/floooh/sokol-d/actions/workflows/build.yml/badge.svg)](https://github.com/floooh/sokol-d/actions/workflows/build.yml)[![C3](https://github.com/floooh/sokol-c3/actions/workflows/build.yml/badge.svg)](https://github.com/floooh/sokol-c3/actions/workflows/build.yml)
 

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -1963,6 +1963,7 @@ typedef struct sapp_gl_swapchain {
 } sapp_gl_swapchain;
 
 typedef struct sapp_swapchain {
+    bool invalid;
     int width;
     int height;
     int sample_count;
@@ -2744,6 +2745,7 @@ typedef struct {
     VkDevice device;
     VkQueue queue;
     VkSwapchainKHR swapchain;
+    bool swapchain_valid;
     bool swapchain_acquired;
     uint32_t num_swapchain_images;
     uint32_t cur_swapchain_image_index;
@@ -4610,6 +4612,7 @@ _SOKOL_PRIVATE VkSurfaceFormatKHR _sapp_vk_pick_surface_format(void) {
 
 _SOKOL_PRIVATE void _sapp_vk_create_sync_objects(void) {
     SOKOL_ASSERT(_sapp.vk.device);
+    SOKOL_ASSERT(_sapp.vk.num_swapchain_images > 0);
     _SAPP_STRUCT(VkSemaphoreCreateInfo, create_info);
     create_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
     VkResult res;
@@ -4628,13 +4631,17 @@ _SOKOL_PRIVATE void _sapp_vk_create_sync_objects(void) {
 
 _SOKOL_PRIVATE void _sapp_vk_destroy_sync_objects(void) {
     SOKOL_ASSERT(_sapp.vk.device);
+    SOKOL_ASSERT(_sapp.vk.num_swapchain_images > 0);
     for (uint32_t i = 0; i < _sapp.vk.num_swapchain_images; i++) {
-        SOKOL_ASSERT(_sapp.vk.sync[i].present_complete_sem);
         SOKOL_ASSERT(_sapp.vk.sync[i].render_finished_sem);
-        vkDestroySemaphore(_sapp.vk.device, _sapp.vk.sync[i].present_complete_sem, 0);
-        vkDestroySemaphore(_sapp.vk.device, _sapp.vk.sync[i].render_finished_sem, 0);
-        _sapp.vk.sync[i].present_complete_sem = 0;
-        _sapp.vk.sync[i].render_finished_sem = 0;
+        if (_sapp.vk.sync[i].present_complete_sem) {
+            vkDestroySemaphore(_sapp.vk.device, _sapp.vk.sync[i].present_complete_sem, 0);
+            _sapp.vk.sync[i].present_complete_sem = 0;
+        }
+        if (_sapp.vk.sync[i].render_finished_sem) {
+            vkDestroySemaphore(_sapp.vk.device, _sapp.vk.sync[i].render_finished_sem, 0);
+            _sapp.vk.sync[i].render_finished_sem = 0;
+        }
     }
 }
 
@@ -4681,7 +4688,6 @@ _SOKOL_PRIVATE void _sapp_vk_swapchain_destroy_surface(_sapp_vk_swapchain_surfac
 
 _SOKOL_PRIVATE void _sapp_vk_swapchain_create_surface(
     _sapp_vk_swapchain_surface_t* surf,
-    bool recreate,
     VkFormat format,
     uint32_t width,
     uint32_t height,
@@ -4694,7 +4700,7 @@ _SOKOL_PRIVATE void _sapp_vk_swapchain_create_surface(
     SOKOL_ASSERT(_sapp.vk.physical_device);
     SOKOL_ASSERT(_sapp.vk.device);
     SOKOL_ASSERT(surf);
-    if (recreate) {
+    if (surf->img) {
         _sapp_vk_swapchain_destroy_surface(surf);
     }
     SOKOL_ASSERT(0 == surf->img);
@@ -4795,23 +4801,42 @@ _SOKOL_PRIVATE void _sapp_vk_destroy_swapchain_image_view(uint32_t image_index) 
     _sapp.vk.swapchain_views[image_index] = 0;
 }
 
-_SOKOL_PRIVATE void _sapp_vk_create_swapchain(bool recreate) {
+_SOKOL_PRIVATE void _sapp_vk_destroy_swapchain(void) {
+    SOKOL_ASSERT(_sapp.vk.device);
+    if (_sapp.vk.msaa.img) {
+        _sapp_vk_swapchain_destroy_surface(&_sapp.vk.msaa);
+    }
+    if (_sapp.vk.depth.img) {
+        _sapp_vk_swapchain_destroy_surface(&_sapp.vk.depth);
+    }
+    for (uint32_t i = 0; i < _sapp.vk.num_swapchain_images; i++) {
+        _sapp_vk_destroy_swapchain_image_view(i);
+        _sapp.vk.swapchain_images[i] = 0;
+    }
+    if (_sapp.vk.swapchain) {
+        vkDestroySwapchainKHR(_sapp.vk.device, _sapp.vk.swapchain, 0);
+        _sapp.vk.swapchain = 0;
+    }
+    _sapp_vk_destroy_sync_objects();
+    _sapp.vk.num_swapchain_images = 0;
+    _sapp.vk.swapchain_valid = false;
+}
+
+_SOKOL_PRIVATE void _sapp_vk_create_swapchain(void) {
     SOKOL_ASSERT(_sapp.vk.physical_device);
     SOKOL_ASSERT(_sapp.vk.surface);
     SOKOL_ASSERT(_sapp.vk.device);
-    if (!recreate) {
-        SOKOL_ASSERT(0 == _sapp.vk.swapchain);
-        SOKOL_ASSERT(0 == _sapp.vk.num_swapchain_images);
-        SOKOL_ASSERT(0 == _sapp.vk.swapchain_images[0]);
-        SOKOL_ASSERT(0 == _sapp.vk.swapchain_views[0]);
-    } else {
+    if (_sapp.vk.swapchain_valid) {
         SOKOL_ASSERT(_sapp.vk.swapchain);
         SOKOL_ASSERT(_sapp.vk.num_swapchain_images > 0);
         SOKOL_ASSERT(_sapp.vk.swapchain_images[0]);
         SOKOL_ASSERT(_sapp.vk.swapchain_views[0]);
+    } else {
+        SOKOL_ASSERT(0 == _sapp.vk.swapchain);
+        SOKOL_ASSERT(0 == _sapp.vk.num_swapchain_images);
+        SOKOL_ASSERT(0 == _sapp.vk.swapchain_images[0]);
+        SOKOL_ASSERT(0 == _sapp.vk.swapchain_views[0]);
     }
-
-    VkSwapchainKHR old_swapchain = _sapp.vk.swapchain;
 
     _SAPP_STRUCT(VkSurfaceCapabilitiesKHR, surf_caps);
     VkResult res = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(_sapp.vk.physical_device, _sapp.vk.surface, &surf_caps);
@@ -4819,6 +4844,17 @@ _SOKOL_PRIVATE void _sapp_vk_create_swapchain(bool recreate) {
     const uint32_t fb_width = surf_caps.currentExtent.width;
     const uint32_t fb_height = surf_caps.currentExtent.height;
 
+    // minized window has zero width/height on some platforms (e.g. Windows)
+    if ((0 == fb_width) || (0 == fb_height)) {
+        if (_sapp.vk.swapchain_valid) {
+            _sapp_vk_destroy_swapchain();
+        }
+        _sapp.framebuffer_width = 0;
+        _sapp.framebuffer_height = 0;
+        return;
+    }
+
+    VkSwapchainKHR old_swapchain = _sapp.vk.swapchain;
     _sapp.vk.surface_format = _sapp_vk_pick_surface_format();
     const VkPresentModeKHR present_mode = VK_PRESENT_MODE_FIFO_KHR;
 
@@ -4852,6 +4888,7 @@ _SOKOL_PRIVATE void _sapp_vk_create_swapchain(bool recreate) {
             _sapp_vk_destroy_swapchain_image_view(i);
         }
         vkDestroySwapchainKHR(_sapp.vk.device, old_swapchain, 0);
+        _sapp_vk_destroy_sync_objects();
     }
 
     _sapp.vk.num_swapchain_images = _SAPP_VK_MAX_SWAPCHAIN_IMAGES;
@@ -4868,7 +4905,6 @@ _SOKOL_PRIVATE void _sapp_vk_create_swapchain(bool recreate) {
 
     // create depth-stencil buffer
     _sapp_vk_swapchain_create_surface(&_sapp.vk.depth,
-        recreate,
         VK_FORMAT_D32_SFLOAT_S8_UINT,
         fb_width,
         fb_height,
@@ -4881,7 +4917,6 @@ _SOKOL_PRIVATE void _sapp_vk_create_swapchain(bool recreate) {
     // optionally create MSAA surface
     if (_sapp.sample_count > 1) {
         _sapp_vk_swapchain_create_surface(&_sapp.vk.msaa,
-            recreate,
             _sapp.vk.surface_format.format,
             fb_width,
             fb_height,
@@ -4896,23 +4931,8 @@ _SOKOL_PRIVATE void _sapp_vk_create_swapchain(bool recreate) {
     // _sapp.framebuffer_width/height
     _sapp.framebuffer_width = (int)fb_width;
     _sapp.framebuffer_height = (int)fb_height;
-}
-
-_SOKOL_PRIVATE void _sapp_vk_destroy_swapchain(void) {
-    SOKOL_ASSERT(_sapp.vk.device);
-    SOKOL_ASSERT(_sapp.vk.swapchain);
-    SOKOL_ASSERT(_sapp.vk.num_swapchain_images > 0);
-    if (_sapp.vk.msaa.img) {
-        _sapp_vk_swapchain_destroy_surface(&_sapp.vk.msaa);
-    }
-    _sapp_vk_swapchain_destroy_surface(&_sapp.vk.depth);
-    for (uint32_t i = 0; i < _sapp.vk.num_swapchain_images; i++) {
-        _sapp_vk_destroy_swapchain_image_view(i);
-        _sapp.vk.swapchain_images[i] = 0;
-    }
-    vkDestroySwapchainKHR(_sapp.vk.device, _sapp.vk.swapchain, 0);
-    _sapp.vk.swapchain = 0;
-    _sapp.vk.num_swapchain_images = 0;
+    _sapp_vk_create_sync_objects();
+    _sapp.vk.swapchain_valid = true;
 }
 
 #if defined(_SAPP_LINUX)
@@ -4927,7 +4947,7 @@ _SOKOL_PRIVATE void _sapp_vk_recreate_swapchain(void) {
     vkDeviceWaitIdle(_sapp.vk.device);
     int fb_width = _sapp.framebuffer_width;
     int fb_height = _sapp.framebuffer_height;
-    _sapp_vk_create_swapchain(true);
+    _sapp_vk_create_swapchain();
     if ((fb_width != _sapp.framebuffer_width) || (fb_height != _sapp.framebuffer_height)) {
         if (!_sapp.first_frame) {
             #if defined(_SAPP_LINUX)
@@ -4946,14 +4966,12 @@ _SOKOL_PRIVATE void _sapp_vk_init(void) {
     _sapp_vk_create_surface();
     _sapp_vk_pick_physical_device();
     _sapp_vk_create_device();
-    _sapp_vk_create_swapchain(false);
-    _sapp_vk_create_sync_objects();
+    _sapp_vk_create_swapchain();
 }
 
 _SOKOL_PRIVATE void _sapp_vk_discard(void) {
     SOKOL_ASSERT(_sapp.vk.device);
     vkDeviceWaitIdle(_sapp.vk.device);
-    _sapp_vk_destroy_sync_objects();
     _sapp_vk_destroy_swapchain();
     _sapp_vk_destroy_device();
     _sapp_vk_destroy_surface();
@@ -4962,6 +4980,14 @@ _SOKOL_PRIVATE void _sapp_vk_discard(void) {
 
 _SOKOL_PRIVATE void _sapp_vk_swapchain_next(void) {
     SOKOL_ASSERT(_sapp.vk.device);
+    if (!_sapp.vk.swapchain_valid) {
+        // try to re-create swapchain and resume normal operation when succeeded
+        _sapp_vk_recreate_swapchain();
+        if (!_sapp.vk.swapchain_valid) {
+            _sapp.vk.swapchain_acquired = false;
+            return;
+        }
+    }
     SOKOL_ASSERT(_sapp.vk.swapchain);
     _sapp.vk.swapchain_acquired = true;
     VkResult res = vkAcquireNextImageKHR(
@@ -5001,7 +5027,9 @@ _SOKOL_PRIVATE void _sapp_vk_present(void) {
 _SOKOL_PRIVATE void _sapp_vk_frame(void) {
     _sapp_frame();
     _sapp_vk_present();
-    _sapp.vk.sync_slot = (_sapp.vk.sync_slot + 1) % _sapp.vk.num_swapchain_images;
+    if (_sapp.vk.swapchain_valid) {
+        _sapp.vk.sync_slot = (_sapp.vk.sync_slot + 1) % _sapp.vk.num_swapchain_images;
+    }
 }
 
 #endif // SOKOL_VULKAN
@@ -14366,6 +14394,10 @@ SOKOL_API_IMPL sapp_swapchain sapp_get_swapchain(void) {
     #endif
     #if defined(SOKOL_VULKAN)
         _sapp_vk_swapchain_next();
+        res.invalid = !_sapp.vk.swapchain_valid;
+        if (res.invalid) {
+            return res;
+        }
         // FIXME: swapchain_view being null must be allowed and should skip the frame
         uint32_t img_idx = _sapp.vk.cur_swapchain_image_index;
         if (_sapp.sample_count > 1) {

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -4849,8 +4849,10 @@ _SOKOL_PRIVATE void _sapp_vk_create_swapchain(void) {
         if (_sapp.vk.swapchain_valid) {
             _sapp_vk_destroy_swapchain();
         }
-        _sapp.framebuffer_width = 0;
-        _sapp.framebuffer_height = 0;
+        // NOTE: keep stored framebuffer width/height unchanged here instead
+        // of resetting to 0 is intended! (harmonizes behaviour with other
+        // platforms and backends, and avoids things like Dear ImGui
+        // piling up its windows in the top-left corner)
         return;
     }
 
@@ -4949,7 +4951,7 @@ _SOKOL_PRIVATE void _sapp_vk_recreate_swapchain(void) {
     int fb_height = _sapp.framebuffer_height;
     _sapp_vk_create_swapchain();
     if ((fb_width != _sapp.framebuffer_width) || (fb_height != _sapp.framebuffer_height)) {
-        if (!_sapp.first_frame) {
+        if (_sapp.vk.swapchain_valid && !_sapp.first_frame) {
             #if defined(_SAPP_LINUX)
             _sapp_x11_app_event(SAPP_EVENTTYPE_RESIZED);
             #endif
@@ -5028,6 +5030,7 @@ _SOKOL_PRIVATE void _sapp_vk_frame(void) {
     _sapp_frame();
     _sapp_vk_present();
     if (_sapp.vk.swapchain_valid) {
+        SOKOL_ASSERT(_sapp.vk.num_swapchain_images > 0);
         _sapp.vk.sync_slot = (_sapp.vk.sync_slot + 1) % _sapp.vk.num_swapchain_images;
     }
 }
@@ -14398,7 +14401,6 @@ SOKOL_API_IMPL sapp_swapchain sapp_get_swapchain(void) {
         if (res.invalid) {
             return res;
         }
-        // FIXME: swapchain_view being null must be allowed and should skip the frame
         uint32_t img_idx = _sapp.vk.cur_swapchain_image_index;
         if (_sapp.sample_count > 1) {
             SOKOL_ASSERT(_sapp.vk.msaa.img && _sapp.vk.msaa.view);

--- a/sokol_glue.h
+++ b/sokol_glue.h
@@ -178,6 +178,10 @@ SOKOL_API_IMPL sg_swapchain sglue_swapchain(void) {
     sg_swapchain res;
     memset(&res, 0, sizeof(res));
     const sapp_swapchain sc = sapp_get_swapchain();
+    res.invalid = sc.invalid;
+    if (res.invalid) {
+        return res;
+    }
     res.width = sc.width;
     res.height = sc.height;
     res.sample_count = sc.sample_count;


### PR DESCRIPTION
Fixes https://github.com/floooh/sokol/issues/1470

(e.g. on the Intel Windows driver, trying to create a swapchain in window minimized state failed because the surface width and height are 0, on Nvidia Windows swapchain creation works but throws validation layer warnings)

The PR skips swapchain creation when the reported surface size is 0, and passes the new 'swapchain invalid' flag to sokol-gfx which skips all render pass operations.

As long as the swapchain is in invalid state, the swapchain is attempted to be created each frame before `vkAcquireNextImageKHR` (which continues to fail as long as the window is minized, but then succeeds once the window is unminimized).

TODO:

- [x] write changelog
- [x] test on:
    - [x] windows + nvidia 
    - [x] windows + intel
    - [x] linux (intel)