### PR TITLE
Fix storage image bugs in wgpu BindGroupLayout creation and glBindImageTexture call.

### DIFF
--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -12016,7 +12016,9 @@ _SOKOL_PRIVATE bool _sg_gl_apply_bindings(_sg_bindings_ptrs_t* bnd) {
                 GLuint gl_tex = img->gl.tex[img->cmn.active_slot];
                 GLint level = (GLint)view->cmn.img.mip_level;
                 GLint layer = (GLint)view->cmn.img.slice;
-                GLboolean layered = shd->cmn.views[i].image_type != SG_IMAGETYPE_2D;
+                // NOTE: when picking a specific layer, the 'layered' flag must be false,
+                // this was previously bugged
+                GLboolean layered = GL_FALSE;
                 GLenum access = shd->cmn.views[i].simg_writeonly ? GL_WRITE_ONLY : GL_READ_WRITE;
                 GLenum format = _sg_gl_teximage_internal_format(shd->cmn.views[i].access_format);
                 // NOTE: we specifically don't go through the GL cache since storage images

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -18312,7 +18312,7 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_shader(_sg_shader_t* shd, const
                 bgl_entry->storageTexture.access = WGPUStorageTextureAccess_ReadWrite;
             }
             bgl_entry->storageTexture.format = _sg_wgpu_textureformat(shd->cmn.views[i].access_format);
-            bgl_entry->texture.viewDimension = _sg_wgpu_texture_view_dimension(shd->cmn.views[i].image_type);
+            bgl_entry->storageTexture.viewDimension = _sg_wgpu_texture_view_dimension(shd->cmn.views[i].image_type);
         } else {
             SOKOL_UNREACHABLE;
         }


### PR DESCRIPTION
Primarily fixes this WebGPU bug: https://github.com/floooh/sokol/issues/1522

But also, the `layered` boolean in `glBindImageTexture()` call in the GL backend must actually be `GL_FALSE` when a specific layer is picked (otherwise the `layer` arg is ignored, see: https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBindImageTexture.xhtml