### PR TITLE
sokol_gfx.h wgpu: fix bug when uniform-block bindslots have gaps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 ## Updates
 
-### 18-Aug-2025
+### 26-Aug-2026
+
+- sokol_gfx.h wgpu: small but important bug-fix in the WebGPU backend when using
+  sparse uniform-block bindslots.
+
+  Ticket: https://github.com/floooh/sokol/issues/1586
+  PR: https://github.com/floooh/sokol/pull/1587
+
+  New regression sample: https://floooh.github.io/sokol-webgpu/sparse-ub-slots-sapp.html
+
+### 18-Aug-2026
 
 - sokol_gfx_imgui.h: fix a potential buffer overrun when the sokol_gfx.h resource pools
   are filled up to the last slot, this was caused by off-by-one error when allocating

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -19128,8 +19128,8 @@ _SOKOL_PRIVATE sg_resource_state _sg_wgpu_create_shader(_sg_shader_t* shd, const
         bg_entry->binding = bgl_entry->binding;
         bg_entry->buffer = _sg.wgpu.uniform.buf;
         bg_entry->size = _SG_WGPU_MAX_UNIFORM_UPDATE_SIZE;
-        dynoffset_map[i].sokol_slot = (uint8_t)i;
-        dynoffset_map[i].wgpu_slot = (uint8_t)bgl_entry->binding;
+        dynoffset_map[bgl_index].sokol_slot = (uint8_t)i;
+        dynoffset_map[bgl_index].wgpu_slot = (uint8_t)bgl_entry->binding;
         bgl_index += 1;
     }
     bgl_desc.entryCount = bgl_index;


### PR DESCRIPTION
Fixes https://github.com/floooh/sokol/issues/1586