### PR TITLE
fix sokol_imgui.h for Dear ImGui v1.92.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Updates
 
+### 25-Jul-2026
+
+sokol_imgui.h has been fixed for Dear ImGui v1.92.9: in the result of `ImGui::GetDrawData()`
+call, the `CmdListsCount` item has been obsoleted in favour of `CmdLists.Size`. The symptom
+is that your UI suddenly comes out blank (e.g. no UI rendered).
+
 ### 19-Jul-2026
 
 sokol_shape.h: some breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ sokol_imgui.h has been fixed for Dear ImGui v1.92.9: in the result of `ImGui::Ge
 call, the `CmdListsCount` item has been obsoleted in favour of `CmdLists.Size`. The symptom
 is that your UI suddenly comes out blank (e.g. no UI rendered).
 
+Fixed in PR: https://github.com/floooh/sokol/pull/1555
+
 ### 19-Jul-2026
 
 sokol_shape.h: some breaking changes:

--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -2800,7 +2800,7 @@ SOKOL_API_IMPL void simgui_render(void) {
     }
 
     // catch up with texture updates (important: this needs to happen before
-    // checking the CmdListsCount, otherwise textures might get stuck in
+    // checking the CmdLists.Size, otherwise textures might get stuck in
     // 'WantCreate' state)
     if (draw_data->Textures) {
         for (size_t i = 0; i < (size_t)draw_data->Textures->Size; i++) {
@@ -2812,7 +2812,7 @@ SOKOL_API_IMPL void simgui_render(void) {
     }
 
     // early-out if nothing needs to be rendered
-    if (draw_data->CmdListsCount == 0) {
+    if (draw_data->CmdLists.Size == 0) {
         return;
     }
 
@@ -2824,7 +2824,7 @@ SOKOL_API_IMPL void simgui_render(void) {
     size_t all_vtx_size = 0;
     size_t all_idx_size = 0;
     int cmd_list_count = 0;
-    for (int cl_index = 0; cl_index < draw_data->CmdListsCount; cl_index++, cmd_list_count++) {
+    for (int cl_index = 0; cl_index < draw_data->CmdLists.Size; cl_index++, cmd_list_count++) {
         ImDrawList* cl = _simgui_imdrawlist_at(draw_data, cl_index);
         const size_t vtx_size = (size_t)cl->VtxBuffer.Size * sizeof(ImDrawVert);
         const size_t idx_size = (size_t)cl->IdxBuffer.Size * sizeof(ImDrawIdx);


### PR DESCRIPTION
`ImDrawData.CmdListsCount` no longer works in v1.92.9, replaced by `ImDrawData.CmdLists.Size`.

(release notes: https://github.com/ocornut/imgui/releases/tag/v1.92.9)