### PR TITLE
sokol_gfx_imgui.h: fix buffer overflow for resource pools (fixes #1584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Updates
 
+### 18-Aug-2025
+
+- sokol_gfx_imgui.h: fix a potential buffer overrun when the sokol_gfx.h resource pools
+  are filled up to the last slot, this was caused by off-by-one error when allocating
+  the associated pools on the sokol_gfx_imgui.h side. In general all the related
+  code with pool slot lookups is now much cleaner and robust (like new debug-mode range
+  checks via asserts).
+
+  Ticket: https://github.com/floooh/sokol/issues/1584
+  PR: https://github.com/floooh/sokol/pull/1585
+
 ### 17-Aug-2026
 
 - In sokol_gfx.h fixed broken storage image validation (this was a regression from the

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -1102,6 +1102,7 @@ _SOKOL_PRIVATE void _sgimgui_free(const sgimgui_allocator_t* allocator, void* pt
 _SOKOL_PRIVATE int _sgimgui_slot_index(uint32_t id, int num_slots) {
     int slot_index = (int) (id & _SGIMGUI_SLOT_MASK);
     SOKOL_ASSERT((slot_index > 0) && (slot_index < num_slots));
+    _SOKOL_UNUSED(num_slots);
     return slot_index;
 }
 

--- a/util/sokol_gfx_imgui.h
+++ b/util/sokol_gfx_imgui.h
@@ -1099,10 +1099,40 @@ _SOKOL_PRIVATE void _sgimgui_free(const sgimgui_allocator_t* allocator, void* pt
     return new_ptr;
 }
 
-_SOKOL_PRIVATE int _sgimgui_slot_index(uint32_t id) {
+_SOKOL_PRIVATE int _sgimgui_slot_index(uint32_t id, int num_slots) {
     int slot_index = (int) (id & _SGIMGUI_SLOT_MASK);
-    SOKOL_ASSERT(0 != slot_index);
+    SOKOL_ASSERT((slot_index > 0) && (slot_index < num_slots));
     return slot_index;
+}
+
+_SOKOL_PRIVATE _sgimgui_buffer_t* _sgimgui_buf_ptr(_sgimgui_t* ctx, sg_buffer buf) {
+    const int slot_index = _sgimgui_slot_index(buf.id, ctx->buffer_window.num_slots);
+    return &ctx->buffer_window.slots[slot_index];
+}
+
+_SOKOL_PRIVATE _sgimgui_image_t* _sgimgui_img_ptr(_sgimgui_t* ctx, sg_image img) {
+    const int slot_index = _sgimgui_slot_index(img.id, ctx->image_window.num_slots);
+    return &ctx->image_window.slots[slot_index];
+}
+
+_SOKOL_PRIVATE _sgimgui_sampler_t* _sgimgui_smp_ptr(_sgimgui_t* ctx, sg_sampler smp) {
+    const int slot_index = _sgimgui_slot_index(smp.id, ctx->sampler_window.num_slots);
+    return &ctx->sampler_window.slots[slot_index];
+}
+
+_SOKOL_PRIVATE _sgimgui_view_t* _sgimgui_view_ptr(_sgimgui_t* ctx, sg_view view) {
+    const int slot_index = _sgimgui_slot_index(view.id, ctx->view_window.num_slots);
+    return &ctx->view_window.slots[slot_index];
+}
+
+_SOKOL_PRIVATE _sgimgui_shader_t* _sgimgui_shd_ptr(_sgimgui_t* ctx, sg_shader shd) {
+    const int slot_index = _sgimgui_slot_index(shd.id, ctx->shader_window.num_slots);
+    return &ctx->shader_window.slots[slot_index];
+}
+
+_SOKOL_PRIVATE _sgimgui_pipeline_t* _sgimgui_pip_ptr(_sgimgui_t* ctx, sg_pipeline pip) {
+    const int slot_index = _sgimgui_slot_index(pip.id, ctx->pipeline_window.num_slots);
+    return &ctx->pipeline_window.slots[slot_index];
 }
 
 _SOKOL_PRIVATE uint32_t _sgimgui_align_u32(uint32_t val, uint32_t align) {
@@ -1615,7 +1645,7 @@ _SOKOL_PRIVATE _sgimgui_str_t _sgimgui_res_id_string(uint32_t res_id, const char
 
 _SOKOL_PRIVATE _sgimgui_str_t _sgimgui_buffer_id_string(_sgimgui_t* ctx, sg_buffer buf_id) {
     if (buf_id.id != SG_INVALID_ID) {
-        const _sgimgui_buffer_t* buf_ui = &ctx->buffer_window.slots[_sgimgui_slot_index(buf_id.id)];
+        const _sgimgui_buffer_t* buf_ui = _sgimgui_buf_ptr(ctx, buf_id);
         return _sgimgui_res_id_string(buf_id.id, buf_ui->label.buf);
     } else {
         return _sgimgui_make_str("<invalid>");
@@ -1624,7 +1654,7 @@ _SOKOL_PRIVATE _sgimgui_str_t _sgimgui_buffer_id_string(_sgimgui_t* ctx, sg_buff
 
 _SOKOL_PRIVATE _sgimgui_str_t _sgimgui_image_id_string(_sgimgui_t* ctx, sg_image img_id) {
     if (img_id.id != SG_INVALID_ID) {
-        const _sgimgui_image_t* img_ui = &ctx->image_window.slots[_sgimgui_slot_index(img_id.id)];
+        const _sgimgui_image_t* img_ui = _sgimgui_img_ptr(ctx, img_id);
         return _sgimgui_res_id_string(img_id.id, img_ui->label.buf);
     } else {
         return _sgimgui_make_str("<invalid>");
@@ -1633,7 +1663,7 @@ _SOKOL_PRIVATE _sgimgui_str_t _sgimgui_image_id_string(_sgimgui_t* ctx, sg_image
 
 _SOKOL_PRIVATE _sgimgui_str_t _sgimgui_sampler_id_string(_sgimgui_t* ctx, sg_sampler smp_id) {
     if (smp_id.id != SG_INVALID_ID) {
-        const _sgimgui_sampler_t* smp_ui = &ctx->sampler_window.slots[_sgimgui_slot_index(smp_id.id)];
+        const _sgimgui_sampler_t* smp_ui = _sgimgui_smp_ptr(ctx, smp_id);
         return _sgimgui_res_id_string(smp_id.id, smp_ui->label.buf);
     } else {
         return _sgimgui_make_str("<invalid>");
@@ -1642,7 +1672,7 @@ _SOKOL_PRIVATE _sgimgui_str_t _sgimgui_sampler_id_string(_sgimgui_t* ctx, sg_sam
 
 _SOKOL_PRIVATE _sgimgui_str_t _sgimgui_shader_id_string(_sgimgui_t* ctx, sg_shader shd_id) {
     if (shd_id.id != SG_INVALID_ID) {
-        const _sgimgui_shader_t* shd_ui = &ctx->shader_window.slots[_sgimgui_slot_index(shd_id.id)];
+        const _sgimgui_shader_t* shd_ui = _sgimgui_shd_ptr(ctx, shd_id);
         return _sgimgui_res_id_string(shd_id.id, shd_ui->label.buf);
     } else {
         return _sgimgui_make_str("<invalid>");
@@ -1651,7 +1681,7 @@ _SOKOL_PRIVATE _sgimgui_str_t _sgimgui_shader_id_string(_sgimgui_t* ctx, sg_shad
 
 _SOKOL_PRIVATE _sgimgui_str_t _sgimgui_pipeline_id_string(_sgimgui_t* ctx, sg_pipeline pip_id) {
     if (pip_id.id != SG_INVALID_ID) {
-        const _sgimgui_pipeline_t* pip_ui = &ctx->pipeline_window.slots[_sgimgui_slot_index(pip_id.id)];
+        const _sgimgui_pipeline_t* pip_ui = _sgimgui_pip_ptr(ctx, pip_id);
         return _sgimgui_res_id_string(pip_id.id, pip_ui->label.buf);
     } else {
         return _sgimgui_make_str("<invalid>");
@@ -1660,7 +1690,7 @@ _SOKOL_PRIVATE _sgimgui_str_t _sgimgui_pipeline_id_string(_sgimgui_t* ctx, sg_pi
 
 _SOKOL_PRIVATE _sgimgui_str_t _sgimgui_view_id_string(_sgimgui_t* ctx, sg_view view_id) {
     if (view_id.id != SG_INVALID_ID) {
-        const _sgimgui_view_t* view_ui = &ctx->view_window.slots[_sgimgui_slot_index(view_id.id)];
+        const _sgimgui_view_t* view_ui = _sgimgui_view_ptr(ctx, view_id);
         return _sgimgui_res_id_string(view_id.id, view_ui->label.buf);
     } else {
         return _sgimgui_make_str("<invalid>");
@@ -1668,53 +1698,46 @@ _SOKOL_PRIVATE _sgimgui_str_t _sgimgui_view_id_string(_sgimgui_t* ctx, sg_view v
 }
 
 /*--- RESOURCE HELPERS -------------------------------------------------------*/
-_SOKOL_PRIVATE void _sgimgui_buffer_created(_sgimgui_t* ctx, sg_buffer res_id, int slot_index, const sg_buffer_desc* desc) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->buffer_window.num_slots));
-    _sgimgui_buffer_t* buf = &ctx->buffer_window.slots[slot_index];
-    buf->res_id = res_id;
+_SOKOL_PRIVATE void _sgimgui_buffer_created(_sgimgui_t* ctx, sg_buffer buf_id, const sg_buffer_desc* desc) {
+    _sgimgui_buffer_t* buf = _sgimgui_buf_ptr(ctx, buf_id);
+    buf->res_id = buf_id;
     buf->desc = *desc;
     buf->label = _sgimgui_make_str(desc->label);
 }
 
-_SOKOL_PRIVATE void _sgimgui_buffer_destroyed(_sgimgui_t* ctx, int slot_index) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->buffer_window.num_slots));
-    _sgimgui_buffer_t* buf = &ctx->buffer_window.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_buffer_destroyed(_sgimgui_t* ctx, sg_buffer buf_id) {
+    _sgimgui_buffer_t* buf = _sgimgui_buf_ptr(ctx, buf_id);
     buf->res_id.id = SG_INVALID_ID;
 }
 
-_SOKOL_PRIVATE void _sgimgui_image_created(_sgimgui_t* ctx, sg_image res_id, int slot_index, const sg_image_desc* desc) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->image_window.num_slots));
-    _sgimgui_image_t* img = &ctx->image_window.slots[slot_index];
-    img->res_id = res_id;
+_SOKOL_PRIVATE void _sgimgui_image_created(_sgimgui_t* ctx, sg_image img_id, const sg_image_desc* desc) {
+    _sgimgui_image_t* img = _sgimgui_img_ptr(ctx, img_id);
+    img->res_id = img_id;
     img->desc = *desc;
     img->ui_scale = 1.0f;
     img->label = _sgimgui_make_str(desc->label);
 }
 
-_SOKOL_PRIVATE void _sgimgui_image_destroyed(_sgimgui_t* ctx, int slot_index) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->image_window.num_slots));
-    _sgimgui_image_t* img = &ctx->image_window.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_image_destroyed(_sgimgui_t* ctx, sg_image img_id) {
+    _sgimgui_image_t* img = _sgimgui_img_ptr(ctx, img_id);
     img->res_id.id = SG_INVALID_ID;
 }
 
-_SOKOL_PRIVATE void _sgimgui_sampler_created(_sgimgui_t* ctx, sg_sampler res_id, int slot_index, const sg_sampler_desc* desc) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->sampler_window.num_slots));
-    _sgimgui_sampler_t* smp = &ctx->sampler_window.slots[slot_index];
-    smp->res_id = res_id;
+_SOKOL_PRIVATE void _sgimgui_sampler_created(_sgimgui_t* ctx, sg_sampler smp_id, const sg_sampler_desc* desc) {
+    _sgimgui_sampler_t* smp = _sgimgui_smp_ptr(ctx, smp_id);
+    smp->res_id = smp_id;
     smp->desc = *desc;
     smp->label = _sgimgui_make_str(desc->label);
 }
 
-_SOKOL_PRIVATE void _sgimgui_sampler_destroyed(_sgimgui_t* ctx, int slot_index) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->sampler_window.num_slots));
-    _sgimgui_sampler_t* smp = &ctx->sampler_window.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_sampler_destroyed(_sgimgui_t* ctx, sg_sampler smp_id) {
+    _sgimgui_sampler_t* smp = _sgimgui_smp_ptr(ctx, smp_id);
     smp->res_id.id = SG_INVALID_ID;
 }
 
-_SOKOL_PRIVATE void _sgimgui_shader_created(_sgimgui_t* ctx, sg_shader res_id, int slot_index, const sg_shader_desc* desc) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->shader_window.num_slots));
-    _sgimgui_shader_t* shd = &ctx->shader_window.slots[slot_index];
-    shd->res_id = res_id;
+_SOKOL_PRIVATE void _sgimgui_shader_created(_sgimgui_t* ctx, sg_shader shd_id, const sg_shader_desc* desc) {
+    _sgimgui_shader_t* shd = _sgimgui_shd_ptr(ctx, shd_id);
+    shd->res_id = shd_id;
     shd->desc = *desc;
     shd->label = _sgimgui_make_str(desc->label);
     if (shd->desc.vertex_func.entry) {
@@ -1787,9 +1810,8 @@ _SOKOL_PRIVATE void _sgimgui_shader_created(_sgimgui_t* ctx, sg_shader res_id, i
     }
 }
 
-_SOKOL_PRIVATE void _sgimgui_shader_destroyed(_sgimgui_t* ctx, int slot_index) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->shader_window.num_slots));
-    _sgimgui_shader_t* shd = &ctx->shader_window.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_shader_destroyed(_sgimgui_t* ctx, sg_shader shd_id) {
+    _sgimgui_shader_t* shd = _sgimgui_shd_ptr(ctx, shd_id);
     shd->res_id.id = SG_INVALID_ID;
     if (shd->desc.vertex_func.source) {
         _sgimgui_free(&ctx->desc.allocator, (void*)shd->desc.vertex_func.source);
@@ -1817,33 +1839,29 @@ _SOKOL_PRIVATE void _sgimgui_shader_destroyed(_sgimgui_t* ctx, int slot_index) {
     }
 }
 
-_SOKOL_PRIVATE void _sgimgui_pipeline_created(_sgimgui_t* ctx, sg_pipeline res_id, int slot_index, const sg_pipeline_desc* desc) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->pipeline_window.num_slots));
-    _sgimgui_pipeline_t* pip = &ctx->pipeline_window.slots[slot_index];
-    pip->res_id = res_id;
+_SOKOL_PRIVATE void _sgimgui_pipeline_created(_sgimgui_t* ctx, sg_pipeline pip_id, const sg_pipeline_desc* desc) {
+    _sgimgui_pipeline_t* pip = _sgimgui_pip_ptr(ctx, pip_id);
+    pip->res_id = pip_id;
     pip->label = _sgimgui_make_str(desc->label);
     pip->desc = *desc;
 
 }
 
-_SOKOL_PRIVATE void _sgimgui_pipeline_destroyed(_sgimgui_t* ctx, int slot_index) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->pipeline_window.num_slots));
-    _sgimgui_pipeline_t* pip = &ctx->pipeline_window.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_pipeline_destroyed(_sgimgui_t* ctx, sg_pipeline pip_id) {
+    _sgimgui_pipeline_t* pip = _sgimgui_pip_ptr(ctx, pip_id);
     pip->res_id.id = SG_INVALID_ID;
 }
 
-_SOKOL_PRIVATE void _sgimgui_view_created(_sgimgui_t* ctx, sg_view res_id, int slot_index, const sg_view_desc* desc) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->view_window.num_slots));
-    _sgimgui_view_t* view = &ctx->view_window.slots[slot_index];
-    view->res_id = res_id;
+_SOKOL_PRIVATE void _sgimgui_view_created(_sgimgui_t* ctx, sg_view view_id, const sg_view_desc* desc) {
+    _sgimgui_view_t* view = _sgimgui_view_ptr(ctx, view_id);
+    view->res_id = view_id;
     view->ui_scale = 1.0f;
     view->label = _sgimgui_make_str(desc->label);
     view->desc = *desc;
 }
 
-_SOKOL_PRIVATE void _sgimgui_view_destroyed(_sgimgui_t* ctx, int slot_index) {
-    SOKOL_ASSERT((slot_index > 0) && (slot_index < ctx->view_window.num_slots));
-    _sgimgui_view_t* view = &ctx->view_window.slots[slot_index];
+_SOKOL_PRIVATE void _sgimgui_view_destroyed(_sgimgui_t* ctx, sg_view view_id) {
+    _sgimgui_view_t* view = _sgimgui_view_ptr(ctx, view_id);
     view->res_id.id = SG_INVALID_ID;
 }
 
@@ -2394,7 +2412,7 @@ _SOKOL_PRIVATE void _sgimgui_make_buffer(const sg_buffer_desc* desc, sg_buffer b
         ctx->hooks.make_buffer(desc, buf_id, ctx->hooks.user_data);
     }
     if (buf_id.id != SG_INVALID_ID) {
-        _sgimgui_buffer_created(ctx, buf_id, _sgimgui_slot_index(buf_id.id), desc);
+        _sgimgui_buffer_created(ctx, buf_id, desc);
     }
 }
 
@@ -2411,7 +2429,7 @@ _SOKOL_PRIVATE void _sgimgui_make_image(const sg_image_desc* desc, sg_image img_
         ctx->hooks.make_image(desc, img_id, ctx->hooks.user_data);
     }
     if (img_id.id != SG_INVALID_ID) {
-        _sgimgui_image_created(ctx, img_id, _sgimgui_slot_index(img_id.id), desc);
+        _sgimgui_image_created(ctx, img_id, desc);
     }
 }
 
@@ -2428,7 +2446,7 @@ _SOKOL_PRIVATE void _sgimgui_make_sampler(const sg_sampler_desc* desc, sg_sample
         ctx->hooks.make_sampler(desc, smp_id, ctx->hooks.user_data);
     }
     if (smp_id.id != SG_INVALID_ID) {
-        _sgimgui_sampler_created(ctx, smp_id, _sgimgui_slot_index(smp_id.id), desc);
+        _sgimgui_sampler_created(ctx, smp_id, desc);
     }
 }
 
@@ -2445,7 +2463,7 @@ _SOKOL_PRIVATE void _sgimgui_make_shader(const sg_shader_desc* desc, sg_shader s
         ctx->hooks.make_shader(desc, shd_id, ctx->hooks.user_data);
     }
     if (shd_id.id != SG_INVALID_ID) {
-        _sgimgui_shader_created(ctx, shd_id, _sgimgui_slot_index(shd_id.id), desc);
+        _sgimgui_shader_created(ctx, shd_id, desc);
     }
 }
 
@@ -2462,7 +2480,7 @@ _SOKOL_PRIVATE void _sgimgui_make_pipeline(const sg_pipeline_desc* desc, sg_pipe
         ctx->hooks.make_pipeline(desc, pip_id, ctx->hooks.user_data);
     }
     if (pip_id.id != SG_INVALID_ID) {
-        _sgimgui_pipeline_created(ctx, pip_id, _sgimgui_slot_index(pip_id.id), desc);
+        _sgimgui_pipeline_created(ctx, pip_id, desc);
     }
 }
 
@@ -2479,7 +2497,7 @@ _SOKOL_PRIVATE void _sgimgui_make_view(const sg_view_desc* desc, sg_view view_id
         ctx->hooks.make_view(desc, view_id, ctx->hooks.user_data);
     }
     if (view_id.id != SG_INVALID_ID) {
-        _sgimgui_view_created(ctx, view_id, _sgimgui_slot_index(view_id.id), desc);
+        _sgimgui_view_created(ctx, view_id, desc);
     }
 }
 
@@ -2496,7 +2514,7 @@ _SOKOL_PRIVATE void _sgimgui_destroy_buffer(sg_buffer buf, void* user_data) {
         ctx->hooks.destroy_buffer(buf, ctx->hooks.user_data);
     }
     if (buf.id != SG_INVALID_ID) {
-        _sgimgui_buffer_destroyed(ctx, _sgimgui_slot_index(buf.id));
+        _sgimgui_buffer_destroyed(ctx, buf);
     }
 }
 
@@ -2513,7 +2531,7 @@ _SOKOL_PRIVATE void _sgimgui_destroy_image(sg_image img, void* user_data) {
         ctx->hooks.destroy_image(img, ctx->hooks.user_data);
     }
     if (img.id != SG_INVALID_ID) {
-        _sgimgui_image_destroyed(ctx, _sgimgui_slot_index(img.id));
+        _sgimgui_image_destroyed(ctx, img);
     }
 }
 
@@ -2530,7 +2548,7 @@ _SOKOL_PRIVATE void _sgimgui_destroy_sampler(sg_sampler smp, void* user_data) {
         ctx->hooks.destroy_sampler(smp, ctx->hooks.user_data);
     }
     if (smp.id != SG_INVALID_ID) {
-        _sgimgui_sampler_destroyed(ctx, _sgimgui_slot_index(smp.id));
+        _sgimgui_sampler_destroyed(ctx, smp);
     }
 }
 
@@ -2547,7 +2565,7 @@ _SOKOL_PRIVATE void _sgimgui_destroy_shader(sg_shader shd, void* user_data) {
         ctx->hooks.destroy_shader(shd, ctx->hooks.user_data);
     }
     if (shd.id != SG_INVALID_ID) {
-        _sgimgui_shader_destroyed(ctx, _sgimgui_slot_index(shd.id));
+        _sgimgui_shader_destroyed(ctx, shd);
     }
 }
 
@@ -2564,7 +2582,7 @@ _SOKOL_PRIVATE void _sgimgui_destroy_pipeline(sg_pipeline pip, void* user_data) 
         ctx->hooks.destroy_pipeline(pip, ctx->hooks.user_data);
     }
     if (pip.id != SG_INVALID_ID) {
-        _sgimgui_pipeline_destroyed(ctx, _sgimgui_slot_index(pip.id));
+        _sgimgui_pipeline_destroyed(ctx, pip);
     }
 }
 
@@ -2581,7 +2599,7 @@ _SOKOL_PRIVATE void _sgimgui_destroy_view(sg_view view, void* user_data) {
         ctx->hooks.destroy_view(view, ctx->hooks.user_data);
     }
     if (view.id != SG_INVALID_ID) {
-        _sgimgui_view_destroyed(ctx, _sgimgui_slot_index(view.id));
+        _sgimgui_view_destroyed(ctx, view);
     }
 }
 
@@ -3053,7 +3071,7 @@ _SOKOL_PRIVATE void _sgimgui_init_buffer(sg_buffer buf_id, const sg_buffer_desc*
         ctx->hooks.init_buffer(buf_id, desc, ctx->hooks.user_data);
     }
     if (buf_id.id != SG_INVALID_ID) {
-        _sgimgui_buffer_created(ctx, buf_id, _sgimgui_slot_index(buf_id.id), desc);
+        _sgimgui_buffer_created(ctx, buf_id, desc);
     }
 }
 
@@ -3070,7 +3088,7 @@ _SOKOL_PRIVATE void _sgimgui_init_image(sg_image img_id, const sg_image_desc* de
         ctx->hooks.init_image(img_id, desc, ctx->hooks.user_data);
     }
     if (img_id.id != SG_INVALID_ID) {
-        _sgimgui_image_created(ctx, img_id, _sgimgui_slot_index(img_id.id), desc);
+        _sgimgui_image_created(ctx, img_id, desc);
     }
 }
 
@@ -3087,7 +3105,7 @@ _SOKOL_PRIVATE void _sgimgui_init_sampler(sg_sampler smp_id, const sg_sampler_de
         ctx->hooks.init_sampler(smp_id, desc, ctx->hooks.user_data);
     }
     if (smp_id.id != SG_INVALID_ID) {
-        _sgimgui_sampler_created(ctx, smp_id, _sgimgui_slot_index(smp_id.id), desc);
+        _sgimgui_sampler_created(ctx, smp_id, desc);
     }
 }
 
@@ -3104,7 +3122,7 @@ _SOKOL_PRIVATE void _sgimgui_init_shader(sg_shader shd_id, const sg_shader_desc*
         ctx->hooks.init_shader(shd_id, desc, ctx->hooks.user_data);
     }
     if (shd_id.id != SG_INVALID_ID) {
-        _sgimgui_shader_created(ctx, shd_id, _sgimgui_slot_index(shd_id.id), desc);
+        _sgimgui_shader_created(ctx, shd_id, desc);
     }
 }
 
@@ -3121,7 +3139,7 @@ _SOKOL_PRIVATE void _sgimgui_init_pipeline(sg_pipeline pip_id, const sg_pipeline
         ctx->hooks.init_pipeline(pip_id, desc, ctx->hooks.user_data);
     }
     if (pip_id.id != SG_INVALID_ID) {
-        _sgimgui_pipeline_created(ctx, pip_id, _sgimgui_slot_index(pip_id.id), desc);
+        _sgimgui_pipeline_created(ctx, pip_id, desc);
     }
 }
 
@@ -3138,7 +3156,7 @@ _SOKOL_PRIVATE void _sgimgui_init_view(sg_view view_id, const sg_view_desc* desc
         ctx->hooks.init_view(view_id, desc, ctx->hooks.user_data);
     }
     if (view_id.id != SG_INVALID_ID) {
-        _sgimgui_view_created(ctx, view_id, _sgimgui_slot_index(view_id.id), desc);
+        _sgimgui_view_created(ctx, view_id, desc);
     }
 }
 
@@ -3155,7 +3173,7 @@ _SOKOL_PRIVATE void _sgimgui_uninit_buffer(sg_buffer buf, void* user_data) {
         ctx->hooks.uninit_buffer(buf, ctx->hooks.user_data);
     }
     if (buf.id != SG_INVALID_ID) {
-        _sgimgui_buffer_destroyed(ctx, _sgimgui_slot_index(buf.id));
+        _sgimgui_buffer_destroyed(ctx, buf);
     }
 }
 
@@ -3172,7 +3190,7 @@ _SOKOL_PRIVATE void _sgimgui_uninit_image(sg_image img, void* user_data) {
         ctx->hooks.uninit_image(img, ctx->hooks.user_data);
     }
     if (img.id != SG_INVALID_ID) {
-        _sgimgui_image_destroyed(ctx, _sgimgui_slot_index(img.id));
+        _sgimgui_image_destroyed(ctx, img);
     }
 }
 
@@ -3189,7 +3207,7 @@ _SOKOL_PRIVATE void _sgimgui_uninit_sampler(sg_sampler smp, void* user_data) {
         ctx->hooks.uninit_sampler(smp, ctx->hooks.user_data);
     }
     if (smp.id != SG_INVALID_ID) {
-        _sgimgui_sampler_destroyed(ctx, _sgimgui_slot_index(smp.id));
+        _sgimgui_sampler_destroyed(ctx, smp);
     }
 }
 
@@ -3206,7 +3224,7 @@ _SOKOL_PRIVATE void _sgimgui_uninit_shader(sg_shader shd, void* user_data) {
         ctx->hooks.uninit_shader(shd, ctx->hooks.user_data);
     }
     if (shd.id != SG_INVALID_ID) {
-        _sgimgui_shader_destroyed(ctx, _sgimgui_slot_index(shd.id));
+        _sgimgui_shader_destroyed(ctx, shd);
     }
 }
 
@@ -3223,7 +3241,7 @@ _SOKOL_PRIVATE void _sgimgui_uninit_pipeline(sg_pipeline pip, void* user_data) {
         ctx->hooks.uninit_pipeline(pip, ctx->hooks.user_data);
     }
     if (pip.id != SG_INVALID_ID) {
-        _sgimgui_pipeline_destroyed(ctx, _sgimgui_slot_index(pip.id));
+        _sgimgui_pipeline_destroyed(ctx, pip);
     }
 }
 
@@ -3240,7 +3258,7 @@ _SOKOL_PRIVATE void _sgimgui_uninit_view(sg_view view, void* user_data) {
         ctx->hooks.uninit_view(view, ctx->hooks.user_data);
     }
     if (view.id != SG_INVALID_ID) {
-        _sgimgui_view_destroyed(ctx, _sgimgui_slot_index(view.id));
+        _sgimgui_view_destroyed(ctx, view);
     }
 }
 
@@ -3444,7 +3462,7 @@ _SOKOL_PRIVATE bool _sgimgui_draw_resid_link(uint32_t res_type, uint32_t res_id,
 _SOKOL_PRIVATE bool _sgimgui_draw_buffer_link(_sgimgui_t* ctx, sg_buffer buf) {
     bool retval = false;
     if (buf.id != SG_INVALID_ID) {
-        const _sgimgui_buffer_t* buf_ui = &ctx->buffer_window.slots[_sgimgui_slot_index(buf.id)];
+        const _sgimgui_buffer_t* buf_ui = _sgimgui_buf_ptr(ctx, buf);
         retval = _sgimgui_draw_resid_link(1, buf.id, buf_ui->label.buf);
     }
     return retval;
@@ -3453,7 +3471,7 @@ _SOKOL_PRIVATE bool _sgimgui_draw_buffer_link(_sgimgui_t* ctx, sg_buffer buf) {
 _SOKOL_PRIVATE bool _sgimgui_draw_image_link(_sgimgui_t* ctx, sg_image img) {
     bool retval = false;
     if (img.id != SG_INVALID_ID) {
-        const _sgimgui_image_t* img_ui = &ctx->image_window.slots[_sgimgui_slot_index(img.id)];
+        const _sgimgui_image_t* img_ui = _sgimgui_img_ptr(ctx, img);
         retval = _sgimgui_draw_resid_link(2, img.id, img_ui->label.buf);
     }
     return retval;
@@ -3462,7 +3480,7 @@ _SOKOL_PRIVATE bool _sgimgui_draw_image_link(_sgimgui_t* ctx, sg_image img) {
 _SOKOL_PRIVATE bool _sgimgui_draw_sampler_link(_sgimgui_t* ctx, sg_sampler smp) {
     bool retval = false;
     if (smp.id != SG_INVALID_ID) {
-        const _sgimgui_sampler_t* smp_ui = &ctx->sampler_window.slots[_sgimgui_slot_index(smp.id)];
+        const _sgimgui_sampler_t* smp_ui = _sgimgui_smp_ptr(ctx, smp);
         retval = _sgimgui_draw_resid_link(3, smp.id, smp_ui->label.buf);
     }
     return retval;
@@ -3471,7 +3489,7 @@ _SOKOL_PRIVATE bool _sgimgui_draw_sampler_link(_sgimgui_t* ctx, sg_sampler smp) 
 _SOKOL_PRIVATE bool _sgimgui_draw_shader_link(_sgimgui_t* ctx, sg_shader shd) {
     bool retval = false;
     if (shd.id != SG_INVALID_ID) {
-        const _sgimgui_shader_t* shd_ui = &ctx->shader_window.slots[_sgimgui_slot_index(shd.id)];
+        const _sgimgui_shader_t* shd_ui = _sgimgui_shd_ptr(ctx, shd);
         retval = _sgimgui_draw_resid_link(4, shd.id, shd_ui->label.buf);
     }
     return retval;
@@ -3480,7 +3498,7 @@ _SOKOL_PRIVATE bool _sgimgui_draw_shader_link(_sgimgui_t* ctx, sg_shader shd) {
 _SOKOL_PRIVATE bool _sgimgui_draw_view_link(_sgimgui_t* ctx, sg_view view) {
     bool retval = false;
     if (view.id != SG_INVALID_ID) {
-        const _sgimgui_view_t* view_ui = &ctx->view_window.slots[_sgimgui_slot_index(view.id)];
+        const _sgimgui_view_t* view_ui = _sgimgui_view_ptr(ctx, view);
         retval = _sgimgui_draw_resid_link(5, view.id, view_ui->label.buf);
         if (_sgimgui_igisitemhovered(0)) {
             sg_image img = sg_query_view_image(view);
@@ -3654,7 +3672,7 @@ _SOKOL_PRIVATE void _sgimgui_draw_buffer_panel(_sgimgui_t* ctx, sg_buffer buf) {
         _sgimgui_igbeginchild("buffer", IMVEC2(0,0), ImGuiChildFlags_None, ImGuiWindowFlags_None);
         sg_buffer_info info = sg_query_buffer_info(buf);
         if (info.slot.state == SG_RESOURCESTATE_VALID) {
-            const _sgimgui_buffer_t* buf_ui = &ctx->buffer_window.slots[_sgimgui_slot_index(buf.id)];
+            const _sgimgui_buffer_t* buf_ui = _sgimgui_buf_ptr(ctx, buf);
             _sgimgui_igtext("Label: %s", buf_ui->label.buf[0] ? buf_ui->label.buf : "---");
             _sgimgui_draw_resource_slot(&info.slot);
             _sgimgui_igseparator();
@@ -3688,7 +3706,7 @@ _SOKOL_PRIVATE void _sgimgui_draw_image_panel(_sgimgui_t* ctx, sg_image img) {
         _sgimgui_igbeginchild("image", IMVEC2(0,0), ImGuiChildFlags_None, ImGuiWindowFlags_None);
         sg_image_info info = sg_query_image_info(img);
         if (info.slot.state == SG_RESOURCESTATE_VALID) {
-            _sgimgui_image_t* img_ui = &ctx->image_window.slots[_sgimgui_slot_index(img.id)];
+            _sgimgui_image_t* img_ui = _sgimgui_img_ptr(ctx, img);
             const sg_image_desc* desc = &img_ui->desc;
             _sgimgui_igtext("Label: %s", img_ui->label.buf[0] ? img_ui->label.buf : "---");
             _sgimgui_draw_resource_slot(&info.slot);
@@ -3729,7 +3747,7 @@ _SOKOL_PRIVATE void _sgimgui_draw_sampler_panel(_sgimgui_t* ctx, sg_sampler smp)
         _sgimgui_igbeginchild("sampler", IMVEC2(0,0), ImGuiChildFlags_None, ImGuiWindowFlags_None);
         sg_sampler_info info = sg_query_sampler_info(smp);
         if (info.slot.state == SG_RESOURCESTATE_VALID) {
-            _sgimgui_sampler_t* smp_ui = &ctx->sampler_window.slots[_sgimgui_slot_index(smp.id)];
+            _sgimgui_sampler_t* smp_ui = _sgimgui_smp_ptr(ctx, smp);
             const sg_sampler_desc* desc = &smp_ui->desc;
             _sgimgui_igtext("Label: %s", smp_ui->label.buf[0] ? smp_ui->label.buf : "---");
             _sgimgui_draw_resource_slot(&info.slot);
@@ -3784,7 +3802,7 @@ _SOKOL_PRIVATE void _sgimgui_draw_shader_panel(_sgimgui_t* ctx, sg_shader shd) {
         _sgimgui_igbeginchild("shader", IMVEC2(0,0), ImGuiChildFlags_None, ImGuiWindowFlags_HorizontalScrollbar);
         sg_shader_info info = sg_query_shader_info(shd);
         if (info.slot.state == SG_RESOURCESTATE_VALID) {
-            const _sgimgui_shader_t* shd_ui = &ctx->shader_window.slots[_sgimgui_slot_index(shd.id)];
+            const _sgimgui_shader_t* shd_ui = _sgimgui_shd_ptr(ctx, shd);
             _sgimgui_igtext("Label: %s", shd_ui->label.buf[0] ? shd_ui->label.buf : "---");
             _sgimgui_draw_resource_slot(&info.slot);
             _sgimgui_igseparator();
@@ -4041,7 +4059,7 @@ _SOKOL_PRIVATE void _sgimgui_draw_pipeline_panel(_sgimgui_t* ctx, sg_pipeline pi
         _sgimgui_igbeginchild("pipeline", IMVEC2(0,0), ImGuiChildFlags_None, ImGuiWindowFlags_None);
         sg_pipeline_info info = sg_query_pipeline_info(pip);
         if (info.slot.state == SG_RESOURCESTATE_VALID) {
-            const _sgimgui_pipeline_t* pip_ui = &ctx->pipeline_window.slots[_sgimgui_slot_index(pip.id)];
+            const _sgimgui_pipeline_t* pip_ui = _sgimgui_pip_ptr(ctx, pip);
             _sgimgui_igtext("Label: %s", pip_ui->label.buf[0] ? pip_ui->label.buf : "---");
             _sgimgui_draw_resource_slot(&info.slot);
             _sgimgui_igseparator();
@@ -4106,7 +4124,7 @@ _SOKOL_PRIVATE void _sgimgui_draw_image_view(_sgimgui_t* ctx, const char* title,
     _sgimgui_igtext("  Mip Level: %d", desc->mip_level);
     _sgimgui_igtext("  Slice: %d", desc->slice);
     _sgimgui_igseparator();
-    _sgimgui_view_t* view_ui = &ctx->view_window.slots[_sgimgui_slot_index(view.id)];
+    _sgimgui_view_t* view_ui = _sgimgui_view_ptr(ctx, view);
     _sgimgui_draw_image(ctx, desc->image, &view_ui->ui_scale, 4096.0f);
 }
 
@@ -4121,7 +4139,7 @@ _SOKOL_PRIVATE void _sgimgui_draw_texture_view(_sgimgui_t* ctx, const char* titl
     _sgimgui_igtext("  Slices Base: %d", desc->slices.base);
     _sgimgui_igtext("  Slices Count: %d", desc->slices.count);
     _sgimgui_igseparator();
-    _sgimgui_view_t* view_ui = &ctx->view_window.slots[_sgimgui_slot_index(view.id)];
+    _sgimgui_view_t* view_ui = _sgimgui_view_ptr(ctx, view);
     _sgimgui_draw_image(ctx, desc->image, &view_ui->ui_scale, 4096.0f);
 }
 
@@ -4130,7 +4148,7 @@ _SOKOL_PRIVATE void _sgimgui_draw_view_panel(_sgimgui_t* ctx, sg_view view) {
         _sgimgui_igbeginchild("view", IMVEC2(0,0), ImGuiChildFlags_None, ImGuiWindowFlags_None);
         sg_view_info info = sg_query_view_info(view);
         if (info.slot.state == SG_RESOURCESTATE_VALID) {
-            _sgimgui_view_t* view_ui = &ctx->view_window.slots[_sgimgui_slot_index(view.id)];
+            _sgimgui_view_t* view_ui = _sgimgui_view_ptr(ctx, view);
             _sgimgui_igtext("Label: %s", view_ui->label.buf[0] ? view_ui->label.buf : "---");
             _sgimgui_draw_resource_slot(&info.slot);
             _sgimgui_igseparator();
@@ -4226,12 +4244,12 @@ _SOKOL_PRIVATE void _sgimgui_draw_uniforms_panel(_sgimgui_t* ctx, const _sgimgui
         _sgimgui_igtext("Pipeline object not valid!");
         return;
     }
-    _sgimgui_pipeline_t* pip_ui = &ctx->pipeline_window.slots[_sgimgui_slot_index(args->pipeline.id)];
+    _sgimgui_pipeline_t* pip_ui = _sgimgui_pip_ptr(ctx, args->pipeline);
     if (sg_query_shader_state(pip_ui->desc.shader) != SG_RESOURCESTATE_VALID) {
         _sgimgui_igtext("Shader object not valid!");
         return;
     }
-    _sgimgui_shader_t* shd_ui = &ctx->shader_window.slots[_sgimgui_slot_index(pip_ui->desc.shader.id)];
+    _sgimgui_shader_t* shd_ui = _sgimgui_shd_ptr(ctx, pip_ui->desc.shader);
     SOKOL_ASSERT(shd_ui->res_id.id == pip_ui->desc.shader.id);
     const sg_shader_uniform_block* ub_desc = &shd_ui->desc.uniform_blocks[args->ub_slot];
     SOKOL_ASSERT(args->data_size <= ub_desc->size);
@@ -4366,7 +4384,7 @@ _SOKOL_PRIVATE void _sgimgui_draw_passaction_panel(const sg_pass_action* action,
 _SOKOL_PRIVATE void _sgimgui_draw_attachments_panel(_sgimgui_t* ctx, const sg_attachments* atts, int num_color_atts) {
     _sgimgui_igtext("Attachments:");
     for (int i = 0; i < num_color_atts; i++) {
-        if (atts->colors[i].id!= SG_INVALID_ID) {
+        if (atts->colors[i].id != SG_INVALID_ID) {
             sg_view view = atts->colors[i];
             _sgimgui_igtext("  Color Attachment #%d:", i); _sgimgui_igsameline();
             if (_sgimgui_draw_view_link(ctx, view)) {
@@ -4536,7 +4554,7 @@ _SOKOL_PRIVATE void _sgimgui_draw_capture_panel(_sgimgui_t* ctx) {
             _sgimgui_draw_buffer_panel(ctx, item->args.append_buffer.buffer);
             break;
         case _SGIMGUI_CMD_WRITE_BUFFER_UNSEALED:
-            _sgimgui_draw_buffer_panel(ctx, item->args.write_buffer_unsealed.dst.buffer);;
+            _sgimgui_draw_buffer_panel(ctx, item->args.write_buffer_unsealed.dst.buffer);
             break;
         case _SGIMGUI_CMD_WRITE_IMAGE_UNSEALED:
             _sgimgui_draw_image_panel(ctx, item->args.write_image_unsealed.dst.image);
@@ -5027,14 +5045,14 @@ SOKOL_API_IMPL void sgimgui_setup(const sgimgui_desc_t* desc) {
     hooks.pop_debug_group = _sgimgui_pop_debug_group;
     _sgimgui.hooks = sg_install_trace_hooks(&hooks);
 
-    /* allocate resource debug-info slots */
+    // allocate resource debug-info slots (note: slot 0 is reserved for the invalid id, same as in sokol-gfx
     const sg_desc sgdesc = sg_query_desc();
-    _sgimgui.buffer_window.num_slots = sgdesc.buffer_pool_size;
-    _sgimgui.image_window.num_slots = sgdesc.image_pool_size;
-    _sgimgui.sampler_window.num_slots = sgdesc.sampler_pool_size;
-    _sgimgui.shader_window.num_slots = sgdesc.shader_pool_size;
-    _sgimgui.pipeline_window.num_slots = sgdesc.pipeline_pool_size;
-    _sgimgui.view_window.num_slots = sgdesc.view_pool_size;
+    _sgimgui.buffer_window.num_slots = sgdesc.buffer_pool_size + 1;
+    _sgimgui.image_window.num_slots = sgdesc.image_pool_size + 1;
+    _sgimgui.sampler_window.num_slots = sgdesc.sampler_pool_size + 1;
+    _sgimgui.shader_window.num_slots = sgdesc.shader_pool_size + 1;
+    _sgimgui.pipeline_window.num_slots = sgdesc.pipeline_pool_size + 1;
+    _sgimgui.view_window.num_slots = sgdesc.view_pool_size + 1;
 
     const size_t buffer_pool_size = (size_t)_sgimgui.buffer_window.num_slots * sizeof(_sgimgui_buffer_t);
     _sgimgui.buffer_window.slots = (_sgimgui_buffer_t*) _sgimgui_malloc_clear(&_sgimgui.desc.allocator, buffer_pool_size);
@@ -5063,8 +5081,9 @@ SOKOL_API_IMPL void sgimgui_shutdown(void) {
     _sgimgui_capture_discard(&_sgimgui);
     if (_sgimgui.buffer_window.slots) {
         for (int i = 0; i < _sgimgui.buffer_window.num_slots; i++) {
-            if (_sgimgui.buffer_window.slots[i].res_id.id != SG_INVALID_ID) {
-                _sgimgui_buffer_destroyed(&_sgimgui, i);
+            const sg_buffer buf = _sgimgui.buffer_window.slots[i].res_id;
+            if (buf.id != SG_INVALID_ID) {
+                _sgimgui_buffer_destroyed(&_sgimgui, buf);
             }
         }
         _sgimgui_free(&_sgimgui.desc.allocator, (void*)_sgimgui.buffer_window.slots);
@@ -5072,8 +5091,9 @@ SOKOL_API_IMPL void sgimgui_shutdown(void) {
     }
     if (_sgimgui.image_window.slots) {
         for (int i = 0; i < _sgimgui.image_window.num_slots; i++) {
-            if (_sgimgui.image_window.slots[i].res_id.id != SG_INVALID_ID) {
-                _sgimgui_image_destroyed(&_sgimgui, i);
+            const sg_image img = _sgimgui.image_window.slots[i].res_id;
+            if (img.id != SG_INVALID_ID) {
+                _sgimgui_image_destroyed(&_sgimgui, img);
             }
         }
         _sgimgui_free(&_sgimgui.desc.allocator, (void*)_sgimgui.image_window.slots);
@@ -5081,8 +5101,9 @@ SOKOL_API_IMPL void sgimgui_shutdown(void) {
     }
     if (_sgimgui.sampler_window.slots) {
         for (int i = 0; i < _sgimgui.sampler_window.num_slots; i++) {
-            if (_sgimgui.sampler_window.slots[i].res_id.id != SG_INVALID_ID) {
-                _sgimgui_sampler_destroyed(&_sgimgui, i);
+            const sg_sampler smp = _sgimgui.sampler_window.slots[i].res_id;
+            if (smp.id != SG_INVALID_ID) {
+                _sgimgui_sampler_destroyed(&_sgimgui, smp);
             }
         }
         _sgimgui_free(&_sgimgui.desc.allocator, (void*)_sgimgui.sampler_window.slots);
@@ -5090,8 +5111,9 @@ SOKOL_API_IMPL void sgimgui_shutdown(void) {
     }
     if (_sgimgui.shader_window.slots) {
         for (int i = 0; i < _sgimgui.shader_window.num_slots; i++) {
-            if (_sgimgui.shader_window.slots[i].res_id.id != SG_INVALID_ID) {
-                _sgimgui_shader_destroyed(&_sgimgui, i);
+            const sg_shader shd = _sgimgui.shader_window.slots[i].res_id;
+            if (shd.id != SG_INVALID_ID) {
+                _sgimgui_shader_destroyed(&_sgimgui, shd);
             }
         }
         _sgimgui_free(&_sgimgui.desc.allocator, (void*)_sgimgui.shader_window.slots);
@@ -5099,8 +5121,9 @@ SOKOL_API_IMPL void sgimgui_shutdown(void) {
     }
     if (_sgimgui.pipeline_window.slots) {
         for (int i = 0; i < _sgimgui.pipeline_window.num_slots; i++) {
-            if (_sgimgui.pipeline_window.slots[i].res_id.id != SG_INVALID_ID) {
-                _sgimgui_pipeline_destroyed(&_sgimgui, i);
+            const sg_pipeline pip = _sgimgui.pipeline_window.slots[i].res_id;
+            if (pip.id != SG_INVALID_ID) {
+                _sgimgui_pipeline_destroyed(&_sgimgui, pip);
             }
         }
         _sgimgui_free(&_sgimgui.desc.allocator, (void*)_sgimgui.pipeline_window.slots);
@@ -5108,8 +5131,9 @@ SOKOL_API_IMPL void sgimgui_shutdown(void) {
     }
     if (_sgimgui.view_window.slots) {
         for (int i = 0; i < _sgimgui.view_window.num_slots; i++) {
-            if (_sgimgui.view_window.slots[i].res_id.id != SG_INVALID_ID) {
-                _sgimgui_view_destroyed(&_sgimgui, i);
+            const sg_view view = _sgimgui.view_window.slots[i].res_id;
+            if (view.id != SG_INVALID_ID) {
+                _sgimgui_view_destroyed(&_sgimgui, view);
             }
         }
         _sgimgui_free(&_sgimgui.desc.allocator, (void*)_sgimgui.view_window.slots);


### PR DESCRIPTION
...plus some general code cleanup which makes pool slot lookups more robust (range-check asserts etc...).

Fixes #1584 