### PR TITLE
sokol_shape.h: flexible vertex components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## Updates
 
+### 19-Jul-2026
+
+sokol_shape.h: some breaking changes:
+
+- it's now possible to omit vertex components (vertex component formats are still
+  hardwired though)
+- new public constants `SSHAPE_MIN_VERTEX_SIZE` and `SSHAPE_MAX_VERTEX_SIZE`
+- some public structs have been removed or renamed to make more sense with the changed behaviour:
+  - `sshape_vertex_t` => removed, since a hardwired struct doesn't make sense anymore with the
+    flexible vertex layout
+  - `sshape_buffer_t` => `sshape_state_t`
+  - `sshape_buffer_item_t` => `sshape_buffer_state_t`
+- the shape-builder functions now modify the 'shape state struct' in place instead of returning
+  a modified copy
+
+Also check the source code of the updated example [shapes-sapp.c](https://floooh.github.io/sokol-html5/shapes-sapp.html)
+
+PR: https://github.com/floooh/sokol/pull/1550
+
 ### 15-Jul-2026
 
 sokol_app.h android: added a platform-specific 'native' event callback

--- a/bindgen/gen_c3.py
+++ b/bindgen/gen_c3.py
@@ -233,6 +233,12 @@ def is_const_struct_ptr(s):
             return True
     return False
 
+def is_struct_ptr(s):
+    for struct_type in struct_types:
+        if s == f"{struct_type} *":
+            return True
+    return False
+
 def type_default_value(s):
     return prim_defaults[s]
 
@@ -254,6 +260,8 @@ def map_type(type, prefix, sub_type):
     elif util.is_string_ptr(type):
         return "ZString"
     elif is_const_struct_ptr(type):
+        return f"{as_struct_or_enum_type(util.extract_ptr_type(type), prefix)}*"
+    elif is_struct_ptr(type):
         return f"{as_struct_or_enum_type(util.extract_ptr_type(type), prefix)}*"
     elif is_prim_ptr(type):
         return f"{as_prim_type(util.extract_ptr_type(type))}*"

--- a/bindgen/gen_jai.py
+++ b/bindgen/gen_jai.py
@@ -204,6 +204,12 @@ def is_const_struct_ptr(s):
             return True
     return False
 
+def is_struct_ptr(s):
+    for struct_type in struct_types:
+        if s == f"{struct_type} *":
+            return True
+    return False
+
 def type_default_value(s):
     return prim_defaults[s]
 
@@ -223,6 +229,8 @@ def map_type(type, prefix, sub_type):
     elif util.is_string_ptr(type):
         return "*u8"
     elif is_const_struct_ptr(type):
+        return f"*{as_struct_or_enum_type(util.extract_ptr_type(type), prefix)}"
+    elif is_struct_ptr(type):
         return f"*{as_struct_or_enum_type(util.extract_ptr_type(type), prefix)}"
     elif is_prim_ptr(type):
         return f"*{as_prim_type(util.extract_ptr_type(type))}"

--- a/bindgen/gen_nim.py
+++ b/bindgen/gen_nim.py
@@ -251,6 +251,12 @@ def is_const_struct_ptr(s):
             return True
     return False
 
+def is_struct_ptr(s):
+    for struct_type in struct_types:
+        if s == f"{struct_type} *":
+            return True
+    return False
+
 def type_default_value(s):
     return prim_defaults[s]
 
@@ -294,6 +300,8 @@ def as_nim_type(ctype, prefix, struct_ptr_as_value=False):
             return f"{nim_type}"
         else:
             return f"ptr {nim_type}"
+    elif is_struct_ptr(ctype):
+        return f"ptr {as_nim_type(util.extract_ptr_type(ctype), prefix)}"
     elif is_prim_ptr(ctype) or is_const_prim_ptr(ctype):
         return f"ptr {as_nim_type(util.extract_ptr_type(ctype), prefix)}"
     elif util.is_func_ptr(ctype):

--- a/bindgen/gen_odin.py
+++ b/bindgen/gen_odin.py
@@ -218,6 +218,12 @@ def is_const_struct_ptr(s):
             return True
     return False
 
+def is_struct_ptr(s):
+    for struct_type in struct_types:
+        if s == f"{struct_type} *":
+            return True
+    return False
+
 def type_default_value(s):
     return prim_defaults[s]
 
@@ -251,6 +257,8 @@ def map_type(type, prefix, sub_type):
             return f"{as_struct_or_enum_type(util.extract_ptr_type(type), prefix)}"
         else:
             return f"^{as_struct_or_enum_type(util.extract_ptr_type(type), prefix)}"
+    elif is_struct_ptr(type):
+        return f"^{as_struct_or_enum_type(util.extract_ptr_type(type), prefix)}"
     elif is_prim_ptr(type):
         return f"^{as_prim_type(util.extract_ptr_type(type))}"
     elif is_const_prim_ptr(type):

--- a/bindgen/gen_zig.py
+++ b/bindgen/gen_zig.py
@@ -177,6 +177,12 @@ def is_const_struct_ptr(s):
             return True
     return False
 
+def is_struct_ptr(s):
+    for struct_type in struct_types:
+        if s == f"{struct_type} *":
+            return True
+    return False
+
 def type_default_value(s):
     return prim_defaults[s]
 
@@ -197,6 +203,8 @@ def as_c_arg_type(arg_type, prefix):
         return "[*c]const u8"
     elif is_const_struct_ptr(arg_type):
         return f"[*c]const {as_zig_struct_type(util.extract_ptr_type(arg_type), prefix)}"
+    elif is_struct_ptr(arg_type):
+        return f"[*c] {as_zig_struct_type(util.extract_ptr_type(arg_type), prefix)}"
     elif is_prim_ptr(arg_type):
         return f"[*c]{as_zig_prim_type(util.extract_ptr_type(arg_type))}"
     elif is_const_prim_ptr(arg_type):
@@ -227,6 +235,8 @@ def as_zig_arg_type(arg_prefix, arg_type, prefix):
     elif is_const_struct_ptr(arg_type):
         # not a bug, pass const structs by value
         return pre + f"{as_zig_struct_type(util.extract_ptr_type(arg_type), prefix)}"
+    elif is_struct_ptr(arg_type):
+        return pre + f"*{as_zig_struct_type(util.extract_ptr_type(arg_type), prefix)}"
     elif is_prim_ptr(arg_type):
         return pre + f"*{as_zig_prim_type(util.extract_ptr_type(arg_type))}"
     elif is_const_prim_ptr(arg_type):

--- a/tests/compile/sokol_all.c
+++ b/tests/compile/sokol_all.c
@@ -73,7 +73,7 @@ void use_all(void) {
     sgl_setup(&(sgl_desc_t){0});
     const slbx_viewport vp = slbx_letterbox(256, 256, &(slbx_letterbox_desc){0}); (void)vp;
     void* p = smemtrack_alloc(8, 0); (void)p;
-    sshape_plane_sizes(10);
+    sshape_plane_sizes(10, SSHAPE_MAX_VERTEX_SIZE);
     simgui_setup(&(simgui_desc_t){0});
     sgimgui_setup(&(sgimgui_desc_t){0});
     sappimgui_setup();

--- a/tests/compile/sokol_shape.c
+++ b/tests/compile/sokol_shape.c
@@ -3,5 +3,5 @@
 #include "sokol_shape.h"
 
 void use_shape_impl(void) {
-    sshape_plane_sizes(10);
+    sshape_plane_sizes(10, SSHAPE_MAX_VERTEX_SIZE);
 }

--- a/tests/compile/sokol_shape.cc
+++ b/tests/compile/sokol_shape.cc
@@ -3,5 +3,5 @@
 #include "sokol_shape.h"
 
 void use_shape_impl() {
-    sshape_plane_sizes(10);
+    sshape_plane_sizes(10, SSHAPE_MAX_VERTEX_SIZE);
 }

--- a/tests/functional/sokol_shape_test.c
+++ b/tests/functional/sokol_shape_test.c
@@ -168,7 +168,7 @@ UTEST(sokol_shape, torus_buffer_sizes) {
 }
 
 UTEST(sokol_shape, buffer_layout_desc) {
-    sshape_state_t shp = {0};
+    sshape_state_t shp = { .valid = true };
     const sg_vertex_buffer_layout_state l_state = sshape_vertex_buffer_layout_state(&shp);
     T(SSHAPE_MAX_VERTEX_SIZE == l_state.stride);
     T(0 == l_state.step_func);
@@ -176,7 +176,7 @@ UTEST(sokol_shape, buffer_layout_desc) {
 }
 
 UTEST(sokol_shape, attr_descs) {
-    sshape_state_t shp = {0};
+    sshape_state_t shp = { .valid = true };
     {
         const sg_vertex_attr_state a_state = sshape_position_vertex_attr_state(&shp);
         T(0 == a_state.offset);

--- a/tests/functional/sokol_shape_test.c
+++ b/tests/functional/sokol_shape_test.c
@@ -90,136 +90,138 @@ UTEST(sokol_shape, mat4_transpose) {
 UTEST(sokol_shape, plane_buffer_sizes) {
     sshape_sizes_t res;
 
-    res = sshape_plane_sizes(1);
+    res = sshape_plane_sizes(1, SSHAPE_MAX_VERTEX_SIZE);
     T(4 == res.vertices.num);
     T(6 == res.indices.num);
-    T(res.vertices.num * sizeof(sshape_vertex_t) == res.vertices.size);
+    T(res.vertices.num * SSHAPE_MAX_VERTEX_SIZE == res.vertices.size);
     T(res.indices.num * sizeof(uint16_t) == res.indices.size);
 
-    res = sshape_plane_sizes(2);
+    res = sshape_plane_sizes(2, SSHAPE_MAX_VERTEX_SIZE);
     T(9 == res.vertices.num);
     T(24 == res.indices.num);
-    T(res.vertices.num * sizeof(sshape_vertex_t) == res.vertices.size);
+    T(res.vertices.num * SSHAPE_MAX_VERTEX_SIZE== res.vertices.size);
     T(res.indices.num * sizeof(uint16_t) == res.indices.size);
 }
 
 UTEST(sokol_shape, box_buffer_sizes) {
     sshape_sizes_t res;
 
-    res = sshape_box_sizes(1);
+    res = sshape_box_sizes(1, SSHAPE_MAX_VERTEX_SIZE);
     T(24 == res.vertices.num);
     T(36 == res.indices.num);
-    T(res.vertices.num * sizeof(sshape_vertex_t) == res.vertices.size);
+    T(res.vertices.num * SSHAPE_MAX_VERTEX_SIZE == res.vertices.size);
     T(res.indices.num * sizeof(uint16_t) == res.indices.size);
 
-    res = sshape_box_sizes(2);
+    res = sshape_box_sizes(2, SSHAPE_MAX_VERTEX_SIZE);
     T(54 == res.vertices.num);
     T(144 == res.indices.num);
-    T(res.vertices.num * sizeof(sshape_vertex_t) == res.vertices.size);
+    T(res.vertices.num * SSHAPE_MAX_VERTEX_SIZE == res.vertices.size);
     T(res.indices.num * sizeof(uint16_t) == res.indices.size);
 }
 
 UTEST(sokol_shape, sphere_buffer_sizes) {
     sshape_sizes_t res;
 
-    res = sshape_sphere_sizes(3, 2);
+    res = sshape_sphere_sizes(3, 2, SSHAPE_MAX_VERTEX_SIZE);
     T(12 == res.vertices.num);
     T(18 == res.indices.num);
-    T(res.vertices.num * sizeof(sshape_vertex_t) == res.vertices.size);
+    T(res.vertices.num * SSHAPE_MAX_VERTEX_SIZE == res.vertices.size);
     T(res.indices.num * sizeof(uint16_t) == res.indices.size);
 
-    res = sshape_sphere_sizes(36, 12);
+    res = sshape_sphere_sizes(36, 12, SSHAPE_MAX_VERTEX_SIZE);
     T(481 ==  res.vertices.num);
     T(2376 == res.indices.num);
-    T(res.vertices.num * sizeof(sshape_vertex_t) == res.vertices.size);
+    T(res.vertices.num * SSHAPE_MAX_VERTEX_SIZE== res.vertices.size);
     T(res.indices.num * sizeof(uint16_t) == res.indices.size);
 }
 
 UTEST(sokol_shape, cylinder_buffer_sizes) {
     sshape_sizes_t res;
 
-    res = sshape_cylinder_sizes(3, 1);
+    res = sshape_cylinder_sizes(3, 1, SSHAPE_MAX_VERTEX_SIZE);
     T(24 == res.vertices.num);
     T(36 == res.indices.num);
-    T(res.vertices.num * sizeof(sshape_vertex_t) == res.vertices.size);
+    T(res.vertices.num * SSHAPE_MAX_VERTEX_SIZE == res.vertices.size);
     T(res.indices.num * sizeof(uint16_t) == res.indices.size);
 
-    res = sshape_cylinder_sizes(5, 2);
+    res = sshape_cylinder_sizes(5, 2, SSHAPE_MAX_VERTEX_SIZE);
     T(42 == res.vertices.num);
     T(90 == res.indices.num);
-    T(res.vertices.num * sizeof(sshape_vertex_t) == res.vertices.size);
+    T(res.vertices.num * SSHAPE_MAX_VERTEX_SIZE == res.vertices.size);
     T(res.indices.num * sizeof(uint16_t) == res.indices.size);
 }
 
 UTEST(sokol_shape, torus_buffer_sizes) {
     sshape_sizes_t res;
 
-    res = sshape_torus_sizes(3, 3);
+    res = sshape_torus_sizes(3, 3, SSHAPE_MAX_VERTEX_SIZE);
     T(16 == res.vertices.num);
     T(54 == res.indices.num);
-    T(res.vertices.num * sizeof(sshape_vertex_t) == res.vertices.size);
+    T(res.vertices.num * SSHAPE_MAX_VERTEX_SIZE == res.vertices.size);
     T(res.indices.num * sizeof(uint16_t) == res.indices.size);
 
-    res = sshape_torus_sizes(4, 5);
+    res = sshape_torus_sizes(4, 5, SSHAPE_MAX_VERTEX_SIZE);
     T(30 == res.vertices.num);
     T(120 == res.indices.num);
-    T(res.vertices.num * sizeof(sshape_vertex_t) == res.vertices.size);
+    T(res.vertices.num * SSHAPE_MAX_VERTEX_SIZE == res.vertices.size);
     T(res.indices.num * sizeof(uint16_t) == res.indices.size);
 }
 
 UTEST(sokol_shape, buffer_layout_desc) {
-    const sg_vertex_buffer_layout_state l_state = sshape_vertex_buffer_layout_state();
-    T(sizeof(sshape_vertex_t) == l_state.stride);
+    sshape_state_t shp = {0};
+    const sg_vertex_buffer_layout_state l_state = sshape_vertex_buffer_layout_state(&shp);
+    T(SSHAPE_MAX_VERTEX_SIZE == l_state.stride);
     T(0 == l_state.step_func);
     T(0 == l_state.step_rate);
 }
 
 UTEST(sokol_shape, attr_descs) {
+    sshape_state_t shp = {0};
     {
-        const sg_vertex_attr_state a_state = sshape_position_vertex_attr_state();
-        T(offsetof(sshape_vertex_t, x) == a_state.offset);
+        const sg_vertex_attr_state a_state = sshape_position_vertex_attr_state(&shp);
+        T(0 == a_state.offset);
         T(SG_VERTEXFORMAT_FLOAT3 == a_state.format);
         T(0 == a_state.buffer_index);
     }
     {
-        const sg_vertex_attr_state a_state = sshape_normal_vertex_attr_state();
-        T(offsetof(sshape_vertex_t, normal) == a_state.offset);
+        const sg_vertex_attr_state a_state = sshape_normal_vertex_attr_state(&shp);
+        T(12 == a_state.offset);
         T(SG_VERTEXFORMAT_BYTE4N == a_state.format);
         T(0 == a_state.buffer_index);
     }
     {
-        const sg_vertex_attr_state a_state = sshape_texcoord_vertex_attr_state();
-        T(offsetof(sshape_vertex_t, u) == a_state.offset);
+        const sg_vertex_attr_state a_state = sshape_texcoord_vertex_attr_state(&shp);
+        T(16 == a_state.offset);
         T(SG_VERTEXFORMAT_USHORT2N == a_state.format);
         T(0 == a_state.buffer_index);
     }
     {
-        const sg_vertex_attr_state a_state = sshape_color_vertex_attr_state();
-        T(offsetof(sshape_vertex_t, color) == a_state.offset);
+        const sg_vertex_attr_state a_state = sshape_color_vertex_attr_state(&shp);
+        T(20 == a_state.offset);
         T(SG_VERTEXFORMAT_UBYTE4N == a_state.format);
         T(0 == a_state.buffer_index);
     }
 }
 
 UTEST(sokol_shape, buffer_descs_elm_range) {
-    sshape_vertex_t vx[128] = { 0 };
+    uint8_t vx[SSHAPE_MAX_VERTEX_SIZE * 128] = { 0 };
     uint16_t ix[128] = { 0 };
-    sshape_buffer_t buf = {
+    sshape_state_t shp = {
         .vertices.buffer = SSHAPE_RANGE(vx),
         .indices.buffer = SSHAPE_RANGE(ix),
     };
 
     // build a box...
     {
-        buf = sshape_build_box(&buf, &(sshape_box_t) {0});
-        const sg_buffer_desc vbuf_desc = sshape_vertex_buffer_desc(&buf);
-        const sg_buffer_desc ibuf_desc = sshape_index_buffer_desc(&buf);
-        const sshape_element_range_t elm_range = sshape_element_range(&buf);
+        sshape_build_box(&shp, &(sshape_box_t) {0});
+        const sg_buffer_desc vbuf_desc = sshape_vertex_buffer_desc(&shp);
+        const sg_buffer_desc ibuf_desc = sshape_index_buffer_desc(&shp);
+        const sshape_element_range_t elm_range = sshape_element_range(&shp);
         T(vbuf_desc.size == 0);
         T(vbuf_desc.usage.vertex_buffer);
         T(vbuf_desc.usage.immutable);
         T(vbuf_desc.data.ptr == vx);
-        T(vbuf_desc.data.size == 24 * sizeof(sshape_vertex_t));
+        T(vbuf_desc.data.size == 24 * SSHAPE_MAX_VERTEX_SIZE);
         T(ibuf_desc.size == 0);
         T(ibuf_desc.usage.index_buffer);
         T(ibuf_desc.usage.immutable);
@@ -231,15 +233,15 @@ UTEST(sokol_shape, buffer_descs_elm_range) {
 
     // append a plane...
     {
-        buf = sshape_build_plane(&buf, &(sshape_plane_t) {0});
-        const sg_buffer_desc vbuf_desc = sshape_vertex_buffer_desc(&buf);
-        const sg_buffer_desc ibuf_desc = sshape_index_buffer_desc(&buf);
-        const sshape_element_range_t elm_range = sshape_element_range(&buf);
+        sshape_build_plane(&shp, &(sshape_plane_t) {0});
+        const sg_buffer_desc vbuf_desc = sshape_vertex_buffer_desc(&shp);
+        const sg_buffer_desc ibuf_desc = sshape_index_buffer_desc(&shp);
+        const sshape_element_range_t elm_range = sshape_element_range(&shp);
         T(vbuf_desc.size == 0);
         T(vbuf_desc.usage.vertex_buffer);
         T(vbuf_desc.usage.immutable);
         T(vbuf_desc.data.ptr == vx);
-        T(vbuf_desc.data.size == 28 * sizeof(sshape_vertex_t));
+        T(vbuf_desc.data.size == 28 * SSHAPE_MAX_VERTEX_SIZE);
         T(ibuf_desc.size == 0);
         T(ibuf_desc.usage.index_buffer);
         T(ibuf_desc.usage.immutable);
@@ -251,22 +253,24 @@ UTEST(sokol_shape, buffer_descs_elm_range) {
 }
 
 UTEST(sokol_shape, build_plane_defaults) {
-    sshape_vertex_t vx[64] = { 0 };
+    uint8_t vx[SSHAPE_MAX_VERTEX_SIZE * 64] = { 0 };
     uint16_t ix[64] = { 0 };
 
-    sshape_buffer_t buf = {
+    sshape_state_t shp = {
         .vertices.buffer = SSHAPE_RANGE(vx),
         .indices.buffer  = SSHAPE_RANGE(ix),
     };
-    buf = sshape_build_plane(&buf, &(sshape_plane_t) { 0 });
+    sshape_build_plane(&shp, &(sshape_plane_t) { 0 });
 
-    T(buf.valid);
-    T(0 == buf.vertices.shape_offset);
-    T(4 * sizeof(sshape_vertex_t) == buf.vertices.data_size);
-    T(0 == buf.indices.shape_offset);
-    T(6 * sizeof(uint16_t) == buf.indices.data_size);
+    T(shp.valid);
+    T(0 == shp.vertices.shape_offset);
+    T(4 * SSHAPE_MAX_VERTEX_SIZE == shp.vertices.data_size);
+    T(0 == shp.indices.shape_offset);
+    T(6 * sizeof(uint16_t) == shp.indices.data_size);
     for (int i = 0; i < 4; i++) {
-        T(vx[i].color == 0xFFFFFFFF);
+        uint32_t* c_ptr = (uint32_t*)&(vx[i * SSHAPE_MAX_VERTEX_SIZE + 20]);
+        const uint32_t c = *c_ptr;
+        T(c == 0xFFFFFFFF);
     }
     T(ix[0] == 0);
     T(ix[1] == 1);
@@ -277,145 +281,148 @@ UTEST(sokol_shape, build_plane_defaults) {
 }
 
 UTEST(sokol_shape, build_plane_validate) {
-    sshape_vertex_t vx[64] = { 0 };
+    uint8_t vx[SSHAPE_MAX_VERTEX_SIZE * 64] = { 0 };
     uint16_t ix[64] = { 0 };
     const sshape_plane_t params = { 0 };
 
     // vertex buffer too small
     {
-        sshape_buffer_t buf = {
-            .vertices.buffer = { .ptr = vx, .size = 3 * sizeof(sshape_vertex_t) },
+        sshape_state_t shp = {
+            .vertices.buffer = { .ptr = vx, .size = 3 * SSHAPE_MAX_VERTEX_SIZE },
             .indices.buffer  = SSHAPE_RANGE(ix),
         };
-        T(!sshape_build_plane(&buf, &params).valid);
+        sshape_build_plane(&shp, &params);
+        T(!shp.valid);
     }
 
     // index buffer too small
     {
-        sshape_buffer_t buf = {
+        sshape_state_t shp = {
             .vertices.buffer = SSHAPE_RANGE(vx),
             .indices.buffer  = { .ptr = ix, .size = 5 * sizeof(uint16_t) }
         };
-        T(!sshape_build_plane(&buf, &params).valid);
+        sshape_build_plane(&shp, &params);
+        T(!shp.valid);
     }
     // just the right size
     {
-        sshape_buffer_t buf = {
-            .vertices.buffer = { .ptr = vx, .size = 4 * sizeof(sshape_vertex_t) },
+        sshape_state_t shp = {
+            .vertices.buffer = { .ptr = vx, .size = 4 * SSHAPE_MAX_VERTEX_SIZE },
             .indices.buffer  = { .ptr = ix, .size = 6 * sizeof(uint16_t) }
         };
-        T(sshape_build_plane(&buf, &params).valid);
+        sshape_build_plane(&shp, &params);
+        T(shp.valid);
     }
 
     // too small for two planes
     {
-        sshape_buffer_t buf = {
-            .vertices.buffer = { .ptr = vx, .size = 5 * sizeof(sshape_vertex_t) },
+        sshape_state_t shp = {
+            .vertices.buffer = { .ptr = vx, .size = 5 * SSHAPE_MAX_VERTEX_SIZE },
             .indices.buffer  = { .ptr = ix, .size = 7 * sizeof(uint16_t) }
         };
-        buf = sshape_build_plane(&buf, &params);
-        T(buf.valid);
-        buf = sshape_build_plane(&buf, &params);
-        T(!buf.valid);
+        sshape_build_plane(&shp, &params);
+        T(shp.valid);
+        sshape_build_plane(&shp, &params);
+        T(!shp.valid);
     }
 
     // just the right size for two planes
     {
-        sshape_buffer_t buf = {
-            .vertices.buffer = { .ptr = vx, .size = 8 * sizeof(sshape_vertex_t) },
+        sshape_state_t shp = {
+            .vertices.buffer = { .ptr = vx, .size = 8 * SSHAPE_MAX_VERTEX_SIZE },
             .indices.buffer  = { .ptr = ix, .size = 12 * sizeof(uint16_t) }
         };
-        buf = sshape_build_plane(&buf, &params);
-        T(buf.valid);
-        T(buf.vertices.shape_offset == 0);
-        T(buf.vertices.data_size == 4 * sizeof(sshape_vertex_t));
-        T(buf.indices.shape_offset == 0);
-        T(buf.indices.data_size == 6 * sizeof(uint16_t));
-        buf = sshape_build_plane(&buf, &params);
-        T(buf.valid);
-        T(buf.vertices.shape_offset == 4 * sizeof(sshape_vertex_t));
-        T(buf.vertices.data_size == 8 * sizeof(sshape_vertex_t));
-        T(buf.indices.shape_offset == 6 * sizeof(uint16_t));
-        T(buf.indices.data_size == 12 * sizeof(uint16_t));
+        sshape_build_plane(&shp, &params);
+        T(shp.valid);
+        T(shp.vertices.shape_offset == 0);
+        T(shp.vertices.data_size == 4 * SSHAPE_MAX_VERTEX_SIZE);
+        T(shp.indices.shape_offset == 0);
+        T(shp.indices.data_size == 6 * sizeof(uint16_t));
+        sshape_build_plane(&shp, &params);
+        T(shp.valid);
+        T(shp.vertices.shape_offset == 4 * SSHAPE_MAX_VERTEX_SIZE);
+        T(shp.vertices.data_size == 8 * SSHAPE_MAX_VERTEX_SIZE);
+        T(shp.indices.shape_offset == 6 * sizeof(uint16_t));
+        T(shp.indices.data_size == 12 * sizeof(uint16_t));
     }
 }
 
 UTEST(sokol_shape, build_box_defaults) {
-    sshape_vertex_t vx[128] = { 0 };
+    uint8_t vx[SSHAPE_MAX_VERTEX_SIZE * 128] = { 0 };
     uint16_t ix[128] = { 0 };
 
-    sshape_buffer_t buf = {
+    sshape_state_t shp = {
         .vertices.buffer = SSHAPE_RANGE(vx),
         .indices.buffer  = SSHAPE_RANGE(ix),
     };
-    buf = sshape_build_box(&buf, &(sshape_box_t) { .color = 0xFF0000FF });
-    T(buf.valid);
-    T(buf.vertices.buffer.ptr == vx);
-    T(buf.vertices.buffer.size == sizeof(vx));
-    T(buf.indices.buffer.ptr == ix);
-    T(buf.indices.buffer.size == sizeof(ix));
-    T(buf.vertices.shape_offset == 0);
-    T(buf.vertices.data_size == 24 * sizeof(sshape_vertex_t));
-    T(buf.indices.shape_offset == 0);
-    T(buf.indices.data_size == 36 * sizeof(uint16_t));
+    sshape_build_box(&shp, &(sshape_box_t) { .color = 0xFF0000FF });
+    T(shp.valid);
+    T(shp.vertices.buffer.ptr == vx);
+    T(shp.vertices.buffer.size == sizeof(vx));
+    T(shp.indices.buffer.ptr == ix);
+    T(shp.indices.buffer.size == sizeof(ix));
+    T(shp.vertices.shape_offset == 0);
+    T(shp.vertices.data_size == 24 * SSHAPE_MAX_VERTEX_SIZE);
+    T(shp.indices.shape_offset == 0);
+    T(shp.indices.data_size == 36 * sizeof(uint16_t));
 }
 
 UTEST(sokol_shape, build_sphere_defaults) {
-    sshape_vertex_t vx[128] = { 0 };
+    uint8_t vx[SSHAPE_MAX_VERTEX_SIZE * 128] = { 0 };
     uint16_t ix[128] = { 0 };
 
-    sshape_buffer_t buf = {
+    sshape_state_t shp = {
         .vertices.buffer = SSHAPE_RANGE(vx),
         .indices.buffer  = SSHAPE_RANGE(ix),
     };
-    buf = sshape_build_sphere(&buf, &(sshape_sphere_t) { .color = 0xFF0000FF });
-    T(buf.valid);
-    T(buf.vertices.buffer.ptr == vx);
-    T(buf.vertices.buffer.size == sizeof(vx));
-    T(buf.indices.buffer.ptr == ix);
-    T(buf.indices.buffer.size == sizeof(ix));
-    T(buf.vertices.shape_offset == 0);
-    T(buf.vertices.data_size == 30 * sizeof(sshape_vertex_t));
-    T(buf.indices.shape_offset == 0);
-    T(buf.indices.data_size == 90 * sizeof(uint16_t));
+    sshape_build_sphere(&shp, &(sshape_sphere_t) { .color = 0xFF0000FF });
+    T(shp.valid);
+    T(shp.vertices.buffer.ptr == vx);
+    T(shp.vertices.buffer.size == sizeof(vx));
+    T(shp.indices.buffer.ptr == ix);
+    T(shp.indices.buffer.size == sizeof(ix));
+    T(shp.vertices.shape_offset == 0);
+    T(shp.vertices.data_size == 30 * SSHAPE_MAX_VERTEX_SIZE);
+    T(shp.indices.shape_offset == 0);
+    T(shp.indices.data_size == 90 * sizeof(uint16_t));
 }
 
 UTEST(sokol_shape, build_cylinder_defaults) {
-    sshape_vertex_t vx[128] = { 0 };
+    uint8_t vx[SSHAPE_MAX_VERTEX_SIZE * 128] = { 0 };
     uint16_t ix[128] = { 0 };
 
-    sshape_buffer_t buf = {
+    sshape_state_t shp = {
         .vertices.buffer = SSHAPE_RANGE(vx),
         .indices.buffer  = SSHAPE_RANGE(ix)
     };
-    buf = sshape_build_cylinder(&buf, &(sshape_cylinder_t) { .color = 0xFF0000FF });
-    T(buf.valid);
-    T(buf.vertices.buffer.ptr == vx);
-    T(buf.vertices.buffer.size == sizeof(vx));
-    T(buf.indices.buffer.ptr == ix);
-    T(buf.indices.buffer.size == sizeof(ix));
-    T(buf.vertices.shape_offset == 0);
-    T(buf.vertices.data_size == 36 * sizeof(sshape_vertex_t));
-    T(buf.indices.shape_offset == 0);
-    T(buf.indices.data_size == 60 * sizeof(uint16_t));
+    sshape_build_cylinder(&shp, &(sshape_cylinder_t) { .color = 0xFF0000FF });
+    T(shp.valid);
+    T(shp.vertices.buffer.ptr == vx);
+    T(shp.vertices.buffer.size == sizeof(vx));
+    T(shp.indices.buffer.ptr == ix);
+    T(shp.indices.buffer.size == sizeof(ix));
+    T(shp.vertices.shape_offset == 0);
+    T(shp.vertices.data_size == 36 * SSHAPE_MAX_VERTEX_SIZE);
+    T(shp.indices.shape_offset == 0);
+    T(shp.indices.data_size == 60 * sizeof(uint16_t));
 }
 
 UTEST(sokol_shape, build_torus_defaults) {
-    sshape_vertex_t vx[128] = { 0 };
+    uint8_t vx[SSHAPE_MAX_VERTEX_SIZE * 128] = { 0 };
     uint16_t ix[256] = { 0 };
 
-    sshape_buffer_t buf = {
+    sshape_state_t shp = {
         .vertices.buffer = SSHAPE_RANGE(vx),
         .indices.buffer  = SSHAPE_RANGE(ix),
     };
-    buf = sshape_build_torus(&buf, &(sshape_torus_t) { .color = 0xFF0000FF });
-    T(buf.valid);
-    T(buf.vertices.buffer.ptr == vx);
-    T(buf.vertices.buffer.size == sizeof(vx));
-    T(buf.indices.buffer.ptr == ix);
-    T(buf.indices.buffer.size == sizeof(ix));
-    T(buf.vertices.shape_offset == 0);
-    T(buf.vertices.data_size == 36 * sizeof(sshape_vertex_t));
-    T(buf.indices.shape_offset == 0);
-    T(buf.indices.data_size == 150 * sizeof(uint16_t));
+    sshape_build_torus(&shp, &(sshape_torus_t) { .color = 0xFF0000FF });
+    T(shp.valid);
+    T(shp.vertices.buffer.ptr == vx);
+    T(shp.vertices.buffer.size == sizeof(vx));
+    T(shp.indices.buffer.ptr == ix);
+    T(shp.indices.buffer.size == sizeof(ix));
+    T(shp.vertices.shape_offset == 0);
+    T(shp.vertices.data_size == 36 * SSHAPE_MAX_VERTEX_SIZE);
+    T(shp.indices.shape_offset == 0);
+    T(shp.indices.data_size == 150 * sizeof(uint16_t));
 }

--- a/util/sokol_shape.h
+++ b/util/sokol_shape.h
@@ -406,10 +406,12 @@ typedef struct sshape_range_t {
 #define SSHAPE_RANGE(x) (sshape_range_t){ &x, sizeof(x) }
 #endif
 
-// the minumum vertex size in bytes (when no optional components are used)
-#define SSHAPE_MIN_VERTEX_SIZE (12)
-// the maximum vertex size in bytes (when all optional components are used)
-#define SSHAPE_MAX_VERTEX_SIZE (24)
+enum {
+    // the minumum vertex size in bytes (when no optional components are used)
+    SSHAPE_MIN_VERTEX_SIZE = 12,
+    // the maximum vertex size in bytes (when all optional components are used)
+    SSHAPE_MAX_VERTEX_SIZE = 24,
+};
 
 // a 4x4 matrix wrapper struct
 typedef struct sshape_mat4_t { float m[4][4]; } sshape_mat4_t;

--- a/util/sokol_shape.h
+++ b/util/sokol_shape.h
@@ -391,39 +391,43 @@ extern "C" {
     (array or struct), use the SSHAPE_RANGE() macro to build
     an sshape_range struct.
 */
-typedef struct sshape_range {
+typedef struct sshape_range_t {
     const void* ptr;
     size_t size;
-} sshape_range;
+} sshape_range_t;
 
 // disabling this for every includer isn't great, but the warning is also quite pointless
 #if defined(_MSC_VER)
 #pragma warning(disable:4221)   /* /W4 only: nonstandard extension used: 'x': cannot be initialized using address of automatic variable 'y' */
 #endif
 #if defined(__cplusplus)
-#define SSHAPE_RANGE(x) sshape_range{ &x, sizeof(x) }
+#define SSHAPE_RANGE(x) sshape_range_t{ &x, sizeof(x) }
 #else
-#define SSHAPE_RANGE(x) (sshape_range){ &x, sizeof(x) }
+#define SSHAPE_RANGE(x) (sshape_range_t){ &x, sizeof(x) }
 #endif
 
-/* a 4x4 matrix wrapper struct */
+// the minumum vertex size in bytes (when no optional components are used)
+#define SSHAPE_MIN_VERTEX_SIZE (12)
+// the maximum vertex size in bytes (when all optional components are used)
+#define SSHAPE_MAX_VERTEX_SIZE (24)
+
+// a 4x4 matrix wrapper struct
 typedef struct sshape_mat4_t { float m[4][4]; } sshape_mat4_t;
 
-/* vertex layout of the generated geometry */
-typedef struct sshape_vertex_t {
-    float x, y, z;
-    uint32_t normal;        // packed normal as BYTE4N
-    uint16_t u, v;          // packed uv coords as USHORT2N
-    uint32_t color;         // packed color as UBYTE4N (r,g,b,a);
-} sshape_vertex_t;
+// a struct for configuring optional vertex components
+typedef struct sshape_optional_components_t {
+    bool normals;
+    bool texcoords;
+    bool colors;
+} sshape_optional_components_t;
 
-/* a range of draw-elements (sg_draw(int base_element, int num_element, ...)) */
+// a range of draw-elements (sg_draw(int base_element, int num_element, ...))
 typedef struct sshape_element_range_t {
     int base_element;
     int num_elements;
 } sshape_element_range_t;
 
-/* number of elements and byte size of build actions */
+// number of elements and byte size of build actions
 typedef struct sshape_sizes_item_t {
     uint32_t num;       // number of elements
     uint32_t size;      // the same as size in bytes
@@ -434,20 +438,21 @@ typedef struct sshape_sizes_t {
     sshape_sizes_item_t indices;
 } sshape_sizes_t;
 
-/* in/out struct to keep track of mesh-build state */
+// in/out struct to keep track of mesh-build state
 typedef struct sshape_buffer_item_t {
-    sshape_range buffer;    // pointer/size pair of output buffer
+    sshape_range_t buffer;  // pointer/size pair of output buffer
     size_t data_size;       // size in bytes of valid data in buffer
     size_t shape_offset;    // data offset of the most recent shape
 } sshape_buffer_item_t;
 
-typedef struct sshape_buffer_t {
+typedef struct sshape_state_t {
     bool valid;
-    sshape_buffer_item_t vertices;
-    sshape_buffer_item_t indices;
-} sshape_buffer_t;
+    sshape_optional_components_t disable;
+    sshape_buffer_item_t vertices;  // memory buffer for vertex data
+    sshape_buffer_item_t indices;   // memory buffer for index data
+} sshape_state_t;
 
-/* creation parameters for the different shape types */
+// creation parameters for the different shape types
 typedef struct sshape_plane_t {
     float width, depth;             // default: 1.0
     uint16_t tiles;                 // default: 1
@@ -498,37 +503,40 @@ typedef struct sshape_torus_t {
     sshape_mat4_t transform;        // default: identity matrix
 } sshape_torus_t;
 
-/* shape builder functions */
-SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_plane(const sshape_buffer_t* buf, const sshape_plane_t* params);
-SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_box(const sshape_buffer_t* buf, const sshape_box_t* params);
-SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_sphere(const sshape_buffer_t* buf, const sshape_sphere_t* params);
-SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_cylinder(const sshape_buffer_t* buf, const sshape_cylinder_t* params);
-SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_torus(const sshape_buffer_t* buf, const sshape_torus_t* params);
+// shape builder functions
+SOKOL_SHAPE_API_DECL void sshape_build_plane(sshape_state_t* state, const sshape_plane_t* params);
+SOKOL_SHAPE_API_DECL void sshape_build_box(sshape_state_t* state, const sshape_box_t* params);
+SOKOL_SHAPE_API_DECL void sshape_build_sphere(sshape_state_t* state, const sshape_sphere_t* params);
+SOKOL_SHAPE_API_DECL void sshape_build_cylinder(sshape_state_t* state, const sshape_cylinder_t* params);
+SOKOL_SHAPE_API_DECL void sshape_build_torus(sshape_state_t* state, const sshape_torus_t* params);
 
-/* query required vertex- and index-buffer sizes in bytes */
-SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_plane_sizes(uint32_t tiles);
-SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_box_sizes(uint32_t tiles);
-SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_sphere_sizes(uint32_t slices, uint32_t stacks);
-SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_cylinder_sizes(uint32_t slices, uint32_t stacks);
-SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_torus_sizes(uint32_t sides, uint32_t rings);
+// compute size of vertex given optional components
+SOKOL_SHAPE_API_DECL size_t sshape_vertex_size(const sshape_optional_components_t* components);
 
-/* extract sokol-gfx desc structs and primitive ranges from build state */
-SOKOL_SHAPE_API_DECL sshape_element_range_t sshape_element_range(const sshape_buffer_t* buf);
-SOKOL_SHAPE_API_DECL sg_buffer_desc sshape_vertex_buffer_desc(const sshape_buffer_t* buf);
-SOKOL_SHAPE_API_DECL sg_buffer_desc sshape_index_buffer_desc(const sshape_buffer_t* buf);
-SOKOL_SHAPE_API_DECL sg_vertex_buffer_layout_state sshape_vertex_buffer_layout_state(void);
-SOKOL_SHAPE_API_DECL sg_vertex_attr_state sshape_position_vertex_attr_state(void);
-SOKOL_SHAPE_API_DECL sg_vertex_attr_state sshape_normal_vertex_attr_state(void);
-SOKOL_SHAPE_API_DECL sg_vertex_attr_state sshape_texcoord_vertex_attr_state(void);
-SOKOL_SHAPE_API_DECL sg_vertex_attr_state sshape_color_vertex_attr_state(void);
+// query required vertex- and index-buffer sizes in bytes
+SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_plane_sizes(uint32_t tiles, size_t vertex_size);
+SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_box_sizes(uint32_t tiles, size_t vetrex_size);
+SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_sphere_sizes(uint32_t slices, uint32_t stacks, size_t vertex_size);
+SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_cylinder_sizes(uint32_t slices, uint32_t stacks, size_t vertex_size);
+SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_torus_sizes(uint32_t sides, uint32_t rings, size_t vertex_size);
 
-/* helper functions to build packed color value from floats or bytes */
+// extract sokol-gfx desc structs and primitive ranges from build state
+SOKOL_SHAPE_API_DECL sshape_element_range_t sshape_element_range(const sshape_state_t* state);
+SOKOL_SHAPE_API_DECL sg_buffer_desc sshape_vertex_buffer_desc(const sshape_state_t* state);
+SOKOL_SHAPE_API_DECL sg_buffer_desc sshape_index_buffer_desc(const sshape_state_t* state);
+SOKOL_SHAPE_API_DECL sg_vertex_buffer_layout_state sshape_vertex_buffer_layout_state(const sshape_state_t* state);
+SOKOL_SHAPE_API_DECL sg_vertex_attr_state sshape_position_vertex_attr_state(const sshape_state_t* state);
+SOKOL_SHAPE_API_DECL sg_vertex_attr_state sshape_normal_vertex_attr_state(const sshape_state_t* state);
+SOKOL_SHAPE_API_DECL sg_vertex_attr_state sshape_texcoord_vertex_attr_state(const sshape_state_t* state);
+SOKOL_SHAPE_API_DECL sg_vertex_attr_state sshape_color_vertex_attr_state(const sshape_state_t* state);
+
+// helper functions to build packed color value from floats or bytes
 SOKOL_SHAPE_API_DECL uint32_t sshape_color_4f(float r, float g, float b, float a);
 SOKOL_SHAPE_API_DECL uint32_t sshape_color_3f(float r, float g, float b);
 SOKOL_SHAPE_API_DECL uint32_t sshape_color_4b(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 SOKOL_SHAPE_API_DECL uint32_t sshape_color_3b(uint8_t r, uint8_t g, uint8_t b);
 
-/* adapter function for filling matrix struct from generic float[16] array */
+// adapter function for filling matrix struct from generic float[16] array
 SOKOL_SHAPE_API_DECL sshape_mat4_t sshape_mat4(const float m[16]);
 SOKOL_SHAPE_API_DECL sshape_mat4_t sshape_mat4_transpose(const float m[16]);
 
@@ -706,11 +714,64 @@ static bool _sshape_validate_buffer_item(const sshape_buffer_item_t* item, uint3
     return true;
 }
 
-static bool _sshape_validate_buffer(const sshape_buffer_t* buf, uint32_t num_vertices, uint32_t num_indices) {
-    if (!_sshape_validate_buffer_item(&buf->vertices, num_vertices * sizeof(sshape_vertex_t))) {
+static size_t _sshape_vertex_size(bool has_normals, bool has_texcoords, bool has_colors) {
+    size_t s = 3 * sizeof(float);
+    if (has_normals) {
+        s += sizeof(uint32_t);
+    }
+    if (has_texcoords) {
+        s += 2 * sizeof(uint16_t);
+    }
+    if (has_colors) {
+        s += sizeof(uint32_t);
+    }
+    return s;
+}
+
+static int _sshape_vertex_position_offset(const sshape_state_t* state) {
+    (void)state;
+    return 0;
+}
+
+static int _sshape_vertex_normal_offset(const sshape_state_t* state) {
+    SOKOL_ASSERT(!state->disable.normals);
+    return 3 * sizeof(float);
+}
+
+static int _sshape_vertex_texcoord_offset(const sshape_state_t* state) {
+    SOKOL_ASSERT(!state->disable.texcoords);
+    int offset = 3 * sizeof(float);
+    if (!state->disable.normals) {
+        offset += sizeof(uint32_t);
+    }
+    return offset;
+}
+
+static int _sshape_vertex_color_offset(const sshape_state_t* state) {
+    SOKOL_ASSERT(!state->disable.colors);
+    int offset = 3 * sizeof(float);
+    if (!state->disable.normals) {
+        offset += sizeof(uint32_t);
+    }
+    if (!state->disable.texcoords) {
+        offset += 2 * sizeof(uint16_t);
+    }
+    return offset;
+}
+
+static size_t _sshape_vertex_size_from_state(const sshape_state_t* state) {
+    const bool has_normals = !state->disable.normals;
+    const bool has_texcoords = !state->disable.texcoords;
+    const bool has_colors = !state->disable.colors;
+    return _sshape_vertex_size(has_normals, has_texcoords, has_colors);
+}
+
+static bool _sshape_validate_state(const sshape_state_t* state, uint32_t num_vertices, uint32_t num_indices) {
+    const size_t vertex_size = _sshape_vertex_size_from_state(state);
+    if (!_sshape_validate_buffer_item(&state->vertices, num_vertices * vertex_size)) {
         return false;
     }
-    if (!_sshape_validate_buffer_item(&buf->indices, num_indices * sizeof(uint16_t))) {
+    if (!_sshape_validate_buffer_item(&state->indices, num_indices * sizeof(uint16_t))) {
         return false;
     }
     return true;
@@ -720,8 +781,9 @@ static void _sshape_advance_offset(sshape_buffer_item_t* item) {
     item->shape_offset = item->data_size;
 }
 
-static uint16_t _sshape_base_index(const sshape_buffer_t* buf) {
-    return (uint16_t) (buf->vertices.data_size / sizeof(sshape_vertex_t));
+static uint16_t _sshape_base_index(const sshape_state_t* state) {
+    const size_t vertex_size = _sshape_vertex_size_from_state(state);
+    return (uint16_t) (state->vertices.data_size / vertex_size);
 }
 
 static sshape_plane_t _sshape_plane_defaults(const sshape_plane_t* params) {
@@ -777,25 +839,32 @@ static sshape_torus_t _sshape_torus_defaults(const sshape_torus_t* params) {
     return res;
 }
 
-static void _sshape_add_vertex(sshape_buffer_t* buf, _sshape_vec4_t pos, _sshape_vec4_t norm, _sshape_vec2_t uv, uint32_t color) {
-    size_t offset = buf->vertices.data_size;
-    SOKOL_ASSERT((offset + sizeof(sshape_vertex_t)) <= buf->vertices.buffer.size);
-    buf->vertices.data_size += sizeof(sshape_vertex_t);
-    sshape_vertex_t* v_ptr = (sshape_vertex_t*) ((uint8_t*)buf->vertices.buffer.ptr + offset);
-    v_ptr->x = pos.x;
-    v_ptr->y = pos.y;
-    v_ptr->z = pos.z;
-    v_ptr->normal = _sshape_pack_f4_byte4n(norm.x, norm.y, norm.z, norm.w);
-    v_ptr->u = _sshape_pack_f_ushortn(uv.x);
-    v_ptr->v = _sshape_pack_f_ushortn(uv.y);
-    v_ptr->color = color;
+static void _sshape_add_vertex(sshape_state_t* state, _sshape_vec4_t pos, _sshape_vec4_t norm, _sshape_vec2_t uv, uint32_t color) {
+    size_t offset = state->vertices.data_size;
+    const size_t vertex_size = _sshape_vertex_size_from_state(state);
+    SOKOL_ASSERT((offset + vertex_size) <= state->vertices.buffer.size);
+    state->vertices.data_size += vertex_size;
+    uint8_t* dst_ptr = (uint8_t*)state->vertices.buffer.ptr + offset;
+    *(float*)dst_ptr = pos.x; dst_ptr += sizeof(float);
+    *(float*)dst_ptr = pos.y; dst_ptr += sizeof(float);
+    *(float*)dst_ptr = pos.z; dst_ptr += sizeof(float);
+    if (!state->disable.normals) {
+        *(uint32_t*)dst_ptr = _sshape_pack_f4_byte4n(norm.x, norm.y, norm.z, norm.w); dst_ptr += sizeof(uint32_t);
+    }
+    if (!state->disable.texcoords) {
+        *(uint16_t*)dst_ptr = _sshape_pack_f_ushortn(uv.x); dst_ptr += sizeof(uint16_t);
+        *(uint16_t*)dst_ptr = _sshape_pack_f_ushortn(uv.y); dst_ptr += sizeof(uint16_t);
+    }
+    if (!state->disable.colors) {
+        *(uint32_t*)dst_ptr = color; dst_ptr += sizeof(uint32_t);
+    }
 }
 
-static void _sshape_add_triangle(sshape_buffer_t* buf, uint16_t i0, uint16_t i1, uint16_t i2) {
-    size_t offset = buf->indices.data_size;
-    SOKOL_ASSERT((offset + 3*sizeof(uint16_t)) <= buf->indices.buffer.size);
-    buf->indices.data_size += 3*sizeof(uint16_t);
-    uint16_t* i_ptr = (uint16_t*) ((uint8_t*)buf->indices.buffer.ptr + offset);
+static void _sshape_add_triangle(sshape_state_t* state, uint16_t i0, uint16_t i1, uint16_t i2) {
+    size_t offset = state->indices.data_size;
+    SOKOL_ASSERT((offset + 3*sizeof(uint16_t)) <= state->indices.buffer.size);
+    state->indices.data_size += 3*sizeof(uint16_t);
+    uint16_t* i_ptr = (uint16_t*) ((uint8_t*)state->indices.buffer.ptr + offset);
     i_ptr[0] = i0;
     i_ptr[1] = i1;
     i_ptr[2] = i2;
@@ -848,52 +917,62 @@ SOKOL_API_IMPL sshape_mat4_t sshape_mat4_transpose(const float m[16]) {
     return res;
 }
 
-SOKOL_API_IMPL sshape_sizes_t sshape_plane_sizes(uint32_t tiles) {
+SOKOL_API_IMPL size_t sshape_vertex_size(const sshape_optional_components_t* comps) {
+    SOKOL_ASSERT(comps);
+    return _sshape_vertex_size(comps->normals, comps->texcoords, comps->colors);
+}
+
+SOKOL_API_IMPL sshape_sizes_t sshape_plane_sizes(uint32_t tiles, size_t vertex_size) {
     SOKOL_ASSERT(tiles >= 1);
+    SOKOL_ASSERT((vertex_size >= SSHAPE_MIN_VERTEX_SIZE) && (vertex_size <= SSHAPE_MAX_VERTEX_SIZE));
     sshape_sizes_t res = { {0} };
     res.vertices.num = _sshape_plane_num_vertices(tiles);
     res.indices.num = _sshape_plane_num_indices(tiles);
-    res.vertices.size = res.vertices.num * sizeof(sshape_vertex_t);
+    res.vertices.size = res.vertices.num * vertex_size;
     res.indices.size = res.indices.num * sizeof(uint16_t);
     return res;
 }
 
-SOKOL_API_IMPL sshape_sizes_t sshape_box_sizes(uint32_t tiles) {
+SOKOL_API_IMPL sshape_sizes_t sshape_box_sizes(uint32_t tiles, size_t vertex_size) {
     SOKOL_ASSERT(tiles >= 1);
+    SOKOL_ASSERT((vertex_size >= SSHAPE_MIN_VERTEX_SIZE) && (vertex_size <= SSHAPE_MAX_VERTEX_SIZE));
     sshape_sizes_t res = { {0} };
     res.vertices.num = _sshape_box_num_vertices(tiles);
     res.indices.num = _sshape_box_num_indices(tiles);
-    res.vertices.size = res.vertices.num * sizeof(sshape_vertex_t);
+    res.vertices.size = res.vertices.num * vertex_size;
     res.indices.size = res.indices.num * sizeof(uint16_t);
     return res;
 }
 
-SOKOL_API_IMPL sshape_sizes_t sshape_sphere_sizes(uint32_t slices, uint32_t stacks) {
+SOKOL_API_IMPL sshape_sizes_t sshape_sphere_sizes(uint32_t slices, uint32_t stacks, size_t vertex_size) {
     SOKOL_ASSERT((slices >= 3) && (stacks >= 2));
+    SOKOL_ASSERT((vertex_size >= SSHAPE_MIN_VERTEX_SIZE) && (vertex_size <= SSHAPE_MAX_VERTEX_SIZE));
     sshape_sizes_t res = { {0} };
     res.vertices.num = _sshape_sphere_num_vertices(slices, stacks);
     res.indices.num = _sshape_sphere_num_indices(slices, stacks);
-    res.vertices.size = res.vertices.num * sizeof(sshape_vertex_t);
+    res.vertices.size = res.vertices.num * vertex_size;
     res.indices.size = res.indices.num * sizeof(uint16_t);
     return res;
 }
 
-SOKOL_API_IMPL sshape_sizes_t sshape_cylinder_sizes(uint32_t slices, uint32_t stacks) {
+SOKOL_API_IMPL sshape_sizes_t sshape_cylinder_sizes(uint32_t slices, uint32_t stacks, size_t vertex_size) {
     SOKOL_ASSERT((slices >= 3) && (stacks >= 1));
+    SOKOL_ASSERT((vertex_size >= SSHAPE_MIN_VERTEX_SIZE) && (vertex_size <= SSHAPE_MAX_VERTEX_SIZE));
     sshape_sizes_t res = { {0} };
     res.vertices.num = _sshape_cylinder_num_vertices(slices, stacks);
     res.indices.num = _sshape_cylinder_num_indices(slices, stacks);
-    res.vertices.size = res.vertices.num * sizeof(sshape_vertex_t);
+    res.vertices.size = res.vertices.num * vertex_size;
     res.indices.size = res.indices.num * sizeof(uint16_t);
     return res;
 }
 
-SOKOL_API_IMPL sshape_sizes_t sshape_torus_sizes(uint32_t sides, uint32_t rings) {
+SOKOL_API_IMPL sshape_sizes_t sshape_torus_sizes(uint32_t sides, uint32_t rings, size_t vertex_size) {
     SOKOL_ASSERT((sides >= 3) && (rings >= 3));
+    SOKOL_ASSERT((vertex_size >= SSHAPE_MIN_VERTEX_SIZE) && (vertex_size <= SSHAPE_MAX_VERTEX_SIZE));
     sshape_sizes_t res = { {0} };
     res.vertices.num = _sshape_torus_num_vertices(sides, rings);
     res.indices.num = _sshape_torus_num_indices(sides, rings);
-    res.vertices.size = res.vertices.num * sizeof(sshape_vertex_t);
+    res.vertices.size = res.vertices.num * vertex_size;
     res.indices.size = res.indices.num * sizeof(uint16_t);
     return res;
 }
@@ -914,21 +993,20 @@ SOKOL_API_IMPL sshape_sizes_t sshape_torus_sizes(uint32_t sides, uint32_t rings)
     | \| \| \| \|
     +--+--+--+--+
 */
-SOKOL_API_IMPL sshape_buffer_t sshape_build_plane(const sshape_buffer_t* in_buf, const sshape_plane_t* in_params) {
-    SOKOL_ASSERT(in_buf && in_params);
+SOKOL_API_IMPL void sshape_build_plane(sshape_state_t* state, const sshape_plane_t* in_params) {
+    SOKOL_ASSERT(state && in_params);
     const sshape_plane_t params = _sshape_plane_defaults(in_params);
     const uint32_t num_vertices = _sshape_plane_num_vertices(params.tiles);
     const uint32_t num_indices = _sshape_plane_num_indices(params.tiles);
-    sshape_buffer_t buf = *in_buf;
-    if (!_sshape_validate_buffer(&buf, num_vertices, num_indices)) {
-        buf.valid = false;
-        return buf;
+    if (!_sshape_validate_state(state, num_vertices, num_indices)) {
+        state->valid = false;
+        return;
     }
-    buf.valid = true;
-    const uint16_t start_index = _sshape_base_index(&buf);
+    state->valid = true;
+    const uint16_t start_index = _sshape_base_index(state);
     if (!params.merge) {
-        _sshape_advance_offset(&buf.vertices);
-        _sshape_advance_offset(&buf.indices);
+        _sshape_advance_offset(&state->vertices);
+        _sshape_advance_offset(&state->indices);
     }
 
     // write vertices
@@ -945,7 +1023,7 @@ SOKOL_API_IMPL sshape_buffer_t sshape_build_plane(const sshape_buffer_t* in_buf,
             const _sshape_vec4_t tpos = _sshape_mat4_mul(&params.transform, pos);
             const _sshape_vec2_t uv = _sshape_vec2(duv*ix, duv*iz);
             const uint32_t color = params.random_colors ? _sshape_rand_color(&rand_seed) : params.color;
-            _sshape_add_vertex(&buf, tpos, tnorm, uv, color);
+            _sshape_add_vertex(state, tpos, tnorm, uv, color);
         }
     }
 
@@ -956,28 +1034,26 @@ SOKOL_API_IMPL sshape_buffer_t sshape_build_plane(const sshape_buffer_t* in_buf,
             const uint16_t i1 = i0 + 1;
             const uint16_t i2 = i0 + params.tiles + 1;
             const uint16_t i3 = i2 + 1;
-            _sshape_add_triangle(&buf, i0, i1, i3);
-            _sshape_add_triangle(&buf, i0, i3, i2);
+            _sshape_add_triangle(state, i0, i1, i3);
+            _sshape_add_triangle(state, i0, i3, i2);
         }
     }
-    return buf;
 }
 
-SOKOL_API_IMPL sshape_buffer_t sshape_build_box(const sshape_buffer_t* in_buf, const sshape_box_t* in_params) {
-    SOKOL_ASSERT(in_buf && in_params);
+SOKOL_API_IMPL void sshape_build_box(sshape_state_t* state, const sshape_box_t* in_params) {
+    SOKOL_ASSERT(state && in_params);
     const sshape_box_t params = _sshape_box_defaults(in_params);
     const uint32_t num_vertices = _sshape_box_num_vertices(params.tiles);
     const uint32_t num_indices = _sshape_box_num_indices(params.tiles);
-    sshape_buffer_t buf = *in_buf;
-    if (!_sshape_validate_buffer(&buf, num_vertices, num_indices)) {
-        buf.valid = false;
-        return buf;
+    if (!_sshape_validate_state(state, num_vertices, num_indices)) {
+        state->valid = false;
+        return;
     }
-    buf.valid = true;
-    const uint16_t start_index = _sshape_base_index(&buf);
+    state->valid = true;
+    const uint16_t start_index = _sshape_base_index(state);
     if (!params.merge) {
-        _sshape_advance_offset(&buf.vertices);
-        _sshape_advance_offset(&buf.indices);
+        _sshape_advance_offset(&state->vertices);
+        _sshape_advance_offset(&state->indices);
     }
 
     // build vertices
@@ -1005,7 +1081,7 @@ SOKOL_API_IMPL sshape_buffer_t sshape_build_box(const sshape_buffer_t* in_buf, c
                 const _sshape_vec4_t tpos = _sshape_mat4_mul(&params.transform, pos);
                 const _sshape_vec2_t uv = _sshape_vec2(ix * duv, iz * duv);
                 const uint32_t color = params.random_colors ? _sshape_rand_color(&rand_seed) : params.color;
-                _sshape_add_vertex(&buf, tpos, tnorm, uv, color);
+                _sshape_add_vertex(state, tpos, tnorm, uv, color);
             }
         }
     }
@@ -1022,7 +1098,7 @@ SOKOL_API_IMPL sshape_buffer_t sshape_build_box(const sshape_buffer_t* in_buf, c
                 const _sshape_vec4_t tpos = _sshape_mat4_mul(&params.transform, pos);
                 const _sshape_vec2_t uv = _sshape_vec2(iy * duv, iz * duv);
                 const uint32_t color = params.random_colors ? _sshape_rand_color(&rand_seed) : params.color;
-                _sshape_add_vertex(&buf, tpos, tnorm, uv, color);
+                _sshape_add_vertex(state, tpos, tnorm, uv, color);
             }
         }
     }
@@ -1039,7 +1115,7 @@ SOKOL_API_IMPL sshape_buffer_t sshape_build_box(const sshape_buffer_t* in_buf, c
                 const _sshape_vec4_t tpos = _sshape_mat4_mul(&params.transform, pos);
                 const _sshape_vec2_t uv = _sshape_vec2(ix * duv, iy * duv);
                 const uint32_t color = params.random_colors ? _sshape_rand_color(&rand_seed) : params.color;
-                _sshape_add_vertex(&buf, tpos, tnorm, uv, color);
+                _sshape_add_vertex(state, tpos, tnorm, uv, color);
             }
         }
     }
@@ -1054,12 +1130,11 @@ SOKOL_API_IMPL sshape_buffer_t sshape_build_box(const sshape_buffer_t* in_buf, c
                 const uint16_t i1 = i0 + 1;
                 const uint16_t i2 = i0 + params.tiles + 1;
                 const uint16_t i3 = i2 + 1;
-                _sshape_add_triangle(&buf, i0, i1, i3);
-                _sshape_add_triangle(&buf, i0, i3, i2);
+                _sshape_add_triangle(state, i0, i1, i3);
+                _sshape_add_triangle(state, i0, i3, i2);
             }
         }
     }
-    return buf;
 }
 
 /*
@@ -1079,21 +1154,20 @@ SOKOL_API_IMPL sshape_buffer_t sshape_build_box(const sshape_buffer_t* in_buf, c
       \| \| \| \| \|
     +  +  +  +  +  +        south pole
 */
-SOKOL_API_IMPL sshape_buffer_t sshape_build_sphere(const sshape_buffer_t* in_buf, const sshape_sphere_t* in_params) {
-    SOKOL_ASSERT(in_buf && in_params);
+SOKOL_API_IMPL void sshape_build_sphere(sshape_state_t* state, const sshape_sphere_t* in_params) {
+    SOKOL_ASSERT(state && in_params);
     const sshape_sphere_t params = _sshape_sphere_defaults(in_params);
     const uint32_t num_vertices = _sshape_sphere_num_vertices(params.slices, params.stacks);
     const uint32_t num_indices = _sshape_sphere_num_indices(params.slices, params.stacks);
-    sshape_buffer_t buf = *in_buf;
-    if (!_sshape_validate_buffer(&buf, num_vertices, num_indices)) {
-        buf.valid = false;
-        return buf;
+    if (!_sshape_validate_state(state, num_vertices, num_indices)) {
+        state->valid = false;
+        return;
     }
-    buf.valid = true;
-    const uint16_t start_index = _sshape_base_index(&buf);
+    state->valid = true;
+    const uint16_t start_index = _sshape_base_index(state);
     if (!params.merge) {
-        _sshape_advance_offset(&buf.vertices);
-        _sshape_advance_offset(&buf.indices);
+        _sshape_advance_offset(&state->vertices);
+        _sshape_advance_offset(&state->indices);
     }
 
     uint32_t rand_seed = 0x12345678;
@@ -1117,7 +1191,7 @@ SOKOL_API_IMPL sshape_buffer_t sshape_build_sphere(const sshape_buffer_t* in_buf
             const _sshape_vec4_t tpos = _sshape_mat4_mul(&params.transform, pos);
             const _sshape_vec2_t uv = _sshape_vec2(1.0f - slice * du, 1.0f - stack * dv);
             const uint32_t color = params.random_colors ? _sshape_rand_color(&rand_seed) : params.color;
-            _sshape_add_vertex(&buf, tpos, tnorm, uv, color);
+            _sshape_add_vertex(state, tpos, tnorm, uv, color);
         }
     }
 
@@ -1127,7 +1201,7 @@ SOKOL_API_IMPL sshape_buffer_t sshape_build_sphere(const sshape_buffer_t* in_buf
         const uint16_t row_a = start_index;
         const uint16_t row_b = row_a + params.slices + 1;
         for (uint16_t slice = 0; slice < params.slices; slice++) {
-            _sshape_add_triangle(&buf, row_a + slice, row_b + slice, row_b + slice + 1);
+            _sshape_add_triangle(state, row_a + slice, row_b + slice, row_b + slice + 1);
         }
     }
     // stack triangles
@@ -1135,8 +1209,8 @@ SOKOL_API_IMPL sshape_buffer_t sshape_build_sphere(const sshape_buffer_t* in_buf
         const uint16_t row_a = start_index + stack * (params.slices + 1);
         const uint16_t row_b = row_a + params.slices + 1;
         for (uint16_t slice = 0; slice < params.slices; slice++) {
-            _sshape_add_triangle(&buf, row_a + slice, row_b + slice + 1, row_a + slice + 1);
-            _sshape_add_triangle(&buf, row_a + slice, row_b + slice, row_b + slice + 1);
+            _sshape_add_triangle(state, row_a + slice, row_b + slice + 1, row_a + slice + 1);
+            _sshape_add_triangle(state, row_a + slice, row_b + slice, row_b + slice + 1);
         }
     }
     {
@@ -1144,10 +1218,9 @@ SOKOL_API_IMPL sshape_buffer_t sshape_build_sphere(const sshape_buffer_t* in_buf
         const uint16_t row_a = start_index + (params.stacks - 1) * (params.slices + 1);
         const uint16_t row_b = row_a + params.slices + 1;
         for (uint16_t slice = 0; slice < params.slices; slice++) {
-            _sshape_add_triangle(&buf, row_a + slice, row_b + slice + 1, row_a + slice + 1);
+            _sshape_add_triangle(state, row_a + slice, row_b + slice + 1, row_a + slice + 1);
         }
     }
-    return buf;
 }
 
 /*
@@ -1169,17 +1242,17 @@ SOKOL_API_IMPL sshape_buffer_t sshape_build_sphere(const sshape_buffer_t* in_buf
       \| \| \| \| \|
     +  +  +  +  +  +
 */
-static void _sshape_build_cylinder_cap_pole(sshape_buffer_t* buf, const sshape_cylinder_t* params, float pos_y, float norm_y, float du, float v, uint32_t* rand_seed) {
+static void _sshape_build_cylinder_cap_pole(sshape_state_t* state, const sshape_cylinder_t* params, float pos_y, float norm_y, float du, float v, uint32_t* rand_seed) {
     const _sshape_vec4_t tnorm = _sshape_vec4_norm(_sshape_mat4_mul(&params->transform, _sshape_vec4(0.0f, norm_y, 0.0f, 0.0f)));
     const _sshape_vec4_t tpos = _sshape_mat4_mul(&params->transform, _sshape_vec4(0.0f, pos_y, 0.0f, 1.0f));
     for (uint32_t slice = 0; slice <= params->slices; slice++) {
         const _sshape_vec2_t uv = _sshape_vec2(slice * du, 1.0f - v);
         const uint32_t color = params->random_colors ? _sshape_rand_color(rand_seed) : params->color;
-        _sshape_add_vertex(buf, tpos, tnorm, uv, color);
+        _sshape_add_vertex(state, tpos, tnorm, uv, color);
     }
 }
 
-static void _sshape_build_cylinder_cap_ring(sshape_buffer_t* buf, const sshape_cylinder_t* params, float pos_y, float norm_y, float du, float v, uint32_t* rand_seed) {
+static void _sshape_build_cylinder_cap_ring(sshape_state_t* state, const sshape_cylinder_t* params, float pos_y, float norm_y, float du, float v, uint32_t* rand_seed) {
     const float two_pi = 2.0f * 3.14159265358979323846f;
     const _sshape_vec4_t tnorm = _sshape_vec4_norm(_sshape_mat4_mul(&params->transform, _sshape_vec4(0.0f, norm_y, 0.0f, 0.0f)));
     for (uint32_t slice = 0; slice <= params->slices; slice++) {
@@ -1190,25 +1263,24 @@ static void _sshape_build_cylinder_cap_ring(sshape_buffer_t* buf, const sshape_c
         const _sshape_vec4_t tpos = _sshape_mat4_mul(&params->transform, pos);
         const _sshape_vec2_t uv = _sshape_vec2(slice * du, 1.0f - v);
         const uint32_t color = params->random_colors ? _sshape_rand_color(rand_seed) : params->color;
-        _sshape_add_vertex(buf, tpos, tnorm, uv, color);
+        _sshape_add_vertex(state, tpos, tnorm, uv, color);
     }
 }
 
-SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_cylinder(const sshape_buffer_t* in_buf, const sshape_cylinder_t* in_params) {
-    SOKOL_ASSERT(in_buf && in_params);
+SOKOL_SHAPE_API_DECL void sshape_build_cylinder(sshape_state_t* state, const sshape_cylinder_t* in_params) {
+    SOKOL_ASSERT(state && in_params);
     const sshape_cylinder_t params = _sshape_cylinder_defaults(in_params);
     const uint32_t num_vertices = _sshape_cylinder_num_vertices(params.slices, params.stacks);
     const uint32_t num_indices = _sshape_cylinder_num_indices(params.slices, params.stacks);
-    sshape_buffer_t buf = *in_buf;
-    if (!_sshape_validate_buffer(&buf, num_vertices, num_indices)) {
-        buf.valid = false;
-        return buf;
+    if (!_sshape_validate_state(state, num_vertices, num_indices)) {
+        state->valid = false;
+        return;
     }
-    buf.valid = true;
-    const uint16_t start_index = _sshape_base_index(&buf);
+    state->valid = true;
+    const uint16_t start_index = _sshape_base_index(state);
     if (!params.merge) {
-        _sshape_advance_offset(&buf.vertices);
-        _sshape_advance_offset(&buf.indices);
+        _sshape_advance_offset(&state->vertices);
+        _sshape_advance_offset(&state->indices);
     }
 
     uint32_t rand_seed = 0x12345678;
@@ -1220,8 +1292,8 @@ SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_cylinder(const sshape_buffer_t
     const float dy = params.height / params.stacks;
 
     // generate vertices
-    _sshape_build_cylinder_cap_pole(&buf, &params, y0, 1.0f, du, 0.0f, &rand_seed);
-    _sshape_build_cylinder_cap_ring(&buf, &params, y0, 1.0f, du, dv, &rand_seed);
+    _sshape_build_cylinder_cap_pole(state, &params, y0, 1.0f, du, 0.0f, &rand_seed);
+    _sshape_build_cylinder_cap_ring(state, &params, y0, 1.0f, du, dv, &rand_seed);
     for (uint32_t stack = 0; stack <= params.stacks; stack++) {
         const float y = y0 - dy * stack;
         const float v = dv * stack + dv;
@@ -1235,11 +1307,11 @@ SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_cylinder(const sshape_buffer_t
             const _sshape_vec4_t tnorm = _sshape_vec4_norm(_sshape_mat4_mul(&params.transform, norm));
             const _sshape_vec2_t uv = _sshape_vec2(slice * du, 1.0f - v);
             const uint32_t color = params.random_colors ? _sshape_rand_color(&rand_seed) : params.color;
-            _sshape_add_vertex(&buf, tpos, tnorm, uv, color);
+            _sshape_add_vertex(state, tpos, tnorm, uv, color);
         }
     }
-    _sshape_build_cylinder_cap_ring(&buf, &params, y1, -1.0f, du, 1.0f - dv, &rand_seed);
-    _sshape_build_cylinder_cap_pole(&buf, &params, y1, -1.0f, du, 1.0f, &rand_seed);
+    _sshape_build_cylinder_cap_ring(state, &params, y1, -1.0f, du, 1.0f - dv, &rand_seed);
+    _sshape_build_cylinder_cap_pole(state, &params, y1, -1.0f, du, 1.0f, &rand_seed);
 
     // generate indices
     {
@@ -1247,7 +1319,7 @@ SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_cylinder(const sshape_buffer_t
         const uint16_t row_a = start_index;
         const uint16_t row_b = row_a + params.slices + 1;
         for (uint16_t slice = 0; slice < params.slices; slice++) {
-            _sshape_add_triangle(&buf, row_a + slice, row_b + slice + 1, row_b + slice);
+            _sshape_add_triangle(state, row_a + slice, row_b + slice + 1, row_b + slice);
         }
     }
     // shaft triangles
@@ -1255,8 +1327,8 @@ SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_cylinder(const sshape_buffer_t
         const uint16_t row_a = start_index + (stack + 2) * (params.slices + 1);
         const uint16_t row_b = row_a + params.slices + 1;
         for (uint16_t slice = 0; slice < params.slices; slice++) {
-            _sshape_add_triangle(&buf, row_a + slice, row_a + slice + 1, row_b + slice + 1);
-            _sshape_add_triangle(&buf, row_a + slice, row_b + slice + 1, row_b + slice);
+            _sshape_add_triangle(state, row_a + slice, row_a + slice + 1, row_b + slice + 1);
+            _sshape_add_triangle(state, row_a + slice, row_b + slice + 1, row_b + slice);
         }
     }
     {
@@ -1264,10 +1336,9 @@ SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_cylinder(const sshape_buffer_t
         const uint16_t row_a = start_index + (params.stacks + 3) * (params.slices + 1);
         const uint16_t row_b = row_a + params.slices + 1;
         for (uint16_t slice = 0; slice < params.slices; slice++) {
-            _sshape_add_triangle(&buf, row_a + slice, row_a + slice + 1, row_b + slice + 1);
+            _sshape_add_triangle(state, row_a + slice, row_a + slice + 1, row_b + slice + 1);
         }
     }
-    return buf;
 }
 
 /*
@@ -1287,21 +1358,20 @@ SOKOL_SHAPE_API_DECL sshape_buffer_t sshape_build_cylinder(const sshape_buffer_t
     | \| \| \| \| \|
     +--+--+--+--+--+
 */
-SOKOL_API_IMPL sshape_buffer_t sshape_build_torus(const sshape_buffer_t* in_buf, const sshape_torus_t* in_params) {
-    SOKOL_ASSERT(in_buf && in_params);
+SOKOL_API_IMPL void sshape_build_torus(sshape_state_t* state, const sshape_torus_t* in_params) {
+    SOKOL_ASSERT(state && in_params);
     const sshape_torus_t params = _sshape_torus_defaults(in_params);
     const uint32_t num_vertices = _sshape_torus_num_vertices(params.sides, params.rings);
     const uint32_t num_indices = _sshape_torus_num_indices(params.sides, params.rings);
-    sshape_buffer_t buf = *in_buf;
-    if (!_sshape_validate_buffer(&buf, num_vertices, num_indices)) {
-        buf.valid = false;
-        return buf;
+    if (!_sshape_validate_state(state, num_vertices, num_indices)) {
+        state->valid = false;
+        return;
     }
-    buf.valid = true;
-    const uint16_t start_index = _sshape_base_index(&buf);
+    state->valid = true;
+    const uint16_t start_index = _sshape_base_index(state);
     if (!params.merge) {
-        _sshape_advance_offset(&buf.vertices);
-        _sshape_advance_offset(&buf.indices);
+        _sshape_advance_offset(&state->vertices);
+        _sshape_advance_offset(&state->indices);
     }
 
     uint32_t rand_seed = 0x12345678;
@@ -1335,7 +1405,7 @@ SOKOL_API_IMPL sshape_buffer_t sshape_build_torus(const sshape_buffer_t* in_buf,
             const _sshape_vec4_t tnorm = _sshape_vec4_norm(_sshape_mat4_mul(&params.transform, norm));
             const _sshape_vec2_t uv = _sshape_vec2(ring * du, 1.0f - side * dv);
             const uint32_t color = params.random_colors ? _sshape_rand_color(&rand_seed) : params.color;
-            _sshape_add_vertex(&buf, tpos, tnorm, uv, color);
+            _sshape_add_vertex(state, tpos, tnorm, uv, color);
         }
     }
 
@@ -1344,85 +1414,88 @@ SOKOL_API_IMPL sshape_buffer_t sshape_build_torus(const sshape_buffer_t* in_buf,
         const uint16_t row_a = start_index + side * (params.rings + 1);
         const uint16_t row_b = row_a + params.rings + 1;
         for (uint16_t ring = 0; ring < params.rings; ring++) {
-            _sshape_add_triangle(&buf, row_a + ring, row_a + ring + 1, row_b + ring + 1);
-            _sshape_add_triangle(&buf, row_a + ring, row_b + ring + 1, row_b + ring);
+            _sshape_add_triangle(state, row_a + ring, row_a + ring + 1, row_b + ring + 1);
+            _sshape_add_triangle(state, row_a + ring, row_b + ring + 1, row_b + ring);
         }
     }
-    return buf;
 }
 
-SOKOL_API_IMPL sg_buffer_desc sshape_vertex_buffer_desc(const sshape_buffer_t* buf) {
-    SOKOL_ASSERT(buf && buf->valid);
+SOKOL_API_IMPL sg_buffer_desc sshape_vertex_buffer_desc(const sshape_state_t* state) {
+    SOKOL_ASSERT(state && state->valid);
     sg_buffer_desc desc = { 0 };
-    if (buf->valid) {
+    if (state->valid) {
         desc.usage.vertex_buffer = true;
         desc.usage.immutable = true;
-        desc.data.ptr = buf->vertices.buffer.ptr;
-        desc.data.size = buf->vertices.data_size;
+        desc.data.ptr = state->vertices.buffer.ptr;
+        desc.data.size = state->vertices.data_size;
     }
     return desc;
 }
 
-SOKOL_API_IMPL sg_buffer_desc sshape_index_buffer_desc(const sshape_buffer_t* buf) {
-    SOKOL_ASSERT(buf && buf->valid);
+SOKOL_API_IMPL sg_buffer_desc sshape_index_buffer_desc(const sshape_state_t* state) {
+    SOKOL_ASSERT(state && state->valid);
     sg_buffer_desc desc = { 0 };
-    if (buf->valid) {
+    if (state->valid) {
         desc.usage.index_buffer = true;
         desc.usage.immutable = true;
-        desc.data.ptr = buf->indices.buffer.ptr;
-        desc.data.size = buf->indices.data_size;
+        desc.data.ptr = state->indices.buffer.ptr;
+        desc.data.size = state->indices.data_size;
     }
     return desc;
 }
 
-SOKOL_SHAPE_API_DECL sshape_element_range_t sshape_element_range(const sshape_buffer_t* buf) {
-    SOKOL_ASSERT(buf && buf->valid);
-    SOKOL_ASSERT(buf->indices.shape_offset < buf->indices.data_size);
-    SOKOL_ASSERT(0 == (buf->indices.shape_offset & (sizeof(uint16_t) - 1)));
-    SOKOL_ASSERT(0 == (buf->indices.data_size & (sizeof(uint16_t) - 1)));
+SOKOL_SHAPE_API_DECL sshape_element_range_t sshape_element_range(const sshape_state_t* state) {
+    SOKOL_ASSERT(state && state->valid);
+    SOKOL_ASSERT(state->indices.shape_offset < state->indices.data_size);
+    SOKOL_ASSERT(0 == (state->indices.shape_offset & (sizeof(uint16_t) - 1)));
+    SOKOL_ASSERT(0 == (state->indices.data_size & (sizeof(uint16_t) - 1)));
     sshape_element_range_t range = { 0 };
-    range.base_element = (int) (buf->indices.shape_offset / sizeof(uint16_t));
-    if (buf->valid) {
-        range.num_elements = (int) ((buf->indices.data_size - buf->indices.shape_offset) / sizeof(uint16_t));
-    }
-    else {
-        range.num_elements = 0;
+    if (state->valid) {
+        range.base_element = (int) (state->indices.shape_offset / sizeof(uint16_t));
+        range.num_elements = (int) ((state->indices.data_size - state->indices.shape_offset) / sizeof(uint16_t));
     }
     return range;
 }
 
-SOKOL_API_IMPL sg_vertex_buffer_layout_state sshape_vertex_buffer_layout_state(void) {
-    sg_vertex_buffer_layout_state state = { 0 };
-    state.stride = sizeof(sshape_vertex_t);
-    return state;
+SOKOL_API_IMPL sg_vertex_buffer_layout_state sshape_vertex_buffer_layout_state(const sshape_state_t* state) {
+    SOKOL_ASSERT(state);
+    sg_vertex_buffer_layout_state layout_state = { 0 };
+    layout_state.stride = _sshape_vertex_size_from_state(state);
+    return layout_state;
 }
 
-SOKOL_API_IMPL sg_vertex_attr_state sshape_position_vertex_attr_state(void) {
-    sg_vertex_attr_state state = { 0 };
-    state.offset = offsetof(sshape_vertex_t, x);
-    state.format = SG_VERTEXFORMAT_FLOAT3;
-    return state;
+SOKOL_API_IMPL sg_vertex_attr_state sshape_position_vertex_attr_state(const sshape_state_t* state) {
+    SOKOL_ASSERT(state);
+    sg_vertex_attr_state attr_state = { 0 };
+    attr_state.offset = _sshape_vertex_position_offset(state);
+    attr_state.format = SG_VERTEXFORMAT_FLOAT3;
+    return attr_state;
 }
 
-SOKOL_API_IMPL sg_vertex_attr_state sshape_normal_vertex_attr_state(void) {
-    sg_vertex_attr_state state = { 0 };
-    state.offset = offsetof(sshape_vertex_t, normal);
-    state.format = SG_VERTEXFORMAT_BYTE4N;
-    return state;
+SOKOL_API_IMPL sg_vertex_attr_state sshape_normal_vertex_attr_state(const sshape_state_t* state) {
+    SOKOL_ASSERT(state);
+    sg_vertex_attr_state attr_state = { 0 };
+    if (!state->disable.normals) {
+        attr_state.offset = _sshape_vertex_normal_offset(state);
+        attr_state.format = SG_VERTEXFORMAT_BYTE4N;
+    }
+    return attr_state;
 }
 
-SOKOL_API_IMPL sg_vertex_attr_state sshape_texcoord_vertex_attr_state(void) {
-    sg_vertex_attr_state state = { 0 };
-    state.offset = offsetof(sshape_vertex_t, u);
-    state.format = SG_VERTEXFORMAT_USHORT2N;
-    return state;
+SOKOL_API_IMPL sg_vertex_attr_state sshape_texcoord_vertex_attr_state(const sshape_state_t* state) {
+    SOKOL_ASSERT(state);
+    sg_vertex_attr_state attr_state = { 0 };
+    attr_state.offset = _sshape_vertex_texcoord_offset(state);
+    attr_state.format = SG_VERTEXFORMAT_USHORT2N;
+    return attr_state;
 }
 
-SOKOL_API_IMPL sg_vertex_attr_state sshape_color_vertex_attr_state(void) {
-    sg_vertex_attr_state state = { 0 };
-    state.offset = offsetof(sshape_vertex_t, color);
-    state.format = SG_VERTEXFORMAT_UBYTE4N;
-    return state;
+SOKOL_API_IMPL sg_vertex_attr_state sshape_color_vertex_attr_state(const sshape_state_t* state) {
+    SOKOL_ASSERT(state);
+    sg_vertex_attr_state attr_state = { 0 };
+    attr_state.offset = _sshape_vertex_color_offset(state);
+    attr_state.format = SG_VERTEXFORMAT_UBYTE4N;
+    return attr_state;
 }
 
 #ifdef __clang__

--- a/util/sokol_shape.h
+++ b/util/sokol_shape.h
@@ -714,16 +714,16 @@ static bool _sshape_validate_buffer_item(const sshape_buffer_item_t* item, uint3
     return true;
 }
 
-static size_t _sshape_vertex_size(bool has_normals, bool has_texcoords, bool has_colors) {
-    size_t s = 3 * sizeof(float);
+static uint32_t _sshape_vertex_size(bool has_normals, bool has_texcoords, bool has_colors) {
+    uint32_t s = 3 * (uint32_t)sizeof(float);
     if (has_normals) {
-        s += sizeof(uint32_t);
+        s += (uint32_t)sizeof(uint32_t);
     }
     if (has_texcoords) {
-        s += 2 * sizeof(uint16_t);
+        s += 2 * (uint32_t)sizeof(uint16_t);
     }
     if (has_colors) {
-        s += sizeof(uint32_t);
+        s += (uint32_t)sizeof(uint32_t);
     }
     return s;
 }
@@ -759,7 +759,7 @@ static int _sshape_vertex_color_offset(const sshape_state_t* state) {
     return offset;
 }
 
-static size_t _sshape_vertex_size_from_state(const sshape_state_t* state) {
+static uint32_t _sshape_vertex_size_from_state(const sshape_state_t* state) {
     const bool has_normals = !state->disable.normals;
     const bool has_texcoords = !state->disable.texcoords;
     const bool has_colors = !state->disable.colors;
@@ -767,7 +767,7 @@ static size_t _sshape_vertex_size_from_state(const sshape_state_t* state) {
 }
 
 static bool _sshape_validate_state(const sshape_state_t* state, uint32_t num_vertices, uint32_t num_indices) {
-    const size_t vertex_size = _sshape_vertex_size_from_state(state);
+    const uint32_t vertex_size = (uint32_t)_sshape_vertex_size_from_state(state);
     if (!_sshape_validate_buffer_item(&state->vertices, num_vertices * vertex_size)) {
         return false;
     }
@@ -928,7 +928,7 @@ SOKOL_API_IMPL sshape_sizes_t sshape_plane_sizes(uint32_t tiles, size_t vertex_s
     sshape_sizes_t res = { {0} };
     res.vertices.num = _sshape_plane_num_vertices(tiles);
     res.indices.num = _sshape_plane_num_indices(tiles);
-    res.vertices.size = res.vertices.num * vertex_size;
+    res.vertices.size = res.vertices.num * (uint32_t)vertex_size;
     res.indices.size = res.indices.num * sizeof(uint16_t);
     return res;
 }
@@ -939,7 +939,7 @@ SOKOL_API_IMPL sshape_sizes_t sshape_box_sizes(uint32_t tiles, size_t vertex_siz
     sshape_sizes_t res = { {0} };
     res.vertices.num = _sshape_box_num_vertices(tiles);
     res.indices.num = _sshape_box_num_indices(tiles);
-    res.vertices.size = res.vertices.num * vertex_size;
+    res.vertices.size = res.vertices.num * (uint32_t)vertex_size;
     res.indices.size = res.indices.num * sizeof(uint16_t);
     return res;
 }
@@ -950,7 +950,7 @@ SOKOL_API_IMPL sshape_sizes_t sshape_sphere_sizes(uint32_t slices, uint32_t stac
     sshape_sizes_t res = { {0} };
     res.vertices.num = _sshape_sphere_num_vertices(slices, stacks);
     res.indices.num = _sshape_sphere_num_indices(slices, stacks);
-    res.vertices.size = res.vertices.num * vertex_size;
+    res.vertices.size = res.vertices.num * (uint32_t)vertex_size;
     res.indices.size = res.indices.num * sizeof(uint16_t);
     return res;
 }
@@ -961,7 +961,7 @@ SOKOL_API_IMPL sshape_sizes_t sshape_cylinder_sizes(uint32_t slices, uint32_t st
     sshape_sizes_t res = { {0} };
     res.vertices.num = _sshape_cylinder_num_vertices(slices, stacks);
     res.indices.num = _sshape_cylinder_num_indices(slices, stacks);
-    res.vertices.size = res.vertices.num * vertex_size;
+    res.vertices.size = res.vertices.num * (uint32_t)vertex_size;
     res.indices.size = res.indices.num * sizeof(uint16_t);
     return res;
 }
@@ -972,7 +972,7 @@ SOKOL_API_IMPL sshape_sizes_t sshape_torus_sizes(uint32_t sides, uint32_t rings,
     sshape_sizes_t res = { {0} };
     res.vertices.num = _sshape_torus_num_vertices(sides, rings);
     res.indices.num = _sshape_torus_num_indices(sides, rings);
-    res.vertices.size = res.vertices.num * vertex_size;
+    res.vertices.size = res.vertices.num * (uint32_t)vertex_size;
     res.indices.size = res.indices.num * sizeof(uint16_t);
     return res;
 }

--- a/util/sokol_shape.h
+++ b/util/sokol_shape.h
@@ -73,7 +73,7 @@
     STEP-BY-STEP:
     =============
 
-    Setup an sshape_state_tt struct with pointers to memory buffers where
+    Setup an sshape_state_t struct with pointers to memory buffers where
     generated vertices and indices will be written to:
 
     ```c
@@ -116,7 +116,7 @@
 
     To find out how big the vertex and index memory buffers must be (in case you want
     to allocate dynamically) call the following functions. For `vertex_size`
-    pass in the result of the `sshape_vetrex_size` function:
+    pass in the result of the `sshape_vertex_size` function:
     ```c
     sshape_sizes_t sshape_plane_sizes(uint32_t tiles, size_t vertex_size);
     sshape_sizes_t sshape_box_sizes(uint32_t tiles, size_t vertex_size);
@@ -251,8 +251,7 @@
     ```
 
     The remaining functions are used to populate the vertex-layout item
-    in sg_pipeline_desc, note that these functions don't depend on the
-    created geometry, they always return the same result:
+    in sg_pipeline_desc:
 
     ```c
     sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
@@ -260,7 +259,7 @@
             .buffers[0] = sshape_vertex_buffer_layout_state(&state),
             .attrs = {
                 [0] = sshape_position_vertex_attr_state(&state),
-                [1] = ssape_normal_vertex_attr_state(&state),
+                [1] = sshape_normal_vertex_attr_state(&state),
                 [2] = sshape_texcoord_vertex_attr_state(&state),
                 [3] = sshape_color_vertex_attr_state(&state)
             }
@@ -539,7 +538,7 @@ SOKOL_SHAPE_API_DECL size_t sshape_vertex_size(const sshape_optional_components_
 
 // query required vertex- and index-buffer sizes in bytes
 SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_plane_sizes(uint32_t tiles, size_t vertex_size);
-SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_box_sizes(uint32_t tiles, size_t vetrex_size);
+SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_box_sizes(uint32_t tiles, size_t vertex_size);
 SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_sphere_sizes(uint32_t slices, uint32_t stacks, size_t vertex_size);
 SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_cylinder_sizes(uint32_t slices, uint32_t stacks, size_t vertex_size);
 SOKOL_SHAPE_API_DECL sshape_sizes_t sshape_torus_sizes(uint32_t sides, uint32_t rings, size_t vertex_size);
@@ -807,7 +806,9 @@ static void _sshape_advance_offset(sshape_buffer_state_t* state) {
 
 static uint16_t _sshape_base_index(const sshape_state_t* state) {
     const size_t vertex_size = _sshape_vertex_size_from_state(state);
-    return (uint16_t) (state->vertices.data_size / vertex_size);
+    const size_t base_index = state->vertices.data_size / vertex_size;
+    SOKOL_ASSERT(base_index <= 0xFFFF);
+    return (uint16_t)base_index;
 }
 
 static sshape_plane_t _sshape_plane_defaults(const sshape_plane_t* params) {
@@ -856,8 +857,8 @@ static sshape_torus_t _sshape_torus_defaults(const sshape_torus_t* params) {
     sshape_torus_t res = *params;
     res.radius = _sshape_def_flt(res.radius, 0.5f);
     res.ring_radius = _sshape_def_flt(res.ring_radius, 0.2f);
-    res.sides = _sshape_def_flt(res.sides, 5);
-    res.rings = _sshape_def_flt(res.rings, 5);
+    res.sides = _sshape_def(res.sides, 5);
+    res.rings = _sshape_def(res.rings, 5);
     res.color = _sshape_def(res.color, _sshape_white);
     res.transform = _sshape_mat4_isnull(&res.transform) ? _sshape_mat4_identity() : res.transform;
     return res;
@@ -1291,7 +1292,7 @@ static void _sshape_build_cylinder_cap_ring(sshape_state_t* state, const sshape_
     }
 }
 
-SOKOL_SHAPE_API_DECL void sshape_build_cylinder(sshape_state_t* state, const sshape_cylinder_t* in_params) {
+SOKOL_API_IMPL void sshape_build_cylinder(sshape_state_t* state, const sshape_cylinder_t* in_params) {
     SOKOL_ASSERT(state && in_params);
     const sshape_cylinder_t params = _sshape_cylinder_defaults(in_params);
     const uint32_t num_vertices = _sshape_cylinder_num_vertices(params.slices, params.stacks);
@@ -1468,13 +1469,13 @@ SOKOL_API_IMPL sg_buffer_desc sshape_index_buffer_desc(const sshape_state_t* sta
     return desc;
 }
 
-SOKOL_SHAPE_API_DECL sshape_element_range_t sshape_element_range(const sshape_state_t* state) {
-    SOKOL_ASSERT(state && state->valid);
-    SOKOL_ASSERT(state->indices.shape_offset < state->indices.data_size);
-    SOKOL_ASSERT(0 == (state->indices.shape_offset & (sizeof(uint16_t) - 1)));
-    SOKOL_ASSERT(0 == (state->indices.data_size & (sizeof(uint16_t) - 1)));
+SOKOL_API_IMPL sshape_element_range_t sshape_element_range(const sshape_state_t* state) {
+    SOKOL_ASSERT(state);
     sshape_element_range_t range = { 0 };
     if (state->valid) {
+        SOKOL_ASSERT(state->indices.shape_offset < state->indices.data_size);
+        SOKOL_ASSERT(0 == (state->indices.shape_offset & (sizeof(uint16_t) - 1)));
+        SOKOL_ASSERT(0 == (state->indices.data_size & (sizeof(uint16_t) - 1)));
         range.base_element = (int) (state->indices.shape_offset / sizeof(uint16_t));
         range.num_elements = (int) ((state->indices.data_size - state->indices.shape_offset) / sizeof(uint16_t));
     }
@@ -1482,14 +1483,14 @@ SOKOL_SHAPE_API_DECL sshape_element_range_t sshape_element_range(const sshape_st
 }
 
 SOKOL_API_IMPL sg_vertex_buffer_layout_state sshape_vertex_buffer_layout_state(const sshape_state_t* state) {
-    SOKOL_ASSERT(state);
+    SOKOL_ASSERT(state && state->valid);
     sg_vertex_buffer_layout_state layout_state = { 0 };
     layout_state.stride = _sshape_vertex_size_from_state(state);
     return layout_state;
 }
 
 SOKOL_API_IMPL sg_vertex_attr_state sshape_position_vertex_attr_state(const sshape_state_t* state) {
-    SOKOL_ASSERT(state);
+    SOKOL_ASSERT(state && state->valid);
     sg_vertex_attr_state attr_state = { 0 };
     attr_state.offset = _sshape_vertex_position_offset(state);
     attr_state.format = SG_VERTEXFORMAT_FLOAT3;
@@ -1497,7 +1498,7 @@ SOKOL_API_IMPL sg_vertex_attr_state sshape_position_vertex_attr_state(const ssha
 }
 
 SOKOL_API_IMPL sg_vertex_attr_state sshape_normal_vertex_attr_state(const sshape_state_t* state) {
-    SOKOL_ASSERT(state);
+    SOKOL_ASSERT(state && state->valid);
     sg_vertex_attr_state attr_state = { 0 };
     if (!state->disable.normals) {
         attr_state.offset = _sshape_vertex_normal_offset(state);
@@ -1507,18 +1508,22 @@ SOKOL_API_IMPL sg_vertex_attr_state sshape_normal_vertex_attr_state(const sshape
 }
 
 SOKOL_API_IMPL sg_vertex_attr_state sshape_texcoord_vertex_attr_state(const sshape_state_t* state) {
-    SOKOL_ASSERT(state);
+    SOKOL_ASSERT(state && state->valid);
     sg_vertex_attr_state attr_state = { 0 };
-    attr_state.offset = _sshape_vertex_texcoord_offset(state);
-    attr_state.format = SG_VERTEXFORMAT_USHORT2N;
+    if (!state->disable.texcoords) {
+        attr_state.offset = _sshape_vertex_texcoord_offset(state);
+        attr_state.format = SG_VERTEXFORMAT_USHORT2N;
+    }
     return attr_state;
 }
 
 SOKOL_API_IMPL sg_vertex_attr_state sshape_color_vertex_attr_state(const sshape_state_t* state) {
-    SOKOL_ASSERT(state);
+    SOKOL_ASSERT(state && state->valid);
     sg_vertex_attr_state attr_state = { 0 };
-    attr_state.offset = _sshape_vertex_color_offset(state);
-    attr_state.format = SG_VERTEXFORMAT_UBYTE4N;
+    if (!state->disable.colors) {
+        attr_state.offset = _sshape_vertex_color_offset(state);
+        attr_state.format = SG_VERTEXFORMAT_UBYTE4N;
+    }
     return attr_state;
 }
 

--- a/util/sokol_shape.h
+++ b/util/sokol_shape.h
@@ -734,7 +734,7 @@ static int _sshape_vertex_position_offset(const sshape_state_t* state) {
 }
 
 static int _sshape_vertex_normal_offset(const sshape_state_t* state) {
-    SOKOL_ASSERT(!state->disable.normals);
+    SOKOL_ASSERT(!state->disable.normals); (void)state;
     return 3 * sizeof(float);
 }
 

--- a/util/sokol_shape.h
+++ b/util/sokol_shape.h
@@ -758,14 +758,14 @@ static int _sshape_vertex_position_offset(const sshape_state_t* state) {
 
 static int _sshape_vertex_normal_offset(const sshape_state_t* state) {
     SOKOL_ASSERT(!state->disable.normals); (void)state;
-    return 3 * sizeof(float);
+    return (int)(3 * sizeof(float));
 }
 
 static int _sshape_vertex_texcoord_offset(const sshape_state_t* state) {
     SOKOL_ASSERT(!state->disable.texcoords);
     int offset = 3 * sizeof(float);
     if (!state->disable.normals) {
-        offset += sizeof(uint32_t);
+        offset += (int)sizeof(uint32_t);
     }
     return offset;
 }
@@ -774,10 +774,10 @@ static int _sshape_vertex_color_offset(const sshape_state_t* state) {
     SOKOL_ASSERT(!state->disable.colors);
     int offset = 3 * sizeof(float);
     if (!state->disable.normals) {
-        offset += sizeof(uint32_t);
+        offset += (int)sizeof(uint32_t);
     }
     if (!state->disable.texcoords) {
-        offset += 2 * sizeof(uint16_t);
+        offset += (int)(2 * sizeof(uint16_t));
     }
     return offset;
 }

--- a/util/sokol_shape.h
+++ b/util/sokol_shape.h
@@ -46,14 +46,13 @@
         - cylinder
         - torus (donut)
 
-    Generated vertices look like this:
+    Generated vertex components have the following format (all components
+    except position are optional):
 
-        typedef struct sshape_vertex_t {
-            float x, y, z;
-            uint32_t normal;        // packed normal as BYTE4N
-            uint16_t u, v;          // packed uv coords as USHORT2N
-            uint32_t color;         // packed color as UBYTE4N (r,g,b,a);
-        } sshape_vertex_t;
+    - position: SG_VERTEXFORMAT_FLOAT3
+    - normal: SG_VERTEXFORMAT_BYTE4N
+    - texcoord: SG_VERTEXFORMAT_USHORT2N
+    - color: SG_VERTEXFORMAT_UBYTE4N
 
     Indices are generally 16-bits wide (SG_INDEXTYPE_UINT16) and the indices
     are written as triangle-lists (SG_PRIMITIVETYPE_TRIANGLES).
@@ -74,67 +73,91 @@
     STEP-BY-STEP:
     =============
 
-    Setup an sshape_buffer_t struct with pointers to memory buffers where
+    Setup an sshape_state_tt struct with pointers to memory buffers where
     generated vertices and indices will be written to:
 
     ```c
-    sshape_vertex_t vertices[512];
+    uint8_t vertices[512 * SSHAPE_MAX_VERTEX_SIZE];
     uint16_t indices[4096];
 
-    sshape_buffer_t buf = {
-        .vertices = {
-            .buffer = SSHAPE_RANGE(vertices),
+    sshape_state_t state = {
+        .vertices = { .buffer = SSHAPE_RANGE(vertices) },
+        .indices = { .buffer = SSHAPE_RANGE(indices) }
+    };
+    ```
+    This generates all vertex components. Optionally you can disable
+    vertex components to be generates:
+
+    ```c
+    sshape_state_t state = {
+        .disable {
+            .normals = false,
+            .texcoords = false,
+            .colors = false,
         },
-        .indices = {
-            .buffer = SSHAPE_RANGE(indices),
-        }
+        .vertices = { .buffer = SSHAPE_RANGE(vertices) },
+        .indices = { .buffer = SSHAPE_RANGE(indices) }
     };
     ```
 
-    To find out how big those memory buffers must be (in case you want
-    to allocate dynamically) call the following functions:
+    Compute the per-vertex size in bytes via (note that the arguments
+    have inverted meaning from `sshape_state_t.disabled`, here you define
+    what components are enabled:
 
     ```c
-    sshape_sizes_t sshape_plane_sizes(uint32_t tiles);
-    sshape_sizes_t sshape_box_sizes(uint32_t tiles);
-    sshape_sizes_t sshape_sphere_sizes(uint32_t slices, uint32_t stacks);
-    sshape_sizes_t sshape_cylinder_sizes(uint32_t slices, uint32_t stacks);
-    sshape_sizes_t sshape_torus_sizes(uint32_t sides, uint32_t rings);
+    size_t vertex_size = sshape_vertex_size(&(sshape_optional_components_t){
+        .normals = true,
+        .texcoords = true,
+        .colors = true,
+    });
+    ```
+    This returns a value between SSHAPE_MIN_VERTEX_SIZE (12) and
+    SSHAPE_MAX_VERTEX_SIZE (24).
+
+    To find out how big the vertex and index memory buffers must be (in case you want
+    to allocate dynamically) call the following functions. For `vertex_size`
+    pass in the result of the `sshape_vetrex_size` function:
+    ```c
+    sshape_sizes_t sshape_plane_sizes(uint32_t tiles, size_t vertex_size);
+    sshape_sizes_t sshape_box_sizes(uint32_t tiles, size_t vertex_size);
+    sshape_sizes_t sshape_sphere_sizes(uint32_t slices, uint32_t stacks, size_t vertex_size);
+    sshape_sizes_t sshape_cylinder_sizes(uint32_t slices, uint32_t stacks, size_t vertex_size);
+    sshape_sizes_t sshape_torus_sizes(uint32_t sides, uint32_t rings, size_t vertex_size);
     ```
 
     The returned sshape_sizes_t struct contains vertex- and index-counts
     as well as the equivalent buffer sizes in bytes. For instance:
 
     ```c
-    sshape_sizes_t sizes = sshape_sphere_sizes(36, 12);
+    const vtx_size = sshape_vertex_size(&(sshape_optional_components){0});
+    sshape_sizes_t sizes = sshape_sphere_sizes(36, 12, vtx_size);
     uint32_t num_vertices = sizes.vertices.num;
     uint32_t num_indices = sizes.indices.num;
     uint32_t vertex_buffer_size = sizes.vertices.size;
     uint32_t index_buffer_size = sizes.indices.size;
     ```
 
-    With the sshape_buffer_t struct that was setup earlier, call any
+    With the sshape_state_t struct that was setup earlier, call any
     of the shape-builder functions:
 
     ```c
-    sshape_buffer_t sshape_build_plane(const sshape_buffer_t* buf, const sshape_plane_t* params);
-    sshape_buffer_t sshape_build_box(const sshape_buffer_t* buf, const sshape_box_t* params);
-    sshape_buffer_t sshape_build_sphere(const sshape_buffer_t* buf, const sshape_sphere_t* params);
-    sshape_buffer_t sshape_build_cylinder(const sshape_buffer_t* buf, const sshape_cylinder_t* params);
-    sshape_buffer_t sshape_build_torus(const sshape_buffer_t* buf, const sshape_torus_t* params);
+    void sshape_build_plane(sshape_state_t* state, const sshape_plane_t* params);
+    void sshape_build_box(sshape_state_t* state, const sshape_box_t* params);
+    void sshape_build_sphere(sshape_state_t* state, const sshape_sphere_t* params);
+    void sshape_build_cylinder(sshape_state_t* state, const sshape_cylinder_t* params);
+    void sshape_build_torus(sshape_state_t* state, const sshape_torus_t* params);
     ```
 
-    Note how the sshape_buffer_t struct is both an input value and the
-    return value. This can be used to append multiple shapes into the
-    same vertex- and index-buffers (more on this later).
+    Note that the `state` arg is a non-const pointer, this indicates
+    that the `sshape_state_t` struct will be mutated.
 
     The second argument is a struct which holds creation parameters.
 
     For instance to build a sphere with radius 2, 36 "cake slices" and 12 stacks:
 
     ```c
-    sshape_buffer_t buf = ...;
-    buf = sshape_build_sphere(&buf, &(sshape_sphere_t){
+    sshape_state_t state = ...;
+    sshape_build_sphere(&state, &(sshape_sphere_t){
         .radius = 2.0f,
         .slices = 36,
         .stacks = 12,
@@ -145,7 +168,7 @@
     indices, the "valid" field in the result will be true:
 
     ```c
-    assert(buf.valid);
+    assert(state.valid);
     ```
 
     The shape creation parameters have "useful defaults", refer to the
@@ -157,8 +180,8 @@
     or a 4x4 transform matrix to move, rotate and scale the generated vertices:
 
     ```c
-    sshape_buffer_t buf = ...;
-    buf = sshape_build_sphere(&buf, &(sshape_sphere_t){
+    sshape_state_t state = ...;
+    sshape_build_sphere(&state, &(sshape_sphere_t){
         .radius = 2.0f,
         .slices = 36,
         .stacks = 12,
@@ -176,7 +199,7 @@
             }
         }
     });
-    assert(buf.valid);
+    assert(state.valid);
     ```
 
     The following helper functions can be used to build a packed
@@ -195,21 +218,21 @@
     are used to extract the build result for plugging into sokol_gfx.h:
 
     ```c
-    sshape_element_range_t sshape_element_range(const sshape_buffer_t* buf);
-    sg_buffer_desc sshape_vertex_buffer_desc(const sshape_buffer_t* buf);
-    sg_buffer_desc sshape_index_buffer_desc(const sshape_buffer_t* buf);
-    sg_vertex_buffer_layout_state sshape_vertex_buffer_layout_state(void);
-    sg_vertex_attr_state sshape_position_vertex_attr_state(void);
-    sg_vertex_attr_state sshape_normal_vertex_attr_state(void);
-    sg_vertex_attr_state sshape_texcoord_vertex_attr_state(void);
-    sg_vertex_attr_state sshape_color_vertex_attr_state(void);
+    sshape_element_range_t sshape_element_range(const sshape_state_t* state);
+    sg_buffer_desc sshape_vertex_buffer_desc(const sshape_state_t* state);
+    sg_buffer_desc sshape_index_buffer_desc(const sshape_state_t* state);
+    sg_vertex_buffer_layout_state sshape_vertex_buffer_layout_state(const sshape_state_t* state);
+    sg_vertex_attr_state sshape_position_vertex_attr_state(const sshape_state_t* state);
+    sg_vertex_attr_state sshape_normal_vertex_attr_state(consts sshape_state_t* state);
+    sg_vertex_attr_state sshape_texcoord_vertex_attr_state(const sshape_state_t* state);
+    sg_vertex_attr_state sshape_color_vertex_attr_state(const sshape_state_t* state);
     ```
 
     The sshape_element_range_t struct contains the base-index and number of
     indices which can be plugged into the sg_draw() call:
 
     ```c
-    sshape_element_range_t elms = sshape_element_range(&buf);
+    sshape_element_range_t elms = sshape_element_range(&state);
     ...
     sg_draw(elms.base_element, elms.num_elements, 1);
     ```
@@ -219,11 +242,11 @@
 
     ```c
     // create sokol-gfx vertex buffer
-    sg_buffer_desc vbuf_desc = sshape_vertex_buffer_desc(&buf);
+    sg_buffer_desc vbuf_desc = sshape_vertex_buffer_desc(&state);
     sg_buffer vbuf = sg_make_buffer(&vbuf_desc);
 
     // create sokol-gfx index buffer
-    sg_buffer_desc ibuf_desc = sshape_index_buffer_desc(&buf);
+    sg_buffer_desc ibuf_desc = sshape_index_buffer_desc(&state);
     sg_buffer ibuf = sg_make_buffer(&ibuf_desc);
     ```
 
@@ -234,18 +257,17 @@
     ```c
     sg_pipeline pip = sg_make_pipeline(&(sg_pipeline_desc){
         .layout = {
-            .buffers[0] = sshape_vertex_buffer_layout_state(),
+            .buffers[0] = sshape_vertex_buffer_layout_state(&state),
             .attrs = {
-                [0] = sshape_position_vertex_attr_state(),
-                [1] = ssape_normal_vertex_attr_state(),
-                [2] = sshape_texcoord_vertex_attr_state(),
-                [3] = sshape_color_vertex_attr_state()
+                [0] = sshape_position_vertex_attr_state(&state),
+                [1] = ssape_normal_vertex_attr_state(&state),
+                [2] = sshape_texcoord_vertex_attr_state(&state),
+                [3] = sshape_color_vertex_attr_state(&state)
             }
         },
         ...
     });
     ```
-
     Note that you don't have to use all generated vertex attributes in the
     pipeline's vertex layout, the sg_vertex_buffer_layout_state struct returned
     by sshape_vertex_buffer_layout_state() contains the correct vertex stride
@@ -261,16 +283,16 @@
     in a single draw-call:
 
     ```
-    sshape_vertex_t vertices[128];
+    uint8_t vertices[128 * SSHAPE_MAX_VERTEX_SIZE];
     uint16_t indices[16];
 
-    sshape_buffer_t buf = {
+    sshape_state_t state = {
         .vertices.buffer = SSHAPE_RANGE(vertices),
         .indices.buffer  = SSHAPE_RANGE(indices)
     };
 
     // first cube at pos x=-2.0 (with default size of 1x1x1)
-    buf = sshape_build_cube(&buf, &(sshape_box_t){
+    sshape_build_cube(&state, &(sshape_box_t){
         .transform = {
             .m = {
                 { 1.0f, 0.0f, 0.0f, 0.0f },
@@ -283,7 +305,7 @@
     // ...and append another cube at pos pos=+1.0
     // NOTE the .merge = true, this tells the shape builder
     // function to not advance the current shape start offset
-    buf = sshape_build_cube(&buf, &(sshape_box_t){
+    sshape_build_cube(&state, &(sshape_box_t){
         .merge = true,
         .transform = {
             .m = {
@@ -294,11 +316,11 @@
             }
         }
     });
-    assert(buf.valid);
+    assert(state.valid);
 
     // skipping buffer- and pipeline-creation...
 
-    sshape_element_range_t elms = sshape_element_range(&buf);
+    sshape_element_range_t elms = sshape_element_range(&state);
     sg_draw(elms.base_element, elms.num_elements, 1);
     ```
 
@@ -307,24 +329,24 @@
     builder-functions:
 
     ```c
-    sshape_vertex_t vertices[128];
+    uint8_t vertices[128 * SSHAPE_MAX_VERTEX_SIZE];
     uint16_t indices[16];
-    sshape_buffer_t buf = {
+    sshape_state_t state = {
         .vertices.buffer = SSHAPE_RANGE(vertices),
         .indices.buffer = SSHAPE_RANGE(indices)
     };
 
     // build a red cube...
-    buf = sshape_build_cube(&buf, &(sshape_box_t){
+    sshape_build_cube(&state, &(sshape_box_t){
         .color = sshape_color_3b(255, 0, 0)
     });
-    sshape_element_range_t red_cube = sshape_element_range(&buf);
+    sshape_element_range_t red_cube = sshape_element_range(&state);
 
     // append a green cube to the same vertex-/index-buffer:
-    buf = sshape_build_cube(&bud, &sshape_box_t){
+    sshape_build_cube(&state, &sshape_box_t){
         .color = sshape_color_3b(0, 255, 0);
     });
-    sshape_element_range_t green_cube = sshape_element_range(&buf);
+    sshape_element_range_t green_cube = sshape_element_range(&state);
 
     // skipping buffer- and pipeline-creation...
 
@@ -386,7 +408,7 @@ extern "C" {
 #endif
 
 /*
-    sshape_range is a pointer-size-pair struct used to pass memory
+    sshape_range_t is a pointer-size-pair struct used to pass memory
     blobs into sokol-shape. When initialized from a value type
     (array or struct), use the SSHAPE_RANGE() macro to build
     an sshape_range struct.
@@ -441,17 +463,17 @@ typedef struct sshape_sizes_t {
 } sshape_sizes_t;
 
 // in/out struct to keep track of mesh-build state
-typedef struct sshape_buffer_item_t {
+typedef struct sshape_buffer_state_t {
     sshape_range_t buffer;  // pointer/size pair of output buffer
     size_t data_size;       // size in bytes of valid data in buffer
     size_t shape_offset;    // data offset of the most recent shape
-} sshape_buffer_item_t;
+} sshape_buffer_state_t;
 
 typedef struct sshape_state_t {
     bool valid;
     sshape_optional_components_t disable;
-    sshape_buffer_item_t vertices;  // memory buffer for vertex data
-    sshape_buffer_item_t indices;   // memory buffer for index data
+    sshape_buffer_state_t vertices; // memory buffer for vertex data
+    sshape_buffer_state_t indices;   // memory buffer for index data
 } sshape_state_t;
 
 // creation parameters for the different shape types
@@ -700,17 +722,17 @@ static uint32_t _sshape_torus_num_indices(uint32_t sides, uint32_t rings) {
     return sides * rings * 2 * 3;
 }
 
-static bool _sshape_validate_buffer_item(const sshape_buffer_item_t* item, uint32_t build_size) {
-    if (0 == item->buffer.ptr) {
+static bool _sshape_validate_buffer_state(const sshape_buffer_state_t* state, uint32_t build_size) {
+    if (0 == state->buffer.ptr) {
         return false;
     }
-    if (0 == item->buffer.size) {
+    if (0 == state->buffer.size) {
         return false;
     }
-    if ((item->data_size + build_size) > item->buffer.size) {
+    if ((state->data_size + build_size) > state->buffer.size) {
         return false;
     }
-    if (item->shape_offset > item->data_size) {
+    if (state->shape_offset > state->data_size) {
         return false;
     }
     return true;
@@ -770,17 +792,17 @@ static uint32_t _sshape_vertex_size_from_state(const sshape_state_t* state) {
 
 static bool _sshape_validate_state(const sshape_state_t* state, uint32_t num_vertices, uint32_t num_indices) {
     const uint32_t vertex_size = (uint32_t)_sshape_vertex_size_from_state(state);
-    if (!_sshape_validate_buffer_item(&state->vertices, num_vertices * vertex_size)) {
+    if (!_sshape_validate_buffer_state(&state->vertices, num_vertices * vertex_size)) {
         return false;
     }
-    if (!_sshape_validate_buffer_item(&state->indices, num_indices * sizeof(uint16_t))) {
+    if (!_sshape_validate_buffer_state(&state->indices, num_indices * sizeof(uint16_t))) {
         return false;
     }
     return true;
 }
 
-static void _sshape_advance_offset(sshape_buffer_item_t* item) {
-    item->shape_offset = item->data_size;
+static void _sshape_advance_offset(sshape_buffer_state_t* state) {
+    state->shape_offset = state->data_size;
 }
 
 static uint16_t _sshape_base_index(const sshape_state_t* state) {

--- a/util/sokol_shape.h
+++ b/util/sokol_shape.h
@@ -1485,7 +1485,7 @@ SOKOL_API_IMPL sshape_element_range_t sshape_element_range(const sshape_state_t*
 SOKOL_API_IMPL sg_vertex_buffer_layout_state sshape_vertex_buffer_layout_state(const sshape_state_t* state) {
     SOKOL_ASSERT(state && state->valid);
     sg_vertex_buffer_layout_state layout_state = { 0 };
-    layout_state.stride = _sshape_vertex_size_from_state(state);
+    layout_state.stride = (int)_sshape_vertex_size_from_state(state);
     return layout_state;
 }
 


### PR DESCRIPTION
Breaking update for sokol_app.h which allows to disable optional vertex components (normals, texcoords, colors).



TODO:
- [x] update changelog
- [x] update sokol_shape.h documentation
- [x] fix tests
- [ ] merge sokol-samples branch with new box3d samples
- [x] fix and merge language binding samples:
    - [x] sokol-zig: https://github.com/floooh/sokol-zig/pull/163
    - [x] sokol-odin: https://github.com/floooh/sokol-odin/pull/41
    - [x] sokol-c3: https://github.com/floooh/sokol-c3/pull/14
    - [x] sokol-jai: https://github.com/colinbellino/sokol-jai/pull/11
    - [x] sokol-d: https://github.com/floooh/sokol-d/pull/103
    - [x] sokol-nim: https://github.com/floooh/sokol-nim/pull/41
    - [x] sokol-rust: https://github.com/floooh/sokol-rust/pull/44
