### PR TITLE
sokol_gfx.h: implement write-transient feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,96 @@
 ## Updates
 
+### 29-Aug-2026
+sokol_gfx.h: the next implementation step of the new resource update API:
+
+The 'stream-update' mode for buffers and images has been replaced with
+a 'write-transient' mode. Write-transient resources must be written
+with CPU-side data in the same frame that data is consumed by the GPU
+(e.g. the data will not survive into the next frame).
+
+This is a breaking change for 'streaming resources', use the following
+change recipe to migrate code over to the write-transient update mode:
+
+- When creating buffers and images, change the usage flag `.usage.stream_update = true`
+to `.usage.write_transient = true`.
+- Replace `sg_update_buffer()` calls with `sg_write_buffer_transient()`,
+e.g. old:
+    ```c
+    sg_update_buffer(buf, &(sg_range){ .ptr = data_ptr, .size = data_size });
+    ```
+    New:
+    ```c
+    sg_write_buffer_transient(&(sg_write_buffer_desc){
+        .src.data = { .ptr = data_ptr, .size = data_size },
+        .dst.buffer = buf,
+    });
+    ```
+- Replace `sg_update_image()` calls with `sg_write_image_transient()`,
+e.g. old:
+    ```c
+    sg_update_image(img, &(sg_image_data){
+        .mip_level[0] = { .ptr = mip_data_ptr, .size = mip_data_size }
+    });
+    ```
+    New:
+    ```c
+    sg_write_image_transient(&(sg_write_image_desc){
+        .src.data = { .ptr = mip_data_ptr, .size = mip_data_size },
+        .dst.image = img,
+    });
+    ```
+- Note that the `sg_write_image_transient()` and `sg_write_buffer_transient()`
+functions slightly differ in behaviour:
+    - The write-transient functions can be called multiple times per frame,
+      but only before the buffer or image is first used in the same frame. If you
+      have been using an intermediate memory buffer to scatter-gather data snippets
+      in order to do a single update call per frame before, this might be a good
+      opportunity to get rid of the intermediate memory buffer and use multiple
+      write-transient calls instead, but be aware of the downsides:
+        - many small updates are still much less efficient than few bigger updates
+        - be aware of the 4-byte alignment requirement for the destination buffer
+          offset in `sg_write_buffer_transient()` (this is usually only a problem
+          for index buffers with 16-bit indices)
+    - Partial updates are possible, e.g. a buffer or image can be incrementally
+      populated with data snippets.
+- Also note that interleaving buffer updates and rendering via
+  `sg_append_buffer()` is no longer possible for write-transient resources (this
+  was never recommended because it incurred a very expensive lock-stall on some
+  backend 3D APIs). The plan to help with such interleaved update/render scenarios
+  is by introducing a new `sokol_cmdbuf.h` header (see:
+  https://github.com/floooh/sokol/issues/1557).
+
+For the full details, read the updated header documentation: search for
+`sg_write_buffer_transient` and `sg_write_image_transient` in the doc
+header of sokol_gfx.h, and read the documentation of the structs
+`sg_write_buffer_desc` and `sg_write_image_desc`.
+
+Also see the updated sokol-samples (WebGPU capable browser needed).
+
+For `sg_write_buffer_transient`:
+
+- [instancing](https://floooh.github.io/sokol-webgpu/instancing-pull-sapp-ui.html)
+- [instancing-pull](https://floooh.github.io/sokol-webgpu/instancing-pull-sapp-ui.html)
+- [ozz-storagebuffer](https://floooh.github.io/sokol-webgpu/ozz-storagebuffer-sapp.html)
+- [slug](https://floooh.github.io/sokol-webgpu/slug-sapp.html)
+- [box3d-simple](https://floooh.github.io/sokol-webgpu/box3d-simple-sapp.html)
+
+...and for `sg_write_image_transient`:
+
+- [dyntex](https://floooh.github.io/sokol-webgpu/dyntex-sapp-ui.html)
+- [dyntex3d](https://floooh.github.io/sokol-webgpu/dyntex3d-sapp.html)
+- [ozz-skin](https://floooh.github.io/sokol-webgpu/ozz-skin-sapp.html)
+- [plmpeg](https://floooh.github.io/sokol-webgpu/plmpeg-sapp.html)
+
+The following 'tier-2' headers have been updated to use `sg_write_buffer_transient`:
+
+- [sokol_imgui.h](https://github.com/floooh/sokol/blob/master/util/sokol_imgui.h)
+- [sokol_nuklear.h](https://github.com/floooh/sokol/blob/master/util/sokol_nuklear.h)
+- [sokol_gl.h](https://github.com/floooh/sokol/blob/master/util/sokol_gl.h)
+- [sokol_debugtext.h](https://github.com/floooh/sokol/blob/master/util/sokol_debugtext.h)
+- [sokol_spine.h](https://github.com/floooh/sokol/blob/master/util/sokol_spine.h)
+
+
 ### 28-Aug-2026
 
 - sokol_gfx/app/fetch.h emscripten: fix a wasm64 compatibility issue of the

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4810,7 +4810,7 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VULKAN_STAGING_CREATE_BUFFER_FAILED, "vulkan: vkCreateBuffer() failed for staging buffer") \
     _SG_LOGITEM_XMACRO(VULKAN_STAGING_ALLOCATE_MEMORY_FAILED, "vulkan: allocating device memory for staging buffer failed") \
     _SG_LOGITEM_XMACRO(VULKAN_STAGING_BIND_BUFFER_MEMORY_FAILED, "vulkan: vkBindBufferMemory() failed for staging buffer") \
-    _SG_LOGITEM_XMACRO(VULKAN_STAGING_STREAM_BUFFER_OVERFLOW, "vulkan: per-frame stream staging buffer has overflown (sg_desc.vulkan.stream_staging_buffer_size)") \
+    _SG_LOGITEM_XMACRO(VULKAN_STAGING_TRANSIENT_BUFFER_OVERFLOW, "vulkan: per-frame transient staging buffer has overflown (sg_desc.vulkan.transient_staging_buffer_size)") \
     _SG_LOGITEM_XMACRO(VULKAN_STAGING_IMAGE_ROW_PITCH_GREATER_STAGING_BUFFER, "vulkan: the row-pitch of an image update operation is greater than the staging buffer size (increase sg_desc.vulkan.copy_staging_buffer_size)") \
     _SG_LOGITEM_XMACRO(VULKAN_CREATE_SHARED_BUFFER_FAILED, "vulkan: vkCreateBuffer() failed for cpu/gpu-shared buffer") \
     _SG_LOGITEM_XMACRO(VULKAN_ALLOCATE_SHARED_BUFFER_MEMORY_FAILED, "vulkan: allocating device memory for cpu/gpu-shared buffer failed") \
@@ -5273,7 +5273,7 @@ typedef enum sg_log_item {
     .wgpu.disable_bindgroups_cache      false
     .wgpu.bindgroups_cache_size         1024
     .vulkan.copy_staging_buffer_size    4 MB
-    .vulkan.stream_staging_buffer_size  16 MB
+    .vulkan.transient_staging_buffer_size  16 MB
     .vulkan.descriptor_buffer_size      16 MB
 
     .allocator.alloc_fn     0 (in this case, malloc() will be called)
@@ -5345,13 +5345,13 @@ typedef enum sg_log_item {
             .usage.dynamic_update resources. The default is 4 MB,
             bigger resource updates are split into multiple chunks
             of the staging buffer size
-        .vulkan.stream_staging_buffer_size
-            Size of the staging buffer in bytes for updating .usage.stream_update
+        .vulkan.transient_staging_buffer_size
+            Size of the staging buffer in bytes for updating .usage.write_transient
             resources. The default is 16 MB. The size must be big enough
-            to accomodate all update into .usage.stream_update resources.
+            to accomodate all writes into .usage.write_transient resources.
             Any additional data will cause an error log message and
             incomplete rendering. Note that the actually allocated size
-            will be twice as much because the stream-staging-buffer is
+            will be twice as much because the transient-staging-buffer is
             double-buffered.
         .vulkan.descriptor_buffer_size
             Size of the descriptor-upload buffer in bytes. The default
@@ -5468,9 +5468,9 @@ typedef struct sg_wgpu_desc {
 } sg_wgpu_desc;
 
 typedef struct sg_vulkan_desc {
-    int copy_staging_buffer_size;    // size of staging buffer for immutable and dynamic resources (default: 4 MB)
-    int stream_staging_buffer_size;  // size of per-frame staging buffer for updating streaming resources (default: 16 MB)
-    int descriptor_buffer_size;      // size of per-frame descriptor buffer for updating resource bindings (default: 16 MB)
+    int copy_staging_buffer_size;       // size of staging buffer for immutable and dynamic resources (default: 4 MB)
+    int transient_staging_buffer_size;  // size of per-frame staging buffer for write-transient resources (default: 16 MB)
+    int descriptor_buffer_size;         // size of per-frame descriptor buffer for updating resource bindings (default: 16 MB)
 } sg_vulkan_desc;
 
 typedef struct sg_desc {
@@ -6620,7 +6620,7 @@ enum {
     _SG_DEFAULT_MAX_COMMIT_LISTENERS = 1024,
     _SG_DEFAULT_WGPU_BINDGROUP_CACHE_SIZE = 1024,
     _SG_DEFAULT_VK_COPY_STAGING_SIZE = (4 * 1024 * 1024),
-    _SG_DEFAULT_VK_STREAM_STAGING_SIZE = (16 * 1024 * 1024),
+    _SG_DEFAULT_VK_TRANSIENT_STAGING_SIZE = (16 * 1024 * 1024),
     _SG_DEFAULT_VK_DESCRIPTOR_BUFFER_SIZE = (16 * 1024 * 1024),
     _SG_MAX_STORAGEBUFFER_BINDINGS_PER_STAGE = SG_MAX_VIEW_BINDSLOTS,
     _SG_MAX_STORAGEIMAGE_BINDINGS_PER_STAGE = SG_MAX_VIEW_BINDSLOTS,
@@ -21084,11 +21084,11 @@ _SOKOL_PRIVATE void _sg_vk_staging_copy_image_data(_sg_image_t* img, const sg_im
     }
 }
 
-// staging system for non-blocking streaming updates with a max per-frame data limit
+// staging system for non-blocking streaming (aka transient) updates with a max per-frame data limit
 _SOKOL_PRIVATE void _sg_vk_staging_stream_init(void) {
-    SOKOL_ASSERT(_sg.desc.vulkan.stream_staging_buffer_size > 0);
+    SOKOL_ASSERT(_sg.desc.vulkan.transient_staging_buffer_size > 0);
     _sg_vk_shared_buffer_init(&_sg.vk.stage.stream,
-        (uint32_t)_sg.desc.vulkan.stream_staging_buffer_size,
+        (uint32_t)_sg.desc.vulkan.transient_staging_buffer_size,
         16, // NOTE: arbitrary alignment (FIXME?)
         _SG_VK_MEMTYPE_STAGING_STREAM,
         "shared-stream-buffer");
@@ -21118,7 +21118,7 @@ _SOKOL_PRIVATE void _sg_vk_staging_stream_buffer_data(_sg_buffer_t* buf, const s
     const uint8_t* src_ptr = (const uint8_t*)src_data->ptr + src_offset;
     const VkDeviceSize vk_stage_offset = _sg_vk_shared_buffer_memcpy(&_sg.vk.stage.stream, src_ptr, (uint32_t)copy_size);
     if (vk_stage_offset == _SG_VK_SHARED_BUFFER_OVERFLOW_RESULT) {
-        _SG_ERROR(VULKAN_STAGING_STREAM_BUFFER_OVERFLOW);
+        _SG_ERROR(VULKAN_STAGING_TRANSIENT_BUFFER_OVERFLOW);
         return;
     }
     VkCommandBuffer cmd_buf = _sg.vk.frame.stream_cmd_buf;
@@ -21194,7 +21194,7 @@ _SOKOL_PRIVATE void _sg_vk_staging_stream_miplevel_data(_sg_image_t* img,
     const size_t vk_size = (size_t)src_bytes_per_slice * (size_t)num_slices;
     const uint32_t vk_src_offset = (uint32_t)_sg_vk_shared_buffer_memcpy(&_sg.vk.stage.stream, vk_src_ptr, (uint32_t)vk_size);
     if (vk_src_offset == _SG_VK_SHARED_BUFFER_OVERFLOW_RESULT) {
-        _SG_ERROR(VULKAN_STAGING_STREAM_BUFFER_OVERFLOW);
+        _SG_ERROR(VULKAN_STAGING_TRANSIENT_BUFFER_OVERFLOW);
     }
     region.bufferOffset = vk_src_offset;
     vkCmdCopyBufferToImage2(cmd_buf, &copy_info);
@@ -26295,7 +26295,7 @@ _SOKOL_PRIVATE sg_desc _sg_desc_defaults(const sg_desc* desc) {
     res.max_commit_listeners = _sg_def(res.max_commit_listeners, _SG_DEFAULT_MAX_COMMIT_LISTENERS);
     res.wgpu.bindgroups_cache_size = _sg_def(res.wgpu.bindgroups_cache_size, _SG_DEFAULT_WGPU_BINDGROUP_CACHE_SIZE);
     res.vulkan.copy_staging_buffer_size = _sg_def(res.vulkan.copy_staging_buffer_size, _SG_DEFAULT_VK_COPY_STAGING_SIZE);
-    res.vulkan.stream_staging_buffer_size = _sg_def(res.vulkan.stream_staging_buffer_size, _SG_DEFAULT_VK_STREAM_STAGING_SIZE);
+    res.vulkan.transient_staging_buffer_size = _sg_def(res.vulkan.transient_staging_buffer_size, _SG_DEFAULT_VK_TRANSIENT_STAGING_SIZE);
     res.vulkan.descriptor_buffer_size = _sg_def(res.vulkan.descriptor_buffer_size, _SG_DEFAULT_VK_DESCRIPTOR_BUFFER_SIZE);
     return res;
 }

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -27562,6 +27562,7 @@ SOKOL_API_IMPL void sg_write_buffer_transient(const sg_write_buffer_desc* desc) 
 SOKOL_API_IMPL void sg_write_image_transient(const sg_write_image_desc* desc) {
     SOKOL_ASSERT(_sg.valid);
     SOKOL_ASSERT(desc);
+    _sg_stats_inc(num_write_image_transient);
     _sg_image_t* img = _sg_lookup_image(desc->dst.image.id);
     if (img) {
         sg_write_image_desc desc_def = _sg_write_image_desc_defaults(img, desc);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -5856,8 +5856,8 @@ inline void sg_init_shader(sg_shader shd, const sg_shader_desc& desc) { return s
 inline void sg_init_pipeline(sg_pipeline pip, const sg_pipeline_desc& desc) { return sg_init_pipeline(pip, &desc); }
 inline void sg_init_view(sg_view view, const sg_view_desc& desc) { return sg_init_view(view, &desc); }
 
-inline void sg_write_buffer_transient(const sg_write_buffer_desc* desc) { return sg_write_buffer_transient(&desc); }
-inline void sg_write_image_transient(const sg_write_image_desc* desc) { return sg_write_image_transient(&desc); }
+inline void sg_write_buffer_transient(const sg_write_buffer_desc& desc) { return sg_write_buffer_transient(&desc); }
+inline void sg_write_image_transient(const sg_write_image_desc& desc) { return sg_write_image_transient(&desc); }
 inline void sg_write_buffer_unsealed(const sg_write_buffer_desc& desc) { return sg_write_buffer_unsealed(&desc); }
 inline void sg_write_image_unsealed(const sg_write_image_desc& desc) { return sg_write_image_unsealed(&desc); }
 inline void sg_update_image(sg_image img, const sg_image_data& data) { return sg_update_image(img, &data); }

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3378,8 +3378,6 @@ typedef struct sg_buffer_usage {
     bool write_unsealed;
     bool write_transient;
     bool dynamic_update;
-    // deprecated:
-    bool stream_update;
 } sg_buffer_usage;
 
 /*
@@ -3486,8 +3484,6 @@ typedef struct sg_buffer_desc {
         TODO: docs
     .dynamic_update (default: false)
         the image content is updated infrequently by the CPU via sg_update_image()
-    .stream_update (deprecated, default: false)
-        the image content is updated each frame by the CPU via sg_update_image()
 
     Note that creating a texture view from the image to be used for
     texture-sampling in vertex-, fragment- or compute-shaders
@@ -3500,9 +3496,7 @@ typedef struct sg_image_usage {
     bool depth_stencil_attachment;
     bool immutable;
     bool write_unsealed;
-    bool write_transient;
     bool dynamic_update;
-    // deprecated:
     bool stream_update;
 } sg_image_usage;
 
@@ -4899,7 +4893,7 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(SHADERDESC_TOO_MANY_FRAGMENTSTAGE_TEXTURESAMPLERPAIRS, "sg_shader_desc: too many texture-sampler-pairs on fragment shader stage (sg_limits.max_texture_bindings_per_stage)") \
     _SG_LOGITEM_XMACRO(SHADERDESC_TOO_MANY_COMPUTESTAGE_TEXTURESAMPLERPAIRS, "sg_shader_desc: too many texture-sampler-pairs on compute shader stage (sg_limits.max_texture_bindings_per_stage)") \
     _SG_LOGITEM_XMACRO(VALIDATE_BUFFERDESC_CANARY, "sg_buffer_desc not initialized") \
-    _SG_LOGITEM_XMACRO(VALIDATE_BUFFERDESC_IMMUTABLE_DYNAMIC_STREAM, "sg_buffer_desc.usage: only one of .immutable, .dynamic_update, .stream_update can be true") \
+    _SG_LOGITEM_XMACRO(VALIDATE_BUFFERDESC_IMMUTABLE_VS_WRITABLE, "sg_buffer_desc.usage: only one of .immutable, .dynamic_update, .write_transient can be true") \
     _SG_LOGITEM_XMACRO(VALIDATE_BUFFERDESC_UNSEALED_VS_IMMUTABLE, "sg_buffer_desc.usage: .write_unsealed only allowed for .immutable buffers") \
     _SG_LOGITEM_XMACRO(VALIDATE_BUFFERDESC_SEPARATE_BUFFER_TYPES, "sg_buffer_desc.usage: on WebGL2, only one of .vertex_buffer or .index_buffer can be true (check sg_features.separate_buffer_types)") \
     _SG_LOGITEM_XMACRO(VALIDATE_BUFFERDESC_EXPECT_NONZERO_SIZE, "sg_buffer_desc.size must be greater zero") \
@@ -17525,7 +17519,7 @@ _SOKOL_PRIVATE void _sg_mtl_write_buffer_transient(_sg_buffer_t* buf, const sg_w
 _SOKOL_PRIVATE void _sg_mtl_write_image_transient(_sg_image_t* img, const sg_write_image_desc* desc) {
     SOKOL_ASSERT(img && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_VALID == img->slot.state);
-    SOKOL_ASSERT(img->cmn.usage.write_transient);
+//    SOKOL_ASSERT(img->cmn.usage.write_transient);
 
     SOKOL_ASSERT(false && "FIXME: _sg_mtl_write_image_transient");
 }
@@ -23629,7 +23623,7 @@ _SOKOL_PRIVATE bool _sg_validate_end(void) {
 #endif
 
 _SOKOL_PRIVATE bool _sg_one(bool b0, bool b1, bool b2) {
-    return (b0 && !b1 && !b2) || (!b0 && b1 && !b2) || (!b0 && !b1 && b2);
+    return (b0 + b1 + b2) == 1;
 }
 
 _SOKOL_PRIVATE bool _sg_validate_buffer_desc(const sg_buffer_desc* desc) {
@@ -23645,7 +23639,7 @@ _SOKOL_PRIVATE bool _sg_validate_buffer_desc(const sg_buffer_desc* desc) {
         _SG_VALIDATE(desc->_start_canary == 0, VALIDATE_BUFFERDESC_CANARY);
         _SG_VALIDATE(desc->_end_canary == 0, VALIDATE_BUFFERDESC_CANARY);
         _SG_VALIDATE(desc->size > 0, VALIDATE_BUFFERDESC_EXPECT_NONZERO_SIZE);
-        _SG_VALIDATE(_sg_one(desc->usage.immutable, desc->usage.dynamic_update, desc->usage.stream_update), VALIDATE_BUFFERDESC_IMMUTABLE_DYNAMIC_STREAM);
+        _SG_VALIDATE(_sg_one(desc->usage.immutable, desc->usage.dynamic_update, desc->usage.write_transient), VALIDATE_BUFFERDESC_IMMUTABLE_VS_WRITABLE);
         if (_sg.features.separate_buffer_types) {
             _SG_VALIDATE(_sg_one(desc->usage.vertex_buffer, desc->usage.index_buffer, desc->usage.storage_buffer), VALIDATE_BUFFERDESC_SEPARATE_BUFFER_TYPES);
         }
@@ -25388,7 +25382,7 @@ _SOKOL_PRIVATE sg_buffer_usage _sg_buffer_usage_defaults(const sg_buffer_usage* 
     if (!(def.vertex_buffer || def.index_buffer || def.storage_buffer)) {
         def.vertex_buffer = true;
     }
-    if (!(def.immutable || def.stream_update || def.dynamic_update)) {
+    if (!(def.immutable || def.write_transient || def.dynamic_update)) {
         def.immutable = true;
     }
     return def;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -13410,19 +13410,25 @@ static inline D3D_FEATURE_LEVEL _sg_d3d11_GetFeatureLevel(ID3D11Device* self) {
 
 //-- enum translation functions ------------------------------------------------
 _SOKOL_PRIVATE D3D11_USAGE _sg_d3d11_image_usage(const sg_image_usage* usg) {
-    if (usg->immutable) {
-        if (usg->color_attachment ||
-            usg->resolve_attachment ||
-            usg->depth_stencil_attachment ||
-            usg->storage_image ||
-            usg->write_unsealed)
-        {
-            return D3D11_USAGE_DEFAULT;
-        } else {
-            return D3D11_USAGE_IMMUTABLE;
-        }
-    } else {
+    const bool any_attachment = usg->color_attachment || usg->resolve_attachment || usg->depth_stencil_attachment;
+    const bool any_write_access = usg->write_unsealed || usg->write_transient;
+    if (any_attachment || any_write_access || usg->storage_image) {
+        return D3D11_USAGE_DEFAULT;
+    } else if (usg->dynamic_update) {
+        // FIXME: deprecated
         return D3D11_USAGE_DYNAMIC;
+    } else {
+        SOKOL_ASSERT(usg->immutable);
+        return D3D11_USAGE_IMMUTABLE;
+    }
+}
+
+_SOKOL_PRIVATE UINT _sg_d3d11_image_cpu_access_flags(const sg_image_usage* usg) {
+    if (usg->dynamic_update) {
+        // FIXME: deprecated
+        return D3D11_CPU_ACCESS_WRITE;
+    } else {
+        return 0;
     }
 }
 
@@ -13440,24 +13446,31 @@ _SOKOL_PRIVATE UINT _sg_d3d11_image_bind_flags(const sg_image_usage* usg) {
     return res;
 }
 
-_SOKOL_PRIVATE UINT _sg_d3d11_image_cpu_access_flags(const sg_image_usage* usg) {
-    if (usg->color_attachment ||
-        usg->resolve_attachment ||
-        usg->depth_stencil_attachment ||
-        usg->storage_image ||
-        usg->immutable)
-    {
-        return 0;
+_SOKOL_PRIVATE D3D11_USAGE _sg_d3d11_buffer_usage(const sg_buffer_usage* usg) {
+    if (usg->dynamic_update) {
+        // FIXME: deprecated
+        return D3D11_USAGE_DYNAMIC;
+    } else if (usg->write_transient) {
+        return D3D11_USAGE_DYNAMIC;
+    } else if (usg->write_unsealed) {
+        return D3D11_USAGE_DEFAULT;
+    } else if (usg->storage_buffer) {
+        return D3D11_USAGE_DEFAULT;
+    } else if (usg->immutable) {
+        return D3D11_USAGE_IMMUTABLE;
     } else {
-        return D3D11_CPU_ACCESS_WRITE;
+        return D3D11_USAGE_DEFAULT;
     }
 }
 
-_SOKOL_PRIVATE D3D11_USAGE _sg_d3d11_buffer_usage(const sg_buffer_usage* usg) {
-    if (usg->immutable) {
-        return (usg->storage_buffer || usg->write_unsealed) ? D3D11_USAGE_DEFAULT : D3D11_USAGE_IMMUTABLE;
+_SOKOL_PRIVATE UINT _sg_d3d11_buffer_cpu_access_flags(const sg_buffer_usage* usg) {
+    if (usg->dynamic_update) {
+        // FIXME: deprecated
+        return D3D11_CPU_ACCESS_WRITE;
+    } else if (usg->write_transient) {
+        return D3D11_CPU_ACCESS_WRITE;
     } else {
-        return D3D11_USAGE_DYNAMIC;
+        return 0;
     }
 }
 
@@ -13480,10 +13493,6 @@ _SOKOL_PRIVATE UINT _sg_d3d11_buffer_bind_flags(const sg_buffer_usage* usg) {
 
 _SOKOL_PRIVATE UINT _sg_d3d11_buffer_misc_flags(const sg_buffer_usage* usg) {
     return usg->storage_buffer ? D3D11_RESOURCE_MISC_BUFFER_ALLOW_RAW_VIEWS : 0;
-}
-
-_SOKOL_PRIVATE UINT _sg_d3d11_buffer_cpu_access_flags(const sg_buffer_usage* usg) {
-    return usg->immutable ? 0 : D3D11_CPU_ACCESS_WRITE;
 }
 
 _SOKOL_PRIVATE DXGI_FORMAT _sg_d3d11_base_pixel_format(sg_pixel_format fmt) {
@@ -15386,9 +15395,22 @@ _SOKOL_PRIVATE void _sg_d3d11_write_image_transient(_sg_image_t* img, const sg_w
     SOKOL_ASSERT(img && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_VALID == img->slot.state);
     SOKOL_ASSERT(img->cmn.usage.write_transient);
-
     _SOKOL_UNUSED(first_time_in_frame);
-    SOKOL_ASSERT(false && "FIXME");
+    // NOTE: not using map/unmap but copy-sub-resource for write-transient textures is intended!
+    ID3D11Resource* d3d11_res = img->d3d11.res;
+    _sg_d3d11_write_miplevel_data(img, d3d11_res,
+        (const uint8_t*)desc->src.data.ptr,
+        desc->src.data.size,
+        desc->src.offset,
+        desc->src.bytes_per_row,
+        desc->src.bytes_per_slice,
+        desc->dst.mip_level,
+        desc->dst.x,
+        desc->dst.y,
+        desc->dst.slice,
+        desc->size.width,
+        desc->size.height,
+        desc->size.num_slices);
 }
 
 _SOKOL_PRIVATE void _sg_d3d11_write_image_unsealed(_sg_image_t* img, const sg_write_image_desc* desc) {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -305,13 +305,37 @@
         resource from unsealed into valid state. For more details see the
         doc section `ON POPULATING IMMUTABLE RESOURCES` below.
 
-    --- to update (overwrite) the content of buffer and image resources, call:
+    --- to update the content of buffer and image resources:
+
+        For data that's written by the CPU and consumed by the GPU in the
+        *same frame* and doesn't need to survive into the next frame, call:
+
+            sg_write_buffer_transient(const sg_write_buffer_desc* desc);
+            sg_write_image_transient(const sg_write_image_desc* desc);
+
+        The buffer and image objects which are the destination of
+        write-transient calls must have been created with
+        `.usage.write_transient = true` and cannot be pass attachments.
+
+        Multiple calls to the write-transient functions are allowed in a frame
+        to incrementally populate the resource, but only until the resource is bound.
+        After a resource has been used in a frame it cannot be written to until
+        the next frame.
+
+        Expect that data written with the write-transient functions will not
+        survive into the next frame, e.g. all data written by the CPU is expected
+        to be 'consumed' by the GPU in the same frame. Trying to bind a write-transient
+        buffer or image that hasn't been written to in the same frame is a validation
+        layer error. Calling a write-transient function on a resource that isn't
+        used for rendering in the same frame is allowed but pointless.
+
+        For data that needs to persist across frames, call:
 
             sg_update_buffer(sg_buffer buf, const sg_range* data)
             sg_update_image(sg_image img, const sg_image_data* data)
 
         Buffers and images to be updated must have been created with
-        sg_buffer_desc.usage.dynamic_update or .stream_update.
+        sg_buffer_desc.usage.dynamic_update.
 
         Only one update per frame is allowed for buffer and image resources when
         using the sg_update_*() functions. The rationale is to have a simple
@@ -322,60 +346,8 @@
         operation only references the valid (updated) data in the
         buffer or image.
 
-    --- to append a chunk of data to a buffer resource, call:
-
-            int sg_append_buffer(sg_buffer buf, const sg_range* data)
-
-        The difference to sg_update_buffer() is that sg_append_buffer()
-        can be called multiple times per frame to append new data to the
-        buffer piece by piece, optionally interleaved with draw calls referencing
-        the previously written data.
-
-        sg_append_buffer() returns a byte offset to the start of the
-        written data, this offset can be assigned to
-        sg_bindings.vertex_buffer_offsets[n] or
-        sg_bindings.index_buffer_offset
-
-        Code example:
-
-        for (...) {
-            const void* data = ...;
-            const int num_bytes = ...;
-            int offset = sg_append_buffer(buf, &(sg_range) { .ptr=data, .size=num_bytes });
-            bindings.vertex_buffer_offsets[0] = offset;
-            sg_apply_pipeline(pip);
-            sg_apply_bindings(&bindings);
-            sg_apply_uniforms(...);
-            sg_draw(...);
-        }
-
-        A buffer to be used with sg_append_buffer() must have been created
-        with sg_buffer_desc.usage.dynamic_update or .stream_update.
-
-        If the application appends more data to the buffer then fits into
-        the buffer, the buffer will go into the "overflow" state for the
-        rest of the frame.
-
-        Any draw calls attempting to render an overflown buffer will be
-        silently dropped (in debug mode this will also result in a
-        validation error).
-
-        You can also check manually if a buffer is in overflow-state by calling
-
-            bool sg_query_buffer_overflow(sg_buffer buf)
-
-        You can manually check to see if an overflow would occur before adding
-        any data to a buffer by calling
-
-            bool sg_query_buffer_will_overflow(sg_buffer buf, size_t size)
-
-        NOTE: Due to restrictions in underlying 3D-APIs, appended chunks of
-        data will be 4-byte aligned in the destination buffer. This means
-        that there will be gaps in index buffers containing 16-bit indices
-        when the number of indices in a call to sg_append_buffer() is
-        odd. This isn't a problem when each call to sg_append_buffer()
-        is associated with one draw call, but will be problematic when
-        a single indexed draw call spans several appended chunks of indices.
+        NOTE: the update functions will be replaced with more flexible
+        'write-persistent' functions in the next resource API update!
 
     --- to check at runtime for optional features, limits and pixelformat support,
         call:
@@ -462,7 +434,7 @@
     --- call the following helper functions to compute the number of
         bytes in a texture row or surface for a specific pixel format.
         These functions might be helpful when preparing image data for consumption
-        by sg_make_image() or sg_update_image():
+        by sg_make_image() or the sg_write_image_*() functions:
 
             int sg_query_row_pitch(sg_pixel_format fmt, int width, int int row_align_bytes);
             int sg_query_surface_pitch(sg_pixel_format fmt, int width, int height, int row_align_bytes);
@@ -2186,7 +2158,7 @@ typedef struct sg_range {
     size_t size;
 } sg_range;
 
-// disabling this for every includer isn't great, but the warnings are also quite pointless
+// NOTE: disabling these warnings for every includer isn't great, but the warnings are also quite pointless
 #if defined(_MSC_VER)
 #pragma warning(disable:4221)   // /W4 only: nonstandard extension used: 'x': cannot be initialized using address of automatic variable 'y'
 #pragma warning(disable:4204)   // VS2015: nonstandard extension used: non-constant aggregate initializer
@@ -2278,7 +2250,7 @@ typedef enum sg_backend {
 
     The default pixel format for texture images is SG_PIXELFORMAT_RGBA8.
 
-    The default pixel format for render target images is platform-dependent
+    The default pixel format for pass attachment images is platform-dependent
     and taken from the sg_environment struct passed into sg_setup(). Typically
     the default formats are:
 
@@ -3364,11 +3336,15 @@ typedef struct sg_bindings {
         calling `sg_seal_buffer()` which transitions from 'unsealed'
         to 'valid' resource state
     .write_transient (default: false)
-        TODO: docs
+        the buffer is going to be used as destination in
+        sg_write_buffer_transient() calls, write-transient buffers are used for
+        scenarios where data that's written from the CPU side is consumed in the
+        same frame by the GPU-side and doesn't need to survive into the next
+        frame
     .dynamic_update (default: false)
         the buffer content will be infrequently updated from the CPU side
-    .stream_update (deprecated, default: false)
-        the buffer content will be updated each frame from the CPU side
+        NOTE: dynamic_update is deprecated and will be replaced with a
+        .write_persistent flag in one of the next updates
 */
 typedef struct sg_buffer_usage {
     bool vertex_buffer;
@@ -3377,6 +3353,7 @@ typedef struct sg_buffer_usage {
     bool immutable;
     bool write_unsealed;
     bool write_transient;
+    // deprecated:
     bool dynamic_update;
 } sg_buffer_usage;
 
@@ -3397,17 +3374,14 @@ typedef struct sg_buffer_usage {
     keep the .size item zero-initialized, and set the size together with the
     pointer to the initial data in the .data item.
 
-    For immutable or mutable buffers without initial data, keep the .data item
-    zero-initialized, and set the buffer size in the .size item instead.
+    For buffers without initial data, keep the .data item zero-initialized, and
+    set the buffer size in the .size item instead.
 
-    You can also set both size values, but currently both size values must
-    be identical (this may change in the future when the dynamic resource
-    management may become more flexible).
+    You can also set both size values, but both size values must
+    be identical.
 
-    NOTE: Immutable buffers without storage-buffer-usage *must* be created
-    with initial content, this restriction doesn't apply to storage buffer usage,
-    because storage buffers may also get their initial content by running
-    a compute shader on them.
+    NOTE: Immutable buffers that are neither storage-buffers or have
+    write-unsealed usage *must* be created with initial data.
 
     NOTE: Buffers without initial data will have undefined content, e.g.
     do *not* expect the buffer to be zero-initialized!
@@ -3420,12 +3394,13 @@ typedef struct sg_buffer_usage {
     .gl_buffers[SG_NUM_INFLIGHT_FRAMES]
     .mtl_buffers[SG_NUM_INFLIGHT_FRAMES]
     .d3d11_buffer
+    .wgpu_buffer
 
     You must still provide all other struct items except the .data item, and
     these must match the creation parameters of the native buffers you provide.
     For sg_buffer_desc.usage.immutable buffers, only provide a single native
     3D-API buffer, otherwise you need to provide SG_NUM_INFLIGHT_FRAMES buffers
-    (only for GL and Metal, not D3D11). Providing multiple buffers for GL and
+    (only for GL and Metal, not D3D11 or WebGPU). Providing multiple buffers for GL and
     Metal is necessary because sokol_gfx will rotate through them when calling
     sg_update_buffer() to prevent lock-stalls.
 
@@ -3481,9 +3456,15 @@ typedef struct sg_buffer_desc {
         calling `sg_seal_image()` which transitions from 'unsealed'
         to 'valid' resource state
     .write_transient (default: false)
-        TODO: docs
+        the image is going to be used as destination in
+        sg_write_image_transient() calls, write-transient images are used for
+        scenarios where data that's written from the CPU side is consumed in the
+        same frame by the GPU-side and doesn't need to survive into the next
+        frame
     .dynamic_update (default: false)
         the image content is updated infrequently by the CPU via sg_update_image()
+        NOTE: dynamic_update is deprecated and will be replaced with a
+        .write_persistent flag in one of the next updates
 
     Note that creating a texture view from the image to be used for
     texture-sampling in vertex-, fragment- or compute-shaders
@@ -3581,7 +3562,7 @@ typedef struct sg_image_location {
     Describes the data to be written from CPU memory into an image:
 
     .data
-        Pointer to and size of the data in CPU memory
+        Pointer to and size (in bytes) of the data in CPU memory
     .offset
         Optional offset that's added to data.ptr
     .bytes_per_row
@@ -3597,6 +3578,10 @@ typedef struct sg_image_location {
         slices, can be left zero-initialized when the image data is tightly
         packed (e.g. no gaps between slices). Must be a multiple of
         .bytes_per_row
+
+    NOTE: use the helper functions sg_query_row_pitch() and sg_query_surface_pitch()
+    to compute values compatible with the .bytes_per_row and .bytes_per_slice
+    restrictions.
 */
 typedef struct sg_write_image_source {
     sg_range data;
@@ -3609,7 +3594,7 @@ typedef struct sg_write_image_source {
     sg_write_image_desc
 
     Describes a write operation into a single mipmap from CPU memory into
-    an image object.
+    an image object. Parameter of the sg_write_image_*() functions.
 
     .src
         Defines the location and layout of the source data in CPU memory.
@@ -3631,7 +3616,7 @@ typedef struct sg_write_image_source {
     .src.bytes_per_slice
         Same as above, default-zero indicates that the source data is layed
         out as a tightly packed complete mip-map (e.g. when writing data into
-        miplevel 0 of a 256x256 image, .src.bytes_per_slice will be 256*1024).
+        miplevel 0 of a 256x256 image, .src.bytes_per_slice will be 256*256*4).
     .size.width, .size.height, .size.num_slices
         Default-zero means 'the remaining width, height and num_slices' taking
         .dst.x/y/slice into account. E.g. when .dst.x/y/num_slices are all zero,
@@ -3648,6 +3633,8 @@ typedef struct sg_write_image_desc {
     sg_buffer_location
 
     Describes the source or destination location in a buffer.
+
+    NOTE: .offset must be 4-byte aligned (ensured by the validation layer)
 */
 typedef struct sg_buffer_location {
     sg_buffer buffer;
@@ -3657,7 +3644,7 @@ typedef struct sg_buffer_location {
 /*
     sg_write_buffer_source
 
-    Describes the data to be written from CPU memory into a buffer.
+    Describes the CPU-side source data to be written into a buffer.
 
     .data
         Pointer to and size of the data in CPU memory
@@ -3673,7 +3660,7 @@ typedef struct sg_write_buffer_source {
     sg_write_buffer_desc
 
     Describes a write operation into a buffer from CPU memory into
-    a buffer object.
+    a buffer object. Parameter of the sg_write_buffer_*() functions.
 
     .src
         Defines the location of the source data in CPU memory.
@@ -4433,19 +4420,21 @@ typedef struct sg_slot_info {
 
 typedef struct sg_buffer_info {
     sg_slot_info slot;              // resource pool slot info
+    int num_slots;                  // number of renaming-slots for dynamically updated buffers
+    int active_slot;                // currently active write-slot for dynamically updated buffers
+    // deprecated
     uint32_t update_frame_index;    // frame index of last sg_update_buffer()
     uint32_t append_frame_index;    // frame index of last sg_append_buffer()
     int append_pos;                 // current position in buffer for sg_append_buffer()
     bool append_overflow;           // is buffer in overflow state (due to sg_append_buffer)
-    int num_slots;                  // number of renaming-slots for dynamically updated buffers
-    int active_slot;                // currently active write-slot for dynamically updated buffers
 } sg_buffer_info;
 
 typedef struct sg_image_info {
     sg_slot_info slot;              // resource pool slot info
-    uint32_t upd_frame_index;       // frame index of last sg_update_image()
     int num_slots;                  // number of renaming-slots for dynamically updated images
     int active_slot;                // currently active write-slot for dynamically updated images
+    // deprecated
+    uint32_t upd_frame_index;       // frame index of last sg_update_image()
 } sg_image_info;
 
 typedef struct sg_sampler_info {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -6636,7 +6636,7 @@ typedef struct {
     int size;
     int num_slots;
     int active_slot;
-    uint32_t bind_frame_index;  // last frame index buffer was bound
+    uint32_t bind_frame_index;  // last frame index the buffer was bound
     uint32_t write_transient_frame_index; // last frame index when written to
     sg_buffer_usage usage;
     // deprecated
@@ -6649,7 +6649,7 @@ typedef struct {
 typedef struct {
     int num_slots;
     int active_slot;
-    uint32_t bind_frame_index;  // last frame index buffer was bound
+    uint32_t bind_frame_index;  // last frame index the image was bound
     uint32_t write_transient_frame_index; // last frame index when written to
     sg_image_type type;
     int width;
@@ -21136,7 +21136,7 @@ _SOKOL_PRIVATE void _sg_vk_staging_stream_buffer_data(_sg_buffer_t* buf, const s
     _sg_vk_buffer_barrier(cmd_buf, buf, _SG_VK_ACCESS_VERTEXBUFFER|_SG_VK_ACCESS_INDEXBUFFER|_SG_VK_ACCESS_STORAGEBUFFER_RO);
 }
 
-_SOKOL_PRIVATE bool _sg_vk_staging_stream_miplevel_data(_sg_image_t* img,
+_SOKOL_PRIVATE void _sg_vk_staging_stream_miplevel_data(_sg_image_t* img,
     const uint8_t* src_ptr,
     size_t src_size,
     size_t src_offset,
@@ -21194,12 +21194,10 @@ _SOKOL_PRIVATE bool _sg_vk_staging_stream_miplevel_data(_sg_image_t* img,
     const uint32_t vk_src_offset = (uint32_t)_sg_vk_shared_buffer_memcpy(&_sg.vk.stage.stream, vk_src_ptr, (uint32_t)vk_size);
     if (vk_src_offset == _SG_VK_SHARED_BUFFER_OVERFLOW_RESULT) {
         _SG_ERROR(VULKAN_STAGING_STREAM_BUFFER_OVERFLOW);
-        return false;
     }
     region.bufferOffset = vk_src_offset;
     vkCmdCopyBufferToImage2(cmd_buf, &copy_info);
     _sg_stats_inc(vk.num_cmd_copy_buffer_to_image);
-    return true;
 }
 
 // uniform data system

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -5212,7 +5212,7 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERUNSEALED_USAGE, "sg_write_buffer_unsealed: buffer usage must be .immutable && .write_unsealed") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERUNSEALED_RESOURCESTATE, "sg_write_buffer_unsealed: buffer resource state must be SG_RESOURCESTATE_UNSEALED") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERTRANSIENT_USAGE, "sg_write_buffer_transient: buffer usage must be !.immutable && .write_transient") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERTRANSIENT_WRITE_BEFORE_BIND, "sg_write_buffer_transient: cannot be called after buffer has been bound in this frame") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERTRANSIENT_WRITE_BEFORE_BIND, "sg_write_buffer_transient: cannot be called after buffer has already been bound in this frame") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFER_SRC_DATA_POINTER, "sg_write_buffer_*: desc.src.data.ptr must be valid") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFER_SRC_DATA_SIZE, "sg_write_buffer_*: desc.src.data.size must be > 0") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFER_SIZE, "sg_write_buffer_*: desc.size must be > 0 and <= desc.src.data.size") \
@@ -17519,12 +17519,32 @@ _SOKOL_PRIVATE void _sg_mtl_update_image(_sg_image_t* img, const sg_image_data* 
     _sg_mtl_copy_image_data(img, mtl_tex, data);
 }
 
+_SOKOL_PRIVATE void _sg_mtl_write_buffer_common(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
+    SOKOL_ASSERT(desc->src.data.ptr && (desc->src.data.size > 0));
+    SOKOL_ASSERT((desc->dst.offset + desc->size) <= (size_t)buf->cmn.size);
+    SOKOL_ASSERT((desc->src.offset + desc->size) <= desc->src.data.size);
+    __unsafe_unretained id<MTLBuffer> mtl_buf = _sg_mtl_id(buf->mtl.buf[buf->cmn.active_slot]);
+    uint8_t* dst_ptr = ((uint8_t*)[mtl_buf contents]) + desc->dst.offset;
+    const uint8_t* src_ptr = ((uint8_t*)desc->src.data.ptr) + desc->src.offset;
+    memcpy(dst_ptr, src_ptr, desc->size);
+}
+
 _SOKOL_PRIVATE void _sg_mtl_write_buffer_transient(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
     SOKOL_ASSERT(buf && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_VALID == buf->slot.state);
     SOKOL_ASSERT(buf->cmn.usage.write_transient);
+    _sg_mtl_write_buffer_common(buf, desc);
+    if (_sg_mtl_resource_options_storage_mode_managed_or_shared() == MTLResourceStorageModeManaged) {
+        __unsafe_unretained id<MTLBuffer> mtl_buf = _sg_mtl_id(buf->mtl.buf[buf->cmn.active_slot]);
+        [mtl_buf didModifyRange:NSMakeRange(desc->dst.offset, desc->size)];
+    }
+}
 
-    SOKOL_ASSERT(false && "FIXME: _sg_mtl_write_buffer_transient");
+_SOKOL_PRIVATE void _sg_mtl_write_buffer_unsealed(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
+    SOKOL_ASSERT(buf && desc);
+    SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == buf->slot.state);
+    SOKOL_ASSERT(buf->cmn.usage.write_unsealed);
+    _sg_mtl_write_buffer_common(buf, desc);
 }
 
 _SOKOL_PRIVATE void _sg_mtl_write_image_transient(_sg_image_t* img, const sg_write_image_desc* desc) {
@@ -17533,18 +17553,6 @@ _SOKOL_PRIVATE void _sg_mtl_write_image_transient(_sg_image_t* img, const sg_wri
 //    SOKOL_ASSERT(img->cmn.usage.write_transient);
 
     SOKOL_ASSERT(false && "FIXME: _sg_mtl_write_image_transient");
-}
-
-_SOKOL_PRIVATE void _sg_mtl_write_buffer_unsealed(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
-    SOKOL_ASSERT(buf && desc);
-    SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == buf->slot.state);
-    SOKOL_ASSERT(desc->src.data.ptr && (desc->src.data.size > 0));
-    SOKOL_ASSERT((desc->dst.offset + desc->size) <= (size_t)buf->cmn.size);
-    SOKOL_ASSERT((desc->src.offset + desc->size) <= desc->src.data.size);
-    __unsafe_unretained id<MTLBuffer> mtl_buf = _sg_mtl_id(buf->mtl.buf[buf->cmn.active_slot]);
-    uint8_t* dst_ptr = ((uint8_t*)[mtl_buf contents]) + desc->dst.offset;
-    const uint8_t* src_ptr = ((uint8_t*)desc->src.data.ptr) + desc->src.offset;
-    memcpy(dst_ptr, src_ptr, desc->size);
 }
 
 _SOKOL_PRIVATE void _sg_mtl_write_image_unsealed(_sg_image_t* img, const sg_write_image_desc* desc) {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3357,25 +3357,29 @@ typedef struct sg_bindings {
     .immutable (default: true)
         the buffer content will never be updated from the CPU side while
         in 'valid' resource state (but may be written to by a compute shader)
-    .dynamic_update (default: false)
-        the buffer content will be infrequently updated from the CPU side
-    .stream_update (default: false)
-        the buffer content will be updated each frame from the CPU side
     .write_unsealed (default: false)
         when true, creates an immutable buffer in 'unsealed' resource state,
         unsealed buffers can be populated with data by one or multiple
         `sg_write_buffer_unsealed()` calls before being 'sealed' by
         calling `sg_seal_buffer()` which transitions from 'unsealed'
         to 'valid' resource state
+    .write_transient (default: false)
+        TODO: docs
+    .dynamic_update (default: false)
+        the buffer content will be infrequently updated from the CPU side
+    .stream_update (deprecated, default: false)
+        the buffer content will be updated each frame from the CPU side
 */
 typedef struct sg_buffer_usage {
     bool vertex_buffer;
     bool index_buffer;
     bool storage_buffer;
     bool immutable;
-    bool dynamic_update;
-    bool stream_update;
     bool write_unsealed;
+    bool write_transient;
+    bool dynamic_update;
+    // deprecated:
+    bool stream_update;
 } sg_buffer_usage;
 
 /*
@@ -3472,16 +3476,18 @@ typedef struct sg_buffer_desc {
     .immutable (default: true)
         the image content cannot be updated from the CPU side
         (but may be updated by the GPU in a render- or compute-pass)
-    .dynamic_update (default: false)
-        the image content is updated infrequently by the CPU via sg_update_image()
-    .stream_update (default: false)
-        the image content is updated each frame by the CPU via sg_update_image()
     .write_unsealed (default: false)
         when true, creates an immutable image in 'unsealed' resource state,
         unsealed images can be populated with data by one or multiple
         `sg_write_image_unsealed()` calls before being 'sealed' by
         calling `sg_seal_image()` which transitions from 'unsealed'
         to 'valid' resource state
+    .write_transient (default: false)
+        TODO: docs
+    .dynamic_update (default: false)
+        the image content is updated infrequently by the CPU via sg_update_image()
+    .stream_update (deprecated, default: false)
+        the image content is updated each frame by the CPU via sg_update_image()
 
     Note that creating a texture view from the image to be used for
     texture-sampling in vertex-, fragment- or compute-shaders
@@ -3493,9 +3499,11 @@ typedef struct sg_image_usage {
     bool resolve_attachment;
     bool depth_stencil_attachment;
     bool immutable;
-    bool dynamic_update;
-    bool stream_update;
     bool write_unsealed;
+    bool write_transient;
+    bool dynamic_update;
+    // deprecated:
+    bool stream_update;
 } sg_image_usage;
 
 /*
@@ -4349,6 +4357,8 @@ typedef struct sg_trace_hooks {
     void (*update_buffer)(sg_buffer buf, const sg_range* data, void* user_data);
     void (*update_image)(sg_image img, const sg_image_data* data, void* user_data);
     void (*append_buffer)(sg_buffer buf, const sg_range* data, int result, void* user_data);
+    void (*write_buffer_transient)(const sg_write_buffer_desc* desc, void* user_data);
+    void (*write_image_transient)(const sg_write_image_desc* desc, void* user_data);
     void (*write_buffer_unsealed)(const sg_write_buffer_desc* desc, void* user_data);
     void (*write_image_unsealed)(const sg_write_image_desc* desc, void* user_data);
     void (*seal_buffer)(sg_buffer buf, void* user_data);
@@ -4668,6 +4678,8 @@ typedef struct sg_frame_stats {
     uint32_t num_update_buffer;
     uint32_t num_append_buffer;
     uint32_t num_update_image;
+    uint32_t num_write_buffer_transient;
+    uint32_t num_write_image_transient;
     uint32_t num_write_buffer_unsealed;
     uint32_t num_write_image_unsealed;
     uint32_t num_seal_buffer;
@@ -4868,6 +4880,8 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(BEGINPASS_TOO_MANY_RESOLVE_ATTACHMENTS, "sg_begin_pass: too many resolve attachments (sg_limits.max_color_attachments)") \
     _SG_LOGITEM_XMACRO(BEGINPASS_ATTACHMENTS_ALIVE, "sg_begin_pass: an attachment was provided that no longer exists") \
     _SG_LOGITEM_XMACRO(DRAW_WITHOUT_BINDINGS, "attempting to draw without resource bindings") \
+    _SG_LOGITEM_XMACRO(WRITE_BUFFER_TRANSIENT_BUFFER_ALIVE, "sg_write_buffer_transient: buffer is no longer alive") \
+    _SG_LOGITEM_XMACRO(WRITE_IMAGE_TRANSIENT_IMAGE_ALIVE, "sg_write_image_transient: image is no longer alive") \
     _SG_LOGITEM_XMACRO(WRITE_BUFFER_UNSEALED_BUFFER_ALIVE, "sg_write_buffer_unsealed: buffer is no longer alive") \
     _SG_LOGITEM_XMACRO(WRITE_IMAGE_UNSEALED_IMAGE_ALIVE, "sg_write_image_unsealed: image is no longer alive") \
     _SG_LOGITEM_XMACRO(SEAL_BUFFER_ALIVE, "sg_seal_buffer: buffer is no longer alive") \
@@ -5517,6 +5531,8 @@ SOKOL_GFX_API_DECL void sg_end_pass(void);
 SOKOL_GFX_API_DECL void sg_commit(void);
 
 // resource update functions (wip new resource update api)
+SOKOL_GFX_API_DECL void sg_write_buffer_transient(const sg_write_buffer_desc* desc);
+SOKOL_GFX_API_DECL void sg_write_image_transient(const sg_write_image_desc* desc);
 SOKOL_GFX_API_DECL void sg_write_buffer_unsealed(const sg_write_buffer_desc* desc);
 SOKOL_GFX_API_DECL void sg_write_image_unsealed(const sg_write_image_desc* desc);
 SOKOL_GFX_API_DECL void sg_seal_buffer(sg_buffer buf);
@@ -5837,6 +5853,8 @@ inline void sg_init_shader(sg_shader shd, const sg_shader_desc& desc) { return s
 inline void sg_init_pipeline(sg_pipeline pip, const sg_pipeline_desc& desc) { return sg_init_pipeline(pip, &desc); }
 inline void sg_init_view(sg_view view, const sg_view_desc& desc) { return sg_init_view(view, &desc); }
 
+inline void sg_write_buffer_transient(const sg_write_buffer_desc* desc) { return sg_write_buffer_transient(&desc); }
+inline void sg_write_image_transient(const sg_write_image_desc* desc) { return sg_write_image_transient(&desc); }
 inline void sg_write_buffer_unsealed(const sg_write_buffer_desc& desc) { return sg_write_buffer_unsealed(&desc); }
 inline void sg_write_image_unsealed(const sg_write_image_desc& desc) { return sg_write_image_unsealed(&desc); }
 inline void sg_update_image(sg_image img, const sg_image_data& data) { return sg_update_image(img, &data); }
@@ -17496,6 +17514,22 @@ _SOKOL_PRIVATE void _sg_mtl_update_image(_sg_image_t* img, const sg_image_data* 
     _sg_mtl_copy_image_data(img, mtl_tex, data);
 }
 
+_SOKOL_PRIVATE void _sg_mtl_write_buffer_transient(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
+    SOKOL_ASSERT(buf && desc);
+    SOKOL_ASSERT(SG_RESOURCESTATE_VALID == buf->slot.state);
+    SOKOL_ASSERT(buf->cmn.usage.write_transient);
+
+    SOKOL_ASSERT(false && "FIXME: _sg_mtl_write_buffer_transient");
+}
+
+_SOKOL_PRIVATE void _sg_mtl_write_image_transient(_sg_image_t* img, const sg_write_image_desc* desc) {
+    SOKOL_ASSERT(img && desc);
+    SOKOL_ASSERT(SG_RESOURCESTATE_VALID == img->slot.state);
+    SOKOL_ASSERT(img->cmn.usage.write_transient);
+
+    SOKOL_ASSERT(false && "FIXME: _sg_mtl_write_image_transient");
+}
+
 _SOKOL_PRIVATE void _sg_mtl_write_buffer_unsealed(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
     SOKOL_ASSERT(buf && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == buf->slot.state);
@@ -23446,6 +23480,42 @@ static inline void _sg_update_image(_sg_image_t* img, const sg_image_data* data)
     #endif
 }
 
+static inline void _sg_write_buffer_transient(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
+    #if defined(_SOKOL_ANY_GL)
+    _sg_gl_write_buffer_transient(buf, desc);
+    #elif defined(SOKOL_METAL)
+    _sg_mtl_write_buffer_transient(buf, desc);
+    #elif defined(SOKOL_D3D11)
+    _sg_d3d11_write_buffer_transient(buf, desc);
+    #elif defined(SOKOL_WGPU)
+    _sg_wgpu_write_buffer_transient(buf, desc);
+    #elif defined(SOKOL_VULKAN)
+    _sg_vk_write_buffer_transient(buf, desc);
+    #elif defined(SOKOL_DUMMY_BACKEND)
+    _sg_dummy_write_buffer_transient(buf, desc);
+    #else
+    #error("INVALID BACKEND");
+    #endif
+}
+
+static inline void _sg_write_image_transient(_sg_image_t* img, const sg_write_image_desc* desc) {
+    #if defined(_SOKOL_ANY_GL)
+    _sg_gl_write_image_transient(img, desc);
+    #elif defined(SOKOL_METAL)
+    _sg_mtl_write_image_transient(img, desc);
+    #elif defined(SOKOL_D3D11)
+    _sg_d3d11_write_image_transient(img, desc);
+    #elif defined(SOKOL_WGPU)
+    _sg_wgpu_write_image_transient(img, desc);
+    #elif defined(SOKOL_VULKAN)
+    _sg_vk_write_image_transient(img, desc);
+    #elif defined(SOKOL_DUMMY_BACKEND)
+    _sg_dummy_write_image_transient(img, desc);
+    #else
+    #error("INVALID BACKEND");
+    #endif
+}
+
 static inline void _sg_write_buffer_unsealed(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
     #if defined(_SOKOL_ANY_GL)
     _sg_gl_write_buffer_unsealed(buf, desc);
@@ -25055,6 +25125,38 @@ _SOKOL_PRIVATE bool _sg_validate_update_image(const _sg_image_t* img, const sg_i
             img->cmn.height,
             img->cmn.num_mipmaps,
             img->cmn.num_slices);
+        return _sg_validate_end();
+    #endif
+}
+
+_SOKOL_PRIVATE bool _sg_validate_write_buffer_transient(const _sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
+    #if !defined(SOKOL_DEBUG)
+        _SOKOL_UNUSED(buf);
+        _SOKOL_UNUSED(desc);
+        return true;
+    #else
+        if (_sg.desc.disable_validation) {
+            return true;
+        }
+        SOKOL_ASSERT(buf && desc);
+        _sg_validate_begin();
+        SOKOL_ASSERT(false && "FIXME: _sg_validate_write_buffer_transient");
+        return _sg_validate_end();
+    #endif
+}
+
+_SOKOL_PRIVATE bool _sg_validate_write_image_transient(const _sg_image_t* img, const sg_write_image_desc* desc) {
+    #if !defined(SOKOL_DEBUG)
+        _SOKOL_UNUSED(img);
+        _SOKOL_UNUSED(desc);
+        return true;
+    #else
+        if (_sg.desc.disable_validation) {
+            return true;
+        }
+        SOKOL_ASSERT(img && desc);
+        _sg_validate_begin();
+        SOKOL_ASSERT(false && "FIXME: _sg_validate_write_image_transient");
         return _sg_validate_end();
     #endif
 }
@@ -27104,6 +27206,37 @@ SOKOL_API_IMPL void sg_update_image(sg_image img_id, const sg_image_data* data) 
         }
     }
     _SG_TRACE_ARGS(update_image, img_id, data);
+}
+
+SOKOL_API_IMPL void sg_write_buffer_transient(const sg_write_buffer_desc* desc) {
+    SOKOL_ASSERT(_sg.valid);
+    SOKOL_ASSERT(desc);
+    _sg_stats_inc(num_write_buffer_transient);
+    _sg_buffer_t* buf = _sg_lookup_buffer(desc->dst.buffer.id);
+    if (buf) {
+        sg_write_buffer_desc desc_def = _sg_write_buffer_desc_defaults(desc);
+        if (_sg_validate_write_buffer_transient(buf, &desc_def)) {
+            _sg_write_buffer_transient(buf, &desc_def);
+        }
+    } else {
+        _SG_ERROR(WRITE_BUFFER_TRANSIENT_BUFFER_ALIVE);
+    }
+    _SG_TRACE_ARGS(write_buffer_transient, desc);
+}
+
+SOKOL_API_IMPL void sg_write_image_transient(const sg_write_image_desc* desc) {
+    SOKOL_ASSERT(_sg.valid);
+    SOKOL_ASSERT(desc);
+    _sg_image_t* img = _sg_lookup_image(desc->dst.image.id);
+    if (img) {
+        sg_write_image_desc desc_def = _sg_write_image_desc_defaults(img, desc);
+        if (_sg_validate_write_image_transient(img, &desc_def)) {
+            _sg_write_image_transient(img, &desc_def);
+        }
+    } else {
+        _SG_ERROR(WRITE_IMAGE_TRANSIENT_IMAGE_ALIVE);
+    }
+    _SG_TRACE_ARGS(write_image_transient, desc);
 }
 
 SOKOL_API_IMPL void sg_write_buffer_unsealed(const sg_write_buffer_desc* desc) {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -16284,8 +16284,8 @@ _SOKOL_PRIVATE void _sg_mtl_discard_buffer(_sg_buffer_t* buf) {
 }
 
 _SOKOL_PRIVATE void _sg_mtl_commit_write_range(_sg_buffer_t* buf) {
-    SOKOL_ASSERT(buf);
     #if defined(_SG_TARGET_MACOS)
+    SOKOL_ASSERT(buf);
     if (buf->mtl.write_range.end > buf->mtl.write_range.start) {
         __unsafe_unretained id<MTLBuffer> mtl_buf = _sg_mtl_id(buf->mtl.buf[buf->cmn.active_slot]);
         if (_sg_mtl_resource_options_storage_mode_managed_or_shared() == MTLResourceStorageModeManaged) {
@@ -16295,6 +16295,8 @@ _SOKOL_PRIVATE void _sg_mtl_commit_write_range(_sg_buffer_t* buf) {
             [mtl_buf didModifyRange:ns_range];
         }
     }
+    #else
+    _SOKOL_UNUSED(buf);
     #endif
     // NOTE: write_range is not reset here, but instead in _sg_mtl_write_buffer_transient().
     // This is because the _sg_mtl_commit_write_range may never actually be called in

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4764,6 +4764,7 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(D3D11_MAP_FOR_UPDATE_BUFFER_FAILED, "Map() failed when updating buffer (d3d11)") \
     _SG_LOGITEM_XMACRO(D3D11_MAP_FOR_APPEND_BUFFER_FAILED, "Map() failed when appending to buffer (d3d11)") \
     _SG_LOGITEM_XMACRO(D3D11_MAP_FOR_UPDATE_IMAGE_FAILED, "Map() failed when updating image (d3d11)") \
+    _SG_LOGITEM_XMACRO(D3D11_MAP_FOR_WRITE_BUFFER_TRANSIENT_FAILED, "Map() failed during sg_write_buffer_transient(d3d11)") \
     _SG_LOGITEM_XMACRO(METAL_CREATE_BUFFER_FAILED, "failed to create buffer object (metal)") \
     _SG_LOGITEM_XMACRO(METAL_TEXTURE_FORMAT_NOT_SUPPORTED, "pixel format not supported for texture (metal)") \
     _SG_LOGITEM_XMACRO(METAL_CREATE_TEXTURE_FAILED, "failed to create texture object (metal)") \
@@ -14985,6 +14986,29 @@ _SOKOL_PRIVATE void _sg_d3d11_apply_pipeline(_sg_pipeline_t* pip) {
     }
 }
 
+_SOKOL_PRIVATE void* _sg_d3d11_map_buffer(_sg_buffer_t* buf, D3D11_MAP d3d11_map_type) {
+    SOKOL_ASSERT(buf);
+    SOKOL_ASSERT(_sg.d3d11.ctx);
+    SOKOL_ASSERT(buf->d3d11.buf);
+    D3D11_MAPPED_SUBRESOURCE d3d11_msr;
+    HRESULT hr = _sg_d3d11_Map(_sg.d3d11.ctx, (ID3D11Resource*)buf->d3d11.buf, 0, d3d11_map_type, 0, &d3d11_msr);
+    _sg_stats_inc(d3d11.num_map);
+    if (SUCCEEDED(hr)) {
+        SOKOL_ASSERT(d3d11_msr.pData);
+        return d3d11_msr.pData;
+    } else {
+        return 0;
+    }
+}
+
+_SOKOL_PRIVATE void _sg_d3d11_unmap_buffer(_sg_buffer_t* buf) {
+    SOKOL_ASSERT(buf);
+    SOKOL_ASSERT(_sg.d3d11.ctx);
+    SOKOL_ASSERT(buf->d3d11.buf);
+    _sg_d3d11_Unmap(_sg.d3d11.ctx, (ID3D11Resource*)buf->d3d11.buf, 0);
+    _sg_stats_inc(d3d11.num_unmap);
+}
+
 _SOKOL_PRIVATE bool _sg_d3d11_apply_bindings(_sg_bindings_ptrs_t* bnd) {
     SOKOL_ASSERT(bnd);
     SOKOL_ASSERT(bnd->pip);
@@ -15173,15 +15197,10 @@ _SOKOL_PRIVATE void _sg_d3d11_commit(void) {
 
 _SOKOL_PRIVATE void _sg_d3d11_update_buffer(_sg_buffer_t* buf, const sg_range* data) {
     SOKOL_ASSERT(buf && data && data->ptr && (data->size > 0));
-    SOKOL_ASSERT(_sg.d3d11.ctx);
-    SOKOL_ASSERT(buf->d3d11.buf);
-    D3D11_MAPPED_SUBRESOURCE d3d11_msr;
-    HRESULT hr = _sg_d3d11_Map(_sg.d3d11.ctx, (ID3D11Resource*)buf->d3d11.buf, 0, D3D11_MAP_WRITE_DISCARD, 0, &d3d11_msr);
-    _sg_stats_inc(d3d11.num_map);
-    if (SUCCEEDED(hr)) {
-        memcpy(d3d11_msr.pData, data->ptr, data->size);
-        _sg_d3d11_Unmap(_sg.d3d11.ctx, (ID3D11Resource*)buf->d3d11.buf, 0);
-        _sg_stats_inc(d3d11.num_unmap);
+    void* mapped_ptr = _sg_d3d11_map_buffer(buf, D3D11_MAP_WRITE_DISCARD);
+    if (mapped_ptr) {
+        memcpy(mapped_ptr, data->ptr, data->size);
+        _sg_d3d11_unmap_buffer(buf);
     } else {
         _SG_ERROR(D3D11_MAP_FOR_UPDATE_BUFFER_FAILED);
     }
@@ -15191,15 +15210,12 @@ _SOKOL_PRIVATE void _sg_d3d11_append_buffer(_sg_buffer_t* buf, const sg_range* d
     SOKOL_ASSERT(buf && data && data->ptr && (data->size > 0));
     SOKOL_ASSERT(_sg.d3d11.ctx);
     SOKOL_ASSERT(buf->d3d11.buf);
-    D3D11_MAP map_type = new_frame ? D3D11_MAP_WRITE_DISCARD : D3D11_MAP_WRITE_NO_OVERWRITE;
-    D3D11_MAPPED_SUBRESOURCE d3d11_msr;
-    HRESULT hr = _sg_d3d11_Map(_sg.d3d11.ctx, (ID3D11Resource*)buf->d3d11.buf, 0, map_type, 0, &d3d11_msr);
-    _sg_stats_inc(d3d11.num_map);
-    if (SUCCEEDED(hr)) {
-        uint8_t* dst_ptr = (uint8_t*)d3d11_msr.pData + buf->cmn.append_pos;
+    D3D11_MAP d3d11_map_type = new_frame ? D3D11_MAP_WRITE_DISCARD : D3D11_MAP_WRITE_NO_OVERWRITE;
+    void* mapped_ptr = _sg_d3d11_map_buffer(buf, d3d11_map_type);
+    if (mapped_ptr) {
+        uint8_t* dst_ptr = (uint8_t*)mapped_ptr + buf->cmn.append_pos;
         memcpy(dst_ptr, data->ptr, data->size);
-        _sg_d3d11_Unmap(_sg.d3d11.ctx, (ID3D11Resource*)buf->d3d11.buf, 0);
-        _sg_stats_inc(d3d11.num_unmap);
+        _sg_d3d11_unmap_buffer(buf);
     } else {
         _SG_ERROR(D3D11_MAP_FOR_APPEND_BUFFER_FAILED);
     }
@@ -15332,9 +15348,19 @@ _SOKOL_PRIVATE void _sg_d3d11_write_buffer_transient(_sg_buffer_t* buf, const sg
     SOKOL_ASSERT(buf && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_VALID == buf->slot.state);
     SOKOL_ASSERT(buf->cmn.usage.write_transient);
-
-    _SOKOL_UNUSED(first_time_in_frame);
-    SOKOL_ASSERT(false && "FIXME");
+    SOKOL_ASSERT(desc->src.data.ptr && (desc->src.data.size > 0));
+    SOKOL_ASSERT((desc->dst.offset + desc->size) <= (size_t)buf->cmn.size);
+    SOKOL_ASSERT((desc->src.offset + desc->size) <= desc->src.data.size);
+    const D3D11_MAP d3d11_map_type = first_time_in_frame ? D3D11_MAP_WRITE_DISCARD : D3D11_MAP_WRITE_NO_OVERWRITE;
+    void* mapped_ptr = _sg_d3d11_map_buffer(buf, d3d11_map_type);
+    if (mapped_ptr) {
+        uint8_t* dst_ptr = (uint8_t*)mapped_ptr + desc->dst.offset;
+        const uint8_t* src_ptr = (uint8_t*)desc->src.data.ptr + desc->src.offset;
+        memcpy(dst_ptr, src_ptr, desc->size);
+        _sg_d3d11_unmap_buffer(buf);
+    } else {
+        _SG_ERROR(D3D11_MAP_FOR_WRITE_BUFFER_TRANSIENT_FAILED);
+    }
 }
 
 _SOKOL_PRIVATE void _sg_d3d11_write_buffer_unsealed(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
@@ -17607,7 +17633,7 @@ _SOKOL_PRIVATE void _sg_mtl_write_buffer_common(_sg_buffer_t* buf, const sg_writ
     // copy data...
     __unsafe_unretained id<MTLBuffer> mtl_buf = _sg_mtl_id(buf->mtl.buf[buf->cmn.active_slot]);
     uint8_t* dst_ptr = ((uint8_t*)[mtl_buf contents]) + desc->dst.offset;
-    const uint8_t* src_ptr = ((uint8_t*)desc->src.data.ptr) + desc->src.offset;
+    const uint8_t* src_ptr = (uint8_t*)desc->src.data.ptr + desc->src.offset;
     memcpy(dst_ptr, src_ptr, desc->size);
 
     // ...and update dirty range

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -5157,11 +5157,13 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_TEXVIEW_EXPECTED_NON_MULTISAMPLED_IMAGE, "sg_apply_bindings: texture bindings expects image with sample_count == 1") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_TEXVIEW_EXPECTED_FILTERABLE_IMAGE, "sg_apply_bindings: filterable image expected") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_TEXVIEW_EXPECTED_DEPTH_IMAGE, "sg_apply_bindings: depth image expected") \
+    _SG_LOGITEM_XMACRO(VALIDATE_ABND_TEXVIEW_IMAGE_WRITE_TRANSIENT, "sg_apply_bindings: sg_write_image_transient() hasn't been called this frame for usage.write_transient texture image in view slot") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_SBVIEW_READWRITE_IMMUTABLE, "sg_apply_bindings: storage buffers bound as read/write must have usage immutable") \
-    _SG_LOGITEM_XMACRO(VALIDATE_ABND_SBVIEW_SBUF_WRITE_TRANSIENT, "sg_apply_bindings: sg_write_buffer_transient() hasn't been called this frame for usage.write_transient storage buffer in view slot") \
+    _SG_LOGITEM_XMACRO(VALIDATE_ABND_SBVIEW_BUFFER_WRITE_TRANSIENT, "sg_apply_bindings: sg_write_buffer_transient() hasn't been called this frame for usage.write_transient storage buffer in view slot") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_SIMGVIEW_COMPUTE_PASS_EXPECTED, "sg_apply_bindings: storage image bindings can only appear on compute passes") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_SIMGVIEW_IMAGETYPE_MISMATCH, "sg_apply_bindings: image type of bound storage image doesn't match shader desc") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_SIMGVIEW_ACCESSFORMAT, "sg_apply_bindings: pixel format of storage image view doesn't match access format in shader desc") \
+    _SG_LOGITEM_XMACRO(VALIDATE_ABND_SIMGVIEW_IMAGE_WRITE_TRANSIENT, "sg_apply_bindings: sg_write_image_transient() hasn't been called this frame for usage.write_transient storage image in view slot") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECTED_SAMPLER_BINDING, "sg_apply_bindings: sampler binding is missing or the sampler handle is invalid") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_UNEXPECTED_SAMPLER_COMPARE_NEVER, "sg_apply_bindings: shader expects SG_SAMPLERTYPE_COMPARISON but sampler has SG_COMPAREFUNC_NEVER") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECTED_SAMPLER_COMPARE_NEVER, "sg_apply_bindings: shader expects SG_SAMPLERTYPE_FILTERING or SG_SAMPLERTYPE_NONFILTERING but sampler doesn't have SG_COMPAREFUNC_NEVER") \
@@ -17557,14 +17559,27 @@ _SOKOL_PRIVATE void _sg_mtl_write_buffer_unsealed(_sg_buffer_t* buf, const sg_wr
 _SOKOL_PRIVATE void _sg_mtl_write_image_transient(_sg_image_t* img, const sg_write_image_desc* desc) {
     SOKOL_ASSERT(img && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_VALID == img->slot.state);
-//    SOKOL_ASSERT(img->cmn.usage.write_transient);
-
-    SOKOL_ASSERT(false && "FIXME: _sg_mtl_write_image_transient");
+    SOKOL_ASSERT(img->cmn.usage.write_transient);
+    __unsafe_unretained id<MTLTexture> mtl_tex = _sg_mtl_id(img->mtl.tex[img->cmn.active_slot]);
+    _sg_mtl_write_miplevel_data(img, mtl_tex,
+        (const uint8_t*)desc->src.data.ptr,
+        desc->src.data.size,
+        desc->src.offset,
+        desc->src.bytes_per_row,
+        desc->src.bytes_per_slice,
+        desc->dst.mip_level,
+        desc->dst.x,
+        desc->dst.y,
+        desc->dst.slice,
+        desc->size.width,
+        desc->size.height,
+        desc->size.num_slices);
 }
 
 _SOKOL_PRIVATE void _sg_mtl_write_image_unsealed(_sg_image_t* img, const sg_write_image_desc* desc) {
     SOKOL_ASSERT(img && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == img->slot.state);
+    SOKOL_ASSERT(img->cmn.usage.write_unsealed);
     __unsafe_unretained id<MTLTexture> mtl_tex = _sg_mtl_id(img->mtl.tex[img->cmn.active_slot]);
     _sg_mtl_write_miplevel_data(img, mtl_tex,
         (const uint8_t*)desc->src.data.ptr,
@@ -24883,6 +24898,9 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bindings) {
                                         default:
                                             break;
                                     }
+                                    if (img->cmn.usage.write_transient) {
+                                        _SG_VALIDATE(img->cmn.write_transient_frame_index == _sg.frame_index, VALIDATE_ABND_TEXVIEW_IMAGE_WRITE_TRANSIENT);
+                                    }
                                 }
                             } else if (shd->cmn.views[i].view_type == SG_VIEWTYPE_STORAGEBUFFER) {
                                 // the view object must be a storage buffer view
@@ -24894,7 +24912,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bindings) {
                                         _SG_VALIDATE(buf->cmn.usage.immutable, VALIDATE_ABND_SBVIEW_READWRITE_IMMUTABLE);
                                     }
                                     if (buf->cmn.usage.write_transient) {
-                                        _SG_VALIDATE(buf->cmn.write_transient_frame_index == _sg.frame_index, VALIDATE_ABND_SBVIEW_SBUF_WRITE_TRANSIENT);
+                                        _SG_VALIDATE(buf->cmn.write_transient_frame_index == _sg.frame_index, VALIDATE_ABND_SBVIEW_BUFFER_WRITE_TRANSIENT);
                                     }
                                 }
                             } else if (shd->cmn.views[i].view_type == SG_VIEWTYPE_STORAGEIMAGE) {
@@ -24907,6 +24925,9 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bindings) {
                                     const _sg_image_t* img = _sg_image_ref_ptr(&view->cmn.img.ref);
                                     _SG_VALIDATE(img->cmn.type == shd->cmn.views[i].image_type, VALIDATE_ABND_SIMGVIEW_IMAGETYPE_MISMATCH);
                                     _SG_VALIDATE(img->cmn.pixel_format == shd->cmn.views[i].access_format, VALIDATE_ABND_SIMGVIEW_ACCESSFORMAT);
+                                    if (img->cmn.usage.write_transient) {
+                                        _SG_VALIDATE(img->cmn.write_transient_frame_index == _sg.frame_index, VALIDATE_ABND_SIMGVIEW_IMAGE_WRITE_TRANSIENT);
+                                    }
                                 }
                             }
                         }
@@ -27297,6 +27318,13 @@ SOKOL_API_IMPL void sg_write_image_transient(const sg_write_image_desc* desc) {
     if (img) {
         sg_write_image_desc desc_def = _sg_write_image_desc_defaults(img, desc);
         if (_sg_validate_write_image_transient(img, &desc_def)) {
+            // if this is the first call in a frame, rotate the 'active_slot'
+            if (img->cmn.write_transient_frame_index != _sg.frame_index) {
+                img->cmn.write_transient_frame_index = _sg.frame_index;
+                if (++img->cmn.active_slot >= img->cmn.num_slots) {
+                    img->cmn.active_slot = 0;
+                }
+            }
             _sg_write_image_transient(img, &desc_def);
         }
     } else {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -9528,6 +9528,20 @@ _SOKOL_PRIVATE void _sg_dummy_update_image(_sg_image_t* img, const sg_image_data
     }
 }
 
+_SOKOL_PRIVATE void _sg_dummy_write_buffer_transient(_sg_buffer_t* buf, const sg_write_buffer_desc* desc, bool first_time_in_frame) {
+    SOKOL_ASSERT(buf && desc);
+    _SOKOL_UNUSED(buf);
+    _SOKOL_UNUSED(desc);
+    _SOKOL_UNUSED(first_time_in_frame);
+}
+
+_SOKOL_PRIVATE void _sg_dummy_write_image_transient(_sg_image_t* img, const sg_write_image_desc* desc, bool first_time_in_frame) {
+    SOKOL_ASSERT(img && desc);
+    _SOKOL_UNUSED(img);
+    _SOKOL_UNUSED(desc);
+    _SOKOL_UNUSED(first_time_in_frame);
+}
+
 _SOKOL_PRIVATE void _sg_dummy_write_buffer_unsealed(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
     SOKOL_ASSERT(buf && desc);
     _SOKOL_UNUSED(buf);
@@ -17677,7 +17691,7 @@ _SOKOL_PRIVATE void _sg_mtl_write_buffer_transient(_sg_buffer_t* buf, const sg_w
     // reset write range trackers when called for the first time in a frame
     // (NOTE: can be removed when removing Intel Mac compatibility)
     if (first_time_in_frame) {
-        buf->mtl.write_range.start = buf->cmn.size;
+        buf->mtl.write_range.start = (size_t)buf->cmn.size;
         buf->mtl.write_range.end = 0;
     }
     _sg_mtl_write_buffer_common(buf, desc);
@@ -25349,6 +25363,7 @@ _SOKOL_PRIVATE bool _sg_validate_update_image(const _sg_image_t* img, const sg_i
     #endif
 }
 
+#if defined(SOKOL_DEBUG)
 _SOKOL_PRIVATE void _sg_validate_write_buffer_common(const _sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
     _SG_VALIDATE(desc->src.data.ptr, VALIDATE_WRITEBUFFER_SRC_DATA_POINTER);
     _SG_VALIDATE(desc->src.data.size > 0, VALIDATE_WRITEBUFFER_SRC_DATA_SIZE);
@@ -25356,6 +25371,7 @@ _SOKOL_PRIVATE void _sg_validate_write_buffer_common(const _sg_buffer_t* buf, co
     _SG_VALIDATE((desc->dst.offset + desc->size) <= (size_t)buf->cmn.size, VALIDATE_WRITEBUFFER_WRITE_OVERFLOW);
     _SG_VALIDATE((desc->src.offset + desc->size) <= desc->src.data.size, VALIDATE_WRITEBUFFER_READ_OVERFLOW);
 }
+#endif
 
 _SOKOL_PRIVATE bool _sg_validate_write_buffer_transient(const _sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
     #if !defined(SOKOL_DEBUG)
@@ -25396,6 +25412,7 @@ _SOKOL_PRIVATE bool _sg_validate_write_buffer_unsealed(const _sg_buffer_t* buf, 
     #endif
 }
 
+#if defined(SOKOL_DEBUG)
 _SOKOL_PRIVATE void _sg_validate_write_image_common(const _sg_image_t* img, const sg_write_image_desc* desc) {
     const size_t write_size = (size_t)desc->src.bytes_per_slice * (size_t)desc->size.num_slices;
     const int mip_width = _sg_miplevel_dim(img->cmn.width, desc->dst.mip_level);
@@ -25418,6 +25435,7 @@ _SOKOL_PRIVATE void _sg_validate_write_image_common(const _sg_image_t* img, cons
     _SG_VALIDATE((desc->dst.y + desc->size.height) <= mip_height, VALIDATE_WRITEIMAGE_WRITE_HEIGHT_OVERFLOW);
     _SG_VALIDATE((desc->dst.slice + desc->size.num_slices) <= mip_depth_or_slices, VALIDATE_WRITEIMAGE_WRITE_NUMSLICES_OVERFLOW);
 }
+#endif
 
 _SOKOL_PRIVATE bool _sg_validate_write_image_transient(const _sg_image_t* img, const sg_write_image_desc* desc) {
     #if !defined(SOKOL_DEBUG)

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4908,8 +4908,9 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDATA_DATA_SIZE, "sg_image_data: data size doesn't match expected surface size") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_CANARY, "sg_image_desc not initialized") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_IMMUTABLE_VS_WRITABLE, "sg_image_desc.usage: only one of .immutable, .dynamic_update, .write_transient can be true") \
-    _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_UNSEALED_VS_IMMUTABLE, "sg_image_desc.usage: .write_unsealed only allowed for .immutable images") \
-    _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_UNSEALED_VS_ATTACHMENT, "sg_image_desc.usage: .write_unsealed not allowed for images with attachment usage") \
+    _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_WRITE_UNSEALED_VS_IMMUTABLE, "sg_image_desc.usage: .write_unsealed only allowed for .immutable images") \
+    _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_WRITE_UNSEALED_VS_ATTACHMENT, "sg_image_desc.usage: .write_unsealed not allowed for images with attachment usage") \
+    _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_WRITE_TRANSIENT_VS_ATTACHMENT, "sg_image_desc.usage: .write_transient not allowed for images with attachment usage") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_ATTACHMENT_COLOR_DEPTH_STENCIL, "sg_image_desc.usage: only one of .color_attachment and .depth_stencil_attachment can be true") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_IMAGETYPE_2D_NUMSLICES, "sg_image_desc.num_slices must be exactly 1 for SG_IMAGETYPE_2D") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_IMAGETYPE_CUBE_NUMSLICES, "sg_image_desc.num_slices must be exactly 6 for SG_IMAGETYPE_CUBE") \
@@ -24037,8 +24038,11 @@ _SOKOL_PRIVATE bool _sg_validate_image_desc(const sg_image_desc* desc) {
             _SG_VALIDATE(desc->sample_count == 1, VALIDATE_IMAGEDESC_STORAGEIMAGE_EXPECT_NO_MSAA);
         }
         if (usg->write_unsealed) {
-            _SG_VALIDATE(usg->immutable, VALIDATE_IMAGEDESC_UNSEALED_VS_IMMUTABLE);
-            _SG_VALIDATE(!any_attachment, VALIDATE_IMAGEDESC_UNSEALED_VS_ATTACHMENT);
+            _SG_VALIDATE(usg->immutable, VALIDATE_IMAGEDESC_WRITE_UNSEALED_VS_IMMUTABLE);
+            _SG_VALIDATE(!any_attachment, VALIDATE_IMAGEDESC_WRITE_UNSEALED_VS_ATTACHMENT);
+        }
+        if (usg->write_transient) {
+            _SG_VALIDATE(!any_attachment, VALIDATE_IMAGEDESC_WRITE_TRANSIENT_VS_ATTACHMENT);
         }
         if (!any_attachment && !usg->storage_image) {
             _SG_VALIDATE(desc->sample_count == 1, VALIDATE_IMAGEDESC_MSAA_BUT_NO_ATTACHMENT);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -5214,6 +5214,7 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERUNSEALED_RESOURCESTATE, "sg_write_buffer_unsealed: buffer resource state must be SG_RESOURCESTATE_UNSEALED") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERTRANSIENT_USAGE, "sg_write_buffer_transient: buffer usage must be !.immutable && .write_transient") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERTRANSIENT_WRITE_BEFORE_BIND, "sg_write_buffer_transient: cannot be called after buffer has already been bound in this frame") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERTRANSIENT_DST_OFFSET_ALIGNMENT, "sg_write_buffer_transient: dst.offset must be a multiple of 4") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFER_SRC_DATA_POINTER, "sg_write_buffer_*: desc.src.data.ptr must be valid") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFER_SRC_DATA_SIZE, "sg_write_buffer_*: desc.src.data.size must be > 0") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFER_SIZE, "sg_write_buffer_*: desc.size must be > 0 and <= desc.src.data.size") \
@@ -7118,6 +7119,11 @@ typedef struct _sg_buffer_s {
     _sg_buffer_common_t cmn;
     struct {
         int buf[SG_NUM_INFLIGHT_FRAMES];  // index into _sg_mtl_pool
+        // NOTE: write range tracking can be removed when removing Intel Mac compatibility
+        struct {
+            size_t start;
+            size_t end;
+        } write_range;
     } mtl;
 } _sg_mtl_buffer_t;
 typedef _sg_mtl_buffer_t _sg_buffer_t;
@@ -16170,16 +16176,26 @@ _SOKOL_PRIVATE void _sg_mtl_discard_buffer(_sg_buffer_t* buf) {
     }
 }
 
-_SOKOL_PRIVATE void _sg_mtl_seal_buffer(_sg_buffer_t* buf) {
+_SOKOL_PRIVATE void _sg_mtl_commit_write_range(_sg_buffer_t* buf) {
     SOKOL_ASSERT(buf);
     #if defined(_SG_TARGET_MACOS)
-    __unsafe_unretained id<MTLBuffer> mtl_buf = _sg_mtl_id(buf->mtl.buf[buf->cmn.active_slot]);
-    if (_sg_mtl_resource_options_storage_mode_managed_or_shared() == MTLResourceStorageModeManaged) {
-        [mtl_buf didModifyRange:NSMakeRange(0, (NSUInteger)buf->cmn.size)];
+    if (buf->mtl.write_range.end > buf->mtl.write_range.start) {
+        __unsafe_unretained id<MTLBuffer> mtl_buf = _sg_mtl_id(buf->mtl.buf[buf->cmn.active_slot]);
+        if (_sg_mtl_resource_options_storage_mode_managed_or_shared() == MTLResourceStorageModeManaged) {
+            const NSRange ns_range = NSMakeRange(
+                buf->mtl.write_range.start,
+                buf->mtl.write_range.end - buf->mtl.write_range.start);
+            [mtl_buf didModifyRange:ns_range];
+        }
     }
-    #else
-    _SOKOL_UNUSED(buf);
     #endif
+    // NOTE: write_range is not reset here, but instead in _sg_mtl_write_buffer_transient().
+    // This is because the _sg_mtl_commit_write_range may never actually be called in
+    // a frame (either because the buffer isn't used, or because the frame's swapchain is invalid)
+}
+
+_SOKOL_PRIVATE void _sg_mtl_seal_buffer(_sg_buffer_t* buf) {
+    _sg_mtl_commit_write_range(buf);
 }
 
 _SOKOL_PRIVATE void _sg_mtl_write_miplevel_data(const _sg_image_t* img,
@@ -17223,14 +17239,20 @@ _SOKOL_PRIVATE bool _sg_mtl_apply_bindings(_sg_bindings_ptrs_t* bnd) {
         _sg.mtl.cache.cur_ibuf_offset = bnd->ib_offset;
         if (bnd->ib) {
             SOKOL_ASSERT(bnd->pip->cmn.index_type != SG_INDEXTYPE_NONE);
+            if (bnd->ib->cmn.usage.write_transient) {
+                _sg_mtl_commit_write_range(bnd->ib);
+            }
         } else {
             SOKOL_ASSERT(bnd->pip->cmn.index_type == SG_INDEXTYPE_NONE);
         }
         // apply vertex buffers
         for (size_t i = 0; i < SG_MAX_VERTEXBUFFER_BINDSLOTS; i++) {
-            const _sg_buffer_t* vb = bnd->vbs[i];
+            _sg_buffer_t* vb = bnd->vbs[i];
             if (vb == 0) {
                 continue;
+            }
+            if (vb->cmn.usage.write_transient) {
+                _sg_mtl_commit_write_range(vb);
             }
             const NSUInteger mtl_slot = _sg_mtl_vertexbuffer_bindslot(i);
             SOKOL_ASSERT(mtl_slot < _SG_MTL_MAX_STAGE_BUFFER_BINDINGS);
@@ -17312,7 +17334,10 @@ _SOKOL_PRIVATE bool _sg_mtl_apply_bindings(_sg_bindings_ptrs_t* bnd) {
             } else SOKOL_UNREACHABLE;
         } else if (shd_view->view_type == SG_VIEWTYPE_STORAGEBUFFER) {
             SOKOL_ASSERT(mtl_slot < _SG_MTL_MAX_STAGE_UB_SBUF_BINDINGS);
-            const _sg_buffer_t* sbuf = _sg_buffer_ref_ptr(&view->cmn.buf.ref);
+            _sg_buffer_t* sbuf = _sg_buffer_ref_ptr(&view->cmn.buf.ref);
+            if (sbuf->cmn.usage.write_transient) {
+                _sg_mtl_commit_write_range(sbuf);
+            }
             const int active_slot = sbuf->cmn.active_slot;
             SOKOL_ASSERT(sbuf->mtl.buf[sbuf->cmn.active_slot] != _SG_MTL_INVALID_SLOT_INDEX);
             const int offset = view->cmn.buf.offset;
@@ -17532,21 +17557,37 @@ _SOKOL_PRIVATE void _sg_mtl_write_buffer_common(_sg_buffer_t* buf, const sg_writ
     SOKOL_ASSERT(desc->src.data.ptr && (desc->src.data.size > 0));
     SOKOL_ASSERT((desc->dst.offset + desc->size) <= (size_t)buf->cmn.size);
     SOKOL_ASSERT((desc->src.offset + desc->size) <= desc->src.data.size);
+
+    // copy data...
     __unsafe_unretained id<MTLBuffer> mtl_buf = _sg_mtl_id(buf->mtl.buf[buf->cmn.active_slot]);
     uint8_t* dst_ptr = ((uint8_t*)[mtl_buf contents]) + desc->dst.offset;
     const uint8_t* src_ptr = ((uint8_t*)desc->src.data.ptr) + desc->src.offset;
     memcpy(dst_ptr, src_ptr, desc->size);
+
+    // ...and update dirty range
+    // (NOTE: can be removed when removing Intel Mac compatibility)
+    const size_t cur_range_start = desc->dst.offset;
+    const size_t cur_range_end = desc->dst.offset + desc->size;
+    if (cur_range_start < buf->mtl.write_range.start) {
+        buf->mtl.write_range.start = cur_range_start;
+    }
+    if (cur_range_end > buf->mtl.write_range.end) {
+        buf->mtl.write_range.end = cur_range_end;
+    }
 }
 
-_SOKOL_PRIVATE void _sg_mtl_write_buffer_transient(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
+_SOKOL_PRIVATE void _sg_mtl_write_buffer_transient(_sg_buffer_t* buf, const sg_write_buffer_desc* desc, bool first_time_in_frame) {
     SOKOL_ASSERT(buf && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_VALID == buf->slot.state);
     SOKOL_ASSERT(buf->cmn.usage.write_transient);
-    _sg_mtl_write_buffer_common(buf, desc);
-    if (_sg_mtl_resource_options_storage_mode_managed_or_shared() == MTLResourceStorageModeManaged) {
-        __unsafe_unretained id<MTLBuffer> mtl_buf = _sg_mtl_id(buf->mtl.buf[buf->cmn.active_slot]);
-        [mtl_buf didModifyRange:NSMakeRange(desc->dst.offset, desc->size)];
+    // reset write range trackers when called for the first time in a frame
+    // (NOTE: can be removed when removing Intel Mac compatibility)
+    if (first_time_in_frame) {
+        buf->mtl.write_range.start = buf->cmn.size;
+        buf->mtl.write_range.end = 0;
     }
+    _sg_mtl_write_buffer_common(buf, desc);
+    // NOTE: didModifyRange happens at bind time
 }
 
 _SOKOL_PRIVATE void _sg_mtl_write_buffer_unsealed(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
@@ -17556,10 +17597,11 @@ _SOKOL_PRIVATE void _sg_mtl_write_buffer_unsealed(_sg_buffer_t* buf, const sg_wr
     _sg_mtl_write_buffer_common(buf, desc);
 }
 
-_SOKOL_PRIVATE void _sg_mtl_write_image_transient(_sg_image_t* img, const sg_write_image_desc* desc) {
+_SOKOL_PRIVATE void _sg_mtl_write_image_transient(_sg_image_t* img, const sg_write_image_desc* desc, bool first_time_in_frame) {
     SOKOL_ASSERT(img && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_VALID == img->slot.state);
     SOKOL_ASSERT(img->cmn.usage.write_transient);
+    _SOKOL_UNUSED(first_time_in_frame);
     __unsafe_unretained id<MTLTexture> mtl_tex = _sg_mtl_id(img->mtl.tex[img->cmn.active_slot]);
     _sg_mtl_write_miplevel_data(img, mtl_tex,
         (const uint8_t*)desc->src.data.ptr,
@@ -23515,37 +23557,37 @@ static inline void _sg_update_image(_sg_image_t* img, const sg_image_data* data)
     #endif
 }
 
-static inline void _sg_write_buffer_transient(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
+static inline void _sg_write_buffer_transient(_sg_buffer_t* buf, const sg_write_buffer_desc* desc, bool first_time_in_frame) {
     #if defined(_SOKOL_ANY_GL)
-    _sg_gl_write_buffer_transient(buf, desc);
+    _sg_gl_write_buffer_transient(buf, desc, first_time_in_frame);
     #elif defined(SOKOL_METAL)
-    _sg_mtl_write_buffer_transient(buf, desc);
+    _sg_mtl_write_buffer_transient(buf, desc, first_time_in_frame);
     #elif defined(SOKOL_D3D11)
-    _sg_d3d11_write_buffer_transient(buf, desc);
+    _sg_d3d11_write_buffer_transient(buf, desc, first_time_in_frame);
     #elif defined(SOKOL_WGPU)
-    _sg_wgpu_write_buffer_transient(buf, desc);
+    _sg_wgpu_write_buffer_transient(buf, desc, first_time_in_frame);
     #elif defined(SOKOL_VULKAN)
-    _sg_vk_write_buffer_transient(buf, desc);
+    _sg_vk_write_buffer_transient(buf, desc, first_time_in_frame);
     #elif defined(SOKOL_DUMMY_BACKEND)
-    _sg_dummy_write_buffer_transient(buf, desc);
+    _sg_dummy_write_buffer_transient(buf, desc, first_time_in_frame);
     #else
     #error("INVALID BACKEND");
     #endif
 }
 
-static inline void _sg_write_image_transient(_sg_image_t* img, const sg_write_image_desc* desc) {
+static inline void _sg_write_image_transient(_sg_image_t* img, const sg_write_image_desc* desc, bool first_time_in_frame) {
     #if defined(_SOKOL_ANY_GL)
-    _sg_gl_write_image_transient(img, desc);
+    _sg_gl_write_image_transient(img, desc, first_time_in_frame);
     #elif defined(SOKOL_METAL)
-    _sg_mtl_write_image_transient(img, desc);
+    _sg_mtl_write_image_transient(img, desc, first_time_in_frame);
     #elif defined(SOKOL_D3D11)
-    _sg_d3d11_write_image_transient(img, desc);
+    _sg_d3d11_write_image_transient(img, desc, first_time_in_frame);
     #elif defined(SOKOL_WGPU)
-    _sg_wgpu_write_image_transient(img, desc);
+    _sg_wgpu_write_image_transient(img, desc, first_time_in_frame);
     #elif defined(SOKOL_VULKAN)
-    _sg_vk_write_image_transient(img, desc);
+    _sg_vk_write_image_transient(img, desc, first_time_in_frame);
     #elif defined(SOKOL_DUMMY_BACKEND)
-    _sg_dummy_write_image_transient(img, desc);
+    _sg_dummy_write_image_transient(img, desc, first_time_in_frame);
     #else
     #error("INVALID BACKEND");
     #endif
@@ -25198,6 +25240,8 @@ _SOKOL_PRIVATE bool _sg_validate_write_buffer_transient(const _sg_buffer_t* buf,
         _SG_VALIDATE(!buf->cmn.usage.immutable && buf->cmn.usage.write_transient, VALIDATE_WRITEBUFFERTRANSIENT_USAGE);
         // write-transient is only allowed before resource is bound in current frame
         _SG_VALIDATE(buf->cmn.bind_frame_index != _sg.frame_index, VALIDATE_WRITEBUFFERTRANSIENT_WRITE_BEFORE_BIND);
+        // WebGPU restriction: offset must be a multiple of 4 (odd size is allowed and specifically handled)
+        _SG_VALIDATE(_sg_multiple_u64(desc->dst.offset, 4), VALIDATE_WRITEBUFFERTRANSIENT_DST_OFFSET_ALIGNMENT);
         _sg_validate_write_buffer_common(buf, desc);
         return _sg_validate_end();
     #endif
@@ -27223,7 +27267,7 @@ SOKOL_API_IMPL int sg_append_buffer(sg_buffer buf_id, const sg_range* data) {
         const int start_pos = buf->cmn.append_pos;
         // NOTE: the multiple-of-4 requirement for the buffer offset is coming
         // from WebGPU, but we want identical behaviour between backends
-        SOKOL_ASSERT(_sg_multiple_u64((uint64_t)start_pos, 4));
+        SOKOL_ASSERT(_sg_multiple(start_pos, 4));
         if (buf->slot.state == SG_RESOURCESTATE_VALID) {
             if (_sg_validate_append_buffer(buf, data)) {
                 if (!buf->cmn.append_overflow && (data->size > 0)) {
@@ -27297,13 +27341,15 @@ SOKOL_API_IMPL void sg_write_buffer_transient(const sg_write_buffer_desc* desc) 
         sg_write_buffer_desc desc_def = _sg_write_buffer_desc_defaults(desc);
         if (_sg_validate_write_buffer_transient(buf, &desc_def)) {
             // if this is the first call in a frame, rotate the 'active_slot'
+            bool first_time_in_frame = false;
             if (buf->cmn.write_transient_frame_index != _sg.frame_index) {
+                first_time_in_frame = true;
                 buf->cmn.write_transient_frame_index = _sg.frame_index;
                 if (++buf->cmn.active_slot >= buf->cmn.num_slots) {
                     buf->cmn.active_slot = 0;
                 }
             }
-            _sg_write_buffer_transient(buf, &desc_def);
+            _sg_write_buffer_transient(buf, &desc_def, first_time_in_frame);
         }
     } else {
         _SG_ERROR(WRITE_BUFFER_TRANSIENT_BUFFER_ALIVE);
@@ -27319,13 +27365,15 @@ SOKOL_API_IMPL void sg_write_image_transient(const sg_write_image_desc* desc) {
         sg_write_image_desc desc_def = _sg_write_image_desc_defaults(img, desc);
         if (_sg_validate_write_image_transient(img, &desc_def)) {
             // if this is the first call in a frame, rotate the 'active_slot'
+            bool first_time_in_frame = false;
             if (img->cmn.write_transient_frame_index != _sg.frame_index) {
+                first_time_in_frame = true;
                 img->cmn.write_transient_frame_index = _sg.frame_index;
                 if (++img->cmn.active_slot >= img->cmn.num_slots) {
                     img->cmn.active_slot = 0;
                 }
             }
-            _sg_write_image_transient(img, &desc_def);
+            _sg_write_image_transient(img, &desc_def, first_time_in_frame);
         }
     } else {
         _SG_ERROR(WRITE_IMAGE_TRANSIENT_IMAGE_ALIVE);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -21136,44 +21136,70 @@ _SOKOL_PRIVATE void _sg_vk_staging_stream_buffer_data(_sg_buffer_t* buf, const s
     _sg_vk_buffer_barrier(cmd_buf, buf, _SG_VK_ACCESS_VERTEXBUFFER|_SG_VK_ACCESS_INDEXBUFFER|_SG_VK_ACCESS_STORAGEBUFFER_RO);
 }
 
-_SOKOL_PRIVATE void _sg_vk_staging_stream_image_data(_sg_image_t* img, const sg_image_data* src_data) {
+_SOKOL_PRIVATE bool _sg_vk_staging_stream_miplevel_data(_sg_image_t* img,
+    const uint8_t* src_ptr,
+    size_t src_size,
+    size_t src_offset,
+    int src_bytes_per_row,
+    int src_bytes_per_slice,
+    int mip_level,
+    int x,
+    int y,
+    int slice,
+    int width,
+    int height,
+    int num_slices)
+{
     SOKOL_ASSERT(_sg.vk.dev);
     SOKOL_ASSERT(_sg.vk.frame.stream_cmd_buf);
     SOKOL_ASSERT(img && img->vk.img);
-    SOKOL_ASSERT(src_data);
+    SOKOL_ASSERT(src_ptr);
+    SOKOL_ASSERT(src_size > 0);
+    SOKOL_ASSERT(src_bytes_per_row > 0);
+    SOKOL_ASSERT(src_bytes_per_slice > 0);
+    SOKOL_ASSERT((mip_level >= 0) && (mip_level < img->cmn.num_mipmaps));
+    SOKOL_ASSERT((x >= 0) && (x < _sg_miplevel_dim(img->cmn.width, mip_level)));
+    SOKOL_ASSERT((y >= 0) && (y < _sg_miplevel_dim(img->cmn.height, mip_level)));
+    SOKOL_ASSERT((slice >= 0) && (slice < img->cmn.num_slices));
+    SOKOL_ASSERT((width > 0) && (x + width <= _sg_miplevel_dim(img->cmn.width, mip_level)));
+    SOKOL_ASSERT((height > 0) && (y + height <= _sg_miplevel_dim(img->cmn.height, mip_level)));
+    SOKOL_ASSERT((num_slices > 0) && (slice + num_slices <= img->cmn.num_slices));
+    SOKOL_ASSERT((src_offset + (size_t)src_bytes_per_slice * (size_t)num_slices) <= src_size);
+    SOKOL_ASSERT(_sg_multiple(src_bytes_per_row, _sg_block_bytesize(img->cmn.pixel_format)));
+    SOKOL_ASSERT(_sg_multiple(src_bytes_per_slice, src_bytes_per_row));
+    _SOKOL_UNUSED(src_size);
+
     VkCommandBuffer cmd_buf = _sg.vk.frame.stream_cmd_buf;
-    _sg_vk_image_barrier(cmd_buf, img, _SG_VK_ACCESS_STAGING);
     _SG_STRUCT(VkBufferImageCopy2, region);
     _SG_STRUCT(VkCopyBufferToImageInfo2, copy_info);
     _sg_vk_init_vk_image_staging_structs(img, _sg.vk.stage.stream.cur_buf, &region, &copy_info);
-    for (int mip_index = 0; mip_index < img->cmn.num_mipmaps; mip_index++) {
-        const sg_range* src_mip = &src_data->mip_levels[mip_index];
-        SOKOL_ASSERT(src_mip->ptr);
-        SOKOL_ASSERT(src_mip->size > 0);
-        const uint32_t src_offset = (uint32_t)_sg_vk_shared_buffer_memcpy(&_sg.vk.stage.stream, src_mip->ptr, (uint32_t)src_mip->size);
-        if (src_offset == _SG_VK_SHARED_BUFFER_OVERFLOW_RESULT) {
-            _SG_ERROR(VULKAN_STAGING_STREAM_BUFFER_OVERFLOW);
-            _sg_vk_image_barrier(cmd_buf, img, _SG_VK_ACCESS_TEXTURE);
-            return;
-        }
-        region.bufferOffset = src_offset;
-        int mip_width = _sg_miplevel_dim(img->cmn.width, mip_index);
-        int mip_height = _sg_miplevel_dim(img->cmn.height, mip_index);
-        int mip_slices = (img->cmn.type == SG_IMAGETYPE_3D) ? _sg_miplevel_dim(img->cmn.num_slices, mip_index) : img->cmn.num_slices;
-        region.imageExtent.width = (uint32_t)mip_width;
-        region.imageExtent.height = (uint32_t)mip_height;
-        region.imageSubresource.mipLevel = (uint32_t)mip_index;
-        if (img->cmn.type == SG_IMAGETYPE_3D) {
-            region.imageExtent.depth = (uint32_t)mip_slices;
-            region.imageSubresource.layerCount = 1;
-        } else {
-            region.imageExtent.depth = 1;
-            region.imageSubresource.layerCount = (uint32_t)mip_slices;
-        }
-        vkCmdCopyBufferToImage2(cmd_buf, &copy_info);
-        _sg_stats_inc(vk.num_cmd_copy_buffer_to_image);
+    const int block_dim = _sg_block_dim(img->cmn.pixel_format);
+    const int block_bytesize = _sg_block_bytesize(img->cmn.pixel_format);
+    region.bufferRowLength = (uint32_t)((src_bytes_per_row / block_bytesize) * block_dim);
+    region.bufferImageHeight = (uint32_t)((src_bytes_per_slice / src_bytes_per_row) * block_dim);
+    region.imageSubresource.mipLevel = (uint32_t)mip_level;
+    region.imageOffset.x = x;
+    region.imageOffset.y = y;
+    region.imageExtent.width = (uint32_t)width;
+    region.imageExtent.height = (uint32_t)height;
+    if (img->cmn.type == SG_IMAGETYPE_3D) {
+        region.imageOffset.z = slice;
+        region.imageExtent.depth = num_slices;
+    } else {
+        region.imageSubresource.baseArrayLayer = slice;
+        region.imageSubresource.layerCount = num_slices;
     }
-    _sg_vk_image_barrier(cmd_buf, img, _SG_VK_ACCESS_TEXTURE);
+    const uint8_t* vk_src_ptr = src_ptr + src_offset;
+    const size_t vk_size = src_bytes_per_slice * (size_t)num_slices;
+    const uint32_t vk_src_offset = (uint32_t)_sg_vk_shared_buffer_memcpy(&_sg.vk.stage.stream, vk_src_ptr, vk_size);
+    if (vk_src_offset == _SG_VK_SHARED_BUFFER_OVERFLOW_RESULT) {
+        _SG_ERROR(VULKAN_STAGING_STREAM_BUFFER_OVERFLOW);
+        return false;
+    }
+    region.bufferOffset = vk_src_offset;
+    vkCmdCopyBufferToImage2(cmd_buf, &copy_info);
+    _sg_stats_inc(vk.num_cmd_copy_buffer_to_image);
+    return true;
 }
 
 // uniform data system
@@ -23168,7 +23194,22 @@ _SOKOL_PRIVATE void _sg_vk_write_image_transient(_sg_image_t* img, const sg_writ
     if (first_time_in_frame) {
         _sg_vk_acquire_frame_command_buffers();
     }
-    SOKOL_ASSERT(false && "FIXME");
+    VkCommandBuffer cmd_buf = _sg.vk.frame.stream_cmd_buf;
+    _sg_vk_image_barrier(cmd_buf, img, _SG_VK_ACCESS_STAGING);
+    _sg_vk_staging_stream_miplevel_data(img,
+        (const uint8_t*)desc->src.data.ptr,
+        desc->src.data.size,
+        desc->src.offset,
+        desc->src.bytes_per_row,
+        desc->src.bytes_per_slice,
+        desc->dst.mip_level,
+        desc->dst.x,
+        desc->dst.y,
+        desc->dst.slice,
+        desc->size.width,
+        desc->size.height,
+        desc->size.num_slices);
+    _sg_vk_image_barrier(cmd_buf, img, _SG_VK_ACCESS_TEXTURE);
 }
 
 _SOKOL_PRIVATE void _sg_vk_write_buffer_unsealed(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -4911,6 +4911,7 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_WRITE_UNSEALED_VS_IMMUTABLE, "sg_image_desc.usage: .write_unsealed only allowed for .immutable images") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_WRITE_UNSEALED_VS_ATTACHMENT, "sg_image_desc.usage: .write_unsealed not allowed for images with attachment usage") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_WRITE_TRANSIENT_VS_ATTACHMENT, "sg_image_desc.usage: .write_transient not allowed for images with attachment usage") \
+    _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_DYNAMIC_UPDATE_VS_ATTACHMENT, "sg_image_desc.usage: .dynamic_update not allowed for images with attachment usage") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_ATTACHMENT_COLOR_DEPTH_STENCIL, "sg_image_desc.usage: only one of .color_attachment and .depth_stencil_attachment can be true") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_IMAGETYPE_2D_NUMSLICES, "sg_image_desc.num_slices must be exactly 1 for SG_IMAGETYPE_2D") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_IMAGETYPE_CUBE_NUMSLICES, "sg_image_desc.num_slices must be exactly 6 for SG_IMAGETYPE_CUBE") \
@@ -21195,6 +21196,7 @@ _SOKOL_PRIVATE void _sg_vk_staging_stream_miplevel_data(_sg_image_t* img,
     const uint32_t vk_src_offset = (uint32_t)_sg_vk_shared_buffer_memcpy(&_sg.vk.stage.stream, vk_src_ptr, (uint32_t)vk_size);
     if (vk_src_offset == _SG_VK_SHARED_BUFFER_OVERFLOW_RESULT) {
         _SG_ERROR(VULKAN_STAGING_TRANSIENT_BUFFER_OVERFLOW);
+        return;
     }
     region.bufferOffset = vk_src_offset;
     vkCmdCopyBufferToImage2(cmd_buf, &copy_info);
@@ -23903,7 +23905,7 @@ _SOKOL_PRIVATE bool _sg_validate_end(void) {
 #endif
 
 _SOKOL_PRIVATE bool _sg_one(bool b0, bool b1, bool b2) {
-    return (b0 + b1 + b2) == 1;
+    return ((int)b0 + (int)b1 + (int)b2) == 1;
 }
 
 _SOKOL_PRIVATE bool _sg_validate_buffer_desc(const sg_buffer_desc* desc) {
@@ -24043,6 +24045,9 @@ _SOKOL_PRIVATE bool _sg_validate_image_desc(const sg_image_desc* desc) {
         }
         if (usg->write_transient) {
             _SG_VALIDATE(!any_attachment, VALIDATE_IMAGEDESC_WRITE_TRANSIENT_VS_ATTACHMENT);
+        }
+        if (usg->dynamic_update) {
+            _SG_VALIDATE(!any_attachment, VALIDATE_IMAGEDESC_DYNAMIC_UPDATE_VS_ATTACHMENT);
         }
         if (!any_attachment && !usg->storage_image) {
             _SG_VALIDATE(desc->sample_count == 1, VALIDATE_IMAGEDESC_MSAA_BUT_NO_ATTACHMENT);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -5141,11 +5141,13 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_VBUF_ALIVE, "sg_apply_bindings: vertex buffer no longer alive") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_VBUF_USAGE, "sg_apply_bindings: buffer in vertex buffer bind slot must have usage.vertex_buffer") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_VBUF_OVERFLOW, "sg_apply_bindings: buffer in vertex buffer bind slot is overflown") \
+    _SG_LOGITEM_XMACRO(VALIDATE_ABND_VBUF_WRITE_TRANSIENT, "sg_apply_bindings: sg_write_buffer_transient() hasn't been called this frame for usage.write_transient buffer in vertex buffer slot") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECTED_NO_IBUF, "sg_apply_bindings: pipeline object defines non-indexed rendering, but index buffer binding provided") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECTED_IBUF, "sg_apply_bindings: pipeline object defines indexed rendering, but no index buffer binding provided") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_IBUF_ALIVE, "sg_apply_bindings: index buffer no longer alive") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_IBUF_USAGE, "sg_apply_bindings: buffer in index buffer bind slot must have usage.index_buffer") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_IBUF_OVERFLOW, "sg_apply_bindings: buffer in index buffer slot is overflown") \
+    _SG_LOGITEM_XMACRO(VALIDATE_ABND_IBUF_WRITE_TRANSIENT, "sg_apply_bindings: sg_write_buffer_transient() hasn't been called this frame for usage.write_transient buffer in index buffer slot") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECTED_VIEW_BINDING, "sg_apply_bindings: view binding is missing or the view handle is invalid") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_VIEW_ALIVE, "sg_apply_bindings: view no longer alive") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECT_TEXVIEW, "sg_apply_bindings: view type mismatch in bindslot (shader expects a texture view)") \
@@ -5157,6 +5159,7 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_TEXVIEW_EXPECTED_FILTERABLE_IMAGE, "sg_apply_bindings: filterable image expected") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_TEXVIEW_EXPECTED_DEPTH_IMAGE, "sg_apply_bindings: depth image expected") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_SBVIEW_READWRITE_IMMUTABLE, "sg_apply_bindings: storage buffers bound as read/write must have usage immutable") \
+    _SG_LOGITEM_XMACRO(VALIDATE_ABND_SBVIEW_SBUF_WRITE_TRANSIENT, "sg_apply_bindings: sg_write_buffer_transient() hasn't been called this frame for usage.write_transient storage buffer in view slot") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_SIMGVIEW_COMPUTE_PASS_EXPECTED, "sg_apply_bindings: storage image bindings can only appear on compute passes") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_SIMGVIEW_IMAGETYPE_MISMATCH, "sg_apply_bindings: image type of bound storage image doesn't match shader desc") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_SIMGVIEW_ACCESSFORMAT, "sg_apply_bindings: pixel format of storage image view doesn't match access format in shader desc") \
@@ -5208,11 +5211,13 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_UPDIMG_ONCE, "sg_update_image: only one update allowed per image and frame") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERUNSEALED_USAGE, "sg_write_buffer_unsealed: buffer usage must be .immutable && .write_unsealed") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERUNSEALED_RESOURCESTATE, "sg_write_buffer_unsealed: buffer resource state must be SG_RESOURCESTATE_UNSEALED") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERUNSEALED_SRC_DATA_POINTER, "sg_write_buffer_unsealed: desc.src.data.ptr must be valid") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERUNSEALED_SRC_DATA_SIZE, "sg_write_buffer_unsealed: desc.src.data.size must be > 0") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERUNSEALED_SIZE, "sg_write_buffer_unsealed: desc.size must be > 0 and <= desc.src.data.size") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERUNSEALED_WRITE_OVERFLOW, "sg_write_buffer_unsealed: desc.dst.offset + desc.size must be <= buffer size") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERUNSEALED_READ_OVERFLOW, "sg_write_buffer_unsealed: desc.src.offset + desc.size must be <= desc.src.data.size") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERTRANSIENT_USAGE, "sg_write_buffer_transient: buffer usage must be !.immutable && .write_transient") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFERTRANSIENT_WRITE_BEFORE_BIND, "sg_write_buffer_transient: cannot be called after buffer has been bound in this frame") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFER_SRC_DATA_POINTER, "sg_write_buffer_*: desc.src.data.ptr must be valid") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFER_SRC_DATA_SIZE, "sg_write_buffer_*: desc.src.data.size must be > 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFER_SIZE, "sg_write_buffer_*: desc.size must be > 0 and <= desc.src.data.size") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFER_WRITE_OVERFLOW, "sg_write_buffer_*: desc.dst.offset + desc.size must be <= buffer size") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFER_READ_OVERFLOW, "sg_write_buffer_*: desc.src.offset + desc.size must be <= desc.src.data.size") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_USAGE, "sg_write_image_unsealed: image usage must be .immutable && .write_unsealed") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_RESOURCESTATE, "sg_write_image_unsealed: image resource state must be SG_RESOURCESTATE_UNSEALED") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_SRC_DATA_POINTER, "sg_write_image_unsealed: desc.src.data.ptr must be valid") \
@@ -6624,19 +6629,23 @@ typedef struct {
 
 typedef struct {
     int size;
+    int num_slots;
+    int active_slot;
+    uint32_t bind_frame_index;  // last frame index buffer was bound
+    uint32_t write_transient_frame_index; // last frame index when written to
+    sg_buffer_usage usage;
+    // deprecated
     int append_pos;
     bool append_overflow;
     uint32_t update_frame_index;
     uint32_t append_frame_index;
-    int num_slots;
-    int active_slot;
-    sg_buffer_usage usage;
 } _sg_buffer_common_t;
 
 typedef struct {
-    uint32_t upd_frame_index;
     int num_slots;
     int active_slot;
+    uint32_t bind_frame_index;  // last frame index buffer was bound
+    uint32_t write_transient_frame_index; // last frame index when written to
     sg_image_type type;
     int width;
     int height;
@@ -6645,6 +6654,8 @@ typedef struct {
     sg_image_usage usage;
     sg_pixel_format pixel_format;
     int sample_count;
+    // deprecated:
+    uint32_t upd_frame_index;
 } _sg_image_common_t;
 
 typedef struct {
@@ -24791,6 +24802,9 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bindings) {
                         if (buf && buf->slot.state == SG_RESOURCESTATE_VALID) {
                             _SG_VALIDATE(buf->cmn.usage.vertex_buffer, VALIDATE_ABND_VBUF_USAGE);
                             _SG_VALIDATE(!buf->cmn.append_overflow, VALIDATE_ABND_VBUF_OVERFLOW);
+                            if (buf->cmn.usage.write_transient) {
+                                _SG_VALIDATE(buf->cmn.write_transient_frame_index == _sg.frame_index, VALIDATE_ABND_VBUF_WRITE_TRANSIENT);
+                            }
                         }
                     }
                 }
@@ -24816,6 +24830,9 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bindings) {
                 if (buf && buf->slot.state == SG_RESOURCESTATE_VALID) {
                     _SG_VALIDATE(buf->cmn.usage.index_buffer, VALIDATE_ABND_IBUF_USAGE);
                     _SG_VALIDATE(!buf->cmn.append_overflow, VALIDATE_ABND_IBUF_OVERFLOW);
+                    if (buf->cmn.usage.write_transient) {
+                        _SG_VALIDATE(buf->cmn.write_transient_frame_index == _sg.frame_index, VALIDATE_ABND_IBUF_WRITE_TRANSIENT);
+                    }
                 }
             }
         }
@@ -24863,6 +24880,9 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bindings) {
                                     const _sg_buffer_t* buf = _sg_buffer_ref_ptr(&view->cmn.buf.ref);
                                     if (!shd->cmn.views[i].sbuf_readonly) {
                                         _SG_VALIDATE(buf->cmn.usage.immutable, VALIDATE_ABND_SBVIEW_READWRITE_IMMUTABLE);
+                                    }
+                                    if (buf->cmn.usage.write_transient) {
+                                        _SG_VALIDATE(buf->cmn.write_transient_frame_index == _sg.frame_index, VALIDATE_ABND_SBVIEW_SBUF_WRITE_TRANSIENT);
                                     }
                                 }
                             } else if (shd->cmn.views[i].view_type == SG_VIEWTYPE_STORAGEIMAGE) {
@@ -25123,6 +25143,14 @@ _SOKOL_PRIVATE bool _sg_validate_update_image(const _sg_image_t* img, const sg_i
     #endif
 }
 
+_SOKOL_PRIVATE void _sg_validate_write_buffer_common(const _sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
+    _SG_VALIDATE(desc->src.data.ptr, VALIDATE_WRITEBUFFER_SRC_DATA_POINTER);
+    _SG_VALIDATE(desc->src.data.size > 0, VALIDATE_WRITEBUFFER_SRC_DATA_SIZE);
+    _SG_VALIDATE((desc->size > 0) && (desc->size <= desc->src.data.size), VALIDATE_WRITEBUFFER_SIZE);
+    _SG_VALIDATE((desc->dst.offset + desc->size) <= (size_t)buf->cmn.size, VALIDATE_WRITEBUFFER_WRITE_OVERFLOW);
+    _SG_VALIDATE((desc->src.offset + desc->size) <= desc->src.data.size, VALIDATE_WRITEBUFFER_READ_OVERFLOW);
+}
+
 _SOKOL_PRIVATE bool _sg_validate_write_buffer_transient(const _sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
     #if !defined(SOKOL_DEBUG)
         _SOKOL_UNUSED(buf);
@@ -25134,23 +25162,10 @@ _SOKOL_PRIVATE bool _sg_validate_write_buffer_transient(const _sg_buffer_t* buf,
         }
         SOKOL_ASSERT(buf && desc);
         _sg_validate_begin();
-        SOKOL_ASSERT(false && "FIXME: _sg_validate_write_buffer_transient");
-        return _sg_validate_end();
-    #endif
-}
-
-_SOKOL_PRIVATE bool _sg_validate_write_image_transient(const _sg_image_t* img, const sg_write_image_desc* desc) {
-    #if !defined(SOKOL_DEBUG)
-        _SOKOL_UNUSED(img);
-        _SOKOL_UNUSED(desc);
-        return true;
-    #else
-        if (_sg.desc.disable_validation) {
-            return true;
-        }
-        SOKOL_ASSERT(img && desc);
-        _sg_validate_begin();
-        SOKOL_ASSERT(false && "FIXME: _sg_validate_write_image_transient");
+        _SG_VALIDATE(!buf->cmn.usage.immutable && buf->cmn.usage.write_transient, VALIDATE_WRITEBUFFERTRANSIENT_USAGE);
+        // write-transient is only allowed before resource is bound in current frame
+        _SG_VALIDATE(buf->cmn.bind_frame_index != _sg.frame_index, VALIDATE_WRITEBUFFERTRANSIENT_WRITE_BEFORE_BIND);
+        _sg_validate_write_buffer_common(buf, desc);
         return _sg_validate_end();
     #endif
 }
@@ -25168,11 +25183,23 @@ _SOKOL_PRIVATE bool _sg_validate_write_buffer_unsealed(const _sg_buffer_t* buf, 
         _sg_validate_begin();
         _SG_VALIDATE(buf->cmn.usage.immutable && buf->cmn.usage.write_unsealed, VALIDATE_WRITEBUFFERUNSEALED_USAGE);
         _SG_VALIDATE(buf->slot.state == SG_RESOURCESTATE_UNSEALED, VALIDATE_WRITEBUFFERUNSEALED_RESOURCESTATE);
-        _SG_VALIDATE(desc->src.data.ptr, VALIDATE_WRITEBUFFERUNSEALED_SRC_DATA_POINTER);
-        _SG_VALIDATE(desc->src.data.size > 0, VALIDATE_WRITEBUFFERUNSEALED_SRC_DATA_SIZE);
-        _SG_VALIDATE((desc->size > 0) && (desc->size <= desc->src.data.size), VALIDATE_WRITEBUFFERUNSEALED_SIZE);
-        _SG_VALIDATE((desc->dst.offset + desc->size) <= (size_t)buf->cmn.size, VALIDATE_WRITEBUFFERUNSEALED_WRITE_OVERFLOW);
-        _SG_VALIDATE((desc->src.offset + desc->size) <= desc->src.data.size, VALIDATE_WRITEBUFFERUNSEALED_READ_OVERFLOW);
+        _sg_validate_write_buffer_common(buf, desc);
+        return _sg_validate_end();
+    #endif
+}
+
+_SOKOL_PRIVATE bool _sg_validate_write_image_transient(const _sg_image_t* img, const sg_write_image_desc* desc) {
+    #if !defined(SOKOL_DEBUG)
+        _SOKOL_UNUSED(img);
+        _SOKOL_UNUSED(desc);
+        return true;
+    #else
+        if (_sg.desc.disable_validation) {
+            return true;
+        }
+        SOKOL_ASSERT(img && desc);
+        _sg_validate_begin();
+        SOKOL_ASSERT(false && "FIXME: _sg_validate_write_image_transient");
         return _sg_validate_end();
     #endif
 }
@@ -26939,27 +26966,46 @@ SOKOL_API_IMPL void sg_apply_bindings(const sg_bindings* bindings) {
         for (size_t i = 0; i < SG_MAX_VERTEXBUFFER_BINDSLOTS; i++) {
             if (bnd.pip->cmn.vertex_buffer_layout_active[i]) {
                 SOKOL_ASSERT(bindings->vertex_buffers[i].id != SG_INVALID_ID);
-                bnd.vbs[i] = _sg_lookup_buffer(bindings->vertex_buffers[i].id);
-                bnd.vb_offsets[i] = bindings->vertex_buffer_offsets[i];
-                _sg.next_draw_valid &= bnd.vbs[i] && (SG_RESOURCESTATE_VALID == bnd.vbs[i]->slot.state);
+                _sg_buffer_t* buf = _sg_lookup_buffer(bindings->vertex_buffers[i].id);
+                if (buf && (SG_RESOURCESTATE_VALID == buf->slot.state)) {
+                    buf->cmn.bind_frame_index = _sg.frame_index;
+                    bnd.vbs[i] = buf;
+                    bnd.vb_offsets[i] = bindings->vertex_buffer_offsets[i];
+                } else {
+                    _sg.next_draw_valid = false;
+                }
             }
         }
         if (bindings->index_buffer.id) {
-            bnd.ib = _sg_lookup_buffer(bindings->index_buffer.id);
-            bnd.ib_offset = bindings->index_buffer_offset;
-            _sg.next_draw_valid &= bnd.ib && (SG_RESOURCESTATE_VALID == bnd.ib->slot.state);
+            _sg_buffer_t* buf = _sg_lookup_buffer(bindings->index_buffer.id);
+            if (buf && (SG_RESOURCESTATE_VALID == buf->slot.state)) {
+                buf->cmn.bind_frame_index = _sg.frame_index;
+                bnd.ib = buf;
+                bnd.ib_offset = bindings->index_buffer_offset;
+            } else {
+                _sg.next_draw_valid = false;
+            }
         }
     }
 
     for (int i = 0; i < SG_MAX_VIEW_BINDSLOTS; i++) {
         if (shd->cmn.views[i].view_type != SG_VIEWTYPE_INVALID) {
             SOKOL_ASSERT(bindings->views[i].id != SG_INVALID_ID);
-            bnd.views[i] = _sg_lookup_view(bindings->views[i].id);
-            if (bnd.views[i]) {
-                if (bnd.views[i]->cmn.type == SG_VIEWTYPE_STORAGEBUFFER) {
-                    _sg.next_draw_valid &= _sg_buffer_ref_valid(&bnd.views[i]->cmn.buf.ref);
+            _sg_view_t* view = _sg_lookup_view(bindings->views[i].id);
+            bnd.views[i] = view;
+            if (view) {
+                if (view->cmn.type == SG_VIEWTYPE_STORAGEBUFFER) {
+                    if (_sg_buffer_ref_valid(&view->cmn.buf.ref)) {
+                        view->cmn.buf.ref.ptr->cmn.bind_frame_index = _sg.frame_index;
+                    } else {
+                        _sg.next_draw_valid = false;
+                    }
                 } else {
-                    _sg.next_draw_valid &= _sg_image_ref_valid(&bnd.views[i]->cmn.img.ref);
+                    if (_sg_image_ref_valid(&view->cmn.img.ref)) {
+                        view->cmn.img.ref.ptr->cmn.bind_frame_index = _sg.frame_index;
+                    } else {
+                        _sg.next_draw_valid = false;
+                    }
                 }
             } else {
                 _sg.next_draw_valid = false;
@@ -27210,6 +27256,13 @@ SOKOL_API_IMPL void sg_write_buffer_transient(const sg_write_buffer_desc* desc) 
     if (buf) {
         sg_write_buffer_desc desc_def = _sg_write_buffer_desc_defaults(desc);
         if (_sg_validate_write_buffer_transient(buf, &desc_def)) {
+            // if this is the first call in a frame, rotate the 'active_slot'
+            if (buf->cmn.write_transient_frame_index != _sg.frame_index) {
+                buf->cmn.write_transient_frame_index = _sg.frame_index;
+                if (++buf->cmn.active_slot >= buf->cmn.num_slots) {
+                    buf->cmn.active_slot = 0;
+                }
+            }
             _sg_write_buffer_transient(buf, &desc_def);
         }
     } else {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -21191,7 +21191,7 @@ _SOKOL_PRIVATE bool _sg_vk_staging_stream_miplevel_data(_sg_image_t* img,
     }
     const uint8_t* vk_src_ptr = src_ptr + src_offset;
     const size_t vk_size = src_bytes_per_slice * (size_t)num_slices;
-    const uint32_t vk_src_offset = (uint32_t)_sg_vk_shared_buffer_memcpy(&_sg.vk.stage.stream, vk_src_ptr, vk_size);
+    const uint32_t vk_src_offset = (uint32_t)_sg_vk_shared_buffer_memcpy(&_sg.vk.stage.stream, vk_src_ptr, (uint32_t)vk_size);
     if (vk_src_offset == _SG_VK_SHARED_BUFFER_OVERFLOW_RESULT) {
         _SG_ERROR(VULKAN_STAGING_STREAM_BUFFER_OVERFLOW);
         return false;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -19841,9 +19841,20 @@ _SOKOL_PRIVATE void _sg_wgpu_write_image_transient(_sg_image_t* img, const sg_wr
     SOKOL_ASSERT(img && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_VALID == img->slot.state);
     SOKOL_ASSERT(img->cmn.usage.write_transient);
-
-    SOKOL_ASSERT(false && "FIXME!");
     _SOKOL_UNUSED(first_time_in_frame);
+    _sg_wgpu_write_miplevel_data(img,
+        (const uint8_t*)desc->src.data.ptr,
+        desc->src.data.size,
+        desc->src.offset,
+        desc->src.bytes_per_row,
+        desc->src.bytes_per_slice,
+        desc->dst.mip_level,
+        desc->dst.x,
+        desc->dst.y,
+        desc->dst.slice,
+        desc->size.width,
+        desc->size.height,
+        desc->size.num_slices);
 }
 
 _SOKOL_PRIVATE void _sg_wgpu_write_image_unsealed(_sg_image_t* img, const sg_write_image_desc* desc) {

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -12897,7 +12897,7 @@ _SOKOL_PRIVATE void _sg_gl_write_buffer_unsealed(_sg_buffer_t* buf, const sg_wri
     SOKOL_ASSERT(buf && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == buf->slot.state);
     SOKOL_ASSERT(buf->cmn.usage.write_unsealed);
-    SOKOL_ASSERT(0 == buf->gl.buf[buf->cmn.active_slot]);
+    SOKOL_ASSERT(buf->gl.buf[buf->cmn.active_slot]);
     _sg_gl_write_buffer_common(buf, desc);
 }
 

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -9784,7 +9784,7 @@ _SOKOL_PRIVATE GLenum _sg_gl_buffer_usage(const sg_buffer_usage* usg) {
         return GL_STATIC_DRAW;
     } else if (usg->dynamic_update) {
         return GL_DYNAMIC_DRAW;
-    } else if (usg->stream_update) {
+    } else if (usg->write_transient) {
         return GL_STREAM_DRAW;
     } else {
         SOKOL_UNREACHABLE; return 0;
@@ -12854,17 +12854,13 @@ _SOKOL_PRIVATE void _sg_gl_update_image(_sg_image_t* img, const sg_image_data* d
     _sg_gl_cache_restore_texture_sampler_binding(0);
 }
 
-_SOKOL_PRIVATE void _sg_gl_write_buffer_unsealed(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
-    SOKOL_ASSERT(buf && desc);
-    SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == buf->slot.state);
+_SOKOL_PRIVATE void _sg_gl_write_buffer_common(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
     SOKOL_ASSERT(desc->src.data.ptr && (desc->src.data.size > 0));
     SOKOL_ASSERT((desc->dst.offset + desc->size) <= (size_t)buf->cmn.size);
     SOKOL_ASSERT((desc->src.offset + desc->size) <= desc->src.data.size);
-
+    SOKOL_ASSERT(buf->cmn.active_slot < buf->cmn.num_slots);
     const GLenum gl_tgt = _sg_gl_buffer_target(&buf->cmn.usage);
-    SOKOL_ASSERT(buf->cmn.active_slot == 0);
-    const GLuint gl_buf = buf->gl.buf[0];
-    SOKOL_ASSERT(gl_buf);
+    const GLuint gl_buf = buf->gl.buf[buf->cmn.active_slot];
     _SG_GL_CHECK_ERROR();
     _sg_gl_cache_store_buffer_binding(gl_tgt);
     _sg_gl_cache_bind_buffer(gl_tgt, gl_buf);
@@ -12874,13 +12870,26 @@ _SOKOL_PRIVATE void _sg_gl_write_buffer_unsealed(_sg_buffer_t* buf, const sg_wri
     _SG_GL_CHECK_ERROR();
 }
 
-_SOKOL_PRIVATE void _sg_gl_write_image_unsealed(_sg_image_t* img, const sg_write_image_desc* desc) {
-    SOKOL_ASSERT(img && desc);
-    SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == img->slot.state);
-    SOKOL_ASSERT(0 == img->cmn.active_slot);
-    SOKOL_ASSERT(0 != img->gl.tex[0]);
+_SOKOL_PRIVATE void _sg_gl_write_buffer_transient(_sg_buffer_t* buf, const sg_write_buffer_desc* desc, bool first_time_in_frame) {
+    SOKOL_ASSERT(buf && desc);
+    SOKOL_ASSERT(SG_RESOURCESTATE_VALID == buf->slot.state);
+    SOKOL_ASSERT(buf->cmn.usage.write_transient);
+    _SOKOL_UNUSED(first_time_in_frame);
+    _sg_gl_write_buffer_common(buf, desc);
+}
+
+_SOKOL_PRIVATE void _sg_gl_write_buffer_unsealed(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
+    SOKOL_ASSERT(buf && desc);
+    SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == buf->slot.state);
+    SOKOL_ASSERT(buf->cmn.usage.write_unsealed);
+    SOKOL_ASSERT(0 == buf->gl.buf[buf->cmn.active_slot]);
+    _sg_gl_write_buffer_common(buf, desc);
+}
+
+_SOKOL_PRIVATE void _sg_gl_write_image_common(_sg_image_t* img, const sg_write_image_desc* desc) {
+    SOKOL_ASSERT(img->cmn.active_slot < img->cmn.num_slots);
     _sg_gl_cache_store_texture_sampler_binding(0);
-    _sg_gl_cache_bind_texture_sampler(0, img->gl.target, img->gl.tex[0], 0);
+    _sg_gl_cache_bind_texture_sampler(0, img->gl.target, img->gl.tex[img->cmn.active_slot], 0);
     _sg_gl_write_miplevel_data(img,
         (const uint8_t*)desc->src.data.ptr,
         desc->src.data.size,
@@ -12895,6 +12904,22 @@ _SOKOL_PRIVATE void _sg_gl_write_image_unsealed(_sg_image_t* img, const sg_write
         desc->size.height,
         desc->size.num_slices);
     _sg_gl_cache_restore_texture_sampler_binding(0);
+}
+
+_SOKOL_PRIVATE void _sg_gl_write_image_transient(_sg_image_t* img, const sg_write_image_desc* desc, bool first_time_in_frame) {
+    SOKOL_ASSERT(img && desc);
+    SOKOL_ASSERT(SG_RESOURCESTATE_VALID == img->slot.state);
+    SOKOL_ASSERT(img->cmn.usage.write_transient);
+    _SOKOL_UNUSED(first_time_in_frame);
+    _sg_gl_write_image_common(img, desc);
+}
+
+_SOKOL_PRIVATE void _sg_gl_write_image_unsealed(_sg_image_t* img, const sg_write_image_desc* desc) {
+    SOKOL_ASSERT(img && desc);
+    SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == img->slot.state);
+    SOKOL_ASSERT(img->cmn.usage.write_unsealed);
+    SOKOL_ASSERT(0 == img->cmn.active_slot);
+    _sg_gl_write_image_common(img, desc);
 }
 
 // ██████  ██████  ██████   ██  ██     ██████   █████   ██████ ██   ██ ███████ ███    ██ ██████
@@ -17557,6 +17582,7 @@ _SOKOL_PRIVATE void _sg_mtl_write_buffer_common(_sg_buffer_t* buf, const sg_writ
     SOKOL_ASSERT(desc->src.data.ptr && (desc->src.data.size > 0));
     SOKOL_ASSERT((desc->dst.offset + desc->size) <= (size_t)buf->cmn.size);
     SOKOL_ASSERT((desc->src.offset + desc->size) <= desc->src.data.size);
+    SOKOL_ASSERT(buf->cmn.active_slot < buf->cmn.num_slots);
 
     // copy data...
     __unsafe_unretained id<MTLBuffer> mtl_buf = _sg_mtl_id(buf->mtl.buf[buf->cmn.active_slot]);
@@ -17594,6 +17620,7 @@ _SOKOL_PRIVATE void _sg_mtl_write_buffer_unsealed(_sg_buffer_t* buf, const sg_wr
     SOKOL_ASSERT(buf && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == buf->slot.state);
     SOKOL_ASSERT(buf->cmn.usage.write_unsealed);
+    SOKOL_ASSERT(0 == buf->cmn.active_slot);
     _sg_mtl_write_buffer_common(buf, desc);
 }
 
@@ -17622,6 +17649,7 @@ _SOKOL_PRIVATE void _sg_mtl_write_image_unsealed(_sg_image_t* img, const sg_writ
     SOKOL_ASSERT(img && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == img->slot.state);
     SOKOL_ASSERT(img->cmn.usage.write_unsealed);
+    SOKOL_ASSERT(0 == img->cmn.active_slot);
     __unsafe_unretained id<MTLTexture> mtl_tex = _sg_mtl_id(img->mtl.tex[img->cmn.active_slot]);
     _sg_mtl_write_miplevel_data(img, mtl_tex,
         (const uint8_t*)desc->src.data.ptr,

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -15328,10 +15328,20 @@ _SOKOL_PRIVATE void _sg_d3d11_write_miplevel_data(const _sg_image_t* img,
     }
 }
 
+_SOKOL_PRIVATE void _sg_d3d11_write_buffer_transient(_sg_buffer_t* buf, const sg_write_buffer_desc* desc, bool first_time_in_frame) {
+    SOKOL_ASSERT(buf && desc);
+    SOKOL_ASSERT(SG_RESOURCESTATE_VALID == buf->slot.state);
+    SOKOL_ASSERT(buf->cmn.usage.write_transient);
+
+    _SOKOL_UNUSED(first_time_in_frame);
+    SOKOL_ASSERT(false && "FIXME");
+}
+
 _SOKOL_PRIVATE void _sg_d3d11_write_buffer_unsealed(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
     SOKOL_ASSERT(_sg.d3d11.ctx);
     SOKOL_ASSERT(buf && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == buf->slot.state);
+    SOKOL_ASSERT(buf->cmn.usage.write_unsealed);
     SOKOL_ASSERT(desc->src.data.ptr && (desc->src.data.size > 0));
     SOKOL_ASSERT((desc->dst.offset + desc->size) <= (size_t)buf->cmn.size);
     SOKOL_ASSERT((desc->src.offset + desc->size) <= desc->src.data.size);
@@ -15346,9 +15356,19 @@ _SOKOL_PRIVATE void _sg_d3d11_write_buffer_unsealed(_sg_buffer_t* buf, const sg_
     _sg_d3d11_UpdateSubresource(_sg.d3d11.ctx, d3d11_buf, 0, &d3d11_dst_box, d3d11_src_ptr, 0, 0);
 }
 
+_SOKOL_PRIVATE void _sg_d3d11_write_image_transient(_sg_image_t* img, const sg_write_image_desc* desc, bool first_time_in_frame) {
+    SOKOL_ASSERT(img && desc);
+    SOKOL_ASSERT(SG_RESOURCESTATE_VALID == img->slot.state);
+    SOKOL_ASSERT(img->cmn.usage.write_transient);
+
+    _SOKOL_UNUSED(first_time_in_frame);
+    SOKOL_ASSERT(false && "FIXME");
+}
+
 _SOKOL_PRIVATE void _sg_d3d11_write_image_unsealed(_sg_image_t* img, const sg_write_image_desc* desc) {
     SOKOL_ASSERT(img && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == img->slot.state);
+    SOKOL_ASSERT(img->cmn.usage.write_unsealed);
     ID3D11Resource* d3d11_res = img->d3d11.res;
     _sg_d3d11_write_miplevel_data(img, d3d11_res,
         (const uint8_t*)desc->src.data.ptr,

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -19039,9 +19039,11 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_image(_sg_image_t* img, const s
     } else {
         _SG_STRUCT(WGPUTextureDescriptor, wgpu_tex_desc);
         wgpu_tex_desc.label = _sg_wgpu_stringview(desc->label);
-        wgpu_tex_desc.usage = WGPUTextureUsage_TextureBinding|WGPUTextureUsage_CopyDst;
+        wgpu_tex_desc.usage = WGPUTextureUsage_TextureBinding;
         if (desc->usage.color_attachment || desc->usage.resolve_attachment || desc->usage.depth_stencil_attachment) {
             wgpu_tex_desc.usage |= WGPUTextureUsage_RenderAttachment;
+        } else {
+            wgpu_tex_desc.usage |= WGPUTextureUsage_CopyDst;
         }
         if (desc->usage.storage_image) {
             wgpu_tex_desc.usage |= WGPUTextureUsage_StorageBinding;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -21184,13 +21184,13 @@ _SOKOL_PRIVATE bool _sg_vk_staging_stream_miplevel_data(_sg_image_t* img,
     region.imageExtent.height = (uint32_t)height;
     if (img->cmn.type == SG_IMAGETYPE_3D) {
         region.imageOffset.z = slice;
-        region.imageExtent.depth = num_slices;
+        region.imageExtent.depth = (uint32_t)num_slices;
     } else {
-        region.imageSubresource.baseArrayLayer = slice;
-        region.imageSubresource.layerCount = num_slices;
+        region.imageSubresource.baseArrayLayer = (uint32_t)slice;
+        region.imageSubresource.layerCount = (uint32_t)num_slices;
     }
     const uint8_t* vk_src_ptr = src_ptr + src_offset;
-    const size_t vk_size = src_bytes_per_slice * (size_t)num_slices;
+    const size_t vk_size = (size_t)src_bytes_per_slice * (size_t)num_slices;
     const uint32_t vk_src_offset = (uint32_t)_sg_vk_shared_buffer_memcpy(&_sg.vk.stage.stream, vk_src_ptr, (uint32_t)vk_size);
     if (vk_src_offset == _SG_VK_SHARED_BUFFER_OVERFLOW_RESULT) {
         _SG_ERROR(VULKAN_STAGING_STREAM_BUFFER_OVERFLOW);

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -23134,38 +23134,47 @@ _SOKOL_PRIVATE void _sg_vk_dispatch(int num_groups_x, int num_groups_y, int num_
 
 _SOKOL_PRIVATE void _sg_vk_update_buffer(_sg_buffer_t* buf, const sg_range* data) {
     SOKOL_ASSERT(buf && data && data->ptr && (data->size > 0));
-    if (buf->cmn.usage.stream_update) {
-        _sg_vk_acquire_frame_command_buffers();
-        _sg_vk_staging_stream_buffer_data(buf, data, 0, 0, data->size);
-    } else {
-        _sg_vk_staging_copy_buffer_data(buf, data, 0, 0, data->size, true);
-    }
+    SOKOL_ASSERT(!buf->cmn.usage.write_transient);
+    _sg_vk_staging_copy_buffer_data(buf, data, 0, 0, data->size, true);
 }
 
 _SOKOL_PRIVATE void _sg_vk_append_buffer(_sg_buffer_t* buf, const sg_range* data, bool new_frame) {
     SOKOL_ASSERT(buf && data && data->ptr && (data->size > 0));
+    SOKOL_ASSERT(!buf->cmn.usage.write_transient);
     _SOKOL_UNUSED(new_frame);
-    if (buf->cmn.usage.stream_update) {
-        _sg_vk_acquire_frame_command_buffers();
-        _sg_vk_staging_stream_buffer_data(buf, data, 0, (size_t)buf->cmn.append_pos, data->size);
-    } else {
-        _sg_vk_staging_copy_buffer_data(buf, data, 0, (size_t)buf->cmn.append_pos, data->size, true);
-    }
+    _sg_vk_staging_copy_buffer_data(buf, data, 0, (size_t)buf->cmn.append_pos, data->size, true);
 }
 
 _SOKOL_PRIVATE void _sg_vk_update_image(_sg_image_t* img, const sg_image_data* data) {
     SOKOL_ASSERT(img && data);
-    if (img->cmn.usage.stream_update) {
+    SOKOL_ASSERT(!img->cmn.usage.write_transient);
+    _sg_vk_staging_copy_image_data(img, data, true);
+}
+
+_SOKOL_PRIVATE void _sg_vk_write_buffer_transient(_sg_buffer_t* buf, const sg_write_buffer_desc* desc, bool first_time_in_frame) {
+    SOKOL_ASSERT(buf && desc);
+    SOKOL_ASSERT(SG_RESOURCESTATE_VALID == buf->slot.state);
+    SOKOL_ASSERT(buf->cmn.usage.write_transient);
+    if (first_time_in_frame) {
         _sg_vk_acquire_frame_command_buffers();
-        _sg_vk_staging_stream_image_data(img, data);
-    } else {
-        _sg_vk_staging_copy_image_data(img, data, true);
     }
+    _sg_vk_staging_stream_buffer_data(buf, &desc->src.data, desc->src.offset, desc->dst.offset, desc->size);
+}
+
+_SOKOL_PRIVATE void _sg_vk_write_image_transient(_sg_image_t* img, const sg_write_image_desc* desc, bool first_time_in_frame) {
+    SOKOL_ASSERT(img && desc);
+    SOKOL_ASSERT(SG_RESOURCESTATE_VALID == img->slot.state);
+    SOKOL_ASSERT(img->cmn.usage.write_transient);
+    if (first_time_in_frame) {
+        _sg_vk_acquire_frame_command_buffers();
+    }
+    SOKOL_ASSERT(false && "FIXME");
 }
 
 _SOKOL_PRIVATE void _sg_vk_write_buffer_unsealed(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
     SOKOL_ASSERT(buf && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == buf->slot.state);
+    SOKOL_ASSERT(buf->cmn.usage.write_unsealed);
     SOKOL_ASSERT(desc->src.data.ptr && (desc->src.data.size > 0));
     SOKOL_ASSERT((desc->dst.offset + desc->size) <= (size_t)buf->cmn.size);
     SOKOL_ASSERT((desc->src.offset + desc->size) <= desc->src.data.size);
@@ -23175,6 +23184,7 @@ _SOKOL_PRIVATE void _sg_vk_write_buffer_unsealed(_sg_buffer_t* buf, const sg_wri
 _SOKOL_PRIVATE void _sg_vk_write_image_unsealed(_sg_image_t* img, const sg_write_image_desc* desc) {
     SOKOL_ASSERT(img && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == img->slot.state);
+    SOKOL_ASSERT(img->cmn.usage.write_unsealed);
     _sg_vk_staging_copy_miplevel_data(img,
         (const uint8_t*)desc->src.data.ptr,
         desc->src.data.size,

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -3496,8 +3496,8 @@ typedef struct sg_image_usage {
     bool depth_stencil_attachment;
     bool immutable;
     bool write_unsealed;
+    bool write_transient;
     bool dynamic_update;
-    bool stream_update;
 } sg_image_usage;
 
 /*
@@ -4906,7 +4906,7 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDATA_NODATA, "sg_image_data: no data (.ptr and/or .size is zero)") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDATA_DATA_SIZE, "sg_image_data: data size doesn't match expected surface size") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_CANARY, "sg_image_desc not initialized") \
-    _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_IMMUTABLE_DYNAMIC_STREAM, "sg_image_desc.usage: only one of .immutable, .dynamic_update, .stream_update can be true") \
+    _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_IMMUTABLE_VS_WRITABLE, "sg_image_desc.usage: only one of .immutable, .dynamic_update, .write_transient can be true") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_UNSEALED_VS_IMMUTABLE, "sg_image_desc.usage: .write_unsealed only allowed for .immutable images") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_UNSEALED_VS_ATTACHMENT, "sg_image_desc.usage: .write_unsealed not allowed for images with attachment usage") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_ATTACHMENT_COLOR_DEPTH_STENCIL, "sg_image_desc.usage: only one of .color_attachment and .depth_stencil_attachment can be true") \
@@ -4934,8 +4934,7 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_STORAGEIMAGE_PIXELFORMAT, "invalid pixel format for storage image") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_STORAGEIMAGE_EXPECT_NO_MSAA, "storage images cannot be multisampled") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_INJECTED_NO_DATA, "images with injected textures cannot be initialized with data") \
-    _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_UNSEALED_NO_DATA, "images with usage .write_unsealed cannot be initialized with data") \
-    _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_DYNAMIC_NO_DATA, "dynamic/stream-update images cannot be initialized with data") \
+    _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_WRITABLE_NO_DATA, "cpu-writable images cannot be initialized with data") \
     _SG_LOGITEM_XMACRO(VALIDATE_IMAGEDESC_COMPRESSED_IMMUTABLE, "compressed images must be immutable") \
     _SG_LOGITEM_XMACRO(VALIDATE_SAMPLERDESC_CANARY, "sg_sampler_desc not initialized") \
     _SG_LOGITEM_XMACRO(VALIDATE_SAMPLERDESC_ANISTROPIC_REQUIRES_LINEAR_FILTERING, "sg_sampler_desc.max_anisotropy > 1 requires min/mag/mipmap_filter to be SG_FILTER_LINEAR") \
@@ -5220,21 +5219,23 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEBUFFER_READ_OVERFLOW, "sg_write_buffer_*: desc.src.offset + desc.size must be <= desc.src.data.size") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_USAGE, "sg_write_image_unsealed: image usage must be .immutable && .write_unsealed") \
     _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_RESOURCESTATE, "sg_write_image_unsealed: image resource state must be SG_RESOURCESTATE_UNSEALED") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_SRC_DATA_POINTER, "sg_write_image_unsealed: desc.src.data.ptr must be valid") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_SRC_DATA_SIZE, "sg_write_image_unsealed: desc.src.data.size must be > 0") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_BYTESPERROW, "sg_write_image_unsealed: desc.src.bytes_per_row must be a multiple of the pixel or compression-block size") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_BYTESPERSLICE, "sg_write_image_unsealed: desc.src.bytes_per_slice must be a multiple of desc.src.bytes_per_row") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_MIPLEVEL, "sg_write_image_unsealed: desc.dst.mip_level must be >= 0 and less than the number of mipmaps in the destination image") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_WIDTH, "sg_write_image_unsealed: desc.size.width must be >= 0 and <= destination image width") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_HEIGHT, "sg_write_image_unsealed: desc.size.height must be >= 0 and <= destination image heigth") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_NUMSLICES, "sg_write_image_unsealed: desc.size.num_slices must be >= 0 and <= destination image num slices") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_READ_OVERFLOW, "sg_write_image_unsealed: desc.src.offset + size of written data must be <= desc.src.data.size") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_DST_X_RANGE, "sg_write_image_unsealed: desc.dst.x must be >= 0 and < miplevel width") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_DST_Y_RANGE, "sg_write_image_unsealed: desc.dst.y must be >= 0 and < miplevel height") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_DST_SLICE_RANGE, "sg_write_image_unsealed: desc.dst.slice must be >= 0 and < miplevel depth or array/cubemap slices") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_WRITE_WIDTH_OVERFLOW, "sg_write_image_unsealed: desc.src.x + desc.size.width must be <= destination mip level width") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_WRITE_HEIGHT_OVERFLOW, "sg_write_image_unsealed: desc.src.y + desc.size.height must be <= destination mip level height") \
-    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGEUNSEALED_WRITE_NUMSLICES_OVERFLOW, "sg_write_image_unsealed: desc.src.slice + desc.size.num_slices must be <= destination number of slices in mip level") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGETRANSIENT_USAGE, "sg_write_image_transient: image usage must be !.immutable && .write_transient") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGETRANSIENT_WRITE_BEFORE_BIND, "sg_write_image_transient: cannot be called after image has already been bound in this frame") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGE_SRC_DATA_POINTER, "sg_write_image_*: desc.src.data.ptr must be valid") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGE_SRC_DATA_SIZE, "sg_write_image_*: desc.src.data.size must be > 0") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGE_BYTESPERROW, "sg_write_image_*: desc.src.bytes_per_row must be a multiple of the pixel or compression-block size") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGE_BYTESPERSLICE, "sg_write_image_*: desc.src.bytes_per_slice must be a multiple of desc.src.bytes_per_row") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGE_MIPLEVEL, "sg_write_image_*: desc.dst.mip_level must be >= 0 and less than the number of mipmaps in the destination image") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGE_WIDTH, "sg_write_image_*: desc.size.width must be >= 0 and <= destination image width") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGE_HEIGHT, "sg_write_image_*: desc.size.height must be >= 0 and <= destination image heigth") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGE_NUMSLICES, "sg_write_image_*: desc.size.num_slices must be >= 0 and <= destination image num slices") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGE_READ_OVERFLOW, "sg_write_image_*: desc.src.offset + size of written data must be <= desc.src.data.size") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGE_DST_X_RANGE, "sg_write_image_*: desc.dst.x must be >= 0 and < miplevel width") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGE_DST_Y_RANGE, "sg_write_image_*: desc.dst.y must be >= 0 and < miplevel height") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGE_DST_SLICE_RANGE, "sg_write_image_*: desc.dst.slice must be >= 0 and < miplevel depth or array/cubemap slices") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGE_WRITE_WIDTH_OVERFLOW, "sg_write_image_*: desc.src.x + desc.size.width must be <= destination mip level width") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGE_WRITE_HEIGHT_OVERFLOW, "sg_write_image_*: desc.src.y + desc.size.height must be <= destination mip level height") \
+    _SG_LOGITEM_XMACRO(VALIDATE_WRITEIMAGE_WRITE_NUMSLICES_OVERFLOW, "sg_write_image_*: desc.src.slice + desc.size.num_slices must be <= destination number of slices in mip level") \
     _SG_LOGITEM_XMACRO(VALIDATE_SEALBUFFER_RESOURCESTATE, "sg_seal_buffer: buffer resource state must be SG_RESOURCESTATE_UNSEALED") \
     _SG_LOGITEM_XMACRO(VALIDATE_SEALIMAGE_RESOURCESTATE, "sg_seal_image: image resource state must be SG_RESOURCESTATE_UNSEALED") \
     _SG_LOGITEM_XMACRO(VALIDATION_FAILED, "validation layer checks failed") \
@@ -8569,19 +8570,23 @@ _SOKOL_PRIVATE bool _sg_is_dualsource_blendfactor(sg_blend_factor f) {
 
 _SOKOL_PRIVATE void _sg_buffer_common_init(_sg_buffer_common_t* cmn, const sg_buffer_desc* desc) {
     cmn->size = (int)desc->size;
+    cmn->num_slots = desc->usage.immutable ? 1 : SG_NUM_INFLIGHT_FRAMES;
+    cmn->active_slot = 0;
+    cmn->bind_frame_index = 0;
+    cmn->write_transient_frame_index = 0;
+    cmn->usage = desc->usage;
+    // deprecated
     cmn->append_pos = 0;
     cmn->append_overflow = false;
     cmn->update_frame_index = 0;
     cmn->append_frame_index = 0;
-    cmn->num_slots = desc->usage.immutable ? 1 : SG_NUM_INFLIGHT_FRAMES;
-    cmn->active_slot = 0;
-    cmn->usage = desc->usage;
 }
 
 _SOKOL_PRIVATE void _sg_image_common_init(_sg_image_common_t* cmn, const sg_image_desc* desc) {
-    cmn->upd_frame_index = 0;
     cmn->num_slots = desc->usage.immutable ? 1 : SG_NUM_INFLIGHT_FRAMES;
     cmn->active_slot = 0;
+    cmn->bind_frame_index = 0;
+    cmn->write_transient_frame_index = 0;
     cmn->type = desc->type;
     cmn->width = desc->width;
     cmn->height = desc->height;
@@ -8590,6 +8595,8 @@ _SOKOL_PRIVATE void _sg_image_common_init(_sg_image_common_t* cmn, const sg_imag
     cmn->usage = desc->usage;
     cmn->pixel_format = desc->pixel_format;
     cmn->sample_count = desc->sample_count;
+    // deprecated
+    cmn->upd_frame_index = 0;
 }
 
 _SOKOL_PRIVATE void _sg_sampler_common_init(_sg_sampler_common_t* cmn, const sg_sampler_desc* desc) {
@@ -23724,7 +23731,7 @@ _SOKOL_PRIVATE bool _sg_validate_image_desc(const sg_image_desc* desc) {
         _sg_validate_begin();
         _SG_VALIDATE(desc->_start_canary == 0, VALIDATE_IMAGEDESC_CANARY);
         _SG_VALIDATE(desc->_end_canary == 0, VALIDATE_IMAGEDESC_CANARY);
-        _SG_VALIDATE(_sg_one(usg->immutable, usg->dynamic_update, usg->stream_update), VALIDATE_IMAGEDESC_IMMUTABLE_DYNAMIC_STREAM);
+        _SG_VALIDATE(_sg_one(usg->immutable, usg->dynamic_update, usg->write_transient), VALIDATE_IMAGEDESC_IMMUTABLE_VS_WRITABLE);
         _SG_VALIDATE(!(usg->color_attachment && usg->depth_stencil_attachment), VALIDATE_IMAGEDESC_ATTACHMENT_COLOR_DEPTH_STENCIL);
         switch (desc->type) {
             case SG_IMAGETYPE_2D:
@@ -23804,11 +23811,8 @@ _SOKOL_PRIVATE bool _sg_validate_image_desc(const sg_image_desc* desc) {
                     if (injected) {
                         _SG_VALIDATE(no_data && no_size, VALIDATE_IMAGEDESC_INJECTED_NO_DATA);
                     }
-                    if (usg->write_unsealed) {
-                        _SG_VALIDATE(no_data && no_size, VALIDATE_IMAGEDESC_UNSEALED_NO_DATA);
-                    }
-                    if (!usg->immutable) {
-                        _SG_VALIDATE(no_data && no_size, VALIDATE_IMAGEDESC_DYNAMIC_NO_DATA);
+                    if (!usg->immutable || usg->write_unsealed) {
+                        _SG_VALIDATE(no_data && no_size, VALIDATE_IMAGEDESC_WRITABLE_NO_DATA);
                     }
                 }
             }
@@ -25196,6 +25200,29 @@ _SOKOL_PRIVATE bool _sg_validate_write_buffer_unsealed(const _sg_buffer_t* buf, 
     #endif
 }
 
+_SOKOL_PRIVATE void _sg_validate_write_image_common(const _sg_image_t* img, const sg_write_image_desc* desc) {
+    const size_t write_size = (size_t)desc->src.bytes_per_slice * (size_t)desc->size.num_slices;
+    const int mip_width = _sg_miplevel_dim(img->cmn.width, desc->dst.mip_level);
+    const int mip_height = _sg_miplevel_dim(img->cmn.height, desc->dst.mip_level);
+    const int mip_depth_or_slices = (SG_IMAGETYPE_3D == img->cmn.type) ? _sg_miplevel_dim(img->cmn.num_slices, desc->dst.mip_level) : img->cmn.num_slices;
+    const int bsize = _sg_block_bytesize(img->cmn.pixel_format);
+    _SG_VALIDATE(desc->src.data.ptr, VALIDATE_WRITEIMAGE_SRC_DATA_POINTER);
+    _SG_VALIDATE(desc->src.data.size, VALIDATE_WRITEIMAGE_SRC_DATA_SIZE);
+    _SG_VALIDATE((desc->src.bytes_per_row > 0) && _sg_multiple(desc->src.bytes_per_row, bsize), VALIDATE_WRITEIMAGE_BYTESPERROW);
+    _SG_VALIDATE((desc->src.bytes_per_slice > 0) && _sg_multiple(desc->src.bytes_per_slice, desc->src.bytes_per_row), VALIDATE_WRITEIMAGE_BYTESPERSLICE);
+    _SG_VALIDATE((desc->dst.mip_level >= 0) && (desc->dst.mip_level < img->cmn.num_mipmaps), VALIDATE_WRITEIMAGE_MIPLEVEL);
+    _SG_VALIDATE((desc->size.width >= 0) && (desc->size.width <= mip_width), VALIDATE_WRITEIMAGE_WIDTH);
+    _SG_VALIDATE((desc->size.height >= 0) && (desc->size.height <= mip_height), VALIDATE_WRITEIMAGE_HEIGHT);
+    _SG_VALIDATE((desc->size.num_slices >= 0) && (desc->size.num_slices <= mip_depth_or_slices), VALIDATE_WRITEIMAGE_NUMSLICES);
+    _SG_VALIDATE((desc->src.offset + write_size) <= desc->src.data.size, VALIDATE_WRITEIMAGE_READ_OVERFLOW);
+    _SG_VALIDATE((desc->dst.x >= 0) && (desc->dst.x < mip_width), VALIDATE_WRITEIMAGE_DST_X_RANGE);
+    _SG_VALIDATE((desc->dst.y >= 0) && (desc->dst.y < mip_height), VALIDATE_WRITEIMAGE_DST_Y_RANGE);
+    _SG_VALIDATE((desc->dst.slice >= 0) && (desc->dst.slice < mip_depth_or_slices), VALIDATE_WRITEIMAGE_DST_SLICE_RANGE);
+    _SG_VALIDATE((desc->dst.x + desc->size.width) <= mip_width, VALIDATE_WRITEIMAGE_WRITE_WIDTH_OVERFLOW);
+    _SG_VALIDATE((desc->dst.y + desc->size.height) <= mip_height, VALIDATE_WRITEIMAGE_WRITE_HEIGHT_OVERFLOW);
+    _SG_VALIDATE((desc->dst.slice + desc->size.num_slices) <= mip_depth_or_slices, VALIDATE_WRITEIMAGE_WRITE_NUMSLICES_OVERFLOW);
+}
+
 _SOKOL_PRIVATE bool _sg_validate_write_image_transient(const _sg_image_t* img, const sg_write_image_desc* desc) {
     #if !defined(SOKOL_DEBUG)
         _SOKOL_UNUSED(img);
@@ -25207,7 +25234,10 @@ _SOKOL_PRIVATE bool _sg_validate_write_image_transient(const _sg_image_t* img, c
         }
         SOKOL_ASSERT(img && desc);
         _sg_validate_begin();
-        SOKOL_ASSERT(false && "FIXME: _sg_validate_write_image_transient");
+        _SG_VALIDATE(!img->cmn.usage.immutable && img->cmn.usage.write_transient, VALIDATE_WRITEIMAGETRANSIENT_USAGE);
+        // write-transient is only allowed before resource is bound in current frame
+        _SG_VALIDATE(img->cmn.bind_frame_index != _sg.frame_index, VALIDATE_WRITEIMAGETRANSIENT_WRITE_BEFORE_BIND);
+        _sg_validate_write_image_common(img, desc);
         return _sg_validate_end();
     #endif
 }
@@ -25222,29 +25252,10 @@ _SOKOL_PRIVATE bool _sg_validate_write_image_unsealed(const _sg_image_t* img, co
             return true;
         }
         SOKOL_ASSERT(img && desc);
-        const size_t write_size = (size_t)desc->src.bytes_per_slice * (size_t)desc->size.num_slices;
-        const int mip_width = _sg_miplevel_dim(img->cmn.width, desc->dst.mip_level);
-        const int mip_height = _sg_miplevel_dim(img->cmn.height, desc->dst.mip_level);
-        const int mip_depth_or_slices = (SG_IMAGETYPE_3D == img->cmn.type) ? _sg_miplevel_dim(img->cmn.num_slices, desc->dst.mip_level) : img->cmn.num_slices;
-        const int bsize = _sg_block_bytesize(img->cmn.pixel_format);
         _sg_validate_begin();
         _SG_VALIDATE(img->cmn.usage.immutable && img->cmn.usage.write_unsealed, VALIDATE_WRITEIMAGEUNSEALED_USAGE);
         _SG_VALIDATE(img->slot.state == SG_RESOURCESTATE_UNSEALED, VALIDATE_WRITEIMAGEUNSEALED_RESOURCESTATE);
-        _SG_VALIDATE(desc->src.data.ptr, VALIDATE_WRITEIMAGEUNSEALED_SRC_DATA_POINTER);
-        _SG_VALIDATE(desc->src.data.size, VALIDATE_WRITEIMAGEUNSEALED_SRC_DATA_SIZE);
-        _SG_VALIDATE((desc->src.bytes_per_row > 0) && _sg_multiple(desc->src.bytes_per_row, bsize), VALIDATE_WRITEIMAGEUNSEALED_BYTESPERROW);
-        _SG_VALIDATE((desc->src.bytes_per_slice > 0) && _sg_multiple(desc->src.bytes_per_slice, desc->src.bytes_per_row), VALIDATE_WRITEIMAGEUNSEALED_BYTESPERSLICE);
-        _SG_VALIDATE((desc->dst.mip_level >= 0) && (desc->dst.mip_level < img->cmn.num_mipmaps), VALIDATE_WRITEIMAGEUNSEALED_MIPLEVEL);
-        _SG_VALIDATE((desc->size.width >= 0) && (desc->size.width <= mip_width), VALIDATE_WRITEIMAGEUNSEALED_WIDTH);
-        _SG_VALIDATE((desc->size.height >= 0) && (desc->size.height <= mip_height), VALIDATE_WRITEIMAGEUNSEALED_HEIGHT);
-        _SG_VALIDATE((desc->size.num_slices >= 0) && (desc->size.num_slices <= mip_depth_or_slices), VALIDATE_WRITEIMAGEUNSEALED_NUMSLICES);
-        _SG_VALIDATE((desc->src.offset + write_size) <= desc->src.data.size, VALIDATE_WRITEIMAGEUNSEALED_READ_OVERFLOW);
-        _SG_VALIDATE((desc->dst.x >= 0) && (desc->dst.x < mip_width), VALIDATE_WRITEIMAGEUNSEALED_DST_X_RANGE);
-        _SG_VALIDATE((desc->dst.y >= 0) && (desc->dst.y < mip_height), VALIDATE_WRITEIMAGEUNSEALED_DST_Y_RANGE);
-        _SG_VALIDATE((desc->dst.slice >= 0) && (desc->dst.slice < mip_depth_or_slices), VALIDATE_WRITEIMAGEUNSEALED_DST_SLICE_RANGE);
-        _SG_VALIDATE((desc->dst.x + desc->size.width) <= mip_width, VALIDATE_WRITEIMAGEUNSEALED_WRITE_WIDTH_OVERFLOW);
-        _SG_VALIDATE((desc->dst.y + desc->size.height) <= mip_height, VALIDATE_WRITEIMAGEUNSEALED_WRITE_HEIGHT_OVERFLOW);
-        _SG_VALIDATE((desc->dst.slice + desc->size.num_slices) <= mip_depth_or_slices, VALIDATE_WRITEIMAGEUNSEALED_WRITE_NUMSLICES_OVERFLOW);
+        _sg_validate_write_image_common(img, desc);
         return _sg_validate_end();
     #endif
 }
@@ -25435,7 +25446,7 @@ _SOKOL_PRIVATE sg_buffer_desc _sg_buffer_desc_defaults(const sg_buffer_desc* des
 
 _SOKOL_PRIVATE sg_image_usage _sg_image_usage_defaults(const sg_image_usage *usg) {
     sg_image_usage def = *usg;
-    if (!(def.immutable || def.stream_update || def.dynamic_update)) {
+    if (!(def.immutable || def.write_transient || def.dynamic_update)) {
         def.immutable = true;
     }
     return def;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -18936,19 +18936,21 @@ _SOKOL_PRIVATE void _sg_wgpu_seal_buffer(_sg_buffer_t* buf) {
     buf->wgpu.mapped_ptr = 0;
 }
 
-_SOKOL_PRIVATE void _sg_wgpu_copy_buffer_data(const _sg_buffer_t* buf, uint64_t offset, const sg_range* data) {
-    SOKOL_ASSERT((offset + data->size) <= (size_t)buf->cmn.size);
+_SOKOL_PRIVATE void _sg_wgpu_copy_buffer_data(const _sg_buffer_t* buf, uint64_t dst_offset, const sg_range* src_data, uint64_t src_offset, uint64_t size) {
+    SOKOL_ASSERT((dst_offset + size) <= (uint64_t)buf->cmn.size);
+    SOKOL_ASSERT((src_offset + size) <= src_data->size);
+    const uint8_t* src_ptr = (uint8_t*)src_data->ptr + src_offset;
     // WebGPU's write-buffer requires the size to be a multiple of four, so we may need to split the copy
     // operation into two writeBuffer calls
-    uint64_t clamped_size = data->size & ~3UL;
-    uint64_t extra_size = data->size & 3UL;
+    uint64_t clamped_size = size & ~3UL;
+    uint64_t extra_size = size & 3UL;
     SOKOL_ASSERT(extra_size < 4);
-    wgpuQueueWriteBuffer(_sg.wgpu.queue, buf->wgpu.buf, offset, data->ptr, clamped_size);
+    wgpuQueueWriteBuffer(_sg.wgpu.queue, buf->wgpu.buf, dst_offset, src_ptr, clamped_size);
     if (extra_size > 0) {
         const uint64_t extra_src_offset = clamped_size;
-        const uint64_t extra_dst_offset = offset + clamped_size;
+        const uint64_t extra_dst_offset = dst_offset + clamped_size;
         uint8_t extra_data[4] = { 0 };
-        const uint8_t* extra_src_ptr = ((uint8_t*)data->ptr) + extra_src_offset;
+        const uint8_t* extra_src_ptr = src_ptr + extra_src_offset;
         for (size_t i = 0; i < extra_size; i++) {
             extra_data[i] = extra_src_ptr[i];
         }
@@ -19797,13 +19799,13 @@ _SOKOL_PRIVATE void _sg_wgpu_dispatch(int num_groups_x, int num_groups_y, int nu
 
 _SOKOL_PRIVATE void _sg_wgpu_update_buffer(_sg_buffer_t* buf, const sg_range* data) {
     SOKOL_ASSERT(buf && data && data->ptr && (data->size > 0));
-    _sg_wgpu_copy_buffer_data(buf, 0, data);
+    _sg_wgpu_copy_buffer_data(buf, 0, data, 0, data->size);
 }
 
 _SOKOL_PRIVATE void _sg_wgpu_append_buffer(_sg_buffer_t* buf, const sg_range* data, bool new_frame) {
     SOKOL_ASSERT(buf && data && data->ptr && (data->size > 0));
     _SOKOL_UNUSED(new_frame);
-    _sg_wgpu_copy_buffer_data(buf, (uint64_t)buf->cmn.append_pos, data);
+    _sg_wgpu_copy_buffer_data(buf, (uint64_t)buf->cmn.append_pos, data, 0, data->size);
 }
 
 _SOKOL_PRIVATE void _sg_wgpu_update_image(_sg_image_t* img, const sg_image_data* data) {
@@ -19811,9 +19813,19 @@ _SOKOL_PRIVATE void _sg_wgpu_update_image(_sg_image_t* img, const sg_image_data*
     _sg_wgpu_copy_image_data(img, data);
 }
 
+_SOKOL_PRIVATE void _sg_wgpu_write_buffer_transient(_sg_buffer_t* buf, const sg_write_buffer_desc* desc, bool first_time_in_frame) {
+    SOKOL_ASSERT(buf && desc);
+    SOKOL_ASSERT(SG_RESOURCESTATE_VALID == buf->slot.state);
+    SOKOL_ASSERT(buf->cmn.usage.write_transient);
+    SOKOL_ASSERT(desc->src.data.ptr && (desc->src.data.size > 0));
+    _SOKOL_UNUSED(first_time_in_frame);
+    _sg_wgpu_copy_buffer_data(buf, desc->dst.offset, &desc->src.data, desc->src.offset, desc->size);
+}
+
 _SOKOL_PRIVATE void _sg_wgpu_write_buffer_unsealed(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {
     SOKOL_ASSERT(buf && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == buf->slot.state);
+    SOKOL_ASSERT(buf->cmn.usage.write_unsealed);
     SOKOL_ASSERT(buf->wgpu.mapped_ptr);
     SOKOL_ASSERT(desc->src.data.ptr && (desc->src.data.size > 0));
     SOKOL_ASSERT((desc->dst.offset + desc->size) <= (size_t)buf->cmn.size);
@@ -19823,9 +19835,19 @@ _SOKOL_PRIVATE void _sg_wgpu_write_buffer_unsealed(_sg_buffer_t* buf, const sg_w
     memcpy(dst_ptr, src_ptr, desc->size);
 }
 
+_SOKOL_PRIVATE void _sg_wgpu_write_image_transient(_sg_image_t* img, const sg_write_image_desc* desc, bool first_time_in_frame) {
+    SOKOL_ASSERT(img && desc);
+    SOKOL_ASSERT(SG_RESOURCESTATE_VALID == img->slot.state);
+    SOKOL_ASSERT(img->cmn.usage.write_transient);
+
+    SOKOL_ASSERT(false && "FIXME!");
+    _SOKOL_UNUSED(first_time_in_frame);
+}
+
 _SOKOL_PRIVATE void _sg_wgpu_write_image_unsealed(_sg_image_t* img, const sg_write_image_desc* desc) {
     SOKOL_ASSERT(img && desc);
     SOKOL_ASSERT(SG_RESOURCESTATE_UNSEALED == img->slot.state);
+    SOKOL_ASSERT(img->cmn.usage.write_unsealed);
     _sg_wgpu_write_miplevel_data(img,
         (const uint8_t*)desc->src.data.ptr,
         desc->src.data.size,

--- a/tests/functional/sokol_gfx_test.c
+++ b/tests/functional/sokol_gfx_test.c
@@ -588,9 +588,9 @@ UTEST(sokol_gfx, query_buffer_defaults) {
     desc = sg_query_buffer_defaults(&(sg_buffer_desc){ .usage.index_buffer = true });
     T(desc.usage.index_buffer);
     T(desc.usage.immutable);
-    desc = sg_query_buffer_defaults(&(sg_buffer_desc){ .usage.stream_update = true });
+    desc = sg_query_buffer_defaults(&(sg_buffer_desc){ .usage.write_transient = true });
     T(desc.usage.vertex_buffer);
-    T(desc.usage.stream_update);
+    T(desc.usage.write_transient);
     sg_shutdown();
 }
 
@@ -791,7 +791,7 @@ UTEST(sokol_gfx, query_buffer_info) {
         .size = 256,
         .usage = {
             .vertex_buffer = true,
-            .stream_update = true,
+            .write_transient = true,
         },
     });
     T(buf.id != SG_INVALID_ID);
@@ -882,13 +882,13 @@ UTEST(sokol_gfx, query_buffer_desc) {
 
     sg_buffer b0 = sg_make_buffer(&(sg_buffer_desc){
         .size = 32,
-        .usage.stream_update = true,
+        .usage.write_transient = true,
         .label = "bla",
     });
     const sg_buffer_desc b0_desc = sg_query_buffer_desc(b0);
     T(b0_desc.size == 32);
     T(b0_desc.usage.vertex_buffer);
-    T(b0_desc.usage.stream_update);
+    T(b0_desc.usage.write_transient);
     T(b0_desc.data.ptr == 0);
     T(b0_desc.data.size == 0);
     T(b0_desc.gl_buffers[0] == 0);
@@ -896,7 +896,7 @@ UTEST(sokol_gfx, query_buffer_desc) {
     T(b0_desc.d3d11_buffer == 0);
     T(b0_desc.wgpu_buffer == 0);
     T(sg_query_buffer_size(b0) == 32);
-    T(sg_query_buffer_usage(b0).stream_update);
+    T(sg_query_buffer_usage(b0).write_transient);
 
     float vtx_data[16];
     sg_buffer b1 = sg_make_buffer(&(sg_buffer_desc){
@@ -930,15 +930,15 @@ UTEST(sokol_gfx, query_buffer_desc) {
     // invalid buffer (returns zeroed desc)
     sg_buffer b3 = sg_make_buffer(&(sg_buffer_desc){
         .size = 32,
-        .usage.stream_update = true,
+        .usage.write_transient = true,
         .label = "bla",
     });
     sg_destroy_buffer(b3);
     const sg_buffer_desc b3_desc = sg_query_buffer_desc(b3);
     T(b3_desc.size == 0);
-    T(!b3_desc.usage.stream_update);
+    T(!b3_desc.usage.write_transient);
     T(sg_query_buffer_size(b3) == 0);
-    T(!sg_query_buffer_usage(b3).stream_update);
+    T(!sg_query_buffer_usage(b3).write_transient);
     sg_shutdown();
 }
 
@@ -1231,7 +1231,7 @@ UTEST(sokol_gfx, buffer_resource_states) {
     setup(&(sg_desc){0});
     sg_buffer buf = sg_alloc_buffer();
     T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_ALLOC);
-    sg_init_buffer(buf, &(sg_buffer_desc){ .usage.stream_update = true, .size = 128 });
+    sg_init_buffer(buf, &(sg_buffer_desc){ .usage.write_transient = true, .size = 128 });
     T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_VALID);
     sg_uninit_buffer(buf);
     T(sg_query_buffer_state(buf) == SG_RESOURCESTATE_ALLOC);
@@ -1312,7 +1312,7 @@ UTEST(sokol_gfx, view_resource_states) {
 
 UTEST(sokol_gfx, buffer_uninit_count) {
     setup(&(sg_desc){0});
-    const sg_buffer_desc desc = { .usage.stream_update = true, .size = 128 };
+    const sg_buffer_desc desc = { .usage.write_transient = true, .size = 128 };
     sg_buffer buf = sg_make_buffer(&desc);
     T(sg_query_buffer_info(buf).slot.uninit_count == 0);
     sg_uninit_buffer(buf);
@@ -1398,7 +1398,7 @@ UTEST(sokol_gfx, query_buffer_will_overflow) {
     setup(&(sg_desc){0});
     sg_buffer buf = sg_make_buffer(&(sg_buffer_desc){
         .size = 64,
-        .usage.stream_update = true,
+        .usage.write_transient = true,
     });
     T(!sg_query_buffer_will_overflow(buf, 32));
     T(!sg_query_buffer_will_overflow(buf, 64));
@@ -2095,7 +2095,7 @@ UTEST(sokol_gfx, make_image_validate_dynamic_no_data) {
         .data.mip_levels[0] = SG_RANGE(pixels),
     });
     T(sg_query_image_state(img) == SG_RESOURCESTATE_FAILED);
-    T(log_items[0] == SG_LOGITEM_VALIDATE_IMAGEDESC_DYNAMIC_NO_DATA);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_IMAGEDESC_WRITABLE_NO_DATA);
     T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
     sg_shutdown();
 }

--- a/util/sokol_debugtext.h
+++ b/util/sokol_debugtext.h
@@ -3985,7 +3985,7 @@ static void _sdtx_init_context(sdtx_context ctx_id, const sdtx_context_desc_t* i
     _sdtx_clear(&vbuf_desc, sizeof(vbuf_desc));
     vbuf_desc.size = vbuf_size;
     vbuf_desc.usage.vertex_buffer = true;
-    vbuf_desc.usage.stream_update = true;
+    vbuf_desc.usage.write_transient = true;
     vbuf_desc.label = "sdtx-vbuf";
     ctx->vbuf = sg_make_buffer(&vbuf_desc);
     SOKOL_ASSERT(SG_INVALID_ID != ctx->vbuf.id);
@@ -4353,8 +4353,12 @@ SOKOL_API_IMPL void _sdtx_draw_layer(_sdtx_context_t* ctx, int layer_id) {
 
         if (ctx->update_frame_id != ctx->frame_id) {
             ctx->update_frame_id = ctx->frame_id;
-            const sg_range range = { ctx->vertices.ptr, (size_t)ctx->vertices.next * sizeof(_sdtx_vertex_t) };
-            sg_update_buffer(ctx->vbuf, &range);
+            sg_write_buffer_desc write_desc;
+            _sdtx_clear(&write_desc, sizeof(write_desc));
+            write_desc.src.data.ptr = ctx->vertices.ptr;
+            write_desc.src.data.size = (size_t)ctx->vertices.next * sizeof(_sdtx_vertex_t);
+            write_desc.dst.buffer = ctx->vbuf;
+            sg_write_buffer_transient(&write_desc);
         }
 
         sg_apply_pipeline(ctx->pip);

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -4834,6 +4834,12 @@ _SOKOL_PRIVATE void _sgimgui_draw_frame_stats_panel(_sgimgui_t* ctx) {
         _sgimgui_frame_stats(prev_frame.num_update_buffer);
         _sgimgui_frame_stats(prev_frame.num_append_buffer);
         _sgimgui_frame_stats(prev_frame.num_update_image);
+        _sgimgui_frame_stats(prev_frame.num_write_buffer_transient);
+        _sgimgui_frame_stats(prev_frame.num_write_image_transient);
+        _sgimgui_frame_stats(prev_frame.num_write_buffer_unsealed);
+        _sgimgui_frame_stats(prev_frame.num_write_image_unsealed);
+        _sgimgui_frame_stats(prev_frame.num_seal_buffer);
+        _sgimgui_frame_stats(prev_frame.num_seal_image);
         _sgimgui_frame_stats(prev_frame.size_apply_uniforms);
         _sgimgui_frame_stats(prev_frame.size_update_buffer);
         _sgimgui_frame_stats(prev_frame.size_append_buffer);
@@ -4846,6 +4852,10 @@ _SOKOL_PRIVATE void _sgimgui_draw_frame_stats_panel(_sgimgui_t* ctx) {
         _sgimgui_frame_stats(prev_frame.images.deallocated);
         _sgimgui_frame_stats(prev_frame.images.inited);
         _sgimgui_frame_stats(prev_frame.images.uninited);
+        _sgimgui_frame_stats(prev_frame.samplers.allocated);
+        _sgimgui_frame_stats(prev_frame.samplers.deallocated);
+        _sgimgui_frame_stats(prev_frame.samplers.inited);
+        _sgimgui_frame_stats(prev_frame.samplers.uninited);
         _sgimgui_frame_stats(prev_frame.views.allocated);
         _sgimgui_frame_stats(prev_frame.views.deallocated);
         _sgimgui_frame_stats(prev_frame.views.inited);
@@ -5001,6 +5011,12 @@ _SOKOL_PRIVATE void _sgimgui_draw_frame_stats_panel(_sgimgui_t* ctx) {
         _sgimgui_frame_stats(total.views.deallocated);
         _sgimgui_frame_stats(total.views.inited);
         _sgimgui_frame_stats(total.views.uninited);
+        _sgimgui_frame_stats(total.shaders.alive);
+        _sgimgui_frame_stats(total.shaders.free);
+        _sgimgui_frame_stats(total.shaders.allocated);
+        _sgimgui_frame_stats(total.shaders.deallocated);
+        _sgimgui_frame_stats(total.shaders.inited);
+        _sgimgui_frame_stats(total.shaders.uninited);
         _sgimgui_frame_stats(total.pipelines.alive);
         _sgimgui_frame_stats(total.pipelines.free);
         _sgimgui_frame_stats(total.pipelines.allocated);

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -3663,9 +3663,9 @@ _SOKOL_PRIVATE void _sgimgui_draw_buffer_panel(_sgimgui_t* ctx, sg_buffer buf) {
             _sgimgui_igtext("  index_buffer: %s", _sgimgui_bool_string(buf_ui->desc.usage.index_buffer));
             _sgimgui_igtext("  storage_buffer: %s", _sgimgui_bool_string(buf_ui->desc.usage.storage_buffer));
             _sgimgui_igtext("  immutable: %s", _sgimgui_bool_string(buf_ui->desc.usage.immutable));
-            _sgimgui_igtext("  dynamic_update: %s", _sgimgui_bool_string(buf_ui->desc.usage.dynamic_update));
-            _sgimgui_igtext("  stream_update: %s", _sgimgui_bool_string(buf_ui->desc.usage.stream_update));
             _sgimgui_igtext("  write_unsealed: %s", _sgimgui_bool_string(buf_ui->desc.usage.write_unsealed));
+            _sgimgui_igtext("  write_transient: %s", _sgimgui_bool_string(buf_ui->desc.usage.write_transient));
+            _sgimgui_igtext("  dynamic_update: %s", _sgimgui_bool_string(buf_ui->desc.usage.dynamic_update));
             _sgimgui_igtext("Size:  %d", (int)buf_ui->desc.size);
             if (!buf_ui->desc.usage.immutable) {
                 _sgimgui_igseparator();
@@ -3702,9 +3702,9 @@ _SOKOL_PRIVATE void _sgimgui_draw_image_panel(_sgimgui_t* ctx, sg_image img) {
             _sgimgui_igtext("  resolve_attachment: %s", _sgimgui_bool_string(desc->usage.resolve_attachment));
             _sgimgui_igtext("  depth_stencil_attachment: %s", _sgimgui_bool_string(desc->usage.depth_stencil_attachment));
             _sgimgui_igtext("  immutable: %s", _sgimgui_bool_string(desc->usage.immutable));
-            _sgimgui_igtext("  dynamic_update: %s", _sgimgui_bool_string(desc->usage.dynamic_update));
-            _sgimgui_igtext("  stream_update: %s", _sgimgui_bool_string(desc->usage.stream_update));
             _sgimgui_igtext("  write_unsealed: %s", _sgimgui_bool_string(desc->usage.write_unsealed));
+            _sgimgui_igtext("  write_transient: %s", _sgimgui_bool_string(desc->usage.write_transient));
+            _sgimgui_igtext("  dynamic_update: %s", _sgimgui_bool_string(desc->usage.dynamic_update));
             _sgimgui_igtext("Width:          %d", desc->width);
             _sgimgui_igtext("Height:         %d", desc->height);
             _sgimgui_igtext("Num Slices:     %d", desc->num_slices);

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -427,6 +427,8 @@ typedef enum {
     _SGIMGUI_CMD_UPDATE_BUFFER,
     _SGIMGUI_CMD_UPDATE_IMAGE,
     _SGIMGUI_CMD_APPEND_BUFFER,
+    _SGIMGUI_CMD_WRITE_BUFFER_TRANSIENT,
+    _SGIMGUI_CMD_WRITE_IMAGE_TRANSIENT,
     _SGIMGUI_CMD_WRITE_BUFFER_UNSEALED,
     _SGIMGUI_CMD_WRITE_IMAGE_UNSEALED,
     _SGIMGUI_CMD_SEAL_BUFFER,
@@ -538,6 +540,22 @@ typedef struct {
     size_t data_size;
     int result;
 } _sgimgui_args_append_buffer_t;
+
+typedef struct {
+    size_t src_data_size;
+    size_t src_data_offset;
+    sg_buffer_location dst;
+    size_t write_size;
+} _sgimgui_args_write_buffer_transient_t;
+
+typedef struct {
+    size_t src_data_size;
+    size_t src_data_offset;
+    int src_bytes_per_row;
+    int src_bytes_per_slice;
+    sg_image_location dst;
+    sg_image_extent write_size;
+} _sgimgui_args_write_image_transient_t;
 
 typedef struct {
     size_t src_data_size;
@@ -752,6 +770,8 @@ typedef union {
     _sgimgui_args_update_buffer_t update_buffer;
     _sgimgui_args_update_image_t update_image;
     _sgimgui_args_append_buffer_t append_buffer;
+    _sgimgui_args_write_buffer_transient_t write_buffer_transient;
+    _sgimgui_args_write_image_transient_t write_image_transient;
     _sgimgui_args_write_buffer_unsealed_t write_buffer_unsealed;
     _sgimgui_args_write_image_unsealed_t write_image_unsealed;
     _sgimgui_args_seal_buffer_t seal_buffer;
@@ -2041,6 +2061,14 @@ _SOKOL_PRIVATE _sgimgui_str_t _sgimgui_capture_item_string(_sgimgui_t* ctx, int 
             }
             break;
 
+        case _SGIMGUI_CMD_WRITE_BUFFER_TRANSIENT:
+            _sgimgui_snprintf(&str, "%d: sg_write_buffer_transient(desc=...)", index);
+            break;
+
+        case _SGIMGUI_CMD_WRITE_IMAGE_TRANSIENT:
+            _sgimgui_snprintf(&str, "%d: sg_write_image_transient(desc=...)", index);
+            break;
+
         case _SGIMGUI_CMD_WRITE_BUFFER_UNSEALED:
             _sgimgui_snprintf(&str, "%d: sg_write_buffer_unsealed(desc=...)", index);
             break;
@@ -2627,6 +2655,42 @@ _SOKOL_PRIVATE void _sgimgui_append_buffer(sg_buffer buf, const sg_range* data, 
     }
     if (ctx->hooks.append_buffer) {
         ctx->hooks.append_buffer(buf, data, result, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sgimgui_write_buffer_transient(const sg_write_buffer_desc* desc, void* user_data) {
+    _sgimgui_t* ctx = (_sgimgui_t*)user_data;
+    SOKOL_ASSERT(ctx);
+    _sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = _SGIMGUI_CMD_WRITE_BUFFER_TRANSIENT;
+        item->color = _SGIMGUI_COLOR_RSRC;
+        item->args.write_buffer_transient.src_data_size = desc->src.data.size;
+        item->args.write_buffer_transient.src_data_offset = desc->src.offset;
+        item->args.write_buffer_transient.dst = desc->dst;
+        item->args.write_buffer_transient.write_size = desc->size;
+    }
+    if (ctx->hooks.write_buffer_transient) {
+        ctx->hooks.write_buffer_transient(desc, ctx->hooks.user_data);
+    }
+}
+
+_SOKOL_PRIVATE void _sgimgui_write_image_transient(const sg_write_image_desc* desc, void* user_data) {
+    _sgimgui_t* ctx = (_sgimgui_t*)user_data;
+    SOKOL_ASSERT(ctx);
+    _sgimgui_capture_item_t* item = _sgimgui_capture_next_write_item(ctx);
+    if (item) {
+        item->cmd = _SGIMGUI_CMD_WRITE_IMAGE_TRANSIENT;
+        item->color = _SGIMGUI_COLOR_RSRC;
+        item->args.write_image_transient.src_data_size = desc->src.data.size;
+        item->args.write_image_transient.src_data_offset = desc->src.offset;
+        item->args.write_image_transient.src_bytes_per_row = desc->src.bytes_per_row;
+        item->args.write_image_transient.src_bytes_per_slice = desc->src.bytes_per_slice;
+        item->args.write_image_transient.dst = desc->dst;
+        item->args.write_image_transient.write_size = desc->size;
+    }
+    if (ctx->hooks.write_image_transient) {
+        ctx->hooks.write_image_transient(desc, ctx->hooks.user_data);
     }
 }
 
@@ -4535,8 +4599,14 @@ _SOKOL_PRIVATE void _sgimgui_draw_capture_panel(_sgimgui_t* ctx) {
         case _SGIMGUI_CMD_APPEND_BUFFER:
             _sgimgui_draw_buffer_panel(ctx, item->args.append_buffer.buffer);
             break;
+        case _SGIMGUI_CMD_WRITE_BUFFER_TRANSIENT:
+            _sgimgui_draw_buffer_panel(ctx, item->args.write_buffer_transient.dst.buffer);
+            break;
+        case _SGIMGUI_CMD_WRITE_IMAGE_TRANSIENT:
+            _sgimgui_draw_image_panel(ctx, item->args.write_image_transient.dst.image);
+            break;
         case _SGIMGUI_CMD_WRITE_BUFFER_UNSEALED:
-            _sgimgui_draw_buffer_panel(ctx, item->args.write_buffer_unsealed.dst.buffer);;
+            _sgimgui_draw_buffer_panel(ctx, item->args.write_buffer_unsealed.dst.buffer);
             break;
         case _SGIMGUI_CMD_WRITE_IMAGE_UNSEALED:
             _sgimgui_draw_image_panel(ctx, item->args.write_image_unsealed.dst.image);
@@ -4978,6 +5048,8 @@ SOKOL_API_IMPL void sgimgui_setup(const sgimgui_desc_t* desc) {
     hooks.update_buffer = _sgimgui_update_buffer;
     hooks.update_image = _sgimgui_update_image;
     hooks.append_buffer = _sgimgui_append_buffer;
+    hooks.write_buffer_transient = _sgimgui_write_buffer_transient;
+    hooks.write_image_transient = _sgimgui_write_image_transient;
     hooks.write_buffer_unsealed = _sgimgui_write_buffer_unsealed;
     hooks.write_image_unsealed = _sgimgui_write_image_unsealed;
     hooks.seal_buffer = _sgimgui_seal_buffer;

--- a/util/sokol_gl.h
+++ b/util/sokol_gl.h
@@ -3024,7 +3024,7 @@ static void _sgl_init_context(sgl_context ctx_id, const sgl_context_desc_t* in_d
     _sgl_clear(&vbuf_desc, sizeof(vbuf_desc));
     vbuf_desc.size = (size_t)ctx->vertices.cap * sizeof(_sgl_vertex_t);
     vbuf_desc.usage.vertex_buffer = true;
-    vbuf_desc.usage.stream_update = true;
+    vbuf_desc.usage.write_transient = true;
     vbuf_desc.label = "sgl-vertex-buffer";
     ctx->vbuf = sg_make_buffer(&vbuf_desc);
     SOKOL_ASSERT(SG_INVALID_ID != ctx->vbuf.id);
@@ -3588,8 +3588,12 @@ static void _sgl_draw(_sgl_context_t* ctx, int layer_id) {
 
         if (ctx->update_frame_id != ctx->frame_id) {
             ctx->update_frame_id = ctx->frame_id;
-            const sg_range range = { ctx->vertices.ptr, (size_t)ctx->vertices.next * sizeof(_sgl_vertex_t) };
-            sg_update_buffer(ctx->vbuf, &range);
+            sg_write_buffer_desc write_desc;
+            _sgl_clear(&write_desc, sizeof(write_desc));
+            write_desc.src.data.ptr = ctx->vertices.ptr;
+            write_desc.src.data.size = (size_t)ctx->vertices.next * sizeof(_sgl_vertex_t);
+            write_desc.dst.buffer = ctx->vbuf;
+            sg_write_buffer_transient(&write_desc);
         }
 
         // render all successfully recorded commands (this may be less than the

--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -2819,7 +2819,8 @@ SOKOL_API_IMPL void simgui_render(void) {
     // copy vertices and indices into an intermediate buffer so that
     // they can be updated with a single sg_write_buffer_transient() call each
     // FIXME: check if it's feasable (WebGL2) to get rid of the intermediate
-    // buffer and instead use multiple write-transient
+    // vertex buffer and instead use multiple write-transient (not possible
+    // for index buffer because of 4-byte alignment restriction for dest-offset)
     // But check WebGL2 performance!
     size_t all_vtx_size = 0;
     size_t all_idx_size = 0;

--- a/util/sokol_imgui.h
+++ b/util/sokol_imgui.h
@@ -2660,7 +2660,7 @@ SOKOL_API_IMPL void simgui_setup(const simgui_desc_t* desc) {
     // NOTE: since we're in C++ mode here we can't use C99 designated init
     sg_buffer_desc vb_desc;
     _simgui_clear(&vb_desc, sizeof(vb_desc));
-    vb_desc.usage.stream_update = true;
+    vb_desc.usage.write_transient = true;
     vb_desc.size = _simgui.vertices.size;
     vb_desc.label = "sokol-imgui-vertices";
     _simgui.vbuf = sg_make_buffer(&vb_desc);
@@ -2668,7 +2668,7 @@ SOKOL_API_IMPL void simgui_setup(const simgui_desc_t* desc) {
     sg_buffer_desc ib_desc;
     _simgui_clear(&ib_desc, sizeof(ib_desc));
     ib_desc.usage.index_buffer = true;
-    ib_desc.usage.stream_update = true;
+    ib_desc.usage.write_transient = true;
     ib_desc.size = _simgui.indices.size;
     ib_desc.label = "sokol-imgui-indices";
     _simgui.ibuf = sg_make_buffer(&ib_desc);
@@ -2817,10 +2817,10 @@ SOKOL_API_IMPL void simgui_render(void) {
     }
 
     // copy vertices and indices into an intermediate buffer so that
-    // they can be updated with a single sg_update_buffer() call each
-    // (sg_append_buffer() has performance problems on some GL platforms),
-    // also keep track of valid number of command lists in case of a
-    // buffer overflow
+    // they can be updated with a single sg_write_buffer_transient() call each
+    // FIXME: check if it's feasable (WebGL2) to get rid of the intermediate
+    // buffer and instead use multiple write-transient
+    // But check WebGL2 performance!
     size_t all_vtx_size = 0;
     size_t all_idx_size = 0;
     int cmd_list_count = 0;
@@ -2857,15 +2857,19 @@ SOKOL_API_IMPL void simgui_render(void) {
 
     // update the sokol-gfx vertex- and index-buffer
     sg_push_debug_group("sokol-imgui");
+    sg_write_buffer_desc desc;
+    _simgui_clear(&desc, sizeof(desc));
     if (all_vtx_size > 0) {
-        sg_range vtx_data = _simgui.vertices;
-        vtx_data.size = all_vtx_size;
-        sg_update_buffer(_simgui.vbuf, &vtx_data);
+        desc.dst.buffer = _simgui.vbuf;
+        desc.src.data.ptr = _simgui.vertices.ptr;
+        desc.src.data.size = all_vtx_size;
+        sg_write_buffer_transient(&desc);
     }
     if (all_idx_size > 0) {
-        sg_range idx_data = _simgui.indices;
-        idx_data.size = all_idx_size;
-        sg_update_buffer(_simgui.ibuf, &idx_data);
+        desc.dst.buffer = _simgui.ibuf;
+        desc.src.data.ptr = _simgui.indices.ptr;
+        desc.src.data.size = all_idx_size;
+        sg_write_buffer_transient(&desc);
     }
 
     // render the ImGui command list

--- a/util/sokol_nuklear.h
+++ b/util/sokol_nuklear.h
@@ -2282,7 +2282,7 @@ SOKOL_API_IMPL void snk_setup(const snk_desc_t* desc) {
     _snuklear.vbuf = sg_make_buffer(&(sg_buffer_desc){
         .usage = {
             .vertex_buffer = true,
-            .stream_update = true,
+            .write_transient = true,
         },
         .size = _snuklear.vertex_buffer_size,
         .label = "sokol-nuklear-vertices"
@@ -2293,7 +2293,7 @@ SOKOL_API_IMPL void snk_setup(const snk_desc_t* desc) {
     _snuklear.ibuf = sg_make_buffer(&(sg_buffer_desc){
         .usage = {
             .index_buffer = true,
-            .stream_update = true,
+            .write_transient = true,
         },
         .size = _snuklear.index_buffer_size,
         .label = "sokol-nuklear-indices"
@@ -2681,8 +2681,20 @@ SOKOL_API_IMPL void snk_render(int width, int height) {
     if (!vertex_buffer_overflow && !index_buffer_overflow) {
 
         // Setup rendering
-        sg_update_buffer(_snuklear.vbuf, &(sg_range){ nk_buffer_memory_const(&verts), nk_buffer_total(&verts) });
-        sg_update_buffer(_snuklear.ibuf, &(sg_range){ nk_buffer_memory_const(&idx), nk_buffer_total(&idx) });
+        sg_write_buffer_transient(&(sg_write_buffer_desc){
+            .src.data = {
+                .ptr = nk_buffer_memory_const(&verts),
+                .size = nk_buffer_total(&verts),
+            },
+            .dst.buffer = _snuklear.vbuf,
+        });
+        sg_write_buffer_transient(&(sg_write_buffer_desc){
+            .src.data = {
+                .ptr = nk_buffer_memory_const(&idx),
+                .size = nk_buffer_total(&idx),
+            },
+            .dst.buffer = _snuklear.ibuf,
+        });
         const float dpi_scale = _snuklear.desc.dpi_scale;
         const int fb_width = (int)(_snuklear.vs_params.disp_size[0] * dpi_scale);
         const int fb_height = (int)(_snuklear.vs_params.disp_size[1] * dpi_scale);

--- a/util/sokol_spine.h
+++ b/util/sokol_spine.h
@@ -3512,7 +3512,7 @@ static sspine_resource_state _sspine_init_context(_sspine_context_t* ctx, const 
     sg_buffer_desc vbuf_desc;
     _sspine_clear(&vbuf_desc, sizeof(vbuf_desc));
     vbuf_desc.usage.vertex_buffer = true;
-    vbuf_desc.usage.stream_update = true;
+    vbuf_desc.usage.write_transient = true;
     vbuf_desc.size = vbuf_size;
     vbuf_desc.label = "sspine-vbuf";
     ctx->vbuf = sg_make_buffer(&vbuf_desc);
@@ -3521,7 +3521,7 @@ static sspine_resource_state _sspine_init_context(_sspine_context_t* ctx, const 
     sg_buffer_desc ibuf_desc;
     _sspine_clear(&ibuf_desc, sizeof(ibuf_desc));
     ibuf_desc.usage.index_buffer = true;
-    ibuf_desc.usage.stream_update = true;
+    ibuf_desc.usage.write_transient = true;
     ibuf_desc.size = ibuf_size;
     ibuf_desc.label = "sspine-ibuf";
     ctx->ibuf = sg_make_buffer(&ibuf_desc);
@@ -4688,10 +4688,18 @@ static void _sspine_draw_layer(_sspine_context_t* ctx, int layer, const sspine_l
 
         if (ctx->update_frame_id != _sspine.frame_id) {
             ctx->update_frame_id = _sspine.frame_id;
-            const sg_range vtx_range = { ctx->vertices.ptr, (size_t)ctx->vertices.next * sizeof(_sspine_vertex_t) };
-            sg_update_buffer(ctx->vbuf, &vtx_range);
-            const sg_range idx_range = { ctx->indices.ptr, (size_t)ctx->indices.next * sizeof(uint32_t) };
-            sg_update_buffer(ctx->ibuf, &idx_range);
+            sg_write_buffer_desc vbuf_write_desc;
+            _sspine_clear(&vbuf_write_desc, sizeof(vbuf_write_desc));
+            vbuf_write_desc.src.data.ptr = ctx->vertices.ptr;
+            vbuf_write_desc.src.data.size = (size_t)ctx->vertices.next * sizeof(_sspine_vertex_t);
+            vbuf_write_desc.dst.buffer = ctx->vbuf;
+            sg_write_buffer_transient(&vbuf_write_desc);
+            sg_write_buffer_desc ibuf_write_desc;
+            _sspine_clear(&ibuf_write_desc, sizeof(ibuf_write_desc));
+            ibuf_write_desc.src.data.ptr = ctx->indices.ptr;
+            ibuf_write_desc.src.data.size = (size_t)ctx->indices.next * sizeof(uint32_t);
+            ibuf_write_desc.dst.buffer = ctx->ibuf;
+            sg_write_buffer_transient(&ibuf_write_desc);
         }
 
         _sspine_vsparams_t vsparams = _sspine_compute_vsparams(tform);


### PR DESCRIPTION
Next step in the new resource update api (https://github.com/floooh/sokol/issues/1547)

- [x] inline documentation
- [x] changelog
- [ ] post-merge:
    - [ ] merge bindings-updates:
      - [x] zig: https://github.com/floooh/sokol-zig/pull/167
      - [x] nim: https://github.com/floooh/sokol-nim/pull/43
      - [x] odin: https://github.com/floooh/sokol-odin/pull/43
      - [x] rust: https://github.com/floooh/sokol-rust/pull/45
      - [x] c3: https://github.com/floooh/sokol-c3/pull/15
      - [x] d: https://github.com/floooh/sokol-d/pull/109
    - [ ] chips-test: https://github.com/floooh/chips-test/pull/48
    - [ ] v6502r: https://github.com/floooh/v6502r/pull/42
    - [ ] ...?
- [x] ~~sokol_framebuffer.h should get two 'write_transient' hints (one for pixel-, one for palette-image)~~ moved to https://github.com/floooh/sokol/issues/1589
- [x] rename `sg_desc.vulkan.stream_staging_buffer_size` to `sg_desc.vulkan.transient_staging_buffer_size`
- [x] ~~sokol_imgui.h: get rid of intermediate vertex ~~and index~~ sysmem buffer, instead write directly to target buffer (index buffer not possible because dst-offset must be multiple of 4 and Dear ImGui indices are 16-bit)~~ keep it as is for now, the Dear ImGui WebGPU backend also accumulates vertex- and index-updates into intermediate memory chunks and does a single WriteBuffer each.
- [x] update sokol_gfx_imgui.h
- [x] fix tests
- [x] fix bindings examples:
    - [x] zig: https://github.com/floooh/sokol-zig/pull/167
    - [x] nim: https://github.com/floooh/sokol-nim/pull/43
    - [x] odin: https://github.com/floooh/sokol-odin/pull/43
    - [x] rust: https://github.com/floooh/sokol-rust/pull/45
    - [x] c3: https://github.com/floooh/sokol-c3/pull/15
    - [x] d: https://github.com/floooh/sokol-d/pull/109
    - [x] ~~jai~~ (no changed needed)
- [x] fix backend samples:
    - [x] d3d11
    - [x] glfw
    - [x] html5
    - [x] metal
- [x] validate that sg_update/append_*() isn't called on write-transient resources
- [x] validation
     - [x] buffers
          - [x] in sg_make_buffer: check for correct usage flag combo
          - [x] in sg_write_buffer_transient: must not be called after buffer had been bound in current frame
          - [x]  in sg_write_buffer_transient: offset must be multiple of 4 (WebGPU restriction)
          - [x] in sg_apply_bindings: sg_write_buffer_transient must have been called at least once in current frame
              - [x] vertex buffers
              - [x] index buffer
              - [x] storage buffer
     - [x] images
          - [x] in sg_make_image: check for correct usage flag combo
          - [x] in sg_write_image_transient: must not be called after image had been bound in current frame
          - [x] in sg_apply_bindings: sg_write_image_transient must have been called at least once in current frame
- [x] implementation
     - [x] metal
          - [x] sg_make_buffer
          - [x] sg_write_buffer_transient
              - [x] track max update location and only do a single didModifyRange during _sg_mtl_apply_bindings()
          - [x] sg_make_image
          - [x] sg_write_image_transient
     - [x] gl
          - [x] sg_make_buffer
          - [x] sg_write_buffer_transient
          - [x] sg_make_image
          - [x] sg_write_image_transient
     - [x] d3d11
          - [x] sg_make_buffer
          - [x] sg_write_buffer_transient
          - [x] sg_make_image
          - [x] sg_write_image_transient
     - [x] webgpu
          - [x] sg_make_buffer
          - [x] sg_write_buffer_transient
          - [x] sg_make_image
          - [x] sg_write_image_transient
     - [x] vulkan
          - [x] sg_make_buffer
          - [x] sg_write_buffer_transient
          - [x] sg_make_image
          - [x] sg_write_image_transient
     - [x] dummy
         - [x] sg_write_buffer_transient
         - [x] sg_write_image_transient
