### PR TITLE
sokol_framebuffer.h: minor cleanups - remove duplicate macro and fix typo

### DIFF
--- a/util/sokol_framebuffer.h
+++ b/util/sokol_framebuffer.h
@@ -583,7 +583,7 @@ inline void sfb_render_ex(sfb_framebuffer fb, const sfb_render_desc& desc) { ret
     #define SOKOL_ASSERT(c) assert(c)
 #endif
 
-// >#shdgen
+//>#shdgen
 #if defined(SOKOL_GLCORE)
 static const uint8_t _sfb_rgba8_vs_source_glsl410[407] = {
     0x23,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x34,0x31,0x30,0x0a,0x0a,0x75,0x6e,

--- a/util/sokol_framebuffer.h
+++ b/util/sokol_framebuffer.h
@@ -4680,7 +4680,6 @@ typedef struct {
     int* free_queue;
 } _sfb_pool_t;
 
-#define _SFB_INVALID_SLOT_INDEX (0)
 typedef struct {
     _sfb_pool_t framebuffer_pool;
     _sfb_framebuffer_t* framebuffers;

--- a/util/sokol_framebuffer.h
+++ b/util/sokol_framebuffer.h
@@ -583,7 +583,7 @@ inline void sfb_render_ex(sfb_framebuffer fb, const sfb_render_desc& desc) { ret
     #define SOKOL_ASSERT(c) assert(c)
 #endif
 
-//>#shdgen
+// >#shdgen
 #if defined(SOKOL_GLCORE)
 static const uint8_t _sfb_rgba8_vs_source_glsl410[407] = {
     0x23,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x34,0x31,0x30,0x0a,0x0a,0x75,0x6e,

--- a/util/sokol_framebuffer.h
+++ b/util/sokol_framebuffer.h
@@ -337,7 +337,7 @@ typedef struct sfb_framebuffer { uint32_t id; } sfb_framebuffer;
 /*
     sfb_resource_state
 
-    The state of a framebuffer object, obtainable via sfg_query_framebuffer_state().
+    The state of a framebuffer object, obtainable via sfb_query_framebuffer_state().
     Publicly visible values are only SFB_RESOURCESTATE_VALID
     and SFB_RESOURCESTATE_FAILED.
 */


### PR DESCRIPTION
This PR provides cleanup for `sokol_framebuffer.h`:

- Fixes typo in `sfb_resource_state` description (`sfg_query_framebuffer_state`->`sfb_query_framebuffer_state`).
- Removes duplicate `_SFB_INVALID_SLOT_INDEX` macro (kept one closer to `_sfb_slot_t`)
- Adds space in `//>#shdgen` to match sectioning style (`//>#shdgen`->`// >#shdgen`)