### PR TITLE
Updating gen_c3.py to define enums the C3 0.8.x way.

### DIFF
--- a/bindgen/gen_c3.py
+++ b/bindgen/gen_c3.py
@@ -325,7 +325,7 @@ def gen_enum(decl, prefix):
     tpe = "int"
     if any(as_enum_item_name(check_override(item['name'])) == 'FORCE_U32' for item in decl['items']):
         tpe = "uint"
-    l(f'enum {as_struct_or_enum_type(enum_name, prefix)} : const {tpe}')
+    l(f'constdef {as_struct_or_enum_type(enum_name, prefix)} : {tpe}')
     l('{')
     value = "-1"
     for item in decl['items']:


### PR DESCRIPTION
From: https://github.com/floooh/sokol-c3/pull/12#issuecomment-4651670168

Fixing the enum generation so the bindings work with C3 0.8.x