### PR TITLE
docs: add quick build troubleshooting notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,42 @@ Aras Pranckevičius, PC/web port via sokol ([source](https://github.com/aras-p/d
 - [How to build without a build system](https://github.com/floooh/sokol-samples#how-to-build-without-a-build-system):
 useful details for integrating the Sokol headers into your own project with your favourite C/C++ build system
 
+## Quick build troubleshooting
+
+When a first Sokol integration fails to compile or link, the problem is usually
+one of the following configuration mismatches:
+
+- Define `SOKOL_IMPL` (or the per-header `SOKOL_*_IMPL` define) in exactly one
+  C or C++ translation unit before including the Sokol headers. Other files
+  should include the headers without the implementation define.
+- Select exactly one rendering backend in that same implementation translation
+  unit, for example `SOKOL_GLCORE`, `SOKOL_GLES3`, `SOKOL_D3D11`, `SOKOL_METAL`,
+  `SOKOL_WGPU` or `SOKOL_VULKAN`. The backend define must match the shader code
+  and any window/context setup code you use.
+- If `sokol_gfx.h` and `sokol_app.h` are used together, use the same backend
+  define for both headers. `sokol_app.h` creates the matching window and 3D API
+  context; `sokol_glue.h` then forwards the platform-specific environment via
+  `sglue_environment()` and `sglue_swapchain()`.
+- macOS and iOS builds which use `sokol_app.h` or Metal must compile the
+  implementation file as Objective-C or Objective-C++ (`.m` or `.mm`, or the
+  equivalent compiler flag), and link the frameworks listed in the header docs.
+- Emscripten WebGL2 builds require the linker option `-s USE_WEBGL2=1` when using
+  `SOKOL_GLES3`. WebGPU builds use `SOKOL_WGPU` and need the WebGPU port/options
+  described in the `sokol_gfx.h` header comments.
+- On Linux, OpenGL builds commonly need the GL/X11 development packages installed
+  by the platform package manager. `SOKOL_GLCORE` uses GLX by default; define
+  `SOKOL_FORCE_EGL` if your build intentionally uses EGL instead.
+- On Windows, MSVC and Clang builds usually pick up common system libraries via
+  in-source `#pragma comment(lib, ...)` directives. MinGW/MSYS2 builds may need
+  explicit linker flags such as `-ld3d11` for `SOKOL_D3D11`.
+- For shader-related errors, confirm that generated shader headers come from a
+  `sokol-shdc` version compatible with the Sokol headers and were generated for
+  the same backend(s) selected at compile time.
+
+For exact per-header compiler and linker requirements, see the comment block at
+the top of each Sokol header and the build notes in
+[`sokol-samples`](https://github.com/floooh/sokol-samples).
+
 ## Core libraries
 
 - [**sokol\_gfx.h**](https://github.com/floooh/sokol/blob/master/sokol_gfx.h): 3D-API wrapper (GL/GLES3/WebGL2 + Metal + D3D11 + WebGPU)

--- a/README.md
+++ b/README.md
@@ -61,42 +61,6 @@ Aras Pranckevičius, PC/web port via sokol ([source](https://github.com/aras-p/d
 - [How to build without a build system](https://github.com/floooh/sokol-samples#how-to-build-without-a-build-system):
 useful details for integrating the Sokol headers into your own project with your favourite C/C++ build system
 
-## Quick build troubleshooting
-
-When a first Sokol integration fails to compile or link, the problem is usually
-one of the following configuration mismatches:
-
-- Define `SOKOL_IMPL` (or the per-header `SOKOL_*_IMPL` define) in exactly one
-  C or C++ translation unit before including the Sokol headers. Other files
-  should include the headers without the implementation define.
-- Select exactly one rendering backend in that same implementation translation
-  unit, for example `SOKOL_GLCORE`, `SOKOL_GLES3`, `SOKOL_D3D11`, `SOKOL_METAL`,
-  `SOKOL_WGPU` or `SOKOL_VULKAN`. The backend define must match the shader code
-  and any window/context setup code you use.
-- If `sokol_gfx.h` and `sokol_app.h` are used together, use the same backend
-  define for both headers. `sokol_app.h` creates the matching window and 3D API
-  context; `sokol_glue.h` then forwards the platform-specific environment via
-  `sglue_environment()` and `sglue_swapchain()`.
-- macOS and iOS builds which use `sokol_app.h` or Metal must compile the
-  implementation file as Objective-C or Objective-C++ (`.m` or `.mm`, or the
-  equivalent compiler flag), and link the frameworks listed in the header docs.
-- Emscripten WebGL2 builds require the linker option `-s USE_WEBGL2=1` when using
-  `SOKOL_GLES3`. WebGPU builds use `SOKOL_WGPU` and need the WebGPU port/options
-  described in the `sokol_gfx.h` header comments.
-- On Linux, OpenGL builds commonly need the GL/X11 development packages installed
-  by the platform package manager. `SOKOL_GLCORE` uses GLX by default; define
-  `SOKOL_FORCE_EGL` if your build intentionally uses EGL instead.
-- On Windows, MSVC and Clang builds usually pick up common system libraries via
-  in-source `#pragma comment(lib, ...)` directives. MinGW/MSYS2 builds may need
-  explicit linker flags such as `-ld3d11` for `SOKOL_D3D11`.
-- For shader-related errors, confirm that generated shader headers come from a
-  `sokol-shdc` version compatible with the Sokol headers and were generated for
-  the same backend(s) selected at compile time.
-
-For exact per-header compiler and linker requirements, see the comment block at
-the top of each Sokol header and the build notes in
-[`sokol-samples`](https://github.com/floooh/sokol-samples).
-
 ## Core libraries
 
 - [**sokol\_gfx.h**](https://github.com/floooh/sokol/blob/master/sokol_gfx.h): 3D-API wrapper (GL/GLES3/WebGL2 + Metal + D3D11 + WebGPU)
@@ -150,6 +114,42 @@ The core headers are standalone and can be used independently from each other.
 - adds only minimal size overhead to executables
 
 A blog post with more background info: [A Tour of sokol_gfx.h](http://floooh.github.io/2017/07/29/sokol-gfx-tour.html)
+
+## Quick build troubleshooting
+
+When a first Sokol integration fails to compile or link, the problem is usually
+one of the following configuration mismatches:
+
+- Define `SOKOL_IMPL` (or the per-header `SOKOL_*_IMPL` define) in exactly one
+  C or C++ translation unit before including the Sokol headers. Other files
+  should include the headers without the implementation define.
+- Select exactly one rendering backend in that same implementation translation
+  unit, for example `SOKOL_GLCORE`, `SOKOL_GLES3`, `SOKOL_D3D11`, `SOKOL_METAL`,
+  `SOKOL_WGPU` or `SOKOL_VULKAN`. The backend define must match the shader code
+  and any window/context setup code you use.
+- If `sokol_gfx.h` and `sokol_app.h` are used together, use the same backend
+  define for both headers. `sokol_app.h` creates the matching window and 3D API
+  context; `sokol_glue.h` then forwards the platform-specific environment via
+  `sglue_environment()` and `sglue_swapchain()`.
+- macOS and iOS builds which use `sokol_app.h` or Metal must compile the
+  implementation file as Objective-C or Objective-C++ (`.m` or `.mm`, or the
+  equivalent compiler flag), and link the frameworks listed in the header docs.
+- Emscripten WebGL2 builds require the linker option `-s USE_WEBGL2=1` when using
+  `SOKOL_GLES3`. WebGPU builds use `SOKOL_WGPU` and need the WebGPU port/options
+  described in the `sokol_gfx.h` header comments.
+- On Linux, OpenGL builds commonly need the GL/X11 development packages installed
+  by the platform package manager. `SOKOL_GLCORE` uses GLX by default; define
+  `SOKOL_FORCE_EGL` if your build intentionally uses EGL instead.
+- On Windows, MSVC and Clang builds usually pick up common system libraries via
+  in-source `#pragma comment(lib, ...)` directives. MinGW/MSYS2 builds may need
+  explicit linker flags such as `-ld3d11` for `SOKOL_D3D11`.
+- For shader-related errors, confirm that generated shader headers come from a
+  `sokol-shdc` version compatible with the Sokol headers and were generated for
+  the same backend(s) selected at compile time.
+
+For exact per-header compiler and linker requirements, see the comment block at
+the top of each Sokol header and the build notes in
+[`sokol-samples`](https://github.com/floooh/sokol-samples).
 
 # sokol_gfx.h:
 


### PR DESCRIPTION
## Summary
- add a focused README troubleshooting section for common first-integration build issues
- cover implementation defines, backend selection consistency, platform compiler/linker notes, and shader generator/backend mismatches

## Testing
- not run (documentation-only change)