### PR TITLE
sapp: Add generic native_event_cb hook to sapp_desc

### DIFF
--- a/bindgen/gen_c3.py
+++ b/bindgen/gen_c3.py
@@ -112,6 +112,8 @@ aliases = {
         ("StreamCb", "fn void(float*, CInt, CInt)"),
     "void (*)(float *, int, int, void *)":
         ("StreamDataCb", "fn void(float*, CInt, CInt, void*)"),
+    "bool (*)(const void *)":
+        ("NativeEventCb", "fn bool(void*)"),
 }
 
 struct_types = []

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2063,6 +2063,7 @@ typedef struct sapp_desc {
     void (*frame_cb)(void);
     void (*cleanup_cb)(void);
     void (*event_cb)(const sapp_event*);
+    bool (*native_event_cb)(const void* native_event);
 
     void* user_data;                        // these are the user-provided callbacks with user data
     void (*init_userdata_cb)(void*);
@@ -10846,7 +10847,10 @@ _SOKOL_PRIVATE int _sapp_android_input_cb(int fd, int events, void* data) {
             continue;
         }
         int32_t handled = 0;
-        if (_sapp_android_touch_event(event) || _sapp_android_key_event(event)) {
+        if (_sapp.desc.native_event_cb && _sapp.desc.native_event_cb(event)) {
+            handled = 1;
+        }
+        if (!handled && (_sapp_android_touch_event(event) || _sapp_android_key_event(event))) {
             handled = 1;
         }
         AInputQueue_finishEvent(_sapp.android.current.input, event, handled);

--- a/sokol_app.h
+++ b/sokol_app.h
@@ -2058,12 +2058,15 @@ typedef struct sapp_metal_desc {
     bool disable_display_sync;      // feeds into CAMetalLayer.displaySyncEnabled
 } sapp_metal_desc;
 
+typedef struct sapp_android_desc {
+    bool (*native_event_cb)(const void* native_event);
+} sapp_android_desc;
+
 typedef struct sapp_desc {
     void (*init_cb)(void);                  // these are the user-provided callbacks without user data
     void (*frame_cb)(void);
     void (*cleanup_cb)(void);
     void (*event_cb)(const sapp_event*);
-    bool (*native_event_cb)(const void* native_event);
 
     void* user_data;                        // these are the user-provided callbacks with user data
     void (*init_userdata_cb)(void*);
@@ -2098,6 +2101,7 @@ typedef struct sapp_desc {
     sapp_win32_desc win32;
     sapp_html5_desc html5;
     sapp_ios_desc ios;
+    sapp_android_desc android;
 } sapp_desc;
 
 /* HTML5 specific: request and response structs for
@@ -10847,7 +10851,7 @@ _SOKOL_PRIVATE int _sapp_android_input_cb(int fd, int events, void* data) {
             continue;
         }
         int32_t handled = 0;
-        if (_sapp.desc.native_event_cb && _sapp.desc.native_event_cb(event)) {
+        if (_sapp.desc.android.native_event_cb && _sapp.desc.android.native_event_cb(event)) {
             handled = 1;
         }
         if (!handled && (_sapp_android_touch_event(event) || _sapp_android_key_event(event))) {


### PR DESCRIPTION
I am creating an emulator for the Picocomputer 6502 that targets Android with gamepads.  

This is a potential solution that provides a platform-agnostic "escape hatch" allowing applications to intercept raw, OS-level window and input events (e.g.,  AInputEvent*  on Android) before Sokol processes or translates them by adding a generic native event callback ( native_event_cb ) to the  sapp_desc  configuration struct.  If the callback returns true, the event is marked as handled/consumed, and Sokol bypasses its own touch or keyboard translation handlers.  