### PR TITLE
sokol_app.h linux: never return nullptr in sapp_get_clipboard_string()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Updates
 
+### 11-Jun-2026
+
+- sokol_app.h linux: fix a long-standing bug in the sokol-app Linux backend
+  where `sapp_get_clipboard_string()` returns a null pointer instead of an
+  empty string when the clipboard is empty or when an error occurs while
+  querying the clipboard.
+
+  Issue: https://github.com/floooh/sokol/issues/1538
+  PR: https://github.com/floooh/sokol/pull/1539
+
+  Many thanks to @OrfeasPliaridis for reporting the problem!
+
 ### 05-Jun-2026
 
 - sokol_app.h android: Update the default framebuffer config from 16-bit

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -12775,6 +12775,7 @@ _SOKOL_PRIVATE void _sapp_x11_lock_mouse(bool lock) {
 
 _SOKOL_PRIVATE void _sapp_x11_set_clipboard_string(const char* str) {
     SOKOL_ASSERT(_sapp.clipboard.enabled && _sapp.clipboard.buffer);
+    _sapp.clipboard.buffer[0] = 0;
     if (strlen(str) >= (size_t)_sapp.clipboard.buf_size) {
         _SAPP_ERROR(CLIPBOARD_STRING_TOO_BIG);
     }
@@ -12801,10 +12802,10 @@ _SOKOL_PRIVATE const char* _sapp_x11_get_clipboard_string(void) {
                       CurrentTime);
     XEvent event;
     if (!_sapp_x11_wait_for_event(SelectionNotify, 0.1, &event)) {
-        return NULL;
+        return _sapp.clipboard.buffer;
     }
     if (event.xselection.property == None) {
-        return NULL;
+        return _sapp.clipboard.buffer;
     }
     char* data = NULL;
     Atom actualType;
@@ -12826,12 +12827,12 @@ _SOKOL_PRIVATE const char* _sapp_x11_get_clipboard_string(void) {
         if (data != NULL) {
             XFree(data);
         }
-        return NULL;
+        return _sapp.clipboard.buffer;
     }
     if ((actualType == incremental) || (itemCount >= (size_t)_sapp.clipboard.buf_size)) {
         _SAPP_ERROR(CLIPBOARD_STRING_TOO_BIG);
         XFree(data);
-        return NULL;
+        return _sapp.clipboard.buffer;
     }
     _sapp_strcpy(data, _sapp.clipboard.buffer, (size_t)_sapp.clipboard.buf_size);
     XFree(data);


### PR DESCRIPTION
Fixes https://github.com/floooh/sokol/issues/1538

On Linux, `sapp_get_clipboard_string()` returned a nullptr on error or an empty clipboard instead of an empty string.