### PR TITLE
macos+metal: remove displaylink timing

### DIFF
--- a/sokol_app.h
+++ b/sokol_app.h
@@ -5128,6 +5128,7 @@ _SOKOL_PRIVATE void _sapp_macos_mtl_request_next_frame(void) {
                       withObject:nil
                       waitUntilDone:NO
                       modes:@[NSDefaultRunLoopMode, NSEventTrackingRunLoopMode, NSModalPanelRunLoopMode]];
+    CFRunLoopWakeUp(CFRunLoopGetMain());
 }
 
 _SOKOL_PRIVATE bool _sapp_macos_mtl_occluded(void) {
@@ -14322,6 +14323,10 @@ SOKOL_API_IMPL sapp_swapchain sapp_get_swapchain(void) {
     _SAPP_STRUCT(sapp_swapchain, res);
     #if defined(SOKOL_METAL)
         #if defined(_SAPP_MACOS)
+            if (_sapp_macos_mtl_occluded()) {
+                res.invalid = true;
+                return res;
+            }
             res.metal.current_drawable = (__bridge const void*) _sapp_macos_mtl_swapchain_next();
             res.metal.depth_stencil_texture = (__bridge const void*) _sapp.macos.mtl.depth_tex;
             res.metal.msaa_color_texture = (__bridge const void*) _sapp.macos.mtl.msaa_tex;

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2704,10 +2704,6 @@ _SOKOL_PRIVATE void _sapp_timing_update(_sapp_timing_t* t, double external_now) 
 
 }
 
-_SOKOL_PRIVATE double _sapp_timing_get(_sapp_timing_t* t) {
-    return t->smooth_dt;
-}
-
 // ███████ ████████ ██████  ██    ██  ██████ ████████ ███████
 // ██         ██    ██   ██ ██    ██ ██         ██    ██
 // ███████    ██    ██████  ██    ██ ██         ██    ███████
@@ -2805,12 +2801,6 @@ typedef struct {
         NSTimer* fallback_timer;
         id<MTLTexture> depth_tex;
         id<MTLTexture> msaa_tex;
-        // NOTE: CADisplayLink.timestamp seems to be very stable, so we'll use
-        // this instead of the generic measured+filtered frame timing code
-        struct {
-            CFTimeInterval timestamp;
-            CFTimeInterval frame_duration_sec;
-        } timing;
     } mtl;
     #endif
     #if defined(SOKOL_WGPU)
@@ -5137,36 +5127,6 @@ _SOKOL_PRIVATE bool _sapp_macos_mtl_display_link_active(void) {
     return (nil != _sapp.macos.mtl.display_link) && (!_sapp.macos.mtl.display_link.paused);
 }
 
-_SOKOL_PRIVATE void _sapp_macos_mtl_timing_init(void) {
-    _sapp.macos.mtl.timing.timestamp = 0.0;
-    _sapp.macos.mtl.timing.frame_duration_sec = 1.0 / _sapp_macos_max_fps();
-}
-
-_SOKOL_PRIVATE void _sapp_macos_mtl_timing_update(void) {
-    // NOTE: if display link is not active, frame duration will be provided
-    // by the regular platform-agnostic timing code
-    if (_sapp_macos_mtl_display_link_active()) {
-        CFTimeInterval cur_timestamp = _sapp.macos.mtl.display_link.timestamp;
-        // skip first frame (frame_duration had been initialized to display refresh rate)
-        if (_sapp.macos.mtl.timing.timestamp > 0.0) {
-            const double dt = cur_timestamp - _sapp.macos.mtl.timing.timestamp;
-            _sapp.macos.mtl.timing.frame_duration_sec = _sapp_timing_clamp(&_sapp.timing, dt);
-        } else {
-            SOKOL_ASSERT(_sapp.macos.mtl.timing.frame_duration_sec > 0.0);
-        }
-        _sapp.macos.mtl.timing.timestamp = cur_timestamp;
-    }
-}
-
-_SOKOL_PRIVATE double _sapp_macos_mtl_timing_frame_duration(void) {
-    if (_sapp_macos_mtl_display_link_active()) {
-        SOKOL_ASSERT(_sapp.macos.mtl.timing.frame_duration_sec > 0.0);
-        return _sapp.macos.mtl.timing.frame_duration_sec;
-    } else {
-        return _sapp_timing_get(&_sapp.timing);
-    }
-}
-
 _SOKOL_PRIVATE void _sapp_macos_mtl_start_display_link(void) {
     if (nil != _sapp.macos.mtl.display_link) {
         _sapp.macos.mtl.display_link.paused = false;
@@ -5237,7 +5197,6 @@ _SOKOL_PRIVATE void _sapp_macos_mtl_init(void) {
     _sapp.macos.view.wantsLayer = YES;
     _sapp.macos.view.layer = _sapp.macos.mtl.layer;
     _sapp_macos_mtl_start_display_link();
-    _sapp_macos_mtl_timing_init();
 }
 
 _SOKOL_PRIVATE void _sapp_macos_mtl_discard_state(void) {
@@ -5862,9 +5821,6 @@ _SOKOL_PRIVATE void _sapp_macos_set_icon(const sapp_icon_desc* icon_desc, int nu
 
 _SOKOL_PRIVATE void _sapp_macos_frame(void) {
     _sapp_timing_update(&_sapp.timing, 0.0);
-    #if defined(SOKOL_METAL)
-    _sapp_macos_mtl_timing_update();
-    #endif
     #if defined(_SAPP_ANY_GL)
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, (GLint*)&_sapp.gl.framebuffer);
     #endif
@@ -13937,13 +13893,7 @@ SOKOL_API_IMPL uint64_t sapp_frame_count(void) {
 }
 
 SOKOL_API_IMPL double sapp_frame_duration(void) {
-    #if defined(_SAPP_MACOS) && defined(SOKOL_METAL)
-        return _sapp_macos_mtl_timing_frame_duration();
-    #elif defined(_SAPP_IOS) && defined(SOKOL_METAL)
-        return _sapp_ios_mtl_timing_frame_duration();
-    #else
-        return _sapp_timing_get(&_sapp.timing);
-    #endif
+    return _sapp.timing.smooth_dt;
 }
 
 SOKOL_API_IMPL double sapp_frame_duration_unfiltered(void) {

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2775,6 +2775,7 @@ typedef struct {
     @interface _sapp_macos_view : NSView
     - (void)displayLinkFired:(id)sender;
     - (void)fallbackTimerFired:(NSTimer*)timer;
+    - (void)nextFrameRequested;
     @end
 #elif defined(SOKOL_GLCORE)
     @interface _sapp_macos_view : NSOpenGLView
@@ -2799,6 +2800,8 @@ typedef struct {
         CAMetalLayer* layer;
         CADisplayLink* display_link;
         NSTimer* fallback_timer;
+        NSTimer* display_timer;
+        bool display_timer_active;
         id<MTLTexture> depth_tex;
         id<MTLTexture> msaa_tex;
     } mtl;
@@ -5123,6 +5126,7 @@ _SOKOL_PRIVATE id<CAMetalDrawable> _sapp_macos_mtl_swapchain_next(void) {
     return drawable;
 }
 
+/*
 _SOKOL_PRIVATE bool _sapp_macos_mtl_display_link_active(void) {
     return (nil != _sapp.macos.mtl.display_link) && (!_sapp.macos.mtl.display_link.paused);
 }
@@ -5149,6 +5153,44 @@ _SOKOL_PRIVATE void _sapp_macos_mtl_stop_display_link(void) {
         _sapp.macos.mtl.display_link.paused = true;
     }
 }
+*/
+
+_SOKOL_PRIVATE void _sapp_macos_mtl_request_next_frame(void) {
+    [_sapp.macos.view performSelector:@selector(nextFrameRequested)
+                      onThread:[NSThread mainThread]
+                      withObject:nil
+                      waitUntilDone:NO
+                      modes:@[NSDefaultRunLoopMode, NSEventTrackingRunLoopMode, NSModalPanelRunLoopMode]];
+}
+
+_SOKOL_PRIVATE bool _sapp_macos_mtl_display_timer_active(void) {
+    // return nil != _sapp.macos.mtl.display_timer;
+    return _sapp.macos.mtl.display_timer_active;
+}
+
+_SOKOL_PRIVATE void _sapp_macos_mtl_start_display_timer(void) {
+    _sapp.macos.mtl.display_timer_active = true;
+    /*
+    SOKOL_ASSERT(nil == _sapp.macos.mtl.display_timer);
+    _sapp.macos.mtl.display_timer = [NSTimer
+        timerWithTimeInterval: 0.0001
+        target: _sapp.macos.view
+        selector: @selector(fallbackTimerFired:)
+        userInfo: nil
+        repeats: YES];
+    [[NSRunLoop currentRunLoop] addTimer:_sapp.macos.mtl.display_timer forMode:NSRunLoopCommonModes];
+    */
+}
+
+_SOKOL_PRIVATE void _sapp_macos_mtl_stop_display_timer(void) {
+    _sapp.macos.mtl.display_timer_active = false;
+    /*
+    if (nil != _sapp.macos.mtl.display_timer) {
+        [_sapp.macos.mtl.display_timer invalidate];
+        _sapp.macos.mtl.display_timer = nil;
+    }
+    */
+}
 
 _SOKOL_PRIVATE void _sapp_macos_mtl_start_fallback_timer(void) {
     SOKOL_ASSERT(nil == _sapp.macos.mtl.fallback_timer);
@@ -5169,16 +5211,18 @@ _SOKOL_PRIVATE void _sapp_macos_mtl_stop_fallback_timer(void) {
 }
 
 _SOKOL_PRIVATE void _sapp_macos_mtl_transition_to_occluded(void) {
-    if (_sapp_macos_mtl_display_link_active()) {
-        _sapp_macos_mtl_stop_display_link();
+    if (_sapp_macos_mtl_display_timer_active()) {
+        //_sapp_macos_mtl_stop_display_link();
+        _sapp_macos_mtl_stop_display_timer();
         _sapp_macos_mtl_start_fallback_timer();
     }
 }
 
 _SOKOL_PRIVATE void _sapp_macos_mtl_transition_to_visible(void) {
-    if (!_sapp_macos_mtl_display_link_active()) {
+    if (!_sapp_macos_mtl_display_timer_active()) {
         _sapp_macos_mtl_stop_fallback_timer();
-        _sapp_macos_mtl_start_display_link();
+        //_sapp_macos_mtl_start_display_link();
+        _sapp_macos_mtl_start_display_timer();
     }
 }
 
@@ -5196,11 +5240,15 @@ _SOKOL_PRIVATE void _sapp_macos_mtl_init(void) {
     [_sapp.macos.view updateTrackingAreas];
     _sapp.macos.view.wantsLayer = YES;
     _sapp.macos.view.layer = _sapp.macos.mtl.layer;
-    _sapp_macos_mtl_start_display_link();
+    // _sapp_macos_mtl_start_display_link();
+    _sapp_macos_mtl_start_display_timer();
+    _sapp_macos_mtl_request_next_frame();
+
 }
 
 _SOKOL_PRIVATE void _sapp_macos_mtl_discard_state(void) {
-    _sapp_macos_mtl_stop_display_link();
+    //_sapp_macos_mtl_stop_display_link();
+    _sapp_macos_mtl_stop_display_timer();
     _sapp_macos_mtl_stop_fallback_timer();
     _sapp_macos_mtl_swapchain_destroy();
     _SAPP_OBJC_RELEASE(_sapp.macos.mtl.layer);
@@ -5819,7 +5867,23 @@ _SOKOL_PRIVATE void _sapp_macos_set_icon(const sapp_icon_desc* icon_desc, int nu
     CGImageRelease(cg_img);
 }
 
+_SOKOL_PRIVATE void _sapp_macos_drain_events(void) {
+    @autoreleasepool {
+        while (true) {
+            NSEvent* event = [NSApp nextEventMatchingMask:NSEventMaskAny
+                untilDate: [NSDate distantPast]
+                inMode:NSDefaultRunLoopMode
+                dequeue:YES];
+            if (event == nil) {
+                break;
+            }
+            [NSApp sendEvent:event];
+        }
+    }
+}
+
 _SOKOL_PRIVATE void _sapp_macos_frame(void) {
+    _sapp_macos_drain_events();
     _sapp_timing_update(&_sapp.timing, 0.0);
     #if defined(_SAPP_ANY_GL)
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, (GLint*)&_sapp.gl.framebuffer);
@@ -6083,7 +6147,11 @@ _SOKOL_PRIVATE void _sapp_macos_frame(void) {
 #elif defined(SOKOL_METAL) || defined(SOKOL_WGPU)
 - (void)displayLinkFired:(id)sender {
     _SOKOL_UNUSED(sender);
+    //_sapp_macos_frame();
+}
+- (void)nextFrameRequested {
     _sapp_macos_frame();
+    _sapp_macos_mtl_request_next_frame();
 }
 - (void)fallbackTimerFired:(NSTimer*)timer {
     _SOKOL_UNUSED(timer);

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2773,8 +2773,7 @@ typedef struct {
 @end
 #if defined(SOKOL_METAL) || defined(SOKOL_WGPU)
     @interface _sapp_macos_view : NSView
-    - (void)displayLinkFired:(id)sender;
-    - (void)fallbackTimerFired:(NSTimer*)timer;
+    - (void)occludedTimerFired:(NSTimer*)timer;
     - (void)nextFrameRequested;
     @end
 #elif defined(SOKOL_GLCORE)
@@ -2798,10 +2797,7 @@ typedef struct {
     struct {
         id<MTLDevice> device;
         CAMetalLayer* layer;
-        CADisplayLink* display_link;
-        NSTimer* fallback_timer;
-        NSTimer* display_timer;
-        bool display_timer_active;
+        NSTimer* occluded_timer;
         id<MTLTexture> depth_tex;
         id<MTLTexture> msaa_tex;
     } mtl;
@@ -5058,7 +5054,7 @@ _SOKOL_PRIVATE void _sapp_vk_frame(void) {
 // >>macos
 #if defined(_SAPP_MACOS)
 
-#define _SAPP_MACOS_MTL_OBSCURED_FRAME_DURATION_IN_SECONDS (0.0166667)
+#define _SAPP_MACOS_MTL_OCCLUDED_FRAME_DURATION_IN_SECONDS (0.0166667)
 
 _SOKOL_PRIVATE NSInteger _sapp_macos_max_fps(void) {
     return [NSScreen.mainScreen maximumFramesPerSecond];
@@ -5126,35 +5122,6 @@ _SOKOL_PRIVATE id<CAMetalDrawable> _sapp_macos_mtl_swapchain_next(void) {
     return drawable;
 }
 
-/*
-_SOKOL_PRIVATE bool _sapp_macos_mtl_display_link_active(void) {
-    return (nil != _sapp.macos.mtl.display_link) && (!_sapp.macos.mtl.display_link.paused);
-}
-
-_SOKOL_PRIVATE void _sapp_macos_mtl_start_display_link(void) {
-    if (nil != _sapp.macos.mtl.display_link) {
-        _sapp.macos.mtl.display_link.paused = false;
-        return;
-    }
-    // NOTE: CADisplayLink is only available since macOS 14.0
-    SOKOL_ASSERT(nil == _sapp.macos.mtl.display_link);
-    SOKOL_ASSERT(nil == _sapp.macos.mtl.fallback_timer);
-    SOKOL_ASSERT(nil != _sapp.macos.view);
-    NSInteger max_fps = _sapp_macos_max_fps();
-    _sapp.macos.mtl.display_link = [_sapp.macos.view displayLinkWithTarget:_sapp.macos.view selector:@selector(displayLinkFired:)];
-    const float preferred_fps = max_fps / _sapp.swap_interval;
-    const CAFrameRateRange frame_rate_range = { preferred_fps, preferred_fps, preferred_fps };
-    _sapp.macos.mtl.display_link.preferredFrameRateRange = frame_rate_range;
-    [_sapp.macos.mtl.display_link addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
-}
-
-_SOKOL_PRIVATE void _sapp_macos_mtl_stop_display_link(void) {
-    if (nil != _sapp.macos.mtl.display_link) {
-        _sapp.macos.mtl.display_link.paused = true;
-    }
-}
-*/
-
 _SOKOL_PRIVATE void _sapp_macos_mtl_request_next_frame(void) {
     [_sapp.macos.view performSelector:@selector(nextFrameRequested)
                       onThread:[NSThread mainThread]
@@ -5163,66 +5130,38 @@ _SOKOL_PRIVATE void _sapp_macos_mtl_request_next_frame(void) {
                       modes:@[NSDefaultRunLoopMode, NSEventTrackingRunLoopMode, NSModalPanelRunLoopMode]];
 }
 
-_SOKOL_PRIVATE bool _sapp_macos_mtl_display_timer_active(void) {
-    // return nil != _sapp.macos.mtl.display_timer;
-    return _sapp.macos.mtl.display_timer_active;
+_SOKOL_PRIVATE bool _sapp_macos_mtl_occluded(void) {
+    return nil != _sapp.macos.mtl.occluded_timer;
 }
 
-_SOKOL_PRIVATE void _sapp_macos_mtl_start_display_timer(void) {
-    _sapp.macos.mtl.display_timer_active = true;
-    /*
-    SOKOL_ASSERT(nil == _sapp.macos.mtl.display_timer);
-    _sapp.macos.mtl.display_timer = [NSTimer
-        timerWithTimeInterval: 0.0001
+_SOKOL_PRIVATE void _sapp_macos_mtl_start_occluded_timer(void) {
+    SOKOL_ASSERT(nil == _sapp.macos.mtl.occluded_timer);
+    _sapp.macos.mtl.occluded_timer = [NSTimer
+        timerWithTimeInterval: _SAPP_MACOS_MTL_OCCLUDED_FRAME_DURATION_IN_SECONDS
         target: _sapp.macos.view
-        selector: @selector(fallbackTimerFired:)
+        selector: @selector(occludedTimerFired:)
         userInfo: nil
         repeats: YES];
-    [[NSRunLoop currentRunLoop] addTimer:_sapp.macos.mtl.display_timer forMode:NSRunLoopCommonModes];
-    */
+    [[NSRunLoop currentRunLoop] addTimer:_sapp.macos.mtl.occluded_timer forMode:NSRunLoopCommonModes];
 }
 
-_SOKOL_PRIVATE void _sapp_macos_mtl_stop_display_timer(void) {
-    _sapp.macos.mtl.display_timer_active = false;
-    /*
-    if (nil != _sapp.macos.mtl.display_timer) {
-        [_sapp.macos.mtl.display_timer invalidate];
-        _sapp.macos.mtl.display_timer = nil;
-    }
-    */
-}
-
-_SOKOL_PRIVATE void _sapp_macos_mtl_start_fallback_timer(void) {
-    SOKOL_ASSERT(nil == _sapp.macos.mtl.fallback_timer);
-    _sapp.macos.mtl.fallback_timer = [NSTimer
-        timerWithTimeInterval: _SAPP_MACOS_MTL_OBSCURED_FRAME_DURATION_IN_SECONDS
-        target: _sapp.macos.view
-        selector: @selector(fallbackTimerFired:)
-        userInfo: nil
-        repeats: YES];
-    [[NSRunLoop currentRunLoop] addTimer:_sapp.macos.mtl.fallback_timer forMode:NSRunLoopCommonModes];
-}
-
-_SOKOL_PRIVATE void _sapp_macos_mtl_stop_fallback_timer(void) {
-    if (nil != _sapp.macos.mtl.fallback_timer) {
-        [_sapp.macos.mtl.fallback_timer invalidate];
-        _sapp.macos.mtl.fallback_timer = nil;
+_SOKOL_PRIVATE void _sapp_macos_mtl_stop_occluded_timer(void) {
+    if (nil != _sapp.macos.mtl.occluded_timer) {
+        [_sapp.macos.mtl.occluded_timer invalidate];
+        _sapp.macos.mtl.occluded_timer = nil;
     }
 }
 
 _SOKOL_PRIVATE void _sapp_macos_mtl_transition_to_occluded(void) {
-    if (_sapp_macos_mtl_display_timer_active()) {
-        //_sapp_macos_mtl_stop_display_link();
-        _sapp_macos_mtl_stop_display_timer();
-        _sapp_macos_mtl_start_fallback_timer();
+    if (!_sapp_macos_mtl_occluded()) {
+        _sapp_macos_mtl_start_occluded_timer();
     }
 }
 
 _SOKOL_PRIVATE void _sapp_macos_mtl_transition_to_visible(void) {
-    if (!_sapp_macos_mtl_display_timer_active()) {
-        _sapp_macos_mtl_stop_fallback_timer();
-        //_sapp_macos_mtl_start_display_link();
-        _sapp_macos_mtl_start_display_timer();
+    if (_sapp_macos_mtl_occluded()) {
+        _sapp_macos_mtl_stop_occluded_timer();
+        _sapp_macos_mtl_request_next_frame();
     }
 }
 
@@ -5240,16 +5179,12 @@ _SOKOL_PRIVATE void _sapp_macos_mtl_init(void) {
     [_sapp.macos.view updateTrackingAreas];
     _sapp.macos.view.wantsLayer = YES;
     _sapp.macos.view.layer = _sapp.macos.mtl.layer;
-    // _sapp_macos_mtl_start_display_link();
-    _sapp_macos_mtl_start_display_timer();
     _sapp_macos_mtl_request_next_frame();
 
 }
 
 _SOKOL_PRIVATE void _sapp_macos_mtl_discard_state(void) {
-    //_sapp_macos_mtl_stop_display_link();
-    _sapp_macos_mtl_stop_display_timer();
-    _sapp_macos_mtl_stop_fallback_timer();
+    _sapp_macos_mtl_stop_occluded_timer();
     _sapp_macos_mtl_swapchain_destroy();
     _SAPP_OBJC_RELEASE(_sapp.macos.mtl.layer);
     _SAPP_OBJC_RELEASE(_sapp.macos.mtl.device);
@@ -6145,17 +6080,17 @@ _SOKOL_PRIVATE void _sapp_macos_frame(void) {
     _sapp_macos_frame();
 }
 #elif defined(SOKOL_METAL) || defined(SOKOL_WGPU)
-- (void)displayLinkFired:(id)sender {
-    _SOKOL_UNUSED(sender);
-    //_sapp_macos_frame();
-}
 - (void)nextFrameRequested {
-    _sapp_macos_frame();
-    _sapp_macos_mtl_request_next_frame();
+    if (!_sapp_macos_mtl_occluded()) {
+        _sapp_macos_frame();
+        _sapp_macos_mtl_request_next_frame();
+    }
 }
-- (void)fallbackTimerFired:(NSTimer*)timer {
+- (void)occludedTimerFired:(NSTimer*)timer {
     _SOKOL_UNUSED(timer);
-    _sapp_macos_frame();
+    if (_sapp_macos_mtl_occluded()) {
+        _sapp_macos_frame();
+    }
 }
 #endif
 


### PR DESCRIPTION
See #1529 and #1344.

Entirely changes the macos+metal frame pacing (again) by removing CADisplayLink and instead relying on CAMetalLayer alone for vsync throttling. Instead of letting CADisplayLink injecting a selector into the event loop at vsync time (which causes all sorts of weird problems when the application cannot meet the frame budget), sokol_app.h immediately injects the frame callback selector into the runloop at the end of a frame (pretty much like requestAnimationFrame works in web browsers). This will start the next frame at the next possible moment, and the waiting for vsync will always happen in the CAMetalLayer nextDrawable call.

There is still a suprisingly high CPU cost when moving the mouse cursor, but this has a less catastrophic effect when the app cannot meet the frame budget as it has with CADisplayLink (and ultimately this high CPU cost for moving the mouse must be fixed by macOS).

TODO:

- [x] NOTE: draining events breaks event handling in macOS 27 Beta!
- [x] remove CADisplayLink
- [x] rename fallback timer to occluded timer
- [x] trigger next frame in non-occlued state via `performSelector`
- [ ] Q: should we drain the event queue at the start of a frame? there's hardly any events to drain at that point (at most one in very long frames)
- [x] don't call nextDrawable in occluded state, instead return an 'invalid' swapchain-struct in `sapp_get_swapchain()`
- [ ] merge into WIP swapchain-config branch
- [ ] extensively test in debug vs release vs app-bundle vs 'raw' exe

No changes on iOS or WGPU (those will continue to use CADisplayLink for now)