### PR TITLE
sokol_gfx.h vk: fix sync2 validation layer warning for SG_LOADACTION_LOAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Updates
 
+### 29-Jul-2026
+
+sokol_gfx.h vk: fix a synchronization2 validation layer warning when using a a render attachment
+with `SG_LOADACTION_LOAD`.
+
+Ticket: https://github.com/floooh/sokol/issues/1558
+PR: https://github.com/floooh/sokol/pull/1560
+
+Many thanks to @@alexschlessinger for the ticket and investigation!
+
 ### 25-Jul-2026
 
 sokol_imgui.h has been fixed for Dear ImGui v1.92.9: in the result of `ImGui::GetDrawData()`

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -18967,6 +18967,9 @@ _SOKOL_PRIVATE VkAccessFlags2 _sg_vk_access_mask(_sg_vk_access_t access, bool is
     }
     if (access & _SG_VK_ACCESS_COLOR_ATTACHMENT) {
         f |= VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
+        if (is_dst_access) {
+            f |= VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT;
+        }
     }
     if (access & _SG_VK_ACCESS_RESOLVE_ATTACHMENT) {
         f |= VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;


### PR DESCRIPTION
Fixes #1558.