### PR TITLE
Implement sokol_cmdbuf.h

### DIFF
--- a/.github/workflows/gen_bindings.yml
+++ b/.github/workflows/gen_bindings.yml
@@ -156,7 +156,7 @@ jobs:
       fail-fast: false
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     runs-on: ${{matrix.os}}
     steps:
       - if: runner.os == 'Linux'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,9 @@ todo list of concrete warnings and errors.
 ## Reviewing Code
 
 When reviewing code, assume debug build mode (asserts enabled, unreachable panics, validation layers enabled).
+
+## Language bindings
+
+When working under `./bindgen/`, additional per-binding instructions apply.
+
+@bindgen/AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ When creating files, add a 'LLM maintained' note at the top.
 When editing files without the 'LLM maintained' note, ask the user whether
 the note should be added.
 
+Never git add, commit or push on your own.
+
 ## Testing
 
 Tests are located in `./tests/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 ## Updates
 
+### 06-Sep-2026
+
+Added a new header `sokol_cmdbuf.h`. This implements a simple record/replay
+mechanism for sokol_gfx.h functions that need to be issued inside a
+render or compute pass and that way allows to move those calls outside
+of passes.
+
+For more imformation see the header documentation in [util/sokol_cmdbuf.h](https://github.com/floooh/sokol/blob/master/util/sokol_cmdbuf.h),
+and for implementation details see the new sample [cmdbuf-sapp](https://floooh.github.io/sokol-html5/cmdbuf-sapp.html).
+
+Planning ticket: https://github.com/floooh/sokol/issues/1557
+
+PR: https://github.com/floooh/sokol/pull/1593
+
+The new header has also been added to all language bindings.
+
 ### 30-Aug-2026
+
 sokol_gfx.h: the next implementation step of the new resource update API:
 
 The 'stream-update' mode for buffers and images has been replaced with

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Sokol
 
-[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**30-Aug-2026**: sokol_gfx.h: the 'write-transient' update)
+[**See what's new**](https://github.com/floooh/sokol/blob/master/CHANGELOG.md) (**06-Sep-2026**: new utility header sokol_cmdbuf.h)
 
 [![Build](/../../actions/workflows/main.yml/badge.svg)](/../../actions/workflows/main.yml) [![Bindings](/../../actions/workflows/gen_bindings.yml/badge.svg)](/../../actions/workflows/gen_bindings.yml) [![build](https://github.com/floooh/sokol-zig/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-zig/actions/workflows/main.yml) [![build](https://github.com/floooh/sokol-nim/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-nim/actions/workflows/main.yml) [![Odin](https://github.com/floooh/sokol-odin/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-odin/actions/workflows/main.yml)[![Rust](https://github.com/floooh/sokol-rust/actions/workflows/main.yml/badge.svg)](https://github.com/floooh/sokol-rust/actions/workflows/main.yml)[![Dlang](https://github.com/floooh/sokol-d/actions/workflows/build.yml/badge.svg)](https://github.com/floooh/sokol-d/actions/workflows/build.yml)[![C3](https://github.com/floooh/sokol-c3/actions/workflows/build.yml/badge.svg)](https://github.com/floooh/sokol-c3/actions/workflows/build.yml)
 

--- a/bindgen/AGENTS.md
+++ b/bindgen/AGENTS.md
@@ -1,0 +1,155 @@
+# Adding a new sokol header to the language bindings
+
+Applies whenever a new `sokol_*.h` / `util/sokol_*.h` header is added to the
+main repo and needs to reach the language bindings under
+`./bindgen/sokol-<lang>/`. Regeneration alone is not enough for most bindings;
+each language's C build has to learn about the new file too.
+
+## 0. Precondition -- verify each bindings repo is ready
+
+Before running the generator or touching any build script, check every
+`bindgen/sokol-<lang>/` repo:
+
+1. Working tree is clean -- `git -C bindgen/sokol-<lang> status --short`
+   returns no output.
+2. The current branch is a feature branch, **never `master` or `main`**.
+   Check with `git -C bindgen/sokol-<lang> branch --show-current`. Binding
+   regenerations always land on a feature branch (typically the same
+   branch name as the sokol PR that added the header); a repo sitting on
+   `master`/`main` means no feature branch has been created yet.
+
+If any repo is dirty, sitting on `master`/`main`, or on a branch that
+doesn't match what the user asked for, **stop and notify the user** --
+list which repo(s) failed the check and what state they're in. Do not
+attempt to clean, switch, or create branches on your own; those are
+destructive actions the user must direct.
+
+Only proceed to step 1 once every repo passes both checks.
+
+## 1. Register the header with the generator
+
+Add an entry to the `tasks` list in `gen_all.py`:
+
+```python
+[ '../util/sokol_newmodule.h', 'snm_', ['sg_'] ],   # c_path, prefix, deps
+```
+
+Add the prefix → module name mapping in the `module_names` dict in the same
+file (a short lowercase name, matching sokol convention).
+
+Then update each per-language generator's own `module_names` dict when it has
+one (see below). Missing entries cause `gen_all.py` to skip that language for
+the new header and emit `>> warning: skipping generation for {c_prefix} …`.
+
+Per-generator module maps to update:
+- `gen_c3.py`
+- `gen_d.py`
+- `gen_jai.py`
+- `gen_nim.py`
+- `gen_odin.py`
+- `gen_rust.py`
+- `gen_zig.py`
+
+Run `python3 gen_all.py` after the changes and confirm the target `.<ext>` file
+appears in each binding repo. Also confirm the corresponding
+`sokol_<newmodule>.c` and `sokol_<newmodule>.h` land in each binding's
+`c/`-style directory (paths differ per repo -- see below).
+
+## 2. Wire the new `.c` file into each binding's C build
+
+Each repo has its own C build. The header alone is not enough -- the `.c`
+shim must be picked up by the build.
+
+### sokol-zig -- `build.zig`
+
+Add `"sokol_newmodule.c"` to the C source list (search for existing entries
+like `sokol_gfx.c`).
+
+### sokol-nim -- generated `.nim` module
+
+Nothing to do. The generator emits `{.compile: "c/sokol_newmodule.c".}` into
+the produced `newmodule.nim`, and Nim compiles the C source automatically
+when the module is imported.
+
+### sokol-rust -- `build.rs`
+
+Add `"sokol_newmodule.c"` to the `files` array (around the block starting
+`let files = [`).
+
+After running `gen_all.py`, `cd bindgen/sokol-rust && cargo fmt` to
+re-apply rustfmt to the generated `.rs` files. The generator emits code
+that doesn't match rustfmt output, so without this the diff shows large
+formatting-only changes on every regeneration.
+
+### sokol-d -- `build.d`
+
+Add `"sokol_newmodule.c"` to the `sokolSources` array.
+
+### sokol-jai -- 5 build scripts + unified `sokol.c`
+
+Static-lib builds (`sokol/build_clibs_*.sh` / `.cmd`) use one entry per
+config × backend. Insert `sokol_newmodule` lines after the last existing
+module in each block, mirroring the existing pattern. Files to touch:
+
+- `sokol/build_clibs_macos.sh`  -- 8 lines (arm64/x64 × release/debug × metal/gl)
+- `sokol/build_clibs_linux.sh`  -- 2 lines (x64 × release/debug × gl)
+- `sokol/build_clibs_wasm.sh`   -- 2 lines (release/debug × gles3)
+- `sokol/build_clibs_windows.cmd` -- add `newmodule` to the `set sources=…` list
+- `sokol/build_clibs_macos_dylib.sh` -- **no per-module change**; it builds a
+  single unified dylib from `sokol/c/sokol.c` (see next bullet)
+
+Unified compilation unit `sokol/c/sokol.c` (used by the macOS dylib and the
+Windows DLL builds): add `#include "sokol_newmodule.h"`.
+
+### sokol-odin -- 4 build scripts + unified `sokol.c`
+
+Same shape as sokol-jai. Files to touch:
+
+- `sokol/build_clibs_macos.sh`  -- 8 lines
+- `sokol/build_clibs_linux.sh`  -- 2 lines
+- `sokol/build_clibs_wasm.sh`   -- add `"newmodule"` to the bash `libs=(…)` array
+- `sokol/build_clibs_windows.cmd` -- add `newmodule` to `set sources=…`
+- `sokol/build_clibs_macos_dylib.sh` -- **no per-module change**
+- `sokol/c/sokol.c` -- add `#include "sokol_newmodule.h"`
+
+### sokol-c3 -- unified `sokol.c`
+
+`sokol.c3l/c/sokol.c` is the single compilation unit driven by
+`sokol.c3l/manifest.json`. Add `#include "sokol_newmodule.h"` there. The
+`.c3` binding itself is emitted by `gen_c3.py` once the generator's
+`module_names` dict knows the prefix (step 1).
+
+## 3. Verify
+
+For each repo, ensure `git status` shows the expected new/modified files:
+
+- generated language binding (`.zig`, `.nim`, `.rs`, `.d`, `.jai`, `.odin`, `.c3`)
+- `c/sokol_newmodule.h` and `c/sokol_newmodule.c` (path varies per repo)
+- build-script edits from step 2
+
+Then rebuild each binding's example (or the smallest one, usually `clear`)
+to prove the wiring works end to end. Before running examples, rebuild the
+pre-generated C static libs where the repo relies on them -- otherwise the
+example still links the stale `.a` from a previous run. Commands from
+each repo's `README.md`:
+
+| repo | rebuild C libs first | build/run example |
+|---|---|---|
+| sokol-zig | not needed (build.zig compiles C from source) | `cd sokol-zig && zig build examples` |
+| sokol-rust | not needed (build.rs compiles C from source) | `cd sokol-rust && cargo build --all-targets` |
+| sokol-nim | not needed (`.compile` pragma in each `.nim` module) | `cd sokol-nim && nimble clear` |
+| sokol-c3 | not needed (`sokol.c3l` C sources built by c3c) | `cd sokol-c3 && bash build-examples.sh` |
+| sokol-d | `cd sokol-d && rm -f build/*.a && dub build -c sokol-static --compiler=ldc2 --force` | `cd sokol-d/examples/clear && dub build --compiler=ldc2` |
+| sokol-jai | `cd sokol-jai/sokol && ./build_clibs_macos.sh` (or `_linux.sh` / `_windows.cmd`) | `cd sokol-jai && jai-macos examples/first.jai - clear` (binary is `jai-macos` on macOS; `jai-linux` / `jai.exe` elsewhere) |
+| sokol-odin | `cd sokol-odin/sokol && ./build_clibs_macos.sh` (or the equivalent) | `cd sokol-odin && odin run examples/clear -strict-style -debug` |
+
+If a rebuild fails because the toolchain isn't installed (e.g. no `jai`
+compiler), skip that repo and note it in the summary rather than trying
+to install anything.
+
+Then leave every repo's changes uncommitted for the user to review.
+**Do not `git add`, `git commit`, or `git push` in any bindings repo** --
+verification and commit are the user's job. See the top-level
+`bindgen/README.md` for the branch-naming convention (typically the same
+branch name as the sokol PR that added the header) when the user asks you
+to create a feature branch.

--- a/bindgen/AGENTS.md
+++ b/bindgen/AGENTS.md
@@ -26,6 +26,20 @@ destructive actions the user must direct.
 
 Only proceed to step 1 once every repo passes both checks.
 
+Also verify each repo's `master`/`main` branch is up to date with its
+remote before the user creates the feature branch from it -- an outdated
+base would make the eventual PR contain unrelated commits or fall behind
+upstream. From within the repo, run:
+
+```
+git fetch origin
+git rev-list --count master..origin/master   # 0 == up to date; non-zero == behind
+```
+
+(replace `master` with `main` where that's the default branch). If the
+count is non-zero, stop and tell the user which repo(s) are behind so
+they can fast-forward before branching.
+
 ## 1. Register the header with the generator
 
 Add an entry to the `tasks` list in `gen_all.py`:

--- a/bindgen/gen_all.py
+++ b/bindgen/gen_all.py
@@ -16,6 +16,7 @@ tasks = [
     [ '../util/sokol_shape.h',       'sshape_',   ['sg_'] ],
     [ '../util/sokol_framebuffer.h', 'sfb_',      ['sg_'] ],
     [ '../util/sokol_letterbox.h',   'slbx_',     [] ],
+    [ '../util/sokol_cmdbuf.h',      'scb_',      ['sg_'] ],
 ]
 
 # common prefix- to module-names mapping table
@@ -39,6 +40,7 @@ module_names = {
     'smemtrack_': 'memtrack',
     'sfb_':       'framebuffer',
     'slbx_':      'letterbox',
+    'scb_':       'cmdbuf',
 }
 
 # Jai

--- a/bindgen/gen_c3.py
+++ b/bindgen/gen_c3.py
@@ -21,6 +21,9 @@ module_names = {
     'sdtx_':    'sdtx',
     'sshape_':  'sshape',
     'sglue_':   'sglue',
+    'sfb_':     'sfb',
+    'slbx_':    'slbx',
+    'scb_':     'scb',
 }
 
 ignores = [

--- a/bindgen/impl/sokol_cmdbuf.c
+++ b/bindgen/impl/sokol_cmdbuf.c
@@ -1,0 +1,6 @@
+#if defined(IMPL)
+#define SOKOL_CMDBUF_IMPL
+#endif
+#include "sokol_defines.h"
+#include "sokol_gfx.h"
+#include "sokol_cmdbuf.h"

--- a/tests/compile/CMakeLists.txt
+++ b/tests/compile/CMakeLists.txt
@@ -17,6 +17,7 @@ set(c_sources
     sokol_spine.c
     sokol_log.c
     sokol_letterbox.c
+    sokol_framebuffer.c
     sokol_main.c)
 if (NOT ANDROID)
     set(c_sources ${c_sources} sokol_fetch.c)

--- a/tests/compile/sokol_all.c
+++ b/tests/compile/sokol_all.c
@@ -14,6 +14,7 @@
 #include "sokol_letterbox.h"
 #include "sokol_memtrack.h"
 #include "sokol_shape.h"
+#include "sokol_framebuffer.h"
 
 #if defined(_MSC_VER )
 #pragma warning(disable:4201) // nonstandard extension used: nameless struct/union
@@ -80,4 +81,5 @@ void use_all(void) {
     FONScontext* ctx = sfons_create(&(sfons_desc_t){ 0 }); (void)ctx;
     sspine_setup(&(sspine_desc){0});
     snk_setup(&(snk_desc_t){0});
+    sfb_setup(&(sfb_desc){0});
 }

--- a/tests/compile/sokol_all.c
+++ b/tests/compile/sokol_all.c
@@ -15,6 +15,7 @@
 #include "sokol_memtrack.h"
 #include "sokol_shape.h"
 #include "sokol_framebuffer.h"
+#include "sokol_cmdbuf.h"
 
 #if defined(_MSC_VER )
 #pragma warning(disable:4201) // nonstandard extension used: nameless struct/union

--- a/tests/compile/sokol_cmdbuf.c
+++ b/tests/compile/sokol_cmdbuf.c
@@ -1,0 +1,7 @@
+#include "sokol_gfx.h"
+#define SOKOL_IMPL
+#include "sokol_cmdbuf.h"
+
+void use_sokol_cmdbuf(void) {
+    scb_setup(&(scb_desc){0});
+}

--- a/tests/compile/sokol_cmdbuf.cc
+++ b/tests/compile/sokol_cmdbuf.cc
@@ -1,0 +1,7 @@
+#include "sokol_gfx.h"
+#define SOKOL_IMPL
+#include "sokol_cmdbuf.h"
+
+void use_sokol_cmdbuf(void) {
+    scb_setup({});
+}

--- a/tests/compile/sokol_framebuffer.c
+++ b/tests/compile/sokol_framebuffer.c
@@ -1,0 +1,7 @@
+#include "sokol_gfx.h"
+#define SOKOL_IMPL
+#include "sokol_framebuffer.h"
+
+void use_sokol_framebuffer(void) {
+    sfb_setup(&(sfb_desc){0});
+}

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -8,6 +8,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/assets/comsi.s3m DESTINATION ${CMAKE_BINAR
 # covered by the mock libraries yet -- skip in mock mode.
 if (NOT BACKEND_MOCK_ONLY)
     set(c_sources
+        sokol_cmdbuf_test.c
         sokol_log_test.c
         sokol_args_test.c
         sokol_audio_test.c

--- a/tests/functional/sokol_cmdbuf_test.c
+++ b/tests/functional/sokol_cmdbuf_test.c
@@ -696,3 +696,380 @@ UTEST(sokol_cmdbuf, shutdown_destroys_remaining_cmdbufs) {
     shutdown();
     T(_scb.init_tag == 0);
 }
+
+// ============================================================================
+// scb_submit tests — use sokol-gfx trace hooks to observe the sg_* calls
+// that scb_submit produces when decoding a recorded cmdbuf.
+//
+// Trace hooks fire BEFORE the sokol-gfx validation / pass check, so the
+// captured arguments reflect exactly what scb_submit passed in, and no
+// active pass or valid resources are needed.
+// ============================================================================
+
+typedef enum {
+    TCALL_NONE = 0,
+    TCALL_APPLY_VIEWPORT,
+    TCALL_APPLY_SCISSOR_RECT,
+    TCALL_APPLY_PIPELINE,
+    TCALL_APPLY_BINDINGS,
+    TCALL_APPLY_UNIFORMS,
+    TCALL_DRAW,
+    TCALL_DRAW_EX,
+    TCALL_DISPATCH,
+} tcall_kind;
+
+#define TCALL_MAX_CALLS (32)
+#define TCALL_MAX_UNIFORM_SIZE (256)
+
+typedef struct {
+    tcall_kind kind;
+    int i0, i1, i2, i3, i4;
+    bool b0;
+    uint32_t u0;
+    sg_bindings bindings;         // deep copy at hook time (bindings ptr is stack-local)
+    int ub_slot;
+    size_t uniform_size;
+    uint8_t uniform_data[TCALL_MAX_UNIFORM_SIZE];
+} tcall_t;
+
+static tcall_t tcalls[TCALL_MAX_CALLS];
+static int num_tcalls = 0;
+
+static void tcalls_reset(void) {
+    num_tcalls = 0;
+    memset(tcalls, 0, sizeof(tcalls));
+}
+
+static tcall_t* tcalls_push(tcall_kind kind) {
+    if (num_tcalls < TCALL_MAX_CALLS) {
+        tcall_t* c = &tcalls[num_tcalls++];
+        c->kind = kind;
+        return c;
+    }
+    return 0;
+}
+
+static void hook_apply_viewport(int x, int y, int w, int h, bool otl, void* ud) {
+    (void)ud;
+    tcall_t* c = tcalls_push(TCALL_APPLY_VIEWPORT);
+    if (c) { c->i0 = x; c->i1 = y; c->i2 = w; c->i3 = h; c->b0 = otl; }
+}
+
+static void hook_apply_scissor_rect(int x, int y, int w, int h, bool otl, void* ud) {
+    (void)ud;
+    tcall_t* c = tcalls_push(TCALL_APPLY_SCISSOR_RECT);
+    if (c) { c->i0 = x; c->i1 = y; c->i2 = w; c->i3 = h; c->b0 = otl; }
+}
+
+static void hook_apply_pipeline(sg_pipeline pip, void* ud) {
+    (void)ud;
+    tcall_t* c = tcalls_push(TCALL_APPLY_PIPELINE);
+    if (c) { c->u0 = pip.id; }
+}
+
+static void hook_apply_bindings(const sg_bindings* bnd, void* ud) {
+    (void)ud;
+    tcall_t* c = tcalls_push(TCALL_APPLY_BINDINGS);
+    if (c) { c->bindings = *bnd; }
+}
+
+static void hook_apply_uniforms(int ub_slot, const sg_range* data, void* ud) {
+    (void)ud;
+    tcall_t* c = tcalls_push(TCALL_APPLY_UNIFORMS);
+    if (c) {
+        c->ub_slot = ub_slot;
+        c->uniform_size = data->size;
+        SOKOL_ASSERT(data->size <= TCALL_MAX_UNIFORM_SIZE);
+        memcpy(c->uniform_data, data->ptr, data->size);
+    }
+}
+
+static void hook_draw(int base_element, int num_elements, int num_instances, void* ud) {
+    (void)ud;
+    tcall_t* c = tcalls_push(TCALL_DRAW);
+    if (c) { c->i0 = base_element; c->i1 = num_elements; c->i2 = num_instances; }
+}
+
+static void hook_draw_ex(int base_element, int num_elements, int num_instances, int base_vertex, int base_instance, void* ud) {
+    (void)ud;
+    tcall_t* c = tcalls_push(TCALL_DRAW_EX);
+    if (c) {
+        c->i0 = base_element; c->i1 = num_elements; c->i2 = num_instances;
+        c->i3 = base_vertex; c->i4 = base_instance;
+    }
+}
+
+static void hook_dispatch(int x, int y, int z, void* ud) {
+    (void)ud;
+    tcall_t* c = tcalls_push(TCALL_DISPATCH);
+    if (c) { c->i0 = x; c->i1 = y; c->i2 = z; }
+}
+
+static void install_capture_hooks(void) {
+    sg_install_trace_hooks(&(sg_trace_hooks){
+        .apply_viewport = hook_apply_viewport,
+        .apply_scissor_rect = hook_apply_scissor_rect,
+        .apply_pipeline = hook_apply_pipeline,
+        .apply_bindings = hook_apply_bindings,
+        .apply_uniforms = hook_apply_uniforms,
+        .draw = hook_draw,
+        .draw_ex = hook_draw_ex,
+        .dispatch = hook_dispatch,
+    });
+}
+
+// scb log item capture — for verifying error paths in scb_submit
+#define SCB_MAX_LOG_ITEMS (16)
+static scb_log_item scb_log_items[SCB_MAX_LOG_ITEMS];
+static int num_scb_log_items = 0;
+
+static void scb_test_logger(const char* tag, uint32_t log_level, uint32_t log_item_id, const char* msg, uint32_t line_nr, const char* file, void* ud) {
+    (void)tag; (void)log_level; (void)msg; (void)line_nr; (void)file; (void)ud;
+    if (num_scb_log_items < SCB_MAX_LOG_ITEMS) {
+        scb_log_items[num_scb_log_items++] = (scb_log_item)log_item_id;
+    }
+}
+
+static void submit_test_init(void) {
+    tcalls_reset();
+    num_scb_log_items = 0;
+    memset(scb_log_items, 0, sizeof(scb_log_items));
+    sg_setup(&(sg_desc){ .logger = { .func = slog_func }});
+    scb_setup(&(scb_desc){ .logger = { .func = scb_test_logger }});
+    install_capture_hooks();
+}
+
+UTEST(sokol_cmdbuf, submit_empty_cmdbuf) {
+    // submitting an empty cmdbuf must be a no-op (no sg calls fired)
+    submit_test_init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    T(cb.id != SCB_INVALID_ID);
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    T(cbptr->cur == cbptr->buf);
+    scb_submit(cb);
+    T(num_tcalls == 0);
+    T(num_scb_log_items == 0);
+    T(cbptr->cur == cbptr->buf);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, submit_all_commands_roundtrip) {
+    // encode one of every command type and verify each sg call is dispatched
+    // with the exact recorded arguments, in order
+    submit_test_init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_apply_viewport(cb, 10, 20, 30, 40, true);
+    scb_apply_scissor_rect(cb, 1, 2, 3, 4, false);
+    scb_apply_pipeline(cb, (sg_pipeline){ .id = 0xC0FFEE });
+    scb_apply_bindings(cb, &(sg_bindings){
+        .vertex_buffers[0] = { .id = 0x1111 },
+        .vertex_buffer_offsets[0] = 64,
+        .index_buffer = { .id = 0x2222 },
+        .index_buffer_offset = 8,
+    });
+    const float uniforms[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
+    scb_apply_uniforms(cb, 3, &(sg_range){ .ptr = uniforms, .size = sizeof(uniforms) });
+    scb_draw(cb, 100, 200, 300);
+    scb_draw_ex(cb, 1, 2, 3, 4, 5);
+    scb_dispatch(cb, 8, 16, 32);
+    T(cbptr->overflown == false);
+    T(cbptr->cur > cbptr->buf);
+    scb_submit(cb);
+    // rewind: cur must be back at the start of the buffer
+    T(cbptr->cur == cbptr->buf);
+    T(cbptr->overflown == false);
+    // captured trace
+    T(num_tcalls == 8);
+    T(tcalls[0].kind == TCALL_APPLY_VIEWPORT);
+    T(tcalls[0].i0 == 10 && tcalls[0].i1 == 20 && tcalls[0].i2 == 30 && tcalls[0].i3 == 40);
+    T(tcalls[0].b0 == true);
+    T(tcalls[1].kind == TCALL_APPLY_SCISSOR_RECT);
+    T(tcalls[1].i0 == 1 && tcalls[1].i1 == 2 && tcalls[1].i2 == 3 && tcalls[1].i3 == 4);
+    T(tcalls[1].b0 == false);
+    T(tcalls[2].kind == TCALL_APPLY_PIPELINE);
+    T(tcalls[2].u0 == 0xC0FFEEu);
+    T(tcalls[3].kind == TCALL_APPLY_BINDINGS);
+    T(tcalls[3].bindings.vertex_buffers[0].id == 0x1111);
+    T(tcalls[3].bindings.vertex_buffer_offsets[0] == 64);
+    T(tcalls[3].bindings.index_buffer.id == 0x2222);
+    T(tcalls[3].bindings.index_buffer_offset == 8);
+    // unused vertex-buffer slots must decode as SG_INVALID_ID
+    T(tcalls[3].bindings.vertex_buffers[1].id == SG_INVALID_ID);
+    T(tcalls[3].bindings.views[0].id == SG_INVALID_ID);
+    T(tcalls[3].bindings.samplers[0].id == SG_INVALID_ID);
+    T(tcalls[4].kind == TCALL_APPLY_UNIFORMS);
+    T(tcalls[4].ub_slot == 3);
+    T(tcalls[4].uniform_size == sizeof(uniforms));
+    T(0 == memcmp(tcalls[4].uniform_data, uniforms, sizeof(uniforms)));
+    T(tcalls[5].kind == TCALL_DRAW);
+    T(tcalls[5].i0 == 100 && tcalls[5].i1 == 200 && tcalls[5].i2 == 300);
+    T(tcalls[6].kind == TCALL_DRAW_EX);
+    T(tcalls[6].i0 == 1 && tcalls[6].i1 == 2 && tcalls[6].i2 == 3 && tcalls[6].i3 == 4 && tcalls[6].i4 == 5);
+    T(tcalls[7].kind == TCALL_DISPATCH);
+    T(tcalls[7].i0 == 8 && tcalls[7].i1 == 16 && tcalls[7].i2 == 32);
+    T(num_scb_log_items == 0);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, submit_apply_bindings_mask_decode) {
+    // full-mix bindings — every category populated to exercise the mask-based
+    // decode paths (vb + ib + view + sampler)
+    submit_test_init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_apply_bindings(cb, &(sg_bindings){
+        .vertex_buffers[0] = { .id = 0xAA },
+        .vertex_buffer_offsets[0] = 4,
+        .vertex_buffers[2] = { .id = 0xBB },
+        .vertex_buffer_offsets[2] = 8,
+        .index_buffer = { .id = 0xCC },
+        .index_buffer_offset = 12,
+        .views[0] = { .id = 0xD0 },
+        .views[5] = { .id = 0xD5 },
+        .samplers[0] = { .id = 0xE0 },
+        .samplers[3] = { .id = 0xE3 },
+    });
+    scb_submit(cb);
+    T(num_tcalls == 1);
+    T(tcalls[0].kind == TCALL_APPLY_BINDINGS);
+    T(tcalls[0].bindings.vertex_buffers[0].id == 0xAA);
+    T(tcalls[0].bindings.vertex_buffer_offsets[0] == 4);
+    T(tcalls[0].bindings.vertex_buffers[1].id == SG_INVALID_ID);
+    T(tcalls[0].bindings.vertex_buffers[2].id == 0xBB);
+    T(tcalls[0].bindings.vertex_buffer_offsets[2] == 8);
+    T(tcalls[0].bindings.index_buffer.id == 0xCC);
+    T(tcalls[0].bindings.index_buffer_offset == 12);
+    T(tcalls[0].bindings.views[0].id == 0xD0);
+    T(tcalls[0].bindings.views[1].id == SG_INVALID_ID);
+    T(tcalls[0].bindings.views[5].id == 0xD5);
+    T(tcalls[0].bindings.samplers[0].id == 0xE0);
+    T(tcalls[0].bindings.samplers[1].id == SG_INVALID_ID);
+    T(tcalls[0].bindings.samplers[3].id == 0xE3);
+    T(cbptr->cur == cbptr->buf);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, submit_apply_uniforms_preserves_payload) {
+    // uniform blob must round-trip byte-identical for arbitrary sizes
+    submit_test_init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    uint8_t payload[73];
+    for (int i = 0; i < (int)sizeof(payload); i++) {
+        payload[i] = (uint8_t)(i * 7 + 3);
+    }
+    scb_apply_uniforms(cb, 5, &(sg_range){ .ptr = payload, .size = sizeof(payload) });
+    scb_submit(cb);
+    T(num_tcalls == 1);
+    T(tcalls[0].kind == TCALL_APPLY_UNIFORMS);
+    T(tcalls[0].ub_slot == 5);
+    T(tcalls[0].uniform_size == sizeof(payload));
+    T(0 == memcmp(tcalls[0].uniform_data, payload, sizeof(payload)));
+    T(cbptr->cur == cbptr->buf);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, submit_rewinds_cmdbuf) {
+    // record + submit → rewind; a second submit must be a no-op
+    submit_test_init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_draw(cb, 0, 3, 1);
+    scb_draw(cb, 1, 4, 2);
+    T(cbptr->cur > cbptr->buf);
+    scb_submit(cb);
+    T(num_tcalls == 2);
+    T(cbptr->cur == cbptr->buf);
+    T(cbptr->overflown == false);
+    // second submit: cmdbuf is empty, nothing to replay
+    scb_submit(cb);
+    T(num_tcalls == 2);
+    T(cbptr->cur == cbptr->buf);
+    // after rewind we can record and submit again without losing anything
+    scb_dispatch(cb, 1, 2, 3);
+    scb_submit(cb);
+    T(num_tcalls == 3);
+    T(tcalls[2].kind == TCALL_DISPATCH);
+    T(tcalls[2].i0 == 1 && tcalls[2].i1 == 2 && tcalls[2].i2 == 3);
+    T(cbptr->cur == cbptr->buf);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, submit_invalid_handle) {
+    // submit on invalid handle must log CMDBUF_NOT_VALID and fire no sg call
+    submit_test_init();
+    scb_submit((scb_cmdbuf){ .id = SCB_INVALID_ID });
+    T(num_tcalls == 0);
+    T(num_scb_log_items == 1);
+    T(scb_log_items[0] == SCB_LOGITEM_CMDBUF_NOT_VALID);
+    // also test with a stale handle
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    scb_destroy_cmdbuf(cb);
+    scb_submit(cb);
+    T(num_tcalls == 0);
+    T(num_scb_log_items == 2);
+    T(scb_log_items[1] == SCB_LOGITEM_CMDBUF_NOT_VALID);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, submit_overflown_cmdbuf) {
+    // submit on an overflown cmdbuf must NOT replay the (partial) stream,
+    // must log SUBMIT_CMDBUF_OVERFLOWN, and must rewind the buffer
+    submit_test_init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){ .size = 32 });
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    // one draw_ex fits (21 bytes), a second one overflows the 32-byte buffer
+    scb_draw_ex(cb, 1, 2, 3, 4, 5);
+    scb_draw_ex(cb, 6, 7, 8, 9, 10);
+    T(cbptr->overflown == true);
+    T(cbptr->cur > cbptr->buf);
+    // reset the log capture — the encoder already fired CMDBUF_OVERFLOW above,
+    // and we only want to observe what scb_submit itself produces
+    num_scb_log_items = 0;
+    scb_submit(cb);
+    // no sg calls dispatched, log item raised, cmdbuf rewound + overflown cleared
+    T(num_tcalls == 0);
+    T(num_scb_log_items == 1);
+    T(scb_log_items[0] == SCB_LOGITEM_SUBMIT_CMDBUF_OVERFLOWN);
+    T(cbptr->cur == cbptr->buf);
+    T(cbptr->overflown == false);
+    // after the rewind the cmdbuf is usable again
+    scb_draw(cb, 0, 3, 1);
+    scb_submit(cb);
+    T(num_tcalls == 1);
+    T(tcalls[0].kind == TCALL_DRAW);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, submit_corrupt_opcode_terminates) {
+    // corrupt the opcode byte in the recorded stream — scb_submit must
+    // log SUBMIT_INVALID_COMMAND, exit the loop cleanly, and rewind
+    submit_test_init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_draw(cb, 0, 3, 1);
+    // poke the opcode of the recorded command with something unknown; the
+    // decoder must not walk off the end and must not deadlock
+    cbptr->buf[0] = 0xFF;
+    scb_submit(cb);
+    T(num_tcalls == 0);
+    T(num_scb_log_items == 1);
+    T(scb_log_items[0] == SCB_LOGITEM_SUBMIT_INVALID_COMMAND);
+    T(cbptr->cur == cbptr->buf);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}

--- a/tests/functional/sokol_cmdbuf_test.c
+++ b/tests/functional/sokol_cmdbuf_test.c
@@ -28,6 +28,10 @@ static uint32_t read_le_u32(const uint8_t* p) {
          | ((uint32_t)p[3] << 24);
 }
 
+static uint64_t read_le_u64(const uint8_t* p) {
+    return (uint64_t)read_le_u32(p) | ((uint64_t)read_le_u32(p + 4) << 32);
+}
+
 static void init(void) {
     sg_setup(&(sg_desc){ .logger = { .func = slog_func }});
     scb_setup(&(scb_desc){ .logger = { .func = slog_func }});
@@ -520,6 +524,162 @@ UTEST(sokol_cmdbuf, cmdbuf_overflow_smaller_than_one_cmd) {
     T((cbptr->cur - cbptr->buf) == 0);
     T(cbptr->overflown == true);
     scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_apply_bindings_empty) {
+    // empty bindings: slot_mask == 0, no per-slot payload → 1 (opcode) + 8 (mask) = 9 bytes
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_apply_bindings(cb, &(sg_bindings){0});
+    T((cbptr->cur - cbptr->buf) == 9);
+    T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_BINDINGS);
+    T(read_le_u64(&cbptr->buf[1]) == 0);
+    T(cbptr->overflown == false);
+    T(cbptr->cmd_end == 0);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_apply_bindings_vertex_buffer_only) {
+    // single vertex buffer at slot 0 → mask bit 0, payload = id + offset
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_apply_bindings(cb, &(sg_bindings){
+        .vertex_buffers[0] = { .id = 0x1111 },
+        .vertex_buffer_offsets[0] = 64,
+    });
+    // 1 opcode + 8 mask + 4 vb id + 4 vb offset = 17 bytes
+    T((cbptr->cur - cbptr->buf) == 17);
+    T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_BINDINGS);
+    T(read_le_u64(&cbptr->buf[1]) == 0x1ULL);   // vb_start = 0
+    T(read_le_u32(&cbptr->buf[9]) == 0x1111);
+    T(read_le_i32(&cbptr->buf[13]) == 64);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_apply_bindings_full_mix) {
+    // vb0 + vb2 + ib + view0 + view5 + sampler0
+    // slot layout: vb 0..7, ib 8, view 9..40, smp 41..52
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_apply_bindings(cb, &(sg_bindings){
+        .vertex_buffers[0] = { .id = 0xAA },
+        .vertex_buffer_offsets[0] = 4,
+        .vertex_buffers[2] = { .id = 0xBB },
+        .vertex_buffer_offsets[2] = 8,
+        .index_buffer = { .id = 0xCC },
+        .index_buffer_offset = 12,
+        .views[0] = { .id = 0xD0 },
+        .views[5] = { .id = 0xD5 },
+        .samplers[0] = { .id = 0xE0 },
+    });
+    // sizes: opcode 1 + mask 8 + 2 vb (2 * 8) + ib 8 + 2 view (2 * 4) + 1 smp (1 * 4) = 45
+    T((cbptr->cur - cbptr->buf) == 45);
+    T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_BINDINGS);
+    const uint64_t expected_mask =
+        (1ULL << 0) | (1ULL << 2) |     // vb 0, 2
+        (1ULL << 8) |                    // ib
+        (1ULL << 9) | (1ULL << 14) |     // view 0, 5 (view_start = 9)
+        (1ULL << 41);                    // smp 0 (smp_start = 41)
+    T(read_le_u64(&cbptr->buf[1]) == expected_mask);
+    // vb0 id + offset at offset 9
+    T(read_le_u32(&cbptr->buf[9]) == 0xAA);
+    T(read_le_i32(&cbptr->buf[13]) == 4);
+    // vb2 id + offset at offset 17
+    T(read_le_u32(&cbptr->buf[17]) == 0xBB);
+    T(read_le_i32(&cbptr->buf[21]) == 8);
+    // ib id + offset at offset 25
+    T(read_le_u32(&cbptr->buf[25]) == 0xCC);
+    T(read_le_i32(&cbptr->buf[29]) == 12);
+    // view 0 at offset 33, view 5 at offset 37
+    T(read_le_u32(&cbptr->buf[33]) == 0xD0);
+    T(read_le_u32(&cbptr->buf[37]) == 0xD5);
+    // sampler 0 at offset 41
+    T(read_le_u32(&cbptr->buf[41]) == 0xE0);
+    T(cbptr->overflown == false);
+    T(cbptr->cmd_end == 0);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_apply_bindings_invalid_cmdbuf_noop) {
+    init();
+    scb_apply_bindings((scb_cmdbuf){ .id = SCB_INVALID_ID }, &(sg_bindings){
+        .vertex_buffers[0] = { .id = 1 },
+    });
+    T(_scb.init_tag == _SCB_INIT_TAG);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_apply_uniforms) {
+    // 16-byte uniform payload
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    const float payload[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
+    scb_apply_uniforms(cb, 2, &(sg_range){ .ptr = payload, .size = sizeof(payload) });
+    // 1 opcode + 4 ub_slot + 4 size + 16 blob = 25 bytes
+    T((cbptr->cur - cbptr->buf) == 25);
+    T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_UNIFORMS);
+    T(read_le_i32(&cbptr->buf[1]) == 2);
+    T(read_le_u32(&cbptr->buf[5]) == sizeof(payload));
+    T(0 == memcmp(&cbptr->buf[9], payload, sizeof(payload)));
+    T(cbptr->overflown == false);
+    T(cbptr->cmd_end == 0);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_apply_uniforms_different_slot) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    const uint8_t payload[3] = { 0xAA, 0xBB, 0xCC };
+    scb_apply_uniforms(cb, 5, &(sg_range){ .ptr = payload, .size = sizeof(payload) });
+    // 1 + 4 + 4 + 3 = 12 bytes
+    T((cbptr->cur - cbptr->buf) == 12);
+    T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_UNIFORMS);
+    T(read_le_i32(&cbptr->buf[1]) == 5);
+    T(read_le_u32(&cbptr->buf[5]) == 3);
+    T(cbptr->buf[9] == 0xAA);
+    T(cbptr->buf[10] == 0xBB);
+    T(cbptr->buf[11] == 0xCC);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_apply_uniforms_overflow_no_partial_write) {
+    // cmdbuf too small for the payload — must set overflown, cur must not move,
+    // and the source buffer must not be partially copied
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){ .size = 16 });
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    const uint8_t payload[16] = { 0 };  // 1 + 4 + 4 + 16 = 25 > 16
+    scb_apply_uniforms(cb, 0, &(sg_range){ .ptr = payload, .size = sizeof(payload) });
+    T((cbptr->cur - cbptr->buf) == 0);
+    T(cbptr->overflown == true);
+    T(cbptr->cmd_end == 0);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_apply_uniforms_invalid_cmdbuf_noop) {
+    init();
+    const float payload[4] = { 0 };
+    scb_apply_uniforms((scb_cmdbuf){ .id = SCB_INVALID_ID }, 0,
+        &(sg_range){ .ptr = payload, .size = sizeof(payload) });
+    T(_scb.init_tag == _SCB_INIT_TAG);
     shutdown();
 }
 

--- a/tests/functional/sokol_cmdbuf_test.c
+++ b/tests/functional/sokol_cmdbuf_test.c
@@ -1,0 +1,87 @@
+//------------------------------------------------------------------------------
+//  sokol_cmdbuf_test.c
+//  For best results, run with ASAN and UBSAN.
+//------------------------------------------------------------------------------
+#include "sokol_gfx.h"
+#include "sokol_log.h"
+#define SOKOL_CMDBUF_IMPL
+#include "sokol_cmdbuf.h"
+#include "utest.h"
+
+#define T(b) EXPECT_TRUE(b)
+#define TFLT(f0,f1) {T(fabs((f0)-(f1))<=(0.000001));}
+
+static void init(void) {
+    sg_setup(&(sg_desc){ .logger = { .func = slog_func }});
+    scb_setup(&(scb_desc){ .logger = { .func = slog_func }});
+}
+
+static void init_with(const scb_desc* desc) {
+    sg_setup(&(sg_desc){0});
+    scb_setup(desc);
+}
+
+static void shutdown(void) {
+    scb_shutdown();
+    sg_shutdown();
+}
+
+UTEST(sokol_cmdbuf, default_init_shutdown) {
+    init();
+    T(_scb.init_tag == _SCB_INIT_TAG);
+    T(_scb.desc.cmdbuf_pool_size == _SCB_DEFAULT_CMDBUF_POOL_SIZE);
+    T(_scb.pools.cmdbufs);
+    T(_scb.pools.cmdbuf_pool.size == (_SCB_DEFAULT_CMDBUF_POOL_SIZE + 1));
+    T(_scb.pools.cmdbuf_pool.free_queue);
+    T(_scb.pools.cmdbuf_pool.gen_ctrs);
+    shutdown();
+    T(_scb.init_tag == 0);
+}
+
+static void* my_alloc(size_t size, void* user_data) {
+    (void)user_data;
+    return malloc(size);
+}
+
+static void my_free(void* ptr, void* user_data) {
+    (void)user_data;
+    free(ptr);
+}
+
+UTEST(sokol_cmdbuf, init_with_params) {
+    init_with(&(scb_desc){
+        .cmdbuf_pool_size = 128,
+        .allocator = {
+            .alloc_fn = my_alloc,
+            .free_fn = my_free,
+            .user_data = (void*)12345,
+        },
+    });
+    T(_scb.init_tag == _SCB_INIT_TAG);
+    T(_scb.desc.cmdbuf_pool_size == 128);
+    T(_scb.pools.cmdbufs);
+    T(_scb.pools.cmdbuf_pool.size == 129);
+    T(_scb.pools.cmdbuf_pool.free_queue);
+    T(_scb.pools.cmdbuf_pool.gen_ctrs);
+    T(_scb.desc.allocator.alloc_fn == my_alloc);
+    T(_scb.desc.allocator.free_fn == my_free);
+    T(_scb.desc.allocator.user_data == (void*)12345);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, make_destroy_cmdbuf_defaults) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    T(cb.id != SCB_INVALID_ID);
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    T(cbptr->slot.state == SCB_RESOURCESTATE_VALID);
+    T(cbptr->slot.id == cb.id);
+    T(cbptr->buf);
+    T(cbptr->buf == cbptr->cur);
+    T((cbptr->buf + _SCB_DEFAULT_CMDBUF_SIZE) == cbptr->end);
+    T(cbptr->label.buf[0] == 0);
+    scb_destroy_cmdbuf(cb);
+    T(cbptr->slot.id == SCB_INVALID_ID);
+    shutdown();
+}

--- a/tests/functional/sokol_cmdbuf_test.c
+++ b/tests/functional/sokol_cmdbuf_test.c
@@ -1,6 +1,8 @@
 //------------------------------------------------------------------------------
 //  sokol_cmdbuf_test.c
 //  For best results, run with ASAN and UBSAN.
+//
+//  LLM assisted!
 //------------------------------------------------------------------------------
 #include "sokol_gfx.h"
 #include "sokol_log.h"
@@ -84,4 +86,198 @@ UTEST(sokol_cmdbuf, make_destroy_cmdbuf_defaults) {
     scb_destroy_cmdbuf(cb);
     T(cbptr->slot.id == SCB_INVALID_ID);
     shutdown();
+}
+
+UTEST(sokol_cmdbuf, make_cmdbuf_custom_size) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){ .size = 4096 });
+    T(cb.id != SCB_INVALID_ID);
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    T(cbptr->slot.state == SCB_RESOURCESTATE_VALID);
+    T(cbptr->buf);
+    T(cbptr->buf == cbptr->cur);
+    T((cbptr->buf + 4096) == cbptr->end);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, make_cmdbuf_label) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){ .label = "hello" });
+    T(cb.id != SCB_INVALID_ID);
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    T(0 == strcmp(cbptr->label.buf, "hello"));
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, make_cmdbuf_label_truncated) {
+    init();
+    // longer than _SCB_STRING_SIZE (32), must be truncated to fit + null-terminated
+    const char* long_label = "0123456789ABCDEF0123456789ABCDEF_overflow_tail";
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){ .label = long_label });
+    T(cb.id != SCB_INVALID_ID);
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    T(cbptr->label.buf[_SCB_STRING_SIZE - 1] == 0);
+    T(0 == strncmp(cbptr->label.buf, long_label, _SCB_STRING_SIZE - 1));
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, cmdbuf_pool_exhausted) {
+    init_with(&(scb_desc){
+        .cmdbuf_pool_size = 4,
+        .logger.func = slog_func,
+    });
+    scb_cmdbuf cbs[4];
+    for (int i = 0; i < 4; i++) {
+        cbs[i] = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+        T(cbs[i].id != SCB_INVALID_ID);
+        T(_scb_lookup_cmdbuf(cbs[i].id));
+    }
+    // one more must fail
+    scb_cmdbuf overflow = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    T(overflow.id == SCB_INVALID_ID);
+    T(_scb_lookup_cmdbuf(overflow.id) == 0);
+    // after destroying one, a fresh alloc must succeed again
+    scb_destroy_cmdbuf(cbs[2]);
+    scb_cmdbuf recycled = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    T(recycled.id != SCB_INVALID_ID);
+    scb_destroy_cmdbuf(recycled);
+    for (int i = 0; i < 4; i++) {
+        if (i == 2) continue;
+        scb_destroy_cmdbuf(cbs[i]);
+    }
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, destroy_invalid_handle) {
+    init();
+    // destroying the invalid handle must be a silent no-op
+    scb_destroy_cmdbuf((scb_cmdbuf){ .id = SCB_INVALID_ID });
+    T(_scb.init_tag == _SCB_INIT_TAG);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, stale_handle_after_destroy) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    T(cb.id != SCB_INVALID_ID);
+    T(_scb_lookup_cmdbuf(cb.id));
+    scb_destroy_cmdbuf(cb);
+    // stale handle must not lookup, and a redundant destroy must not crash
+    T(_scb_lookup_cmdbuf(cb.id) == 0);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, generation_counter_bumps_on_reuse) {
+    init_with(&(scb_desc){
+        .cmdbuf_pool_size = 1,
+        .logger.func = slog_func,
+    });
+    scb_cmdbuf a = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    T(a.id != SCB_INVALID_ID);
+    scb_destroy_cmdbuf(a);
+    scb_cmdbuf b = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    T(b.id != SCB_INVALID_ID);
+    // same slot index, different generation counter → different id
+    T((a.id & _SCB_SLOT_MASK) == (b.id & _SCB_SLOT_MASK));
+    T(a.id != b.id);
+    // the stale handle must no longer resolve
+    T(_scb_lookup_cmdbuf(a.id) == 0);
+    T(_scb_lookup_cmdbuf(b.id));
+    scb_destroy_cmdbuf(b);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, query_cmdbuf_state) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    T(cb.id != SCB_INVALID_ID);
+    T(scb_query_cmdbuf_state(cb) == SCB_RESOURCESTATE_VALID);
+    scb_destroy_cmdbuf(cb);
+    // stale handle → INVALID
+    T(scb_query_cmdbuf_state(cb) == SCB_RESOURCESTATE_INVALID);
+    // default handle → INVALID
+    T(scb_query_cmdbuf_state((scb_cmdbuf){ .id = SCB_INVALID_ID }) == SCB_RESOURCESTATE_INVALID);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, query_cmdbuf_info_defaults) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    T(cb.id != SCB_INVALID_ID);
+    scb_cmdbuf_info info = scb_query_cmdbuf_info(cb);
+    T(info.size == _SCB_DEFAULT_CMDBUF_SIZE);
+    T(info.remaining == _SCB_DEFAULT_CMDBUF_SIZE);
+    T(info.overflown == false);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, query_cmdbuf_info_custom_size) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){ .size = 4096 });
+    T(cb.id != SCB_INVALID_ID);
+    scb_cmdbuf_info info = scb_query_cmdbuf_info(cb);
+    T(info.size == 4096);
+    T(info.remaining == 4096);
+    T(info.overflown == false);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, query_cmdbuf_info_reflects_cur) {
+    // no public recording API exists yet; simulate a partial record by nudging
+    // the internal `cur` pointer and `overflown` flag to check that the info
+    // accessor reads them back
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){ .size = 1024 });
+    T(cb.id != SCB_INVALID_ID);
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    cbptr->cur = cbptr->buf + 128;
+    scb_cmdbuf_info info = scb_query_cmdbuf_info(cb);
+    T(info.size == 1024);
+    T(info.remaining == (1024 - 128));
+    T(info.overflown == false);
+    cbptr->overflown = true;
+    info = scb_query_cmdbuf_info(cb);
+    T(info.overflown == true);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, query_cmdbuf_info_invalid_handle) {
+    init();
+    // stale / default handles must return a zero-initialized info
+    scb_cmdbuf_info info = scb_query_cmdbuf_info((scb_cmdbuf){ .id = SCB_INVALID_ID });
+    T(info.size == 0);
+    T(info.remaining == 0);
+    T(info.overflown == false);
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    scb_destroy_cmdbuf(cb);
+    info = scb_query_cmdbuf_info(cb);
+    T(info.size == 0);
+    T(info.remaining == 0);
+    T(info.overflown == false);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, shutdown_destroys_remaining_cmdbufs) {
+    // rely on ASAN to catch a leaked cb->buf if shutdown forgets to release it
+    init();
+    scb_cmdbuf a = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    scb_cmdbuf b = scb_make_cmdbuf(&(scb_cmdbuf_desc){ .size = 8192, .label = "b" });
+    T(a.id != SCB_INVALID_ID);
+    T(b.id != SCB_INVALID_ID);
+    T(scb_query_cmdbuf_state(a) == SCB_RESOURCESTATE_VALID);
+    T(scb_query_cmdbuf_state(b) == SCB_RESOURCESTATE_VALID);
+    // no explicit destroy — shutdown must free the underlying buffers
+    shutdown();
+    T(_scb.init_tag == 0);
 }

--- a/tests/functional/sokol_cmdbuf_test.c
+++ b/tests/functional/sokol_cmdbuf_test.c
@@ -716,6 +716,8 @@ typedef enum {
     TCALL_DRAW,
     TCALL_DRAW_EX,
     TCALL_DISPATCH,
+    TCALL_PUSH_DEBUG_GROUP,
+    TCALL_POP_DEBUG_GROUP,
 } tcall_kind;
 
 #define TCALL_MAX_CALLS (32)
@@ -730,6 +732,7 @@ typedef struct {
     int ub_slot;
     size_t uniform_size;
     uint8_t uniform_data[TCALL_MAX_UNIFORM_SIZE];
+    char label[64];
 } tcall_t;
 
 static tcall_t tcalls[TCALL_MAX_CALLS];
@@ -805,6 +808,20 @@ static void hook_dispatch(int x, int y, int z, void* ud) {
     if (c) { c->i0 = x; c->i1 = y; c->i2 = z; }
 }
 
+static void hook_push_debug_group(const char* name, void* ud) {
+    (void)ud;
+    tcall_t* c = tcalls_push(TCALL_PUSH_DEBUG_GROUP);
+    if (c && name) {
+        strncpy(c->label, name, sizeof(c->label) - 1);
+        c->label[sizeof(c->label) - 1] = 0;
+    }
+}
+
+static void hook_pop_debug_group(void* ud) {
+    (void)ud;
+    tcalls_push(TCALL_POP_DEBUG_GROUP);
+}
+
 static void install_capture_hooks(void) {
     sg_install_trace_hooks(&(sg_trace_hooks){
         .apply_viewport = hook_apply_viewport,
@@ -815,6 +832,8 @@ static void install_capture_hooks(void) {
         .draw = hook_draw,
         .draw_ex = hook_draw_ex,
         .dispatch = hook_dispatch,
+        .push_debug_group = hook_push_debug_group,
+        .pop_debug_group = hook_pop_debug_group,
     });
 }
 
@@ -1071,5 +1090,39 @@ UTEST(sokol_cmdbuf, submit_corrupt_opcode_terminates) {
     T(scb_log_items[0] == SCB_LOGITEM_SUBMIT_INVALID_COMMAND);
     T(cbptr->cur == cbptr->buf);
     scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, submit_wraps_in_debug_group_with_label) {
+    // a labeled cmdbuf must bracket its replayed commands with
+    // sg_push_debug_group(label) and sg_pop_debug_group()
+    submit_test_init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){ .label = "my_cb" });
+    T(cb.id != SCB_INVALID_ID);
+    scb_draw(cb, 0, 3, 1);
+    scb_submit(cb);
+    T(num_tcalls == 3);
+    T(tcalls[0].kind == TCALL_PUSH_DEBUG_GROUP);
+    T(0 == strcmp(tcalls[0].label, "my_cb"));
+    T(tcalls[1].kind == TCALL_DRAW);
+    T(tcalls[2].kind == TCALL_POP_DEBUG_GROUP);
+    // an unlabeled cmdbuf must NOT fire debug-group calls
+    tcalls_reset();
+    scb_cmdbuf cb2 = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    scb_draw(cb2, 0, 3, 1);
+    scb_submit(cb2);
+    T(num_tcalls == 1);
+    T(tcalls[0].kind == TCALL_DRAW);
+    // a labeled but empty cmdbuf must still fire push and pop
+    tcalls_reset();
+    scb_cmdbuf cb3 = scb_make_cmdbuf(&(scb_cmdbuf_desc){ .label = "empty" });
+    scb_submit(cb3);
+    T(num_tcalls == 2);
+    T(tcalls[0].kind == TCALL_PUSH_DEBUG_GROUP);
+    T(0 == strcmp(tcalls[0].label, "empty"));
+    T(tcalls[1].kind == TCALL_POP_DEBUG_GROUP);
+    scb_destroy_cmdbuf(cb);
+    scb_destroy_cmdbuf(cb2);
+    scb_destroy_cmdbuf(cb3);
     shutdown();
 }

--- a/tests/functional/sokol_cmdbuf_test.c
+++ b/tests/functional/sokol_cmdbuf_test.c
@@ -1240,3 +1240,88 @@ UTEST(sokol_cmdbuf, submit_wraps_in_debug_group_with_label) {
     scb_destroy_cmdbuf(cb3);
     shutdown();
 }
+
+UTEST(sokol_cmdbuf, reset_rewinds_recorded_cmdbuf) {
+    // record a few commands, reset, verify the buffer is rewound and a
+    // subsequent submit fires nothing
+    submit_test_init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_apply_pipeline(cb, (sg_pipeline){ .id = 42 });
+    scb_draw(cb, 0, 3, 1);
+    T(cbptr->cur > cbptr->buf);
+    T(cbptr->overflown == false);
+    scb_reset(cb);
+    T(cbptr->cur == cbptr->buf);
+    T(cbptr->overflown == false);
+    T(num_scb_log_items == 0);
+    // submit after reset must not replay the discarded commands
+    scb_submit(cb);
+    T(num_tcalls == 0);
+    // the cmdbuf is usable again after reset
+    scb_draw(cb, 5, 6, 7);
+    scb_submit(cb);
+    T(num_tcalls == 1);
+    T(tcalls[0].kind == TCALL_DRAW);
+    T(tcalls[0].i0 == 5 && tcalls[0].i1 == 6 && tcalls[0].i2 == 7);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, reset_empty_cmdbuf) {
+    // reset on a fresh (empty) cmdbuf must be a silent no-op
+    submit_test_init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    T(cbptr->cur == cbptr->buf);
+    scb_reset(cb);
+    T(cbptr->cur == cbptr->buf);
+    T(cbptr->overflown == false);
+    T(num_scb_log_items == 0);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, reset_clears_overflown) {
+    // reset on an overflown cmdbuf must clear the overflown flag and rewind
+    submit_test_init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){ .size = 32 });
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_draw_ex(cb, 1, 2, 3, 4, 5);
+    scb_draw_ex(cb, 6, 7, 8, 9, 10);  // overflows the 32-byte buffer
+    T(cbptr->overflown == true);
+    T(cbptr->cur > cbptr->buf);
+    // encoder already fired CMDBUF_OVERFLOW; reset the log capture to observe
+    // only what scb_reset itself produces (which is nothing)
+    num_scb_log_items = 0;
+    scb_reset(cb);
+    T(cbptr->cur == cbptr->buf);
+    T(cbptr->overflown == false);
+    T(num_scb_log_items == 0);
+    // the cmdbuf is usable again after reset
+    scb_draw(cb, 0, 3, 1);
+    T(cbptr->overflown == false);
+    scb_submit(cb);
+    T(num_tcalls == 1);
+    T(tcalls[0].kind == TCALL_DRAW);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, reset_invalid_handle) {
+    // reset on invalid / stale handles must log CMDBUF_NOT_VALID and be a no-op
+    submit_test_init();
+    scb_reset((scb_cmdbuf){ .id = SCB_INVALID_ID });
+    T(num_scb_log_items == 1);
+    T(scb_log_items[0] == SCB_LOGITEM_CMDBUF_NOT_VALID);
+    // stale handle after destroy
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    scb_destroy_cmdbuf(cb);
+    scb_reset(cb);
+    T(num_scb_log_items == 2);
+    T(scb_log_items[1] == SCB_LOGITEM_CMDBUF_NOT_VALID);
+    shutdown();
+}

--- a/tests/functional/sokol_cmdbuf_test.c
+++ b/tests/functional/sokol_cmdbuf_test.c
@@ -13,6 +13,21 @@
 #define T(b) EXPECT_TRUE(b)
 #define TFLT(f0,f1) {T(fabs((f0)-(f1))<=(0.000001));}
 
+// little-endian read helpers for byte-level payload inspection
+static int32_t read_le_i32(const uint8_t* p) {
+    return (int32_t)((uint32_t)p[0]
+                   | ((uint32_t)p[1] << 8)
+                   | ((uint32_t)p[2] << 16)
+                   | ((uint32_t)p[3] << 24));
+}
+
+static uint32_t read_le_u32(const uint8_t* p) {
+    return (uint32_t)p[0]
+         | ((uint32_t)p[1] << 8)
+         | ((uint32_t)p[2] << 16)
+         | ((uint32_t)p[3] << 24);
+}
+
 static void init(void) {
     sg_setup(&(sg_desc){ .logger = { .func = slog_func }});
     scb_setup(&(scb_desc){ .logger = { .func = slog_func }});
@@ -265,6 +280,246 @@ UTEST(sokol_cmdbuf, query_cmdbuf_info_invalid_handle) {
     T(info.size == 0);
     T(info.remaining == 0);
     T(info.overflown == false);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_apply_viewport) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    T(cb.id != SCB_INVALID_ID);
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_apply_viewport(cb, 10, 20, 30, 40, true);
+    // 1 byte opcode + 4 * 4 byte ints + 1 byte bool = 18 bytes
+    T((cbptr->cur - cbptr->buf) == 18);
+    T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_VIEWPORT);
+    T(read_le_i32(&cbptr->buf[1]) == 10);
+    T(read_le_i32(&cbptr->buf[5]) == 20);
+    T(read_le_i32(&cbptr->buf[9]) == 30);
+    T(read_le_i32(&cbptr->buf[13]) == 40);
+    T(cbptr->buf[17] == 1);
+    T(cbptr->overflown == false);
+    T(cbptr->cmd_end == 0);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_apply_viewportf_truncates) {
+    // float variant truncates to int (matches sokol_gfx.h semantics)
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    T(cb.id != SCB_INVALID_ID);
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_apply_viewportf(cb, 10.9f, 20.1f, -30.9f, 40.5f, false);
+    T((cbptr->cur - cbptr->buf) == 18);
+    T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_VIEWPORT);
+    T(read_le_i32(&cbptr->buf[1]) == 10);
+    T(read_le_i32(&cbptr->buf[5]) == 20);
+    T(read_le_i32(&cbptr->buf[9]) == -30);
+    T(read_le_i32(&cbptr->buf[13]) == 40);
+    T(cbptr->buf[17] == 0);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_apply_scissor_rect) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_apply_scissor_rect(cb, 1, 2, 3, 4, true);
+    T((cbptr->cur - cbptr->buf) == 18);
+    T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_SCISSOR_RECT);
+    T(read_le_i32(&cbptr->buf[1]) == 1);
+    T(read_le_i32(&cbptr->buf[5]) == 2);
+    T(read_le_i32(&cbptr->buf[9]) == 3);
+    T(read_le_i32(&cbptr->buf[13]) == 4);
+    T(cbptr->buf[17] == 1);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_apply_scissor_rectf_truncates) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_apply_scissor_rectf(cb, 1.9f, -2.1f, 3.5f, 4.99f, false);
+    T((cbptr->cur - cbptr->buf) == 18);
+    T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_SCISSOR_RECT);
+    T(read_le_i32(&cbptr->buf[1]) == 1);
+    T(read_le_i32(&cbptr->buf[5]) == -2);
+    T(read_le_i32(&cbptr->buf[9]) == 3);
+    T(read_le_i32(&cbptr->buf[13]) == 4);
+    T(cbptr->buf[17] == 0);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_apply_pipeline) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_apply_pipeline(cb, (sg_pipeline){ .id = 0xDEADBEEF });
+    // 1 byte opcode + 4 byte id = 5 bytes
+    T((cbptr->cur - cbptr->buf) == 5);
+    T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_PIPELINE);
+    T(read_le_u32(&cbptr->buf[1]) == 0xDEADBEEFu);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_draw) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_draw(cb, 100, 200, 300);
+    // 1 byte opcode + 3 * 4 byte ints = 13 bytes
+    T((cbptr->cur - cbptr->buf) == 13);
+    T(cbptr->buf[0] == (uint8_t)_SCB_CMD_DRAW);
+    T(read_le_i32(&cbptr->buf[1]) == 100);
+    T(read_le_i32(&cbptr->buf[5]) == 200);
+    T(read_le_i32(&cbptr->buf[9]) == 300);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_draw_ex) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_draw_ex(cb, 1, 2, 3, 4, 5);
+    // 1 byte opcode + 5 * 4 byte ints = 21 bytes
+    T((cbptr->cur - cbptr->buf) == 21);
+    T(cbptr->buf[0] == (uint8_t)_SCB_CMD_DRAW_EX);
+    T(read_le_i32(&cbptr->buf[1]) == 1);
+    T(read_le_i32(&cbptr->buf[5]) == 2);
+    T(read_le_i32(&cbptr->buf[9]) == 3);
+    T(read_le_i32(&cbptr->buf[13]) == 4);
+    T(read_le_i32(&cbptr->buf[17]) == 5);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_dispatch) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_dispatch(cb, 8, 16, 32);
+    // 1 byte opcode + 3 * 4 byte ints = 13 bytes
+    T((cbptr->cur - cbptr->buf) == 13);
+    T(cbptr->buf[0] == (uint8_t)_SCB_CMD_DISPATCH);
+    T(read_le_i32(&cbptr->buf[1]) == 8);
+    T(read_le_i32(&cbptr->buf[5]) == 16);
+    T(read_le_i32(&cbptr->buf[9]) == 32);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_multiple_commands) {
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    scb_apply_pipeline(cb, (sg_pipeline){ .id = 42 });      // 5 bytes
+    scb_apply_viewport(cb, 0, 0, 640, 480, true);           // 18 bytes
+    scb_draw(cb, 0, 6, 1);                                  // 13 bytes
+    // 5 + 18 + 13 = 36 bytes
+    T((cbptr->cur - cbptr->buf) == 36);
+    T(cbptr->overflown == false);
+    T(cbptr->cmd_end == 0);
+    // pipeline at offset 0
+    T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_PIPELINE);
+    T(read_le_u32(&cbptr->buf[1]) == 42);
+    // viewport at offset 5
+    T(cbptr->buf[5] == (uint8_t)_SCB_CMD_APPLY_VIEWPORT);
+    T(read_le_i32(&cbptr->buf[6]) == 0);
+    T(read_le_i32(&cbptr->buf[10]) == 0);
+    T(read_le_i32(&cbptr->buf[14]) == 640);
+    T(read_le_i32(&cbptr->buf[18]) == 480);
+    T(cbptr->buf[22] == 1);
+    // draw at offset 23
+    T(cbptr->buf[23] == (uint8_t)_SCB_CMD_DRAW);
+    T(read_le_i32(&cbptr->buf[24]) == 0);
+    T(read_le_i32(&cbptr->buf[28]) == 6);
+    T(read_le_i32(&cbptr->buf[32]) == 1);
+    // remaining reported via info
+    scb_cmdbuf_info info = scb_query_cmdbuf_info(cb);
+    T(info.size == _SCB_DEFAULT_CMDBUF_SIZE);
+    T(info.remaining == (_SCB_DEFAULT_CMDBUF_SIZE - 36));
+    T(info.overflown == false);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_invalid_cmdbuf_noop) {
+    init();
+    // recording on the default/invalid handle must not crash and must be a no-op
+    scb_cmdbuf invalid = { .id = SCB_INVALID_ID };
+    scb_apply_viewport(invalid, 1, 2, 3, 4, true);
+    scb_apply_scissor_rect(invalid, 1, 2, 3, 4, true);
+    scb_apply_pipeline(invalid, (sg_pipeline){ .id = 1 });
+    scb_draw(invalid, 0, 3, 1);
+    scb_draw_ex(invalid, 0, 3, 1, 0, 0);
+    scb_dispatch(invalid, 1, 1, 1);
+    T(_scb.init_tag == _SCB_INIT_TAG);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, cmdbuf_overflow) {
+    // size 32 fits one 21-byte draw_ex, but not two (42 > 32)
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){ .size = 32 });
+    T(cb.id != SCB_INVALID_ID);
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+
+    // first draw_ex fits — cur advances, overflown stays false
+    scb_draw_ex(cb, 1, 2, 3, 4, 5);
+    T((cbptr->cur - cbptr->buf) == 21);
+    T(cbptr->overflown == false);
+    T(cbptr->buf[0] == (uint8_t)_SCB_CMD_DRAW_EX);
+
+    // second draw_ex overflows — cur must not advance, overflown flips to true
+    scb_draw_ex(cb, 6, 7, 8, 9, 10);
+    T((cbptr->cur - cbptr->buf) == 21);
+    T(cbptr->overflown == true);
+    // the second draw_ex payload must NOT be visible past the first one
+    T(read_le_i32(&cbptr->buf[1]) == 1);
+
+    // once overflown, subsequent recordings must silently no-op — cur frozen
+    scb_apply_pipeline(cb, (sg_pipeline){ .id = 99 });
+    scb_draw(cb, 0, 3, 1);
+    T((cbptr->cur - cbptr->buf) == 21);
+    T(cbptr->overflown == true);
+
+    // info reflects overflow state
+    scb_cmdbuf_info info = scb_query_cmdbuf_info(cb);
+    T(info.size == 32);
+    T(info.remaining == (32 - 21));
+    T(info.overflown == true);
+
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, cmdbuf_overflow_smaller_than_one_cmd) {
+    // even a single command doesn't fit — first recording must overflow
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){ .size = 4 });
+    T(cb.id != SCB_INVALID_ID);
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    T(cbptr->overflown == false);
+    scb_draw(cb, 0, 3, 1);  // needs 13, only 4 available
+    T((cbptr->cur - cbptr->buf) == 0);
+    T(cbptr->overflown == true);
+    scb_destroy_cmdbuf(cb);
     shutdown();
 }
 

--- a/tests/functional/sokol_cmdbuf_test.c
+++ b/tests/functional/sokol_cmdbuf_test.c
@@ -620,30 +620,29 @@ UTEST(sokol_cmdbuf, record_apply_bindings_invalid_cmdbuf_noop) {
 }
 
 UTEST(sokol_cmdbuf, record_apply_uniforms) {
-    // 16-byte uniform payload; the payload blob must be 16-byte aligned in the
+    // 16-byte uniform payload; the payload blob must be 4-byte aligned in the
     // recorded stream so replay can hand it to sg_apply_uniforms without a copy
     init();
     scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
     _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
     T(cbptr);
-    // sanity: malloc must return a 16-byte-aligned buffer for these offset
-    // assertions to hold (guaranteed on 64-bit targets)
-    T(((uintptr_t)cbptr->buf & 15) == 0);
+    // sanity: malloc returns at least 4-byte-aligned memory
+    T(((uintptr_t)cbptr->buf & 3) == 0);
     const float payload[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
     scb_apply_uniforms(cb, 2, &(sg_range){ .ptr = payload, .size = sizeof(payload) });
-    // 1 opcode + 4 ub_slot + 4 size = 9 bytes header, padded to 16 (7 pad
-    // bytes), + 16 blob = 32 bytes total
-    T((cbptr->cur - cbptr->buf) == 32);
+    // 1 opcode + 4 ub_slot + 4 size = 9 bytes header, padded to 12 (3 pad
+    // bytes), + 16 blob = 28 bytes total
+    T((cbptr->cur - cbptr->buf) == 28);
     T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_UNIFORMS);
     T(read_le_i32(&cbptr->buf[1]) == 2);
     T(read_le_u32(&cbptr->buf[5]) == sizeof(payload));
     // the padding bytes are zeroed by the encoder
-    for (int i = 9; i < 16; i++) {
+    for (int i = 9; i < 12; i++) {
         T(cbptr->buf[i] == 0);
     }
-    T(0 == memcmp(&cbptr->buf[16], payload, sizeof(payload)));
-    // the payload address itself is 16-byte aligned
-    T(((uintptr_t)&cbptr->buf[16] & 15) == 0);
+    T(0 == memcmp(&cbptr->buf[12], payload, sizeof(payload)));
+    // the payload address itself is 4-byte aligned
+    T(((uintptr_t)&cbptr->buf[12] & 3) == 0);
     T(cbptr->overflown == false);
     T(cbptr->cmd_max_end == 0);
     scb_destroy_cmdbuf(cb);
@@ -655,44 +654,44 @@ UTEST(sokol_cmdbuf, record_apply_uniforms_different_slot) {
     scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
     _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
     T(cbptr);
-    T(((uintptr_t)cbptr->buf & 15) == 0);
+    T(((uintptr_t)cbptr->buf & 3) == 0);
     const uint8_t payload[3] = { 0xAA, 0xBB, 0xCC };
     scb_apply_uniforms(cb, 5, &(sg_range){ .ptr = payload, .size = sizeof(payload) });
-    // 1 + 4 + 4 = 9 bytes header, padded to 16, + 3 blob = 19 bytes
-    T((cbptr->cur - cbptr->buf) == 19);
+    // 1 + 4 + 4 = 9 bytes header, padded to 12, + 3 blob = 15 bytes
+    T((cbptr->cur - cbptr->buf) == 15);
     T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_UNIFORMS);
     T(read_le_i32(&cbptr->buf[1]) == 5);
     T(read_le_u32(&cbptr->buf[5]) == 3);
     // padding zeroed
-    for (int i = 9; i < 16; i++) {
+    for (int i = 9; i < 12; i++) {
         T(cbptr->buf[i] == 0);
     }
-    T(cbptr->buf[16] == 0xAA);
-    T(cbptr->buf[17] == 0xBB);
-    T(cbptr->buf[18] == 0xCC);
-    T(((uintptr_t)&cbptr->buf[16] & 15) == 0);
+    T(cbptr->buf[12] == 0xAA);
+    T(cbptr->buf[13] == 0xBB);
+    T(cbptr->buf[14] == 0xCC);
+    T(((uintptr_t)&cbptr->buf[12] & 3) == 0);
     scb_destroy_cmdbuf(cb);
     shutdown();
 }
 
 UTEST(sokol_cmdbuf, record_apply_uniforms_alignment_after_odd_prefix) {
     // any command sequence before apply_uniforms leaves cur at an arbitrary
-    // offset; the encoder must still land the payload on a 16-byte boundary
+    // offset; the encoder must still land the payload on a 4-byte boundary
     init();
     scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
     _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
     T(cbptr);
-    T(((uintptr_t)cbptr->buf & 15) == 0);
+    T(((uintptr_t)cbptr->buf & 3) == 0);
     // a single apply_pipeline consumes 5 bytes → cur at buf+5, an odd offset
     scb_apply_pipeline(cb, (sg_pipeline){ .id = 0x42 });
     T((cbptr->cur - cbptr->buf) == 5);
     const float payload[4] = { 10.0f, 20.0f, 30.0f, 40.0f };
     const uint8_t* uniforms_start = cbptr->cur;
     scb_apply_uniforms(cb, 1, &(sg_range){ .ptr = payload, .size = sizeof(payload) });
-    // opcode written at buf+5, header ends at buf+14 → next 16-aligned is buf+16
+    // opcode written at buf+5, header ends at buf+14 → next 4-aligned is buf+16
     T(uniforms_start[0] == (uint8_t)_SCB_CMD_APPLY_UNIFORMS);
     const uint8_t* payload_ptr = cbptr->buf + 16;
-    T(((uintptr_t)payload_ptr & 15) == 0);
+    T(((uintptr_t)payload_ptr & 3) == 0);
     T(0 == memcmp(payload_ptr, payload, sizeof(payload)));
     // total = 5 (pipeline) + 1 (opcode) + 4 (slot) + 4 (size) + 2 (pad) + 16 (blob) = 32
     T((cbptr->cur - cbptr->buf) == 32);
@@ -705,23 +704,23 @@ UTEST(sokol_cmdbuf, record_apply_uniforms_alignment_after_odd_prefix) {
 
 UTEST(sokol_cmdbuf, record_apply_uniforms_alignment_across_offsets) {
     // sweep prefix sizes 0..15 and confirm every recorded payload is
-    // 16-byte aligned regardless of where the command lands
+    // 4-byte aligned regardless of where the command lands
     init();
     for (int pad_bytes = 0; pad_bytes < 16; pad_bytes++) {
         scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
         _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
         T(cbptr);
-        T(((uintptr_t)cbptr->buf & 15) == 0);
+        T(((uintptr_t)cbptr->buf & 3) == 0);
         // nudge cur by pad_bytes to simulate an arbitrary prior recording
         cbptr->cur = cbptr->buf + pad_bytes;
         const float payload[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
         scb_apply_uniforms(cb, 0, &(sg_range){ .ptr = payload, .size = sizeof(payload) });
-        // find the blob by scanning for its content — must land on 16-byte-aligned addr
+        // find the blob by scanning for its content — must land on 4-byte-aligned addr
         // header: opcode(1) + slot(4) + size(4) = 9 bytes past pad_bytes
         const size_t header_end = (size_t)pad_bytes + 9;
-        const size_t aligned = (header_end + 15) & ~(size_t)15;
+        const size_t aligned = (header_end + 3) & ~(size_t)3;
         const uint8_t* payload_ptr = cbptr->buf + aligned;
-        T(((uintptr_t)payload_ptr & 15) == 0);
+        T(((uintptr_t)payload_ptr & 3) == 0);
         T(0 == memcmp(payload_ptr, payload, sizeof(payload)));
         // header alignment pad bytes must be zero
         for (size_t i = header_end; i < aligned; i++) {
@@ -739,7 +738,7 @@ UTEST(sokol_cmdbuf, record_apply_uniforms_overflow_no_partial_write) {
     scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){ .size = 16 });
     _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
     T(cbptr);
-    // max payload budget = 1 opcode + 4 slot + 4 size + 16 blob + 16 align pad = 41 > 16
+    // max payload budget = 1 opcode + 4 slot + 4 size + 16 blob + 3 align pad = 28 > 16
     const uint8_t payload[16] = { 0 };
     scb_apply_uniforms(cb, 0, &(sg_range){ .ptr = payload, .size = sizeof(payload) });
     T((cbptr->cur - cbptr->buf) == 0);
@@ -806,7 +805,7 @@ typedef struct {
     sg_bindings bindings;         // deep copy at hook time (bindings ptr is stack-local)
     int ub_slot;
     size_t uniform_size;
-    uintptr_t uniform_ptr;        // raw ptr address to verify 16-byte alignment on submit
+    uintptr_t uniform_ptr;        // raw ptr address to verify 4-byte alignment on submit
     uint8_t uniform_data[TCALL_MAX_UNIFORM_SIZE];
     char label[64];
 } tcall_t;
@@ -1001,8 +1000,8 @@ UTEST(sokol_cmdbuf, submit_all_commands_roundtrip) {
     T(tcalls[4].ub_slot == 3);
     T(tcalls[4].uniform_size == sizeof(uniforms));
     T(0 == memcmp(tcalls[4].uniform_data, uniforms, sizeof(uniforms)));
-    // the pointer handed to sg_apply_uniforms must be 16-byte aligned
-    T((tcalls[4].uniform_ptr & 15) == 0);
+    // the pointer handed to sg_apply_uniforms must be 4-byte aligned
+    T((tcalls[4].uniform_ptr & 3) == 0);
     T(tcalls[5].kind == TCALL_DRAW);
     T(tcalls[5].i0 == 100 && tcalls[5].i1 == 200 && tcalls[5].i2 == 300);
     T(tcalls[6].kind == TCALL_DRAW_EX);
@@ -1071,8 +1070,8 @@ UTEST(sokol_cmdbuf, submit_apply_uniforms_preserves_payload) {
     T(tcalls[0].ub_slot == 5);
     T(tcalls[0].uniform_size == sizeof(payload));
     T(0 == memcmp(tcalls[0].uniform_data, payload, sizeof(payload)));
-    // sg_apply_uniforms receives a 16-byte-aligned pointer into the cmdbuf
-    T((tcalls[0].uniform_ptr & 15) == 0);
+    // sg_apply_uniforms receives a 4-byte-aligned pointer into the cmdbuf
+    T((tcalls[0].uniform_ptr & 3) == 0);
     T(cbptr->cur == cbptr->buf);
     scb_destroy_cmdbuf(cb);
     shutdown();
@@ -1080,13 +1079,13 @@ UTEST(sokol_cmdbuf, submit_apply_uniforms_preserves_payload) {
 
 UTEST(sokol_cmdbuf, submit_apply_uniforms_pointer_aligned_after_odd_prefix) {
     // regardless of preceding commands, the pointer passed to sg_apply_uniforms
-    // at replay must be 16-byte aligned
+    // at replay must be 4-byte aligned
     submit_test_init();
     scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
     _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
     T(cbptr);
     // encode a handful of variable-sized commands ahead of the uniforms to
-    // guarantee the uniforms opcode does not land on a 16-byte boundary
+    // guarantee the uniforms opcode does not land on a 4-byte boundary
     scb_apply_pipeline(cb, (sg_pipeline){ .id = 1 });       // 5 bytes
     scb_apply_viewport(cb, 0, 0, 1, 1, true);               // 18 bytes
     scb_apply_pipeline(cb, (sg_pipeline){ .id = 2 });       // 5 bytes → cur at buf+28
@@ -1100,8 +1099,8 @@ UTEST(sokol_cmdbuf, submit_apply_uniforms_pointer_aligned_after_odd_prefix) {
     int n_uniforms = 0;
     for (int i = 0; i < num_tcalls; i++) {
         if (tcalls[i].kind == TCALL_APPLY_UNIFORMS) {
-            // pointer must be 16-byte aligned
-            T((tcalls[i].uniform_ptr & 15) == 0);
+            // pointer must be 4-byte aligned
+            T((tcalls[i].uniform_ptr & 3) == 0);
             n_uniforms++;
         }
     }

--- a/tests/functional/sokol_cmdbuf_test.c
+++ b/tests/functional/sokol_cmdbuf_test.c
@@ -303,7 +303,7 @@ UTEST(sokol_cmdbuf, record_apply_viewport) {
     T(read_le_i32(&cbptr->buf[13]) == 40);
     T(cbptr->buf[17] == 1);
     T(cbptr->overflown == false);
-    T(cbptr->cmd_end == 0);
+    T(cbptr->cmd_max_end == 0);
     scb_destroy_cmdbuf(cb);
     shutdown();
 }
@@ -436,7 +436,7 @@ UTEST(sokol_cmdbuf, record_multiple_commands) {
     // 5 + 18 + 13 = 36 bytes
     T((cbptr->cur - cbptr->buf) == 36);
     T(cbptr->overflown == false);
-    T(cbptr->cmd_end == 0);
+    T(cbptr->cmd_max_end == 0);
     // pipeline at offset 0
     T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_PIPELINE);
     T(read_le_u32(&cbptr->buf[1]) == 42);
@@ -538,7 +538,7 @@ UTEST(sokol_cmdbuf, record_apply_bindings_empty) {
     T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_BINDINGS);
     T(read_le_u64(&cbptr->buf[1]) == 0);
     T(cbptr->overflown == false);
-    T(cbptr->cmd_end == 0);
+    T(cbptr->cmd_max_end == 0);
     scb_destroy_cmdbuf(cb);
     shutdown();
 }
@@ -605,7 +605,7 @@ UTEST(sokol_cmdbuf, record_apply_bindings_full_mix) {
     // sampler 0 at offset 41
     T(read_le_u32(&cbptr->buf[41]) == 0xE0);
     T(cbptr->overflown == false);
-    T(cbptr->cmd_end == 0);
+    T(cbptr->cmd_max_end == 0);
     scb_destroy_cmdbuf(cb);
     shutdown();
 }
@@ -620,21 +620,32 @@ UTEST(sokol_cmdbuf, record_apply_bindings_invalid_cmdbuf_noop) {
 }
 
 UTEST(sokol_cmdbuf, record_apply_uniforms) {
-    // 16-byte uniform payload
+    // 16-byte uniform payload; the payload blob must be 16-byte aligned in the
+    // recorded stream so replay can hand it to sg_apply_uniforms without a copy
     init();
     scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
     _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
     T(cbptr);
+    // sanity: malloc must return a 16-byte-aligned buffer for these offset
+    // assertions to hold (guaranteed on 64-bit targets)
+    T(((uintptr_t)cbptr->buf & 15) == 0);
     const float payload[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
     scb_apply_uniforms(cb, 2, &(sg_range){ .ptr = payload, .size = sizeof(payload) });
-    // 1 opcode + 4 ub_slot + 4 size + 16 blob = 25 bytes
-    T((cbptr->cur - cbptr->buf) == 25);
+    // 1 opcode + 4 ub_slot + 4 size = 9 bytes header, padded to 16 (7 pad
+    // bytes), + 16 blob = 32 bytes total
+    T((cbptr->cur - cbptr->buf) == 32);
     T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_UNIFORMS);
     T(read_le_i32(&cbptr->buf[1]) == 2);
     T(read_le_u32(&cbptr->buf[5]) == sizeof(payload));
-    T(0 == memcmp(&cbptr->buf[9], payload, sizeof(payload)));
+    // the padding bytes are zeroed by the encoder
+    for (int i = 9; i < 16; i++) {
+        T(cbptr->buf[i] == 0);
+    }
+    T(0 == memcmp(&cbptr->buf[16], payload, sizeof(payload)));
+    // the payload address itself is 16-byte aligned
+    T(((uintptr_t)&cbptr->buf[16] & 15) == 0);
     T(cbptr->overflown == false);
-    T(cbptr->cmd_end == 0);
+    T(cbptr->cmd_max_end == 0);
     scb_destroy_cmdbuf(cb);
     shutdown();
 }
@@ -644,17 +655,80 @@ UTEST(sokol_cmdbuf, record_apply_uniforms_different_slot) {
     scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
     _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
     T(cbptr);
+    T(((uintptr_t)cbptr->buf & 15) == 0);
     const uint8_t payload[3] = { 0xAA, 0xBB, 0xCC };
     scb_apply_uniforms(cb, 5, &(sg_range){ .ptr = payload, .size = sizeof(payload) });
-    // 1 + 4 + 4 + 3 = 12 bytes
-    T((cbptr->cur - cbptr->buf) == 12);
+    // 1 + 4 + 4 = 9 bytes header, padded to 16, + 3 blob = 19 bytes
+    T((cbptr->cur - cbptr->buf) == 19);
     T(cbptr->buf[0] == (uint8_t)_SCB_CMD_APPLY_UNIFORMS);
     T(read_le_i32(&cbptr->buf[1]) == 5);
     T(read_le_u32(&cbptr->buf[5]) == 3);
-    T(cbptr->buf[9] == 0xAA);
-    T(cbptr->buf[10] == 0xBB);
-    T(cbptr->buf[11] == 0xCC);
+    // padding zeroed
+    for (int i = 9; i < 16; i++) {
+        T(cbptr->buf[i] == 0);
+    }
+    T(cbptr->buf[16] == 0xAA);
+    T(cbptr->buf[17] == 0xBB);
+    T(cbptr->buf[18] == 0xCC);
+    T(((uintptr_t)&cbptr->buf[16] & 15) == 0);
     scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_apply_uniforms_alignment_after_odd_prefix) {
+    // any command sequence before apply_uniforms leaves cur at an arbitrary
+    // offset; the encoder must still land the payload on a 16-byte boundary
+    init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    T(((uintptr_t)cbptr->buf & 15) == 0);
+    // a single apply_pipeline consumes 5 bytes → cur at buf+5, an odd offset
+    scb_apply_pipeline(cb, (sg_pipeline){ .id = 0x42 });
+    T((cbptr->cur - cbptr->buf) == 5);
+    const float payload[4] = { 10.0f, 20.0f, 30.0f, 40.0f };
+    const uint8_t* uniforms_start = cbptr->cur;
+    scb_apply_uniforms(cb, 1, &(sg_range){ .ptr = payload, .size = sizeof(payload) });
+    // opcode written at buf+5, header ends at buf+14 → next 16-aligned is buf+16
+    T(uniforms_start[0] == (uint8_t)_SCB_CMD_APPLY_UNIFORMS);
+    const uint8_t* payload_ptr = cbptr->buf + 16;
+    T(((uintptr_t)payload_ptr & 15) == 0);
+    T(0 == memcmp(payload_ptr, payload, sizeof(payload)));
+    // total = 5 (pipeline) + 1 (opcode) + 4 (slot) + 4 (size) + 2 (pad) + 16 (blob) = 32
+    T((cbptr->cur - cbptr->buf) == 32);
+    // padding bytes are zeroed
+    T(cbptr->buf[14] == 0);
+    T(cbptr->buf[15] == 0);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, record_apply_uniforms_alignment_across_offsets) {
+    // sweep prefix sizes 0..15 and confirm every recorded payload is
+    // 16-byte aligned regardless of where the command lands
+    init();
+    for (int pad_bytes = 0; pad_bytes < 16; pad_bytes++) {
+        scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+        _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+        T(cbptr);
+        T(((uintptr_t)cbptr->buf & 15) == 0);
+        // nudge cur by pad_bytes to simulate an arbitrary prior recording
+        cbptr->cur = cbptr->buf + pad_bytes;
+        const float payload[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
+        scb_apply_uniforms(cb, 0, &(sg_range){ .ptr = payload, .size = sizeof(payload) });
+        // find the blob by scanning for its content — must land on 16-byte-aligned addr
+        // header: opcode(1) + slot(4) + size(4) = 9 bytes past pad_bytes
+        const size_t header_end = (size_t)pad_bytes + 9;
+        const size_t aligned = (header_end + 15) & ~(size_t)15;
+        const uint8_t* payload_ptr = cbptr->buf + aligned;
+        T(((uintptr_t)payload_ptr & 15) == 0);
+        T(0 == memcmp(payload_ptr, payload, sizeof(payload)));
+        // header alignment pad bytes must be zero
+        for (size_t i = header_end; i < aligned; i++) {
+            T(cbptr->buf[i] == 0);
+        }
+        scb_destroy_cmdbuf(cb);
+    }
     shutdown();
 }
 
@@ -665,11 +739,12 @@ UTEST(sokol_cmdbuf, record_apply_uniforms_overflow_no_partial_write) {
     scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){ .size = 16 });
     _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
     T(cbptr);
-    const uint8_t payload[16] = { 0 };  // 1 + 4 + 4 + 16 = 25 > 16
+    // max payload budget = 1 opcode + 4 slot + 4 size + 16 blob + 16 align pad = 41 > 16
+    const uint8_t payload[16] = { 0 };
     scb_apply_uniforms(cb, 0, &(sg_range){ .ptr = payload, .size = sizeof(payload) });
     T((cbptr->cur - cbptr->buf) == 0);
     T(cbptr->overflown == true);
-    T(cbptr->cmd_end == 0);
+    T(cbptr->cmd_max_end == 0);
     scb_destroy_cmdbuf(cb);
     shutdown();
 }
@@ -731,6 +806,7 @@ typedef struct {
     sg_bindings bindings;         // deep copy at hook time (bindings ptr is stack-local)
     int ub_slot;
     size_t uniform_size;
+    uintptr_t uniform_ptr;        // raw ptr address to verify 16-byte alignment on submit
     uint8_t uniform_data[TCALL_MAX_UNIFORM_SIZE];
     char label[64];
 } tcall_t;
@@ -782,6 +858,7 @@ static void hook_apply_uniforms(int ub_slot, const sg_range* data, void* ud) {
     if (c) {
         c->ub_slot = ub_slot;
         c->uniform_size = data->size;
+        c->uniform_ptr = (uintptr_t)data->ptr;
         SOKOL_ASSERT(data->size <= TCALL_MAX_UNIFORM_SIZE);
         memcpy(c->uniform_data, data->ptr, data->size);
     }
@@ -924,6 +1001,8 @@ UTEST(sokol_cmdbuf, submit_all_commands_roundtrip) {
     T(tcalls[4].ub_slot == 3);
     T(tcalls[4].uniform_size == sizeof(uniforms));
     T(0 == memcmp(tcalls[4].uniform_data, uniforms, sizeof(uniforms)));
+    // the pointer handed to sg_apply_uniforms must be 16-byte aligned
+    T((tcalls[4].uniform_ptr & 15) == 0);
     T(tcalls[5].kind == TCALL_DRAW);
     T(tcalls[5].i0 == 100 && tcalls[5].i1 == 200 && tcalls[5].i2 == 300);
     T(tcalls[6].kind == TCALL_DRAW_EX);
@@ -992,6 +1071,41 @@ UTEST(sokol_cmdbuf, submit_apply_uniforms_preserves_payload) {
     T(tcalls[0].ub_slot == 5);
     T(tcalls[0].uniform_size == sizeof(payload));
     T(0 == memcmp(tcalls[0].uniform_data, payload, sizeof(payload)));
+    // sg_apply_uniforms receives a 16-byte-aligned pointer into the cmdbuf
+    T((tcalls[0].uniform_ptr & 15) == 0);
+    T(cbptr->cur == cbptr->buf);
+    scb_destroy_cmdbuf(cb);
+    shutdown();
+}
+
+UTEST(sokol_cmdbuf, submit_apply_uniforms_pointer_aligned_after_odd_prefix) {
+    // regardless of preceding commands, the pointer passed to sg_apply_uniforms
+    // at replay must be 16-byte aligned
+    submit_test_init();
+    scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+    _scb_cmdbuf_t* cbptr = _scb_lookup_cmdbuf(cb.id);
+    T(cbptr);
+    // encode a handful of variable-sized commands ahead of the uniforms to
+    // guarantee the uniforms opcode does not land on a 16-byte boundary
+    scb_apply_pipeline(cb, (sg_pipeline){ .id = 1 });       // 5 bytes
+    scb_apply_viewport(cb, 0, 0, 1, 1, true);               // 18 bytes
+    scb_apply_pipeline(cb, (sg_pipeline){ .id = 2 });       // 5 bytes → cur at buf+28
+    const float u0[3] = { 0.1f, 0.2f, 0.3f };
+    scb_apply_uniforms(cb, 0, &(sg_range){ .ptr = u0, .size = sizeof(u0) });
+    scb_apply_pipeline(cb, (sg_pipeline){ .id = 3 });       // shifts the next uniform
+    const uint8_t u1[7] = { 1, 2, 3, 4, 5, 6, 7 };
+    scb_apply_uniforms(cb, 1, &(sg_range){ .ptr = u1, .size = sizeof(u1) });
+    scb_submit(cb);
+    // capture the two apply_uniforms calls in order
+    int n_uniforms = 0;
+    for (int i = 0; i < num_tcalls; i++) {
+        if (tcalls[i].kind == TCALL_APPLY_UNIFORMS) {
+            // pointer must be 16-byte aligned
+            T((tcalls[i].uniform_ptr & 15) == 0);
+            n_uniforms++;
+        }
+    }
+    T(n_uniforms == 2);
     T(cbptr->cur == cbptr->buf);
     scb_destroy_cmdbuf(cb);
     shutdown();

--- a/tests/functional/sokol_cmdbuf_test.c
+++ b/tests/functional/sokol_cmdbuf_test.c
@@ -1,8 +1,8 @@
 //------------------------------------------------------------------------------
+//  LLM maintained.
+//
 //  sokol_cmdbuf_test.c
 //  For best results, run with ASAN and UBSAN.
-//
-//  LLM assisted!
 //------------------------------------------------------------------------------
 #include "sokol_gfx.h"
 #include "sokol_log.h"

--- a/tests/functional/sokol_framebuffer_test.c
+++ b/tests/functional/sokol_framebuffer_test.c
@@ -1,0 +1,337 @@
+//------------------------------------------------------------------------------
+//  sokol_framebuffer_test.c
+//  For best results, run with ASAN and UBSAN.
+//
+//  LLM generated!
+//------------------------------------------------------------------------------
+#include "sokol_gfx.h"
+#include "sokol_log.h"
+#define SOKOL_FRAMEBUFFER_IMPL
+#include "sokol_framebuffer.h"
+#include "utest.h"
+
+#define T(b) EXPECT_TRUE(b)
+
+static void init(void) {
+    sg_setup(&(sg_desc){ .logger = { .func = slog_func }});
+    sfb_setup(&(sfb_desc){ .logger = { .func = slog_func }});
+}
+
+static void init_with(const sfb_desc* desc) {
+    sg_setup(&(sg_desc){0});
+    sfb_setup(desc);
+}
+
+static void shutdown(void) {
+    sfb_shutdown();
+    sg_shutdown();
+}
+
+UTEST(sokol_framebuffer, default_init_shutdown) {
+    init();
+    T(_sfb.init_tag == _SFB_INIT_TAG);
+    T(_sfb.desc.framebuffer_pool_size == _SFB_DEFAULT_FRAMEBUFFER_POOL_SIZE);
+    T(_sfb.pools.framebuffers);
+    T(_sfb.pools.framebuffer_pool.size == (_SFB_DEFAULT_FRAMEBUFFER_POOL_SIZE + 1));
+    T(_sfb.pools.framebuffer_pool.free_queue);
+    T(_sfb.pools.framebuffer_pool.gen_ctrs);
+    shutdown();
+    T(_sfb.init_tag == 0);
+}
+
+static void* my_alloc(size_t size, void* user_data) {
+    (void)user_data;
+    return malloc(size);
+}
+
+static void my_free(void* ptr, void* user_data) {
+    (void)user_data;
+    free(ptr);
+}
+
+UTEST(sokol_framebuffer, init_with_params) {
+    init_with(&(sfb_desc){
+        .framebuffer_pool_size = 128,
+        .allocator = {
+            .alloc_fn = my_alloc,
+            .free_fn = my_free,
+            .user_data = (void*)12345,
+        },
+    });
+    T(_sfb.init_tag == _SFB_INIT_TAG);
+    T(_sfb.desc.framebuffer_pool_size == 128);
+    T(_sfb.pools.framebuffers);
+    T(_sfb.pools.framebuffer_pool.size == 129);
+    T(_sfb.pools.framebuffer_pool.free_queue);
+    T(_sfb.pools.framebuffer_pool.gen_ctrs);
+    T(_sfb.desc.allocator.alloc_fn == my_alloc);
+    T(_sfb.desc.allocator.free_fn == my_free);
+    T(_sfb.desc.allocator.user_data == (void*)12345);
+    shutdown();
+}
+
+UTEST(sokol_framebuffer, make_destroy_framebuffer_defaults) {
+    init();
+    sfb_framebuffer fb = sfb_make_framebuffer(&(sfb_framebuffer_desc){
+        .width = 320,
+        .height = 256,
+    });
+    T(fb.id != SFB_INVALID_ID);
+    T(sfb_query_framebuffer_state(fb) == SFB_RESOURCESTATE_VALID);
+    _sfb_framebuffer_t* fbptr = _sfb_lookup_framebuffer(fb.id);
+    T(fbptr);
+    T(fbptr->slot.state == SFB_RESOURCESTATE_VALID);
+    T(fbptr->slot.id == fb.id);
+    T(fbptr->width == 320);
+    T(fbptr->height == 256);
+    T(fbptr->prescale == 1);
+    T(fbptr->format == SFB_FORMAT_RGBA8);
+    T(fbptr->cliprect.x == 0);
+    T(fbptr->cliprect.y == 0);
+    T(fbptr->cliprect.width == 320);
+    T(fbptr->cliprect.height == 256);
+    T(fbptr->rotate90 == false);
+    sfb_destroy_framebuffer(fb);
+    T(fbptr->slot.id == SFB_INVALID_ID);
+    T(sfb_query_framebuffer_state(fb) == SFB_RESOURCESTATE_INVALID);
+    shutdown();
+}
+
+UTEST(sokol_framebuffer, make_framebuffer_palette8) {
+    init();
+    sfb_framebuffer fb = sfb_make_framebuffer(&(sfb_framebuffer_desc){
+        .width = 320,
+        .height = 256,
+        .format = SFB_FORMAT_PALETTE8,
+        .prescale = 2,
+        .rotate90 = true,
+    });
+    T(fb.id != SFB_INVALID_ID);
+    T(sfb_query_framebuffer_state(fb) == SFB_RESOURCESTATE_VALID);
+    _sfb_framebuffer_t* fbptr = _sfb_lookup_framebuffer(fb.id);
+    T(fbptr);
+    T(fbptr->format == SFB_FORMAT_PALETTE8);
+    T(fbptr->prescale == 2);
+    T(fbptr->rotate90 == true);
+    T(fbptr->cliprect.width == 320);
+    T(fbptr->cliprect.height == 256);
+    sfb_destroy_framebuffer(fb);
+    shutdown();
+}
+
+UTEST(sokol_framebuffer, make_framebuffer_cliprect) {
+    init();
+    sfb_framebuffer fb = sfb_make_framebuffer(&(sfb_framebuffer_desc){
+        .width = 512,
+        .height = 512,
+        .cliprect = {
+            .x = 0,
+            .y = 0,
+            .width = 160,
+            .height = 128,
+        },
+    });
+    T(fb.id != SFB_INVALID_ID);
+    T(sfb_query_framebuffer_state(fb) == SFB_RESOURCESTATE_VALID);
+    _sfb_framebuffer_t* fbptr = _sfb_lookup_framebuffer(fb.id);
+    T(fbptr);
+    T(fbptr->width == 512);
+    T(fbptr->height == 512);
+    T(fbptr->cliprect.x == 0);
+    T(fbptr->cliprect.y == 0);
+    T(fbptr->cliprect.width == 160);
+    T(fbptr->cliprect.height == 128);
+    sfb_destroy_framebuffer(fb);
+    shutdown();
+}
+
+UTEST(sokol_framebuffer, make_framebuffer_invalid_width) {
+    init();
+    sfb_framebuffer fb = sfb_make_framebuffer(&(sfb_framebuffer_desc){
+        .width = 0,
+        .height = 256,
+    });
+    T(fb.id != SFB_INVALID_ID);
+    T(sfb_query_framebuffer_state(fb) == SFB_RESOURCESTATE_FAILED);
+    sfb_destroy_framebuffer(fb);
+    T(sfb_query_framebuffer_state(fb) == SFB_RESOURCESTATE_INVALID);
+    shutdown();
+}
+
+UTEST(sokol_framebuffer, make_framebuffer_invalid_height) {
+    init();
+    sfb_framebuffer fb = sfb_make_framebuffer(&(sfb_framebuffer_desc){
+        .width = 320,
+        .height = 0,
+    });
+    T(fb.id != SFB_INVALID_ID);
+    T(sfb_query_framebuffer_state(fb) == SFB_RESOURCESTATE_FAILED);
+    sfb_destroy_framebuffer(fb);
+    shutdown();
+}
+
+UTEST(sokol_framebuffer, query_framebuffer_desc) {
+    init();
+    sfb_framebuffer fb = sfb_make_framebuffer(&(sfb_framebuffer_desc){
+        .width = 320,
+        .height = 256,
+        .format = SFB_FORMAT_PALETTE8,
+        .prescale = 2,
+        .rotate90 = true,
+        .cliprect = { .x = 16, .y = 32, .width = 200, .height = 100 },
+    });
+    T(fb.id != SFB_INVALID_ID);
+    sfb_framebuffer_desc desc = sfb_query_framebuffer_desc(fb);
+    T(desc.width == 320);
+    T(desc.height == 256);
+    T(desc.prescale == 2);
+    T(desc.format == SFB_FORMAT_PALETTE8);
+    T(desc.rotate90 == true);
+    T(desc.cliprect.x == 16);
+    T(desc.cliprect.y == 32);
+    T(desc.cliprect.width == 200);
+    T(desc.cliprect.height == 100);
+    sfb_destroy_framebuffer(fb);
+    shutdown();
+}
+
+UTEST(sokol_framebuffer, query_framebuffer_desc_invalid) {
+    init();
+    sfb_framebuffer_desc desc = sfb_query_framebuffer_desc((sfb_framebuffer){ .id = SFB_INVALID_ID });
+    T(desc.width == 0);
+    T(desc.height == 0);
+    T(desc.prescale == 0);
+    T(desc.format == _SFB_FORMAT_DEFAULT);
+    shutdown();
+}
+
+UTEST(sokol_framebuffer, query_framebuffer_info) {
+    init();
+    sfb_framebuffer fb = sfb_make_framebuffer(&(sfb_framebuffer_desc){
+        .width = 320,
+        .height = 256,
+        .prescale = 2,
+    });
+    T(fb.id != SFB_INVALID_ID);
+    sfb_framebuffer_info info = sfb_query_framebuffer_info(fb);
+    T(info.update.width == 320);
+    T(info.update.height == 256);
+    T(info.update.pixel_format == SG_PIXELFORMAT_RGBA8);
+    T(info.update.image.id != SG_INVALID_ID);
+    T(info.update.tex_view.id != SG_INVALID_ID);
+    T(info.offscreen.width == 640);
+    T(info.offscreen.height == 512);
+    T(info.offscreen.pixel_format == SG_PIXELFORMAT_RGBA8);
+    T(info.offscreen.image.id != SG_INVALID_ID);
+    T(info.offscreen.tex_view.id != SG_INVALID_ID);
+    T(info.palette.width == 256);
+    T(info.palette.height == 1);
+    T(info.palette.pixel_format == SG_PIXELFORMAT_RGBA8);
+    // palette image is only created for SFB_FORMAT_PALETTE8
+    T(info.palette.image.id == SG_INVALID_ID);
+    T(info.palette.tex_view.id == SG_INVALID_ID);
+    T(info.nearest_sampler.id != SG_INVALID_ID);
+    T(info.linear_sampler.id != SG_INVALID_ID);
+    sfb_destroy_framebuffer(fb);
+    shutdown();
+}
+
+UTEST(sokol_framebuffer, query_framebuffer_info_palette8) {
+    init();
+    sfb_framebuffer fb = sfb_make_framebuffer(&(sfb_framebuffer_desc){
+        .width = 320,
+        .height = 256,
+        .format = SFB_FORMAT_PALETTE8,
+    });
+    T(fb.id != SFB_INVALID_ID);
+    sfb_framebuffer_info info = sfb_query_framebuffer_info(fb);
+    T(info.update.pixel_format == SG_PIXELFORMAT_R8);
+    T(info.palette.image.id != SG_INVALID_ID);
+    T(info.palette.tex_view.id != SG_INVALID_ID);
+    sfb_destroy_framebuffer(fb);
+    shutdown();
+}
+
+UTEST(sokol_framebuffer, query_framebuffer_info_invalid) {
+    init();
+    sfb_framebuffer_info info = sfb_query_framebuffer_info((sfb_framebuffer){ .id = SFB_INVALID_ID });
+    T(info.update.image.id == SG_INVALID_ID);
+    T(info.offscreen.image.id == SG_INVALID_ID);
+    T(info.palette.image.id == SG_INVALID_ID);
+    shutdown();
+}
+
+UTEST(sokol_framebuffer, resize_noop) {
+    init();
+    sfb_framebuffer fb = sfb_make_framebuffer(&(sfb_framebuffer_desc){
+        .width = 320,
+        .height = 256,
+    });
+    T(fb.id != SFB_INVALID_ID);
+    bool recreated = sfb_resize(fb, &(sfb_resize_desc){
+        .width = 320,
+        .height = 256,
+    });
+    T(!recreated);
+    T(sfb_query_framebuffer_state(fb) == SFB_RESOURCESTATE_VALID);
+    sfb_destroy_framebuffer(fb);
+    shutdown();
+}
+
+UTEST(sokol_framebuffer, resize_changes_size) {
+    init();
+    sfb_framebuffer fb = sfb_make_framebuffer(&(sfb_framebuffer_desc){
+        .width = 320,
+        .height = 256,
+    });
+    T(fb.id != SFB_INVALID_ID);
+    bool recreated = sfb_resize(fb, &(sfb_resize_desc){
+        .width = 640,
+        .height = 480,
+    });
+    T(recreated);
+    T(sfb_query_framebuffer_state(fb) == SFB_RESOURCESTATE_VALID);
+    sfb_framebuffer_desc desc = sfb_query_framebuffer_desc(fb);
+    T(desc.width == 640);
+    T(desc.height == 480);
+    T(desc.cliprect.width == 640);
+    T(desc.cliprect.height == 480);
+    sfb_destroy_framebuffer(fb);
+    shutdown();
+}
+
+UTEST(sokol_framebuffer, make_destroy_many_framebuffers) {
+    init();
+    sfb_framebuffer fbs[_SFB_DEFAULT_FRAMEBUFFER_POOL_SIZE];
+    for (int i = 0; i < _SFB_DEFAULT_FRAMEBUFFER_POOL_SIZE; i++) {
+        fbs[i] = sfb_make_framebuffer(&(sfb_framebuffer_desc){
+            .width = 64,
+            .height = 64,
+        });
+        T(fbs[i].id != SFB_INVALID_ID);
+        T(sfb_query_framebuffer_state(fbs[i]) == SFB_RESOURCESTATE_VALID);
+    }
+    // one more should exhaust the pool
+    sfb_framebuffer overflow = sfb_make_framebuffer(&(sfb_framebuffer_desc){
+        .width = 64,
+        .height = 64,
+    });
+    T(overflow.id == SFB_INVALID_ID);
+    for (int i = 0; i < _SFB_DEFAULT_FRAMEBUFFER_POOL_SIZE; i++) {
+        sfb_destroy_framebuffer(fbs[i]);
+        T(sfb_query_framebuffer_state(fbs[i]) == SFB_RESOURCESTATE_INVALID);
+    }
+    shutdown();
+}
+
+UTEST(sokol_framebuffer, shutdown_destroys_remaining_framebuffers) {
+    init();
+    sfb_framebuffer fb0 = sfb_make_framebuffer(&(sfb_framebuffer_desc){ .width = 32, .height = 32 });
+    sfb_framebuffer fb1 = sfb_make_framebuffer(&(sfb_framebuffer_desc){ .width = 64, .height = 64 });
+    T(fb0.id != SFB_INVALID_ID);
+    T(fb1.id != SFB_INVALID_ID);
+    T(sfb_query_framebuffer_state(fb0) == SFB_RESOURCESTATE_VALID);
+    T(sfb_query_framebuffer_state(fb1) == SFB_RESOURCESTATE_VALID);
+    // don't destroy explicitly - sfb_shutdown() should clean them up
+    shutdown();
+}

--- a/tests/functional/sokol_framebuffer_test.c
+++ b/tests/functional/sokol_framebuffer_test.c
@@ -1,8 +1,8 @@
 //------------------------------------------------------------------------------
+//  LLM maintained.
+//
 //  sokol_framebuffer_test.c
 //  For best results, run with ASAN and UBSAN.
-//
-//  LLM generated!
 //------------------------------------------------------------------------------
 #include "sokol_gfx.h"
 #include "sokol_log.h"

--- a/tests/functional/sokol_gfx_test.c
+++ b/tests/functional/sokol_gfx_test.c
@@ -6,6 +6,7 @@
 //------------------------------------------------------------------------------
 #include "force_dummy_backend.h"
 #define SOKOL_IMPL
+#define SOKOL_TRACE_HOOKS
 #include "sokol_gfx.h"
 #include "utest.h"
 

--- a/util/sokol_cmdbuf.h
+++ b/util/sokol_cmdbuf.h
@@ -34,7 +34,195 @@
         sokol_gfx.h
 
 
-    FIXME docs
+    OVERVIEW
+    ========
+    Allows to record sokol-gfx apply/draw/dispatch calls into command buffers
+    outside of sokol-gfx passes and then submit the recorded calls inside
+    sokol-gfx render or compute passes. This is mainly useful in two situations:
+
+    - Interleaving resource updates and draw calls (e.g. append
+      data to buffers and then immediately issue a draw/dispatch call which
+      uses this data). Such an interleaved update/consume model cannot be
+      implemented efficiently in some sokol-gfx backends and is disallowed in
+      the 'new' write-transient/persistent update model.
+    - Separating the core frame rendering code from code that's normally
+      not concerned about rendering (e.g. UI or debug rendering).
+
+    Some 'tier 2' sokol headers already use a similar record/replay
+    system internally (e.g. sokol_gl.h, sokol_debugtext.h, sokol_spine.h)
+    and will switch to using sokol_cmdbuf.h to reduce redundant code.
+
+    STEP BY STEP:
+    =============
+
+    - Initialize sokol_cmdbuf.h, provide at least a logging function
+      (for instance slog_func from sokol_log.h), otherwise you won't
+      see any logging output:
+
+        scb_setup(&(scb_desc){
+            .logger.func = slog_func,
+        });
+
+      If you need more than (the default) 16 command buffers to be alive at
+      the same time, set the .cmdbuf_pool_size:
+
+        scb_setup(&(scb_desc){
+            .cmdbuf_pool_size = 128,
+            .logger.func = slog_func,
+        });
+
+      To provide your own memory allocation functions:
+
+        void* my_alloc(size_t size, void* user_data) {
+            return malloc(size);
+        }
+
+        void my_free(void* ptr, void* user_data) {
+            free(ptr);
+        }
+
+        scb_setup(&(scb_desc){
+            .allocator = {
+                .alloc_fn = my_alloc,
+                .free_fn = my_free,
+                .user_data = ...;
+            },
+            .logger.func = slog_func,
+        });
+
+    - Next create command buffer objects, the default command buffer size
+      is 256 kbytes:
+
+        scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){0});
+
+      It often makes sense to provide a specific size in bytes:
+
+        scb_cmdbuf cbuf = scb_make_cmdbuf(&(scb_cmdbuf_desc){
+            .size = 128 * 1024,     // 128 kbytes
+        });
+
+      For information on how to estimate the required size see the section
+      'ESTIMATING COMMAND BUFFER SIZES' below.
+
+      You can provide a label string for the command buffer:
+
+        scb_cmdbuf cbuf = scb_make_cmdbuf(&(scb_cmdbuf_desc){
+            .label = "dbg-phyiscs",
+        });
+
+      When a label string exists, sokol_cmdbuf.h will wrap submitted commands
+      with `sg_push_debug_group(label)` / `sg_pop_debug_group()`
+
+    - Record apply/draw/dispatch commands into a command buffer object
+      (note that these functions directly use sokol_gfx.h types):
+
+        scb_apply_viewport(cb, x, y, width, height, origin_top_left);
+        scb_apply_viewportf(cb, x, y, width, height, origin_top_left);
+
+        scb_apply_scissor_rect(cb, x, y, width, height, origin_top_left);
+        scb_apply_scissor_rectf(cb, x, y, width, height, origin_top_left);
+
+        scb_apply_pipeline(cb, pip);
+        scb_apply_bindings(cb, &(sg_bindings){ ... });
+        scb_apply_uniforms(cb, ub_slot, &(sg_range){ ... });
+        scb_draw(cb, base_element, num_elements, num_instances);
+        scb_draw_ex(cb, base_element, num_elements, num_instances, base_vertex, base_instance);
+        scb_dispatch(cb, num_groups_x, num_groups_y, num_groups_z);
+
+      Uniform data will be copied into the command buffer, and with the
+      required alignment.
+
+      Trying to record more data than fits into the command buffer will
+      result in a logged error message, and the command buffer to
+      go into an 'overflown' state. Submitting an overflown command buffer
+      will only rewind the command buffer but not issue the partially recorded
+      commands to sokol-gfx.
+
+    - Finally, inside a sokol-gfx render- or compute-pass, submit the
+      command buffer. This will decode the recorded commands and call
+      sokol-gfx functions:
+
+        sg_begin_pass(...);
+        // ...
+        scb_submit(cb);
+        // ...
+        sg_end_pass();
+
+      Submitting a command buffer will also automatically rewind, so that the
+      command buffer can be reused for recording new commands.
+
+    - To rewind a recorded command buffer without submitting, call:
+
+        scb_reset(cb)
+
+    - To get current information about a command buffer:
+
+        scb_cmdbuf_info info = scb_query_cmdbuf_info(cb);
+
+      The result contains:
+
+        info.size       the command buffer size in bytes
+        info.remaining  the currently remaining number of free bytes in the command buffer
+        info.overflown  true when the command buffer is currently in overflown state
+
+    - To get a command buffer's 'resource state', call:
+
+        scb_resource_state state = scb_query_cmdbuf_state(cb);
+
+      This returns one of:
+
+        SCB_RESOURCESTATE_VALID:    the command buffer is valid to use
+        SCB_RESOURCESTATE_FAILED:   command buffer allocation has failed
+                                    (can only happen when memory allocation failed)
+        SCB_RESOURCESTATE_INVALID   the handle is invalid or the command buffer
+                                    no longer exists
+
+    - To destroy a command buffer object:
+
+        scb_destroy_cmdbuf(cb);
+
+    - ...and finally to shutdown sokol_cmdbuf.h:
+
+        scb_shutdown();
+
+      ...this will also destroy all remaining command buffer objects.
+
+
+    ESTIMATING COMMAND BUFFER SIZES
+    ===============================
+
+    For most commands, the size taken up in the command buffer can be
+    estimated by adding the parameter sizes plus one byte for the
+    command, e.g.:
+
+    scb_apply_viewport takes 4 integers and one boolean:
+
+        1 byte for the command
+        + (4 * 4) bytes for the integers
+        + 1 byte for the boolean
+
+    There are two special cases:
+
+    - scb_apply_uniforms copies the actual uniform data with 4-byte
+        alignment into the command buffer, the required size is:
+
+        1 byte for the command
+        + 4 bytes for the uniform data size
+        + up to 3 bytes 'alignment gap'
+        + the actual uniform data
+
+    - scb_apply_bindings applies a simple form of compression by
+      not writing unoccupied bind slots. Instead a 64-bit bitmask identifies
+      occupied slots:
+
+        1 byte for the command
+        + 8 bytes for the 64-bit occupation bitmask
+        + 4 bytes for each valid sg_buffer, sg_view, sg_sampler
+          hande in the sg_bindings struct
+        + 4 bytes extra for the buffer offset of each occupied vertex buffer slot
+        + 4 bytes extra for the index buffer offset if the index buffer slot is occupied
+
+      ...or just assume around 256 bytes worst case for an scb_apply_bindings call
 
 
     LICENSE
@@ -150,6 +338,7 @@ typedef struct scb_cmdbuf_info {
 #define _SCB_LOG_ITEMS \
     _SCB_LOGITEM_XMACRO(OK, "Ok") \
     _SCB_LOGITEM_XMACRO(MALLOC_FAILED, "memory allocation failed") \
+    _SCB_LOGITEM_XMACRO(CMDBUF_POOL_EXHAUSTED, "command buffer pool is exhausted (hint: increase scb_desc.cmdbuf_pool_size)") \
     _SCB_LOGITEM_XMACRO(CMDBUF_OVERFLOW, "command buffer has overflown") \
     _SCB_LOGITEM_XMACRO(CMDBUF_NOT_VALID, "command buffer no longer exists or invalid handle") \
     _SCB_LOGITEM_XMACRO(SUBMIT_CMDBUF_OVERFLOWN, "scb_submit: command buffer was overflown") \
@@ -398,7 +587,9 @@ static void* _scb_malloc(size_t size) {
 
 static void* _scb_malloc_clear(size_t size) {
     void* ptr = _scb_malloc(size);
-    _scb_clear(ptr, size);
+    if (ptr) {
+        _scb_clear(ptr, size);
+    }
     return ptr;
 }
 
@@ -433,8 +624,10 @@ static void _scb_pool_init(_scb_pool_t* pool, int num) {
     // generation counters indexable by pool slot index, slot 0 is reserved
     size_t gen_ctrs_size = sizeof(uint32_t) * (size_t)pool->size;
     pool->gen_ctrs = (uint32_t*) _scb_malloc_clear(gen_ctrs_size);
+    SOKOL_ASSERT(pool->gen_ctrs);
     // it's not a bug to only reserve 'num' here
     pool->free_queue = (int*) _scb_malloc_clear(sizeof(int) * (size_t)num);
+    SOKOL_ASSERT(pool->free_queue);
     // never allocate the zero-th pool item since the invalid id is 0
     for (int i = pool->size-1; i >= 1; i--) {
         pool->free_queue[pool->queue_top++] = i;
@@ -489,6 +682,7 @@ static void _scb_setup_pools(_scb_pools_t* p, const scb_desc* desc) {
     _scb_pool_init(&p->cmdbuf_pool, desc->cmdbuf_pool_size);
     size_t cb_pool_byte_size = sizeof(_scb_cmdbuf_t) * (size_t)p->cmdbuf_pool.size;
     p->cmdbufs = (_scb_cmdbuf_t*)_scb_malloc_clear(cb_pool_byte_size);
+    SOKOL_ASSERT(p->cmdbufs);
 }
 
 static void _scb_discard_pools(_scb_pools_t* p) {
@@ -560,6 +754,7 @@ static scb_cmdbuf _scb_alloc_cmdbuf(void) {
         cb_id = _scb_make_cmdbuf_id(_scb_slot_alloc(&_scb.pools.cmdbuf_pool, &_scb.pools.cmdbufs[slot_index].slot, slot_index));
     } else {
         // pool is exhausted
+        _SCB_ERROR(CMDBUF_POOL_EXHAUSTED);
         cb_id = _scb_make_cmdbuf_id(SCB_INVALID_ID);
     }
     return cb_id;
@@ -606,6 +801,7 @@ static scb_desc _scb_desc_defaults(const scb_desc* desc) {
 }
 
 static scb_cmdbuf_desc _scb_cmdbuf_desc_defaults(const scb_cmdbuf_desc* desc) {
+    SOKOL_ASSERT(desc);
     scb_cmdbuf_desc res = *desc;
     res.size = _scb_def(res.size, _SCB_DEFAULT_CMDBUF_SIZE);
     return res;
@@ -704,22 +900,22 @@ static void _scb_enc_blob(_scb_cmdbuf_t* cb, const void* ptr, size_t size) {
     cb->cur += size;
 }
 
-static const uint8_t* _scb_ptr_align16(const uint8_t* ptr) {
-    const uintptr_t align_minus_one = (16 - 1);
+static const uint8_t* _scb_ptr_align4(const uint8_t* ptr) {
+    const uintptr_t align_minus_one = (4 - 1);
     const uintptr_t mask = ~align_minus_one;
     return (uint8_t*)(((uintptr_t)ptr + align_minus_one) & mask);
 }
 
-static void _scb_enc_align16(_scb_cmdbuf_t* cb) {
-    uint8_t* ptr16 = (uint8_t*)_scb_ptr_align16(cb->cur);
-    SOKOL_ASSERT((ptr16 >= cb->cur) && (ptr16 < cb->end));
-    for (; cb->cur < ptr16; cb->cur++) {
+static void _scb_enc_align4(_scb_cmdbuf_t* cb) {
+    uint8_t* ptr = (uint8_t*)_scb_ptr_align4(cb->cur);
+    SOKOL_ASSERT((ptr >= cb->cur) && (ptr <= cb->end));
+    for (; cb->cur < ptr; cb->cur++) {
         *cb->cur = 0;
     }
 }
 
-static const uint8_t* _scb_dec_align16(const uint8_t* ptr) {
-    return _scb_ptr_align16(ptr);
+static const uint8_t* _scb_dec_align4(const uint8_t* ptr) {
+    return _scb_ptr_align4(ptr);
 }
 
 static bool _scb_enc_cmd(_scb_cmdbuf_t* cb, _scb_cmd_t cmd, size_t max_payload_size) {
@@ -885,13 +1081,13 @@ static void _scb_enc_apply_bindings(_scb_cmdbuf_t* cb, const sg_bindings* bindin
     for (int i = 0; i < SG_MAX_VERTEXBUFFER_BINDSLOTS; i++) {
         if (bindings->vertex_buffers[i].id != SG_INVALID_ID) {
             slot_mask |= (1ULL << (i + vb_start));
-            payload_size += sizeof(uint32_t) + sizeof(int);
+            payload_size += sizeof(uint32_t) + sizeof(int32_t);
         }
     }
     // index buffer handle and offset
     if (bindings->index_buffer.id != SG_INVALID_ID) {
         slot_mask |= (1ULL << ib_start);
-        payload_size += sizeof(uint32_t) + sizeof(int);
+        payload_size += sizeof(uint32_t) + sizeof(int32_t);
     }
     // view handles
     for (int i = 0; i < SG_MAX_VIEW_BINDSLOTS; i++) {
@@ -971,12 +1167,12 @@ static const uint8_t* _scb_dec_apply_bindings(const uint8_t* ptr) {
 static void _scb_enc_apply_uniforms(_scb_cmdbuf_t* cb, int ub_slot, const sg_range* data) {
     SOKOL_ASSERT(data->size <= UINT32_MAX);
     SOKOL_ASSERT((ub_slot >= 0) && (ub_slot < SG_MAX_UNIFORMBLOCK_BINDSLOTS));
-    // NOTE: add max alignment gap of 15 bytes to max payload size
-    const size_t max_payload_size = sizeof(int32_t) + sizeof(uint32_t) + data->size + 15;
+    // NOTE: add max alignment gap of 3 bytes to max payload size
+    const size_t max_payload_size = sizeof(int32_t) + sizeof(uint32_t) + data->size + 3;
     if (_scb_enc_cmd(cb, _SCB_CMD_APPLY_UNIFORMS, max_payload_size)) {
         _scb_enc_i32(cb, ub_slot);
         _scb_enc_u32(cb, (uint32_t)data->size);
-        _scb_enc_align16(cb);
+        _scb_enc_align4(cb);
         _scb_enc_blob(cb, data->ptr, data->size);
         _scb_enc_end(cb);
     }
@@ -988,7 +1184,7 @@ static const uint8_t* _scb_dec_apply_uniforms(const uint8_t* ptr) {
     ptr = _scb_dec_i32(ptr, &ub_slot);
     SOKOL_ASSERT((ub_slot >= 0) && (ub_slot < SG_MAX_UNIFORMBLOCK_BINDSLOTS));
     ptr = _scb_dec_u32(ptr, &size_u32);
-    ptr = _scb_dec_align16(ptr);
+    ptr = _scb_dec_align4(ptr);
     sg_range data;
     _scb_clear(&data, sizeof(data));
     data.ptr = ptr;
@@ -1090,6 +1286,7 @@ SOKOL_API_IMPL void scb_apply_viewportf(scb_cmdbuf cb_id, float x, float y, floa
         _SCB_ERROR(CMDBUF_NOT_VALID);
         return;
     }
+    // NOTE: truncating the floats is intended and matched sokol-gfx behaviour
     _scb_enc_apply_viewport(cb, (int)x, (int)y, (int)width, (int)height, origin_top_left);
 }
 
@@ -1110,6 +1307,7 @@ SOKOL_API_IMPL void scb_apply_scissor_rectf(scb_cmdbuf cb_id, float x, float y, 
         _SCB_ERROR(CMDBUF_NOT_VALID);
         return;
     }
+    // NOTE: truncating the floats is intended and matched sokol-gfx behaviour
     _scb_enc_apply_scissor_rect(cb, (int)x, (int)y, (int)width, (int)height, origin_top_left);
 }
 

--- a/util/sokol_cmdbuf.h
+++ b/util/sokol_cmdbuf.h
@@ -1,0 +1,509 @@
+#if defined(SOKOL_IMPL) && !defined(SOKOL_CMDBUF_IMPL)
+#define SOKOL_CMDBUF_IMPL
+#endif
+#ifndef SOKOL_CMDBUF_INCLUDED
+/*
+    sokol_cmdbuf.h  - a software command buffer for sokol_gfx.h
+
+    Project URL: https://github.com/floooh/sokol
+
+    Do this:
+        #define SOKOL_IMPL or
+        #define SOKOL_CMDBUF_IMPL
+    before you include this file in *one* C or C++ file to create the
+    implementation.
+
+    ...optionally provide the following macros to override defaults:
+
+    SOKOL_ASSERT(c)     - your own assert macro (default: assert(c))
+    SOKOL_CMDBUF_API_DECL   - public function declaration prefix (default: extern)
+    SOKOL_API_DECL      - same as SOKOL_CMDBUF_API_DECL
+    SOKOL_API_IMPL      - public function implementation prefix (default: -)
+    SOKOL_UNREACHABLE() - a guard macro for unreachable code (default: assert(false))
+
+    If sokol_cmdbuf.h is compiled as a DLL, define the following before
+    including the declaration or implementation:
+
+    SOKOL_DLL
+
+    On Windows, SOKOL_DLL will define SOKOL_CMDBUF_API_DECL as __declspec(dllexport)
+    or __declspec(dllimport) as needed.
+
+    Include the following headers before including sokol_cmdbuf.h:
+
+        sokol_gfx.h
+
+
+    FIXME docs
+
+
+    LICENSE
+    =======
+    zlib/libpng license
+
+    Copyright (c) 2026 Andre Weissflog
+
+    This software is provided 'as-is', without any express or implied warranty.
+    In no event will the authors be held liable for any damages arising from the
+    use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+        1. The origin of this software must not be misrepresented; you must not
+        claim that you wrote the original software. If you use this software in a
+        product, an acknowledgment in the product documentation would be
+        appreciated but is not required.
+
+        2. Altered source versions must be plainly marked as such, and must not
+        be misrepresented as being the original software.
+
+        3. This notice may not be removed or altered from any source
+        distribution.
+*/
+#define SOKOL_CMDBUF_INCLUDED (1)
+#include <stdint.h>
+#include <stdbool.h>
+
+#if !defined(SOKOL_GFX_INCLUDED)
+#error "Please include sokol_gfx.h before sokol_cmdbuf.h"
+#endif
+
+#if defined(SOKOL_API_DECL) && !defined(SOKOL_CMDBUF_API_DECL)
+#define SOKOL_CMDBUF_API_DECL SOKOL_API_DECL
+#endif
+#ifndef SOKOL_CMDBUF_API_DECL
+#if defined(_WIN32) && defined(SOKOL_DLL) && defined(SOKOL_CMDBUF_IMPL)
+#define SOKOL_CMDBUF_API_DECL __declspec(dllexport)
+#elif defined(_WIN32) && defined(SOKOL_DLL)
+#define SOKOL_CMDBUF_API_DECL __declspec(dllimport)
+#else
+#define SOKOL_CMDBUF_API_DECL extern
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// public constants
+enum {
+    SCB_INVALID_ID = 0,
+};
+
+/*
+    scb_cmdbuf
+
+    A command buffer handle created with scb_make_cmdbuf().
+*/
+typedef struct scb_cmdbuf_s { uint32_t id; } scb_cmdbuf;
+
+/*
+    scb_cmdbuf_desc
+
+    Creation parameters of a command buffer object. Used
+    in scb_make_cmdbuf().
+
+    TODO: information on how to estimate required size
+*/
+typedef struct scb_cmdbuf_desc_s {
+    size_t size;            // command buffer size in bytes (default: 256 * 1024 (256 KBytes))
+    const char* label;
+} scb_cmdbuf_desc;
+
+/*
+    scb_cmdbuf_info
+
+    Result of scb_query_cmdbuf_info.
+*/
+typedef struct scb_cmdbuf_info_s {
+    size_t size;        // overall command buffer size in bytes
+    size_t cur_offset;  // current recording byte offset
+    size_t remaining;   // number of remaining bytes in command buffer
+    bool overflown;     // true if command buffer is in overflown state
+} scb_cmdbuf_info;
+
+/*
+    scb_log_item
+
+    Log items are defined via X-Macro, expanded into an enum scb_log_item
+    and (in debug-mode only also to human readable strings.
+
+    Used as parameter to the logging callback.
+*/
+#define _SCB_LOG_ITEMS \
+    _SCB_LOGITEM_XMACRO(OK, "Ok") \
+    _SCB_LOGITEM_XMACRO(MALLOC_FAILED, "memory allocation failed") \
+
+#define _SCB_LOGITEM_XMACRO(item,msg) SCB_LOGITEM_##item,
+typedef enum scb_log_item_e {
+    _SCB_LOG_ITEMS
+} scb_log_item;
+#undef _SCB_LOGITEM_XMACRO
+
+/*
+    scb_logger
+
+    Used in scb_desc to provide a custom logging and error reporting
+    callback to sokol_cmdbuf.h
+*/
+typedef struct scb_logger_s {
+    void (*func)(
+        const char* tag,                // always "scb"
+        uint32_t log_level,             // 0=panic, 1=error, 2=warning, 3=info
+        uint32_t log_item_id,           // SCB_LOGITEM_*
+        const char* message_or_null,    // a message string, may be nullptr in release mode
+        uint32_t line_nr,               // line number in sokol_debugtext.h
+        const char* filename_or_null,   // source filename, may be nullptr in release mode
+        void* user_data);
+    void* user_data;
+} scb_logger;
+
+/*
+    scb_allocator
+
+    Used in scb_desc to provide custom memory-alloc and -free functions
+    to sokol_cmdbuf.h. If memory management should be overridden, both the
+    alloc_fn and free_fn function must be provided (e.g. it's not valid to
+    override one function but not the other).
+*/
+typedef struct scb_allocator_s {
+    void* (*alloc_fn)(size_t size, void* user_data);
+    void (*free_fn)(void* ptr, void* user_data);
+    void* user_data;
+} scb_allocator;
+
+/*
+    scb_desc
+
+    FIXME: docs
+*/
+typedef struct scb_desc_s {
+    int buffer_pool_size;       // max number of command buffers that can be alive simultanously (default: 16)
+    scb_allocator allocator;    // optional memory allocation overrides (default: malloc/free)
+    scb_logger logger;          // optional log override functions (default: NO LOGGING)
+} scb_desc;
+
+// initialization and shutdown
+SOKOL_CMDBUF_API_DECL void scb_setup(const scb_desc* desc);
+SOKOL_CMDBUF_API_DECL void scb_shutdown(void);
+
+// create and destroy command buffer objects
+SOKOL_CMDBUF_API_DECL scb_cmdbuf scb_make_cmdbuf(const scb_cmdbuf_desc* desc);
+SOKOL_CMDBUF_API_DECL void scb_destroy_cmdbuf(scb_cmdbuf cb);
+
+// submit command buffer to sokol-gfx (call inside a sokol-gfx pass)
+SOKOL_CMDBUF_API_DECL void scb_submit(scb_cmdbuf cb, bool rewind);
+
+// record sokol-gfx commands into command buffer
+SOKOL_CMDBUF_API_DECL void scb_apply_viewport(scb_cmdbuf cb, int x, int y, int width, int height, bool origin_top_left);
+SOKOL_CMDBUF_API_DECL void scb_apply_viewportf(scb_cmdbuf cb, float x, float y, float width, float height, bool origin_top_left);
+SOKOL_CMDBUF_API_DECL void scb_apply_scissor_rect(scb_cmdbuf cb, int x, int y, int width, int height, bool origin_top_left);
+SOKOL_CMDBUF_API_DECL void scb_apply_scissor_rectf(scb_cmdbuf cb, float x, float y, float width, float height, bool origin_top_left);
+SOKOL_CMDBUF_API_DECL void scb_apply_pipeline(scb_cmdbuf cb, sg_pipeline pip);
+SOKOL_CMDBUF_API_DECL void scb_apply_bindings(scb_cmdbuf cb, const sg_bindings* bindings);
+SOKOL_CMDBUF_API_DECL void scb_apply_uniforms(scb_cmdbuf cb, int ub_slot, const sg_range* data);
+SOKOL_CMDBUF_API_DECL void scb_draw(scb_cmdbuf cb, int base_element, int num_elements, int num_instances);
+SOKOL_CMDBUF_API_DECL void scb_draw_ex(scb_cmdbuf cb, int base_element, int num_elements, int num_instances, int base_vertex, int base_instance);
+SOKOL_CMDBUF_API_DECL void scb_dispatch(scb_cmdbuf cb, int num_groups_x, int num_groups_y, int num_groups_z);
+
+// getting info
+SOKOL_CMDBUF_API_DECL scb_desc scb_query_desc(void);
+SOKOL_CMDBUF_API_DECL scb_cmdbuf_desc scb_query_cmdbuf_desc(scb_cmdbuf cb);
+SOKOL_CMDBUF_API_DECL scb_cmdbuf_info scb_query_cmdbuf_info(scb_cmdbuf cb);
+
+#ifdef __cplusplus
+} // extern "C"
+// C++ const-ref wrappers
+FIXME
+#endif
+#endif /* SOKOL_CMDBUF_INCLUDED */
+
+//------------------------------------------------------------------------------
+// >>implementation
+#ifdef SOKOL_CMDBUF_IMPL
+#define SOKOL_CMDBUF_IMPL_INCLUDED (1)
+
+#ifndef SOKOL_API_IMPL
+    #define SOKOL_API_IMPL
+#endif
+#ifndef SOKOL_DEBUG
+    #ifndef NDEBUG
+        #define SOKOL_DEBUG
+    #endif
+#endif
+#ifndef SOKOL_ASSERT
+    #include <assert.h>
+    #define SOKOL_ASSERT(c) assert(c)
+#endif
+
+#ifndef SOKOL_UNREACHABLE
+    #define SOKOL_UNREACHABLE SOKOL_ASSERT(false)
+#endif
+#ifndef _SOKOL_UNUSED
+    #define _SOKOL_UNUSED(x) (void)(x)
+#endif
+
+#define _scb_def(val, def) (((val) == 0) ? (def) : (val))
+#define _SCB_INIT_COOKIE (0xACBAABCA)
+
+#define _SCB_STRING_SIZE (32)
+#define _SCB_DEFAULT_CMDBUF_POOL_SIZE (16)
+#define _SCB_DEFAULT_CMDBUF_SIZE (262144)   // 256 * 1024
+#define _SCB_INVALID_SLOT_INDEX (0)
+#define _SCB_SLOT_SHIFT (16)
+#define _SCB_MAX_POOL_SIZE (1<<_SCB_SLOT_SHIFT)
+#define _SCB_SLOT_MASK (_SCB_MAX_POOL_SIZE-1)
+
+// >>structs
+typedef struct {
+    uint32_t id;
+} _scb_slot_t;
+
+typedef struct {
+    int size;
+    int queue_top;
+    uint32_t* gen_ctrs;
+    int* free_queue;
+} _scb_pool_t;
+
+typedef struct {
+    char buf[_SCB_STRING_SIZE];
+} _scb_str_t;
+
+typedef struct {
+    _scb_slot_t slot;
+    uint8_t* buffer;
+    size_t offset;
+    bool overflown;
+    scb_cmdbuf_desc desc;
+    scb_str_t label;
+} _scb_cmdbuf_t;
+
+typedef struct {
+    _scb_pool_t;
+    _scb_cmdbuf_t* cmdbufs;
+} _scb_cmdbuf_pool_t;
+
+typedef struct {
+    uint32_t init_cookie;
+    scb_desc desc;
+    _scb_cmdbuf_pool_t cmdbuf_pool;
+} _scb_t;
+static _scb_t _scb;
+
+// >>logging
+#if defined(SOKOL_DEBUG)
+#define _SCB_LOGITEM_XMACRO(item,msg) #item ": " msg,
+static const char* _scb_log_messages[] = {
+    _SCB_LOG_ITEMS
+};
+#undef _SCB_LOGITEM_XMACRO
+#endif // SOKOL_DEBUG
+
+#define _SCB_PANIC(code) _scb_log(SCB_LOGITEM_ ##code, 0, __LINE__)
+#define _SCB_ERROR(code) _scb_log(SCB_LOGITEM_ ##code, 1, __LINE__)
+#define _SCB_WARN(code) _scb_log(SCB_LOGITEM_ ##code, 2, __LINE__)
+#define _SCB_INFO(code) _scb_log(SCB_LOGITEM_ ##code, 3, __LINE__)
+
+static void _scb_log(scb_log_item_t log_item, uint32_t log_level, uint32_t line_nr) {
+    if (_scb.desc.logger.func) {
+        #if defined(SOKOL_DEBUG)
+            const char* filename = __FILE__;
+            const char* message = _scb_log_messages[log_item];
+        #else
+            const char* filename = 0;
+            const char* message = 0;
+        #endif
+        _scb.desc.logger.func("scb", log_level, (uint32_t)log_item, message, line_nr, filename, _scb.desc.logger.user_data);
+    } else {
+        // for log level PANIC it would be 'undefined behaviour' to continue
+        if (log_level == 0) {
+            abort();
+        }
+    }
+}
+
+// >>memory
+static void _scb_clear(void* ptr, size_t size) {
+    SOKOL_ASSERT(ptr && (size > 0));
+    memset(ptr, 0, size);
+}
+
+static void* _scb_malloc(size_t size) {
+    SOKOL_ASSERT(size > 0);
+    void* ptr;
+    if (_scb.desc.allocator.alloc_fn) {
+        ptr = _scb.desc.allocator.alloc_fn(size, _scb.desc.allocator.user_data);
+    } else {
+        ptr = malloc(size);
+    }
+    if (0 == ptr) {
+        _SCB_PANIC(MALLOC_FAILED);
+    }
+    return ptr;
+}
+
+static void* _scb_malloc_clear(size_t size) {
+    void* ptr = _scb_malloc(size);
+    _scb_clear(ptr, size);
+    return ptr;
+}
+
+static void _scb_free(void* ptr) {
+    if (_scb.desc.allocator.free_fn) {
+        _scb.desc.allocator.free_fn(ptr, _scb.desc.allocator.user_data);
+    } else {
+        free(ptr);
+    }
+}
+
+// >>pool
+static void _scb(_scb_pool_t* pool, int num) {
+    SOKOL_ASSERT(pool && (num >= 1));
+    // slot 0 is reserved for the 'invalid id', so bump the pool size by 1
+    pool->size = num + 1;
+    pool->queue_top = 0;
+    // generation counters indexable by pool slot index, slot 0 is reserved
+    size_t gen_ctrs_size = sizeof(uint32_t) * (size_t)pool->size;
+    pool->gen_ctrs = (uint32_t*) _scb_malloc_clear(gen_ctrs_size);
+    // it's not a bug to only reserve 'num' here
+    pool->free_queue = (int*) _scb_malloc_clear(sizeof(int) * (size_t)num);
+    // never allocate the zero-th pool item since the invalid id is 0
+    for (int i = pool->size-1; i >= 1; i--) {
+        pool->free_queue[pool->queue_top++] = i;
+    }
+}
+
+static void _scb_discard_pool(_scb_pool_t* pool) {
+    SOKOL_ASSERT(pool);
+    SOKOL_ASSERT(pool->free_queue);
+    _scb_free(pool->free_queue);
+    pool->free_queue = 0;
+    SOKOL_ASSERT(pool->gen_ctrs);
+    _scb_free(pool->gen_ctrs);
+    pool->gen_ctrs = 0;
+    pool->size = 0;
+    pool->queue_top = 0;
+}
+
+static int _scb_pool_alloc_index(_scb_pool_t* pool) {
+    SOKOL_ASSERT(pool);
+    SOKOL_ASSERT(pool->free_queue);
+    if (pool->queue_top > 0) {
+        int slot_index = pool->free_queue[--pool->queue_top];
+        SOKOL_ASSERT((slot_index > 0) && (slot_index < pool->size));
+        return slot_index;
+    } else {
+        // pool exhausted
+        return _SCB_INVALID_SLOT_INDEX;
+    }
+}
+
+static void _scb_pool_free_index(_scb_pool_t* pool, int slot_index) {
+    SOKOL_ASSERT((slot_index > _SCB_INVALID_SLOT_INDEX) && (slot_index < pool->size));
+    SOKOL_ASSERT(pool);
+    SOKOL_ASSERT(pool->free_queue);
+    SOKOL_ASSERT(pool->queue_top < pool->size);
+    #ifdef SOKOL_DEBUG
+    // debug check against double-free
+    for (int i = 0; i < pool->queue_top; i++) {
+        SOKOL_ASSERT(pool->free_queue[i] != slot_index);
+    }
+    #endif
+    pool->free_queue[pool->queue_top++] = slot_index;
+    SOKOL_ASSERT(pool->queue_top <= (pool->size-1));
+}
+
+static void _scb_setup_cmdbuf_pool(const scb_desc_t* desc) {
+    SOKOL_ASSERT(desc);
+    // note: the pool will have an additional item, since slot 0 is reserved
+    SOKOL_ASSERT((desc->context_pool_size > 0) && (desc->context_pool_size < _SCB_MAX_POOL_SIZE));
+    _scb_init_pool(&_scb.context_pool.pool, desc->context_pool_size);
+    size_t pool_byte_size = sizeof(_scb_context_t) * (size_t)_scb.context_pool.pool.size;
+    _scb.context_pool.contexts = (_scb_context_t*) _scb_malloc_clear(pool_byte_size);
+}
+
+static void _scb_discard_cmdbuf_pool(void) {
+    SOKOL_ASSERT(_scb.context_pool.contexts);
+    _scb_free(_scb.context_pool.contexts);
+    _scb.context_pool.contexts = 0;
+    _scb_discard_pool(&_scb.context_pool.pool);
+}
+
+/* allocate the slot at slot_index:
+    - bump the slot's generation counter
+    - create a resource id from the generation counter and slot index
+    - set the slot's id to this id
+    - set the slot's state to ALLOC
+    - return the resource id
+*/
+static uint32_t _scb_slot_alloc(_scb_pool_t* pool, _scb_slot_t* slot, int slot_index) {
+    /* FIXME: add handling for an overflowing generation counter,
+       for now, just overflow (another option is to disable
+       the slot)
+    */
+    SOKOL_ASSERT(pool && pool->gen_ctrs);
+    SOKOL_ASSERT((slot_index > _SCB_INVALID_SLOT_INDEX) && (slot_index < pool->size));
+    SOKOL_ASSERT(slot->id == SG_INVALID_ID);
+    uint32_t ctr = ++pool->gen_ctrs[slot_index];
+    slot->id = (ctr<<_SCB_SLOT_SHIFT)|(slot_index & _SCB_SLOT_MASK);
+    return slot->id;
+}
+
+// extract slot index from id
+static int _scb_slot_index(uint32_t id) {
+    int slot_index = (int) (id & _SCB_SLOT_MASK);
+    SOKOL_ASSERT(_SCB_INVALID_SLOT_INDEX != slot_index);
+    return slot_index;
+}
+
+// get cmdbuf pointer without id-check
+static _scb_cmdbuf_t* _scb_cmdbuf_at(uint32_t cb_id) {
+    SOKOL_ASSERT(SG_INVALID_ID != cb_id);
+    int slot_index = _scb_slot_index(cb_id);
+    SOKOL_ASSERT((slot_index > _SCB_INVALID_SLOT_INDEX) && (slot_index < _scb.cmdbuf_pool.pool.size));
+    return &_scb.cmdbuf_pool.cmdbufs[slot_index];
+}
+
+// get cmdbuf pointer with id-check, returns 0 if no match
+static _scb_cmdbuf_t* _scb_lookup_cmdbuf(uint32_t cb_id) {
+    if (SG_INVALID_ID != cb_id) {
+        _scb_cmdbuf_t* cb = _scb_cmdbuf_at(cb_id);
+        if (cb->slot.id == cb_id) {
+            return cb;
+        }
+    }
+    return 0;
+}
+
+// make cmdbuf handle from raw uint32_t id
+static scb_context _scb_make_cmdbuf_id(uint32_t cb_id) {
+    scb_cmdbuf cb;
+    cb.id = cb_id;
+    return cb;
+}
+
+static scb_cmdbuf _scb_alloc_cmdbuf(void) {
+    scb_cmdbuf cb_id;
+    int slot_index = _scb_pool_alloc_index(&_scb.cmdbuf_pool.pool);
+    if (_SCB_INVALID_SLOT_INDEX != slot_index) {
+        cb_id = _scb_make_cmdbuf_id(_scb_slot_alloc(&_scb.cmdbuf_pool.pool, &_scb.cmdbuf_pool.cmdbufs[slot_index].slot, slot_index));
+    } else {
+        // pool is exhausted
+        cb_id = _scb_make_cmdbuf_id(SCB_INVALID_ID);
+    }
+    return cb_id;
+}
+
+static scb_cmdbuf_desc _scb_cmdbuf_desc_defaults(const scb_cmdbuf_desc* desc) {
+    scb_cmdbuf_desc res = *desc;
+    res.size = _scb_def(res.size, _SCB_DEFAULT_CMDBUF_SIZE);
+    return res;
+}
+
+
+
+
+#endif // SOKOL_CMDBUF_IMPL

--- a/util/sokol_cmdbuf.h
+++ b/util/sokol_cmdbuf.h
@@ -325,7 +325,7 @@ typedef struct {
     uint8_t* buf;
     uint8_t* cur;
     const uint8_t* end;
-    const uint8_t* cmd_end;
+    const uint8_t* cmd_max_end;
     bool overflown; // tried to encode cmd past end
     _scb_str_t label;
 } _scb_cmdbuf_t;
@@ -702,18 +702,36 @@ static void _scb_enc_blob(_scb_cmdbuf_t* cb, const void* ptr, size_t size) {
     cb->cur += size;
 }
 
-static bool _scb_enc_cmd(_scb_cmdbuf_t* cb, _scb_cmd_t cmd, size_t payload_size) {
-    SOKOL_ASSERT(cb->cmd_end == 0);
+static const uint8_t* _scb_ptr_align16(const uint8_t* ptr) {
+    const uintptr_t align_minus_one = (16 - 1);
+    const uintptr_t mask = ~align_minus_one;
+    return (uint8_t*)(((uintptr_t)ptr + align_minus_one) & mask);
+}
+
+static void _scb_enc_align16(_scb_cmdbuf_t* cb) {
+    uint8_t* ptr16 = (uint8_t*)_scb_ptr_align16(cb->cur);
+    SOKOL_ASSERT((ptr16 >= cb->cur) && (ptr16 < cb->end));
+    for (; cb->cur < ptr16; cb->cur++) {
+        *cb->cur = 0;
+    }
+}
+
+static const uint8_t* _scb_dec_align16(const uint8_t* ptr) {
+    return _scb_ptr_align16(ptr);
+}
+
+static bool _scb_enc_cmd(_scb_cmdbuf_t* cb, _scb_cmd_t cmd, size_t max_payload_size) {
+    SOKOL_ASSERT(cb->cmd_max_end == 0);
     if (cb->overflown) {
         return false;
     }
-    const size_t cmd_payload_size = payload_size + 1;
-    if ((cb->cur + cmd_payload_size) > cb->end) {
+    const size_t max_cmd_payload_size = max_payload_size + 1;
+    if ((cb->cur + max_cmd_payload_size) > cb->end) {
         cb->overflown = true;
         _SCB_ERROR(CMDBUF_OVERFLOW);
         return false;
     }
-    cb->cmd_end = cb->cur + cmd_payload_size;
+    cb->cmd_max_end = cb->cur + max_cmd_payload_size;
     _scb_enc_u8(cb, (uint8_t)cmd);
     return true;
 }
@@ -724,8 +742,8 @@ static const uint8_t* _scb_dec_cmd(const uint8_t* ptr, _scb_cmd_t* out_cmd) {
 }
 
 static void _scb_enc_end(_scb_cmdbuf_t* cb) {
-    SOKOL_ASSERT(cb->cmd_end && (cb->cur == cb->cmd_end));
-    cb->cmd_end = 0;
+    SOKOL_ASSERT(cb->cmd_max_end && (cb->cur <= cb->cmd_max_end));
+    cb->cmd_max_end = 0;
 }
 
 static void _scb_enc_apply_viewport(_scb_cmdbuf_t* cb, int x, int y, int width, int height, bool origin_top_left) {
@@ -951,10 +969,12 @@ static const uint8_t* _scb_dec_apply_bindings(const uint8_t* ptr) {
 static void _scb_enc_apply_uniforms(_scb_cmdbuf_t* cb, int ub_slot, const sg_range* data) {
     SOKOL_ASSERT(data->size <= UINT32_MAX);
     SOKOL_ASSERT((ub_slot >= 0) && (ub_slot < SG_MAX_UNIFORMBLOCK_BINDSLOTS));
-    const size_t payload_size = sizeof(int32_t) + sizeof(uint32_t) + data->size;
-    if (_scb_enc_cmd(cb, _SCB_CMD_APPLY_UNIFORMS, payload_size)) {
+    // NOTE: add max alignment gap of 15 bytes to max payload size
+    const size_t max_payload_size = sizeof(int32_t) + sizeof(uint32_t) + data->size + 15;
+    if (_scb_enc_cmd(cb, _SCB_CMD_APPLY_UNIFORMS, max_payload_size)) {
         _scb_enc_i32(cb, ub_slot);
         _scb_enc_u32(cb, (uint32_t)data->size);
+        _scb_enc_align16(cb);
         _scb_enc_blob(cb, data->ptr, data->size);
         _scb_enc_end(cb);
     }
@@ -966,6 +986,7 @@ static const uint8_t* _scb_dec_apply_uniforms(const uint8_t* ptr) {
     ptr = _scb_dec_i32(ptr, &ub_slot);
     SOKOL_ASSERT((ub_slot >= 0) && (ub_slot < SG_MAX_UNIFORMBLOCK_BINDSLOTS));
     ptr = _scb_dec_u32(ptr, &size_u32);
+    ptr = _scb_dec_align16(ptr);
     sg_range data;
     _scb_clear(&data, sizeof(data));
     data.ptr = ptr;

--- a/util/sokol_cmdbuf.h
+++ b/util/sokol_cmdbuf.h
@@ -85,7 +85,7 @@
             .allocator = {
                 .alloc_fn = my_alloc,
                 .free_fn = my_free,
-                .user_data = ...;
+                .user_data = ...,
             },
             .logger.func = slog_func,
         });
@@ -97,7 +97,7 @@
 
       It often makes sense to provide a specific size in bytes:
 
-        scb_cmdbuf cbuf = scb_make_cmdbuf(&(scb_cmdbuf_desc){
+        scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){
             .size = 128 * 1024,     // 128 kbytes
         });
 
@@ -106,8 +106,8 @@
 
       You can provide a label string for the command buffer:
 
-        scb_cmdbuf cbuf = scb_make_cmdbuf(&(scb_cmdbuf_desc){
-            .label = "dbg-phyiscs",
+        scb_cmdbuf cb = scb_make_cmdbuf(&(scb_cmdbuf_desc){
+            .label = "dbg-physics",
         });
 
       When a label string exists, sokol_cmdbuf.h will wrap submitted commands
@@ -207,7 +207,8 @@
         alignment into the command buffer, the required size is:
 
         1 byte for the command
-        + 4 bytes for the uniform data size
+        + 4 bytes for ub_slot
+        + 4 bytes for the uniform data size (truncated from size_t)
         + up to 3 bytes 'alignment gap'
         + the actual uniform data
 
@@ -218,7 +219,7 @@
         1 byte for the command
         + 8 bytes for the 64-bit occupation bitmask
         + 4 bytes for each valid sg_buffer, sg_view, sg_sampler
-          hande in the sg_bindings struct
+          handle in the sg_bindings struct
         + 4 bytes extra for the buffer offset of each occupied vertex buffer slot
         + 4 bytes extra for the index buffer offset if the index buffer slot is occupied
 
@@ -291,8 +292,8 @@ typedef struct scb_cmdbuf { uint32_t id; } scb_cmdbuf;
     scb_resource_state
 
     The state of a command buffer object, obtainable via scb_query_cmdbuf_state().
-    Publicly visible values are only SCB_RESOURCESTATE_VALID
-    and SCB_RESOURCESTATE_FAILED.
+    Publicly visible values are only SCB_RESOURCESTATE_VALID,
+    SCB_RESOURCESTATE_FAILED and SCB_RESOURCESTATE_INVALID.
 */
 typedef enum scb_resource_state {
     SCB_RESOURCESTATE_INITIAL,
@@ -309,10 +310,14 @@ typedef enum scb_resource_state {
     Creation parameters of a command buffer object. Used
     in scb_make_cmdbuf().
 
-    TODO: information on how to estimate required size
+    See doc section ESTIMATING COMMAND BUFFER SIZES about
+    how command buffer size can be estimated.
+
+    When a label is set, sokol_cmdbuf.h will wrap
+    submitted commands with `sg_push/pop_debug_group()`.
 */
 typedef struct scb_cmdbuf_desc {
-    size_t size;            // command buffer size in bytes (default: 256 * 1024 (256 KBytes))
+    size_t size;        // command buffer size in bytes (default: 256 * 1024 (256 KBytes))
     const char* label;
 } scb_cmdbuf_desc;
 
@@ -385,10 +390,10 @@ typedef struct scb_allocator {
 /*
     scb_desc
 
-    FIXME: docs
+    Initialization options passed into scb_setup.
 */
 typedef struct scb_desc {
-    int cmdbuf_pool_size;       // max number of command buffers that can be alive simultanously (default: 16)
+    int cmdbuf_pool_size;       // max number of command buffers that can be alive simultaneously (default: 16)
     scb_allocator allocator;    // optional memory allocation overrides (default: malloc/free)
     scb_logger logger;          // optional log override functions (default: NO LOGGING)
 } scb_desc;
@@ -428,7 +433,7 @@ SOKOL_CMDBUF_API_DECL void scb_draw_ex(scb_cmdbuf cb, int base_element, int num_
 // record dispatch command
 SOKOL_CMDBUF_API_DECL void scb_dispatch(scb_cmdbuf cb, int num_groups_x, int num_groups_y, int num_groups_z);
 
-// query command buffer resource state (valid or failed)
+// query command buffer resource state (valid, failed, invalid)
 SOKOL_CMDBUF_API_DECL scb_resource_state scb_query_cmdbuf_state(scb_cmdbuf cb);
 // query current command buffer properties
 SOKOL_CMDBUF_API_DECL scb_cmdbuf_info scb_query_cmdbuf_info(scb_cmdbuf cb);

--- a/util/sokol_cmdbuf.h
+++ b/util/sokol_cmdbuf.h
@@ -254,7 +254,7 @@ inline void scb_apply_uniforms(scb_cmdbuf cb, int ub_slot, const sg_range& data)
 #ifdef SOKOL_CMDBUF_IMPL
 #define SOKOL_CMDBUF_IMPL_INCLUDED (1)
 
-#include <string.h> // memset, strncpy
+#include <string.h> // memset, memcpy, strncpy
 #include <stdlib.h> // malloc/free/abort
 
 #ifndef SOKOL_API_IMPL
@@ -625,26 +625,45 @@ static void _scb_enc_u8(_scb_cmdbuf_t* cb, uint8_t val) {
 }
 
 static void _scb_enc_bool(_scb_cmdbuf_t* cb, bool val) {
-    SOKOL_ASSERT((cb->cur + 1) <= cb->end);
+    SOKOL_ASSERT((cb->cur + sizeof(uint8_t)) <= cb->end);
     *cb->cur++ = (uint8_t)val;
 }
 
-static void _scb_enc_int(_scb_cmdbuf_t* cb, int val) {
-    SOKOL_ASSERT((cb->cur + 4) <= cb->end);
+static void _scb_enc_i32(_scb_cmdbuf_t* cb, int32_t val) {
+    SOKOL_ASSERT((cb->cur + sizeof(int32_t)) <= cb->end);
     cb->cur[0] = (uint8_t)val;
     cb->cur[1] = (uint8_t)(val >> 8);
     cb->cur[2] = (uint8_t)(val >> 16);
     cb->cur[3] = (uint8_t)(val >> 24);
-    cb->cur += 4;
+    cb->cur += sizeof(int32_t);
 }
 
 static void _scb_enc_u32(_scb_cmdbuf_t* cb, uint32_t val) {
-    SOKOL_ASSERT((cb->cur + 4) <= cb->end);
+    SOKOL_ASSERT((cb->cur + sizeof(uint32_t)) <= cb->end);
     cb->cur[0] = (uint8_t)val;
     cb->cur[1] = (uint8_t)(val >> 8);
     cb->cur[2] = (uint8_t)(val >> 16);
     cb->cur[3] = (uint8_t)(val >> 24);
-    cb->cur += 4;
+    cb->cur += sizeof(uint32_t);
+}
+
+static void _scb_enc_u64(_scb_cmdbuf_t* cb, uint64_t val) {
+    SOKOL_ASSERT((cb->cur + sizeof(uint64_t)) <= cb->end);
+    cb->cur[0] = (uint8_t)val;
+    cb->cur[1] = (uint8_t)(val >> 8);
+    cb->cur[2] = (uint8_t)(val >> 16);
+    cb->cur[3] = (uint8_t)(val >> 24);
+    cb->cur[4] = (uint8_t)(val >> 32);
+    cb->cur[5] = (uint8_t)(val >> 40);
+    cb->cur[6] = (uint8_t)(val >> 48);
+    cb->cur[7] = (uint8_t)(val >> 56);
+    cb->cur += sizeof(uint64_t);
+}
+
+static void _scb_enc_blob(_scb_cmdbuf_t* cb, const void* ptr, size_t size) {
+    SOKOL_ASSERT((cb->cur + size) <= cb->end);
+    memcpy(cb->cur, ptr, size);
+    cb->cur += size;
 }
 
 static bool _scb_enc_cmd(_scb_cmdbuf_t* cb, _scb_cmd_t cmd, size_t payload_size) {
@@ -669,24 +688,24 @@ static void _scb_enc_end(_scb_cmdbuf_t* cb) {
 }
 
 static void _scb_enc_apply_viewport(_scb_cmdbuf_t* cb, int x, int y, int width, int height, bool origin_top_left) {
-    const size_t payload_size = 4 * sizeof(int) + sizeof(uint8_t);
+    const size_t payload_size = 4 * sizeof(int32_t) + sizeof(uint8_t);
     if (_scb_enc_cmd(cb, _SCB_CMD_APPLY_VIEWPORT, payload_size)) {
-        _scb_enc_int(cb, x);
-        _scb_enc_int(cb, y);
-        _scb_enc_int(cb, width);
-        _scb_enc_int(cb, height);
+        _scb_enc_i32(cb, x);
+        _scb_enc_i32(cb, y);
+        _scb_enc_i32(cb, width);
+        _scb_enc_i32(cb, height);
         _scb_enc_bool(cb, origin_top_left);
         _scb_enc_end(cb);
     }
 }
 
 static void _scb_enc_apply_scissor_rect(_scb_cmdbuf_t* cb, int x, int y, int width, int height, bool origin_top_left) {
-    const size_t payload_size = 4 * sizeof(int) + sizeof(uint8_t);
+    const size_t payload_size = 4 * sizeof(int32_t) + sizeof(uint8_t);
     if (_scb_enc_cmd(cb, _SCB_CMD_APPLY_SCISSOR_RECT, payload_size)) {
-        _scb_enc_int(cb, x);
-        _scb_enc_int(cb, y);
-        _scb_enc_int(cb, width);
-        _scb_enc_int(cb, height);
+        _scb_enc_i32(cb, x);
+        _scb_enc_i32(cb, y);
+        _scb_enc_i32(cb, width);
+        _scb_enc_i32(cb, height);
         _scb_enc_bool(cb, origin_top_left);
         _scb_enc_end(cb);
     }
@@ -701,33 +720,108 @@ static void _scb_enc_apply_pipeline(_scb_cmdbuf_t* cb, uint32_t pip_id) {
 }
 
 static void _scb_enc_draw(_scb_cmdbuf_t* cb, int base_element, int num_elements, int num_instances) {
-    const size_t payload_size = 3 * sizeof(int);
+    const size_t payload_size = 3 * sizeof(int32_t);
     if (_scb_enc_cmd(cb, _SCB_CMD_DRAW, payload_size)) {
-        _scb_enc_int(cb, base_element);
-        _scb_enc_int(cb, num_elements);
-        _scb_enc_int(cb, num_instances);
+        _scb_enc_i32(cb, base_element);
+        _scb_enc_i32(cb, num_elements);
+        _scb_enc_i32(cb, num_instances);
         _scb_enc_end(cb);
     }
 }
 
 static void _scb_enc_draw_ex(_scb_cmdbuf_t* cb, int base_element, int num_elements, int num_instances, int base_vertex, int base_instance) {
-    const size_t payload_size = 5 * sizeof(int);
+    const size_t payload_size = 5 * sizeof(int32_t);
     if (_scb_enc_cmd(cb, _SCB_CMD_DRAW_EX, payload_size)) {
-        _scb_enc_int(cb, base_element);
-        _scb_enc_int(cb, num_elements);
-        _scb_enc_int(cb, num_instances);
-        _scb_enc_int(cb, base_vertex);
-        _scb_enc_int(cb, base_instance);
+        _scb_enc_i32(cb, base_element);
+        _scb_enc_i32(cb, num_elements);
+        _scb_enc_i32(cb, num_instances);
+        _scb_enc_i32(cb, base_vertex);
+        _scb_enc_i32(cb, base_instance);
         _scb_enc_end(cb);
     }
 }
 
 static void _scb_enc_dispatch(_scb_cmdbuf_t* cb, int num_groups_x, int num_groups_y, int num_groups_z) {
-    const size_t payload_size = 3 * sizeof(int);
+    const size_t payload_size = 3 * sizeof(int32_t);
     if (_scb_enc_cmd(cb, _SCB_CMD_DISPATCH, payload_size)) {
-        _scb_enc_int(cb, num_groups_x);
-        _scb_enc_int(cb, num_groups_y);
-        _scb_enc_int(cb, num_groups_z);
+        _scb_enc_i32(cb, num_groups_x);
+        _scb_enc_i32(cb, num_groups_y);
+        _scb_enc_i32(cb, num_groups_z);
+        _scb_enc_end(cb);
+    }
+}
+
+static void _scb_enc_apply_bindings(_scb_cmdbuf_t* cb, const sg_bindings* bindings) {
+    // create an occupied slot mask and compute payload size
+    size_t payload_size = 0;
+    uint64_t slot_mask = 0;
+    const int vb_start = 0;
+    const int ib_start = vb_start + SG_MAX_VERTEXBUFFER_BINDSLOTS;
+    const int view_start = ib_start + 1;
+    const int smp_start = view_start + SG_MAX_VIEW_BINDSLOTS;
+    SOKOL_ASSERT((smp_start + SG_MAX_SAMPLER_BINDSLOTS) <= 64);
+    // vertex buffer handles and offsets
+    for (int i = 0; i < SG_MAX_VERTEXBUFFER_BINDSLOTS; i++) {
+        if (bindings->vertex_buffers[i].id != SG_INVALID_ID) {
+            slot_mask |= (1ULL << (i + vb_start));
+            payload_size += sizeof(uint32_t) + sizeof(int);
+        }
+    }
+    // index buffer handle and offset
+    if (bindings->index_buffer.id != SG_INVALID_ID) {
+        slot_mask |= (1ULL << ib_start);
+        payload_size += sizeof(uint32_t) + sizeof(int);
+    }
+    // view handles
+    for (int i = 0; i < SG_MAX_VIEW_BINDSLOTS; i++) {
+        if (bindings->views[i].id != SG_INVALID_ID) {
+            slot_mask |= (1ULL << (view_start + i));
+            payload_size += sizeof(uint32_t);
+        }
+    }
+    // sampler handles
+    for (int i = 0; i < SG_MAX_SAMPLER_BINDSLOTS; i++) {
+        if (bindings->samplers[i].id != SG_INVALID_ID) {
+            slot_mask |= (1ULL << (smp_start + i));
+            payload_size += sizeof(uint32_t);
+        }
+    }
+    // the slot_mask is part of the payload
+    payload_size += sizeof(slot_mask);
+    if (_scb_enc_cmd(cb, _SCB_CMD_APPLY_BINDINGS, payload_size)) {
+        _scb_enc_u64(cb, slot_mask);
+        for (int i = 0; i < SG_MAX_VERTEXBUFFER_BINDSLOTS; i++) {
+            if (bindings->vertex_buffers[i].id != SG_INVALID_ID) {
+                _scb_enc_u32(cb, bindings->vertex_buffers[i].id);
+                _scb_enc_i32(cb, bindings->vertex_buffer_offsets[i]);
+            }
+        }
+        if (bindings->index_buffer.id != SG_INVALID_ID) {
+            _scb_enc_u32(cb, bindings->index_buffer.id);
+            _scb_enc_i32(cb, bindings->index_buffer_offset);
+        }
+        for (int i = 0; i < SG_MAX_VIEW_BINDSLOTS; i++) {
+            if (bindings->views[i].id != SG_INVALID_ID) {
+                _scb_enc_u32(cb, bindings->views[i].id);
+            }
+        }
+        for (int i = 0; i < SG_MAX_SAMPLER_BINDSLOTS; i++) {
+            if (bindings->samplers[i].id != SG_INVALID_ID) {
+                _scb_enc_u32(cb, bindings->samplers[i].id);
+            }
+        }
+        _scb_enc_end(cb);
+    }
+}
+
+static void _scb_enc_apply_uniforms(_scb_cmdbuf_t* cb, int ub_slot, const sg_range* data) {
+    SOKOL_ASSERT(data->size <= UINT32_MAX);
+    SOKOL_ASSERT((ub_slot >= 0) && (ub_slot < SG_MAX_UNIFORMBLOCK_BINDSLOTS));
+    const size_t payload_size = sizeof(int32_t) + sizeof(uint32_t) + data->size;
+    if (_scb_enc_cmd(cb, _SCB_CMD_APPLY_UNIFORMS, payload_size)) {
+        _scb_enc_i32(cb, ub_slot);
+        _scb_enc_u32(cb, (uint32_t)data->size);
+        _scb_enc_blob(cb, data->ptr, data->size);
         _scb_enc_end(cb);
     }
 }
@@ -837,6 +931,24 @@ SOKOL_API_IMPL void scb_apply_pipeline(scb_cmdbuf cb_id, sg_pipeline pip) {
     _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
     if (_scb_cmdbuf_valid(cb)) {
         _scb_enc_apply_pipeline(cb, pip.id);
+    }
+}
+
+SOKOL_API_IMPL void scb_apply_bindings(scb_cmdbuf cb_id, const sg_bindings* bindings) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    SOKOL_ASSERT(bindings);
+    _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
+    if (_scb_cmdbuf_valid(cb)) {
+        _scb_enc_apply_bindings(cb, bindings);
+    }
+}
+
+SOKOL_API_IMPL void scb_apply_uniforms(scb_cmdbuf cb_id, int ub_slot, const sg_range* data) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    SOKOL_ASSERT(data && data->ptr && (data->size > 0));
+    _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
+    if (_scb_cmdbuf_valid(cb)) {
+        _scb_enc_apply_uniforms(cb, ub_slot, data);
     }
 }
 

--- a/util/sokol_cmdbuf.h
+++ b/util/sokol_cmdbuf.h
@@ -215,6 +215,8 @@ SOKOL_CMDBUF_API_DECL scb_cmdbuf scb_make_cmdbuf(const scb_cmdbuf_desc* desc);
 SOKOL_CMDBUF_API_DECL void scb_destroy_cmdbuf(scb_cmdbuf cb);
 // submit command buffer to sokol-gfx and rewind the command buffer (call inside a sokol-gfx pass)
 SOKOL_CMDBUF_API_DECL void scb_submit(scb_cmdbuf cb);
+// reset a recorded command buffer, discarding its content
+SOKOL_CMDBUF_API_DECL void scb_reset(scb_cmdbuf cb);
 
 // record apply-viewport command (integer variant)
 SOKOL_CMDBUF_API_DECL void scb_apply_viewport(scb_cmdbuf cb, int x, int y, int width, int height, bool origin_top_left);
@@ -1234,4 +1236,13 @@ SOKOL_API_IMPL void scb_submit(scb_cmdbuf cb_id) {
     }
 }
 
+SOKOL_API_IMPL void scb_reset(scb_cmdbuf cb_id) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
+    if (!_scb_cmdbuf_valid(cb)) {
+        _SCB_ERROR(CMDBUF_NOT_VALID);
+        return;
+    }
+    _scb_rewind(cb);
+}
 #endif // SOKOL_CMDBUF_IMPL

--- a/util/sokol_cmdbuf.h
+++ b/util/sokol_cmdbuf.h
@@ -1168,6 +1168,10 @@ SOKOL_API_IMPL void scb_submit(scb_cmdbuf cb_id) {
     SOKOL_ASSERT(cb->cur);
     SOKOL_ASSERT(cb->buf <= cb->cur);
     const uint8_t* ptr = cb->buf;
+    bool has_label = cb->label.buf[0] != 0;
+    if (has_label) {
+        sg_push_debug_group(cb->label.buf);
+    }
     while (ptr < cb->cur) {
         _scb_cmd_t cmd = _SCB_CMD_NONE;
         ptr = _scb_dec_cmd(ptr, &cmd);
@@ -1204,6 +1208,9 @@ SOKOL_API_IMPL void scb_submit(scb_cmdbuf cb_id) {
         }
     }
     _scb_rewind(cb);
+    if (has_label) {
+        sg_pop_debug_group();
+    }
 }
 
 #endif // SOKOL_CMDBUF_IMPL

--- a/util/sokol_cmdbuf.h
+++ b/util/sokol_cmdbuf.h
@@ -151,6 +151,9 @@ typedef struct scb_cmdbuf_info {
     _SCB_LOGITEM_XMACRO(OK, "Ok") \
     _SCB_LOGITEM_XMACRO(MALLOC_FAILED, "memory allocation failed") \
     _SCB_LOGITEM_XMACRO(CMDBUF_OVERFLOW, "command buffer has overflown") \
+    _SCB_LOGITEM_XMACRO(CMDBUF_NOT_VALID, "command buffer no longer exists or invalid handle") \
+    _SCB_LOGITEM_XMACRO(SUBMIT_CMDBUF_OVERFLOWN, "scb_submit: command buffer was overflown") \
+    _SCB_LOGITEM_XMACRO(SUBMIT_INVALID_COMMAND, "scb_submit: invalid command (command buffer corrupted?)") \
 
 #define _SCB_LOGITEM_XMACRO(item,msg) SCB_LOGITEM_##item,
 typedef enum scb_log_item {
@@ -210,7 +213,7 @@ SOKOL_CMDBUF_API_DECL void scb_shutdown(void);
 SOKOL_CMDBUF_API_DECL scb_cmdbuf scb_make_cmdbuf(const scb_cmdbuf_desc* desc);
 // destroy cmdbuf object
 SOKOL_CMDBUF_API_DECL void scb_destroy_cmdbuf(scb_cmdbuf cb);
-// submit command buffer to sokol-gfx (call inside a sokol-gfx pass)
+// submit command buffer to sokol-gfx and rewind the command buffer (call inside a sokol-gfx pass)
 SOKOL_CMDBUF_API_DECL void scb_submit(scb_cmdbuf cb);
 
 // record apply-viewport command (integer variant)
@@ -620,13 +623,18 @@ static bool _scb_cmdbuf_valid(_scb_cmdbuf_t* cb) {
 }
 
 static void _scb_enc_u8(_scb_cmdbuf_t* cb, uint8_t val) {
-    SOKOL_ASSERT((cb->cur + 1) <= cb->end);
+    SOKOL_ASSERT((cb->cur + sizeof(uint8_t)) <= cb->end);
     *cb->cur++ = val;
 }
 
 static void _scb_enc_bool(_scb_cmdbuf_t* cb, bool val) {
     SOKOL_ASSERT((cb->cur + sizeof(uint8_t)) <= cb->end);
     *cb->cur++ = (uint8_t)val;
+}
+
+static const uint8_t* _scb_dec_bool(const uint8_t* ptr, bool* out_val) {
+    *out_val = (bool)(*ptr++);
+    return ptr;
 }
 
 static void _scb_enc_i32(_scb_cmdbuf_t* cb, int32_t val) {
@@ -638,6 +646,14 @@ static void _scb_enc_i32(_scb_cmdbuf_t* cb, int32_t val) {
     cb->cur += sizeof(int32_t);
 }
 
+static const uint8_t* _scb_dec_i32(const uint8_t* ptr, int32_t* out_val) {
+    *out_val = (int32_t)((uint32_t)ptr[0]
+        | ((uint32_t)ptr[1]<<8)
+        | ((uint32_t)ptr[2]<<16)
+        | ((uint32_t)ptr[3]<<24));
+    return ptr + sizeof(int32_t);
+}
+
 static void _scb_enc_u32(_scb_cmdbuf_t* cb, uint32_t val) {
     SOKOL_ASSERT((cb->cur + sizeof(uint32_t)) <= cb->end);
     cb->cur[0] = (uint8_t)val;
@@ -645,6 +661,14 @@ static void _scb_enc_u32(_scb_cmdbuf_t* cb, uint32_t val) {
     cb->cur[2] = (uint8_t)(val >> 16);
     cb->cur[3] = (uint8_t)(val >> 24);
     cb->cur += sizeof(uint32_t);
+}
+
+static const uint8_t* _scb_dec_u32(const uint8_t* ptr, uint32_t* out_val) {
+    *out_val = (uint32_t)ptr[0]
+        | ((uint32_t)ptr[1]<<8)
+        | ((uint32_t)ptr[2]<<16)
+        | ((uint32_t)ptr[3]<<24);
+    return ptr + sizeof(uint32_t);
 }
 
 static void _scb_enc_u64(_scb_cmdbuf_t* cb, uint64_t val) {
@@ -658,6 +682,18 @@ static void _scb_enc_u64(_scb_cmdbuf_t* cb, uint64_t val) {
     cb->cur[6] = (uint8_t)(val >> 48);
     cb->cur[7] = (uint8_t)(val >> 56);
     cb->cur += sizeof(uint64_t);
+}
+
+static const uint8_t* _scb_dec_u64(const uint8_t* ptr, uint64_t* out_val) {
+    *out_val = (uint64_t)ptr[0]
+        | ((uint64_t)ptr[1]<<8)
+        | ((uint64_t)ptr[2]<<16)
+        | ((uint64_t)ptr[3]<<24)
+        | ((uint64_t)ptr[4]<<32)
+        | ((uint64_t)ptr[5]<<40)
+        | ((uint64_t)ptr[6]<<48)
+        | ((uint64_t)ptr[7]<<56);
+    return ptr + sizeof(uint64_t);
 }
 
 static void _scb_enc_blob(_scb_cmdbuf_t* cb, const void* ptr, size_t size) {
@@ -682,6 +718,11 @@ static bool _scb_enc_cmd(_scb_cmdbuf_t* cb, _scb_cmd_t cmd, size_t payload_size)
     return true;
 }
 
+static const uint8_t* _scb_dec_cmd(const uint8_t* ptr, _scb_cmd_t* out_cmd) {
+    *out_cmd = (_scb_cmd_t)(*ptr++);
+    return ptr;
+}
+
 static void _scb_enc_end(_scb_cmdbuf_t* cb) {
     SOKOL_ASSERT(cb->cmd_end && (cb->cur == cb->cmd_end));
     cb->cmd_end = 0;
@@ -699,6 +740,18 @@ static void _scb_enc_apply_viewport(_scb_cmdbuf_t* cb, int x, int y, int width, 
     }
 }
 
+static const uint8_t* _scb_dec_apply_viewport(const uint8_t* ptr) {
+    int x, y, width, height;
+    bool origin_top_left;
+    ptr = _scb_dec_i32(ptr, &x);
+    ptr = _scb_dec_i32(ptr, &y);
+    ptr = _scb_dec_i32(ptr, &width);
+    ptr = _scb_dec_i32(ptr, &height);
+    ptr = _scb_dec_bool(ptr, &origin_top_left);
+    sg_apply_viewport(x, y, width, height, origin_top_left);
+    return ptr;
+}
+
 static void _scb_enc_apply_scissor_rect(_scb_cmdbuf_t* cb, int x, int y, int width, int height, bool origin_top_left) {
     const size_t payload_size = 4 * sizeof(int32_t) + sizeof(uint8_t);
     if (_scb_enc_cmd(cb, _SCB_CMD_APPLY_SCISSOR_RECT, payload_size)) {
@@ -711,12 +764,31 @@ static void _scb_enc_apply_scissor_rect(_scb_cmdbuf_t* cb, int x, int y, int wid
     }
 }
 
+static const uint8_t* _scb_dec_apply_scissor_rect(const uint8_t* ptr) {
+    int x, y, width, height;
+    bool origin_top_left;
+    ptr = _scb_dec_i32(ptr, &x);
+    ptr = _scb_dec_i32(ptr, &y);
+    ptr = _scb_dec_i32(ptr, &width);
+    ptr = _scb_dec_i32(ptr, &height);
+    ptr = _scb_dec_bool(ptr, &origin_top_left);
+    sg_apply_scissor_rect(x, y, width, height, origin_top_left);
+    return ptr;
+}
+
 static void _scb_enc_apply_pipeline(_scb_cmdbuf_t* cb, uint32_t pip_id) {
     const size_t payload_size = sizeof(uint32_t);
     if (_scb_enc_cmd(cb, _SCB_CMD_APPLY_PIPELINE, payload_size)) {
         _scb_enc_u32(cb, pip_id);
         _scb_enc_end(cb);
     }
+}
+
+static const uint8_t* _scb_dec_apply_pipeline(const uint8_t* ptr) {
+    sg_pipeline pip;
+    ptr = _scb_dec_u32(ptr, &pip.id);
+    sg_apply_pipeline(pip);
+    return ptr;
 }
 
 static void _scb_enc_draw(_scb_cmdbuf_t* cb, int base_element, int num_elements, int num_instances) {
@@ -727,6 +799,15 @@ static void _scb_enc_draw(_scb_cmdbuf_t* cb, int base_element, int num_elements,
         _scb_enc_i32(cb, num_instances);
         _scb_enc_end(cb);
     }
+}
+
+static const uint8_t* _scb_dec_draw(const uint8_t* ptr) {
+    int base_element, num_elements, num_instances;
+    ptr = _scb_dec_i32(ptr, &base_element);
+    ptr = _scb_dec_i32(ptr, &num_elements);
+    ptr = _scb_dec_i32(ptr, &num_instances);
+    sg_draw(base_element, num_elements, num_instances);
+    return ptr;
 }
 
 static void _scb_enc_draw_ex(_scb_cmdbuf_t* cb, int base_element, int num_elements, int num_instances, int base_vertex, int base_instance) {
@@ -741,6 +822,17 @@ static void _scb_enc_draw_ex(_scb_cmdbuf_t* cb, int base_element, int num_elemen
     }
 }
 
+static const uint8_t* _scb_dec_draw_ex(const uint8_t* ptr) {
+    int base_element, num_elements, num_instances, base_vertex, base_instance;
+    ptr = _scb_dec_i32(ptr, &base_element);
+    ptr = _scb_dec_i32(ptr, &num_elements);
+    ptr = _scb_dec_i32(ptr, &num_instances);
+    ptr = _scb_dec_i32(ptr, &base_vertex);
+    ptr = _scb_dec_i32(ptr, &base_instance);
+    sg_draw_ex(base_element, num_elements, num_instances, base_vertex, base_instance);
+    return ptr;
+}
+
 static void _scb_enc_dispatch(_scb_cmdbuf_t* cb, int num_groups_x, int num_groups_y, int num_groups_z) {
     const size_t payload_size = 3 * sizeof(int32_t);
     if (_scb_enc_cmd(cb, _SCB_CMD_DISPATCH, payload_size)) {
@@ -749,6 +841,15 @@ static void _scb_enc_dispatch(_scb_cmdbuf_t* cb, int num_groups_x, int num_group
         _scb_enc_i32(cb, num_groups_z);
         _scb_enc_end(cb);
     }
+}
+
+static const uint8_t* _scb_dec_dispatch(const uint8_t* ptr) {
+    int num_groups_x, num_groups_y, num_groups_z;
+    ptr = _scb_dec_i32(ptr, &num_groups_x);
+    ptr = _scb_dec_i32(ptr, &num_groups_y);
+    ptr = _scb_dec_i32(ptr, &num_groups_z);
+    sg_dispatch(num_groups_x, num_groups_y, num_groups_z);
+    return ptr;
 }
 
 static void _scb_enc_apply_bindings(_scb_cmdbuf_t* cb, const sg_bindings* bindings) {
@@ -814,6 +915,39 @@ static void _scb_enc_apply_bindings(_scb_cmdbuf_t* cb, const sg_bindings* bindin
     }
 }
 
+static const uint8_t* _scb_dec_apply_bindings(const uint8_t* ptr) {
+    const int vb_start = 0;
+    const int ib_start = vb_start + SG_MAX_VERTEXBUFFER_BINDSLOTS;
+    const int view_start = ib_start + 1;
+    const int smp_start = view_start + SG_MAX_VIEW_BINDSLOTS;
+    uint64_t slot_mask;
+    ptr = _scb_dec_u64(ptr, &slot_mask);
+    sg_bindings bnd;
+    _scb_clear(&bnd, sizeof(bnd));
+    for (int i = 0; i < SG_MAX_VERTEXBUFFER_BINDSLOTS; i++) {
+        if (slot_mask & (1ULL << (i + vb_start))) {
+            ptr = _scb_dec_u32(ptr, &bnd.vertex_buffers[i].id);
+            ptr = _scb_dec_i32(ptr, &bnd.vertex_buffer_offsets[i]);
+        }
+    }
+    if (slot_mask & (1ULL << ib_start)) {
+        ptr = _scb_dec_u32(ptr, &bnd.index_buffer.id);
+        ptr = _scb_dec_i32(ptr, &bnd.index_buffer_offset);
+    }
+    for (int i = 0; i < SG_MAX_VIEW_BINDSLOTS; i++) {
+        if (slot_mask & (1ULL << (i + view_start))) {
+            ptr = _scb_dec_u32(ptr, &bnd.views[i].id);
+        }
+    }
+    for (int i = 0; i < SG_MAX_SAMPLER_BINDSLOTS; i++) {
+        if (slot_mask & (1ULL << (i + smp_start))) {
+            ptr = _scb_dec_u32(ptr, &bnd.samplers[i].id);
+        }
+    }
+    sg_apply_bindings(&bnd);
+    return ptr;
+}
+
 static void _scb_enc_apply_uniforms(_scb_cmdbuf_t* cb, int ub_slot, const sg_range* data) {
     SOKOL_ASSERT(data->size <= UINT32_MAX);
     SOKOL_ASSERT((ub_slot >= 0) && (ub_slot < SG_MAX_UNIFORMBLOCK_BINDSLOTS));
@@ -824,6 +958,28 @@ static void _scb_enc_apply_uniforms(_scb_cmdbuf_t* cb, int ub_slot, const sg_ran
         _scb_enc_blob(cb, data->ptr, data->size);
         _scb_enc_end(cb);
     }
+}
+
+static const uint8_t* _scb_dec_apply_uniforms(const uint8_t* ptr) {
+    int ub_slot;
+    uint32_t size_u32;
+    ptr = _scb_dec_i32(ptr, &ub_slot);
+    SOKOL_ASSERT((ub_slot >= 0) && (ub_slot < SG_MAX_UNIFORMBLOCK_BINDSLOTS));
+    ptr = _scb_dec_u32(ptr, &size_u32);
+    sg_range data;
+    _scb_clear(&data, sizeof(data));
+    data.ptr = ptr;
+    data.size = size_u32;
+    sg_apply_uniforms(ub_slot, &data);
+    return ptr + size_u32;
+}
+
+static void _scb_rewind(_scb_cmdbuf_t* cb) {
+    SOKOL_ASSERT(cb->cur);
+    SOKOL_ASSERT(cb->buf);
+    SOKOL_ASSERT(cb->cur >= cb->buf);
+    cb->cur = cb->buf;
+    cb->overflown = false;
 }
 
 // >>public
@@ -897,83 +1053,157 @@ SOKOL_API_IMPL scb_cmdbuf_info scb_query_cmdbuf_info(scb_cmdbuf cb_id) {
 SOKOL_API_IMPL void scb_apply_viewport(scb_cmdbuf cb_id, int x, int y, int width, int height, bool origin_top_left) {
     SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
     _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
-    if (_scb_cmdbuf_valid(cb)) {
-        _scb_enc_apply_viewport(cb, x, y, width, height, origin_top_left);
+    if (!_scb_cmdbuf_valid(cb)) {
+        _SCB_ERROR(CMDBUF_NOT_VALID);
+        return;
     }
+    _scb_enc_apply_viewport(cb, x, y, width, height, origin_top_left);
 }
 
 SOKOL_API_IMPL void scb_apply_viewportf(scb_cmdbuf cb_id, float x, float y, float width, float height, bool origin_top_left) {
     SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
     _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
-    if (_scb_cmdbuf_valid(cb)) {
-        _scb_enc_apply_viewport(cb, (int)x, (int)y, (int)width, (int)height, origin_top_left);
+    if (!_scb_cmdbuf_valid(cb)) {
+        _SCB_ERROR(CMDBUF_NOT_VALID);
+        return;
     }
+    _scb_enc_apply_viewport(cb, (int)x, (int)y, (int)width, (int)height, origin_top_left);
 }
 
 SOKOL_API_IMPL void scb_apply_scissor_rect(scb_cmdbuf cb_id, int x, int y, int width, int height, bool origin_top_left) {
     SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
     _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
-    if (_scb_cmdbuf_valid(cb)) {
-        _scb_enc_apply_scissor_rect(cb, x, y, width, height, origin_top_left);
+    if (!_scb_cmdbuf_valid(cb)) {
+        _SCB_ERROR(CMDBUF_NOT_VALID);
+        return;
     }
+    _scb_enc_apply_scissor_rect(cb, x, y, width, height, origin_top_left);
 }
 
 SOKOL_API_IMPL void scb_apply_scissor_rectf(scb_cmdbuf cb_id, float x, float y, float width, float height, bool origin_top_left) {
     SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
     _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
-    if (_scb_cmdbuf_valid(cb)) {
-        _scb_enc_apply_scissor_rect(cb, (int)x, (int)y, (int)width, (int)height, origin_top_left);
+    if (!_scb_cmdbuf_valid(cb)) {
+        _SCB_ERROR(CMDBUF_NOT_VALID);
+        return;
     }
+    _scb_enc_apply_scissor_rect(cb, (int)x, (int)y, (int)width, (int)height, origin_top_left);
 }
 
 SOKOL_API_IMPL void scb_apply_pipeline(scb_cmdbuf cb_id, sg_pipeline pip) {
     SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
     _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
-    if (_scb_cmdbuf_valid(cb)) {
-        _scb_enc_apply_pipeline(cb, pip.id);
+    if (!_scb_cmdbuf_valid(cb)) {
+        _SCB_ERROR(CMDBUF_NOT_VALID);
+        return;
     }
+    _scb_enc_apply_pipeline(cb, pip.id);
 }
 
 SOKOL_API_IMPL void scb_apply_bindings(scb_cmdbuf cb_id, const sg_bindings* bindings) {
     SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
     SOKOL_ASSERT(bindings);
     _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
-    if (_scb_cmdbuf_valid(cb)) {
-        _scb_enc_apply_bindings(cb, bindings);
+    if (!_scb_cmdbuf_valid(cb)) {
+        _SCB_ERROR(CMDBUF_NOT_VALID);
+        return;
     }
+    _scb_enc_apply_bindings(cb, bindings);
 }
 
 SOKOL_API_IMPL void scb_apply_uniforms(scb_cmdbuf cb_id, int ub_slot, const sg_range* data) {
     SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
     SOKOL_ASSERT(data && data->ptr && (data->size > 0));
     _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
-    if (_scb_cmdbuf_valid(cb)) {
-        _scb_enc_apply_uniforms(cb, ub_slot, data);
+    if (!_scb_cmdbuf_valid(cb)) {
+        _SCB_ERROR(CMDBUF_NOT_VALID);
+        return;
     }
+    _scb_enc_apply_uniforms(cb, ub_slot, data);
 }
 
 SOKOL_API_IMPL void scb_draw(scb_cmdbuf cb_id, int base_element, int num_elements, int num_instances) {
     SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
     _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
-    if (_scb_cmdbuf_valid(cb)) {
-        _scb_enc_draw(cb, base_element, num_elements, num_instances);
+    if (!_scb_cmdbuf_valid(cb)) {
+        _SCB_ERROR(CMDBUF_NOT_VALID);
+        return;
     }
+    _scb_enc_draw(cb, base_element, num_elements, num_instances);
 }
 
 SOKOL_API_IMPL void scb_draw_ex(scb_cmdbuf cb_id, int base_element, int num_elements, int num_instances, int base_vertex, int base_instance) {
     SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
     _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
-    if (_scb_cmdbuf_valid(cb)) {
-        _scb_enc_draw_ex(cb, base_element, num_elements, num_instances, base_vertex, base_instance);
+    if (!_scb_cmdbuf_valid(cb)) {
+        _SCB_ERROR(CMDBUF_NOT_VALID);
+        return;
     }
+    _scb_enc_draw_ex(cb, base_element, num_elements, num_instances, base_vertex, base_instance);
 }
 
 SOKOL_API_IMPL void scb_dispatch(scb_cmdbuf cb_id, int num_groups_x, int num_groups_y, int num_groups_z) {
     SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
     _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
-    if (_scb_cmdbuf_valid(cb)) {
-        _scb_enc_dispatch(cb, num_groups_x, num_groups_y, num_groups_z);
+    if (!_scb_cmdbuf_valid(cb)) {
+        _SCB_ERROR(CMDBUF_NOT_VALID);
+        return;
     }
+    _scb_enc_dispatch(cb, num_groups_x, num_groups_y, num_groups_z);
+}
+
+SOKOL_API_IMPL void scb_submit(scb_cmdbuf cb_id) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
+    if (!_scb_cmdbuf_valid(cb)) {
+        _SCB_ERROR(CMDBUF_NOT_VALID);
+        return;
+    }
+    if (cb->overflown) {
+        _SCB_ERROR(SUBMIT_CMDBUF_OVERFLOWN);
+        _scb_rewind(cb);
+        return;
+    }
+    SOKOL_ASSERT(cb->buf);
+    SOKOL_ASSERT(cb->cur);
+    SOKOL_ASSERT(cb->buf <= cb->cur);
+    const uint8_t* ptr = cb->buf;
+    while (ptr < cb->cur) {
+        _scb_cmd_t cmd = _SCB_CMD_NONE;
+        ptr = _scb_dec_cmd(ptr, &cmd);
+        switch (cmd) {
+            case _SCB_CMD_APPLY_VIEWPORT:
+                ptr = _scb_dec_apply_viewport(ptr);
+                break;
+            case _SCB_CMD_APPLY_SCISSOR_RECT:
+                ptr = _scb_dec_apply_scissor_rect(ptr);
+                break;
+            case _SCB_CMD_APPLY_PIPELINE:
+                ptr = _scb_dec_apply_pipeline(ptr);
+                break;
+            case _SCB_CMD_APPLY_BINDINGS:
+                ptr = _scb_dec_apply_bindings(ptr);
+                break;
+            case _SCB_CMD_APPLY_UNIFORMS:
+                ptr = _scb_dec_apply_uniforms(ptr);
+                break;
+            case _SCB_CMD_DRAW:
+                ptr = _scb_dec_draw(ptr);
+                break;
+            case _SCB_CMD_DRAW_EX:
+                ptr = _scb_dec_draw_ex(ptr);
+                break;
+            case _SCB_CMD_DISPATCH:
+                ptr = _scb_dec_dispatch(ptr);
+                break;
+            default:
+                _SCB_ERROR(SUBMIT_INVALID_COMMAND);
+                // break loop
+                ptr = cb->cur;
+                break;
+        }
+    }
+    _scb_rewind(cb);
 }
 
 #endif // SOKOL_CMDBUF_IMPL

--- a/util/sokol_cmdbuf.h
+++ b/util/sokol_cmdbuf.h
@@ -244,7 +244,10 @@ SOKOL_CMDBUF_API_DECL scb_cmdbuf_desc scb_query_cmdbuf_desc(scb_cmdbuf cb);
 #ifdef __cplusplus
 } // extern "C"
 // C++ const-ref wrappers
-FIXME
+inline void scb_setup(const scb_desc& desc) { return scb_setup(&desc); }
+inline scb_cmdbuf scb_make_cmdbuf(const scb_cmdbuf_desc& desc) { return scb_make_cmdbuf(&desc); }
+inline void scb_apply_bindings(scb_cmdbuf cb, const sg_bindings& bindings) { return scb_apply_bindings(cb, &bindings); }
+inline void scb_apply_uniforms(scb_cmdbuf cb, int ub_slot, const sg_range& data) { return scb_apply_uniforms(cb, ub_slot, &data); }
 #endif
 #endif /* SOKOL_CMDBUF_INCLUDED */
 
@@ -252,6 +255,9 @@ FIXME
 // >>implementation
 #ifdef SOKOL_CMDBUF_IMPL
 #define SOKOL_CMDBUF_IMPL_INCLUDED (1)
+
+#include <string.h> // memset, strncpy
+#include <stdlib.h> // malloc/free/abort
 
 #ifndef SOKOL_API_IMPL
     #define SOKOL_API_IMPL
@@ -404,9 +410,11 @@ static void _scb_strcpy(_scb_str_t* dst, const char* src) {
     }
 }
 
+/* FIXME
 static const char* _scb_strptr(const _scb_str_t* str) {
     return &str->buf[0];
 }
+*/
 
 // >>pool
 static void _scb_pool_init(_scb_pool_t* pool, int num) {
@@ -515,8 +523,8 @@ static int _scb_slot_index(uint32_t id) {
 static _scb_cmdbuf_t* _scb_cmdbuf_at(uint32_t cb_id) {
     SOKOL_ASSERT(SCB_INVALID_ID != cb_id);
     int slot_index = _scb_slot_index(cb_id);
-    SOKOL_ASSERT((slot_index > _SCB_INVALID_SLOT_INDEX) && (slot_index < _scb.cmdbuf_pool.pool.size));
-    return &_scb.cmdbuf_pool.cmdbufs[slot_index];
+    SOKOL_ASSERT((slot_index > _SCB_INVALID_SLOT_INDEX) && (slot_index < _scb.pools.cmdbuf_pool.size));
+    return &_scb.pools.cmdbufs[slot_index];
 }
 
 // get cmdbuf pointer with id-check, returns 0 if no match
@@ -531,7 +539,7 @@ static _scb_cmdbuf_t* _scb_lookup_cmdbuf(uint32_t cb_id) {
 }
 
 // make cmdbuf handle from raw uint32_t id
-static scb_context _scb_make_cmdbuf_id(uint32_t cb_id) {
+static scb_cmdbuf _scb_make_cmdbuf_id(uint32_t cb_id) {
     scb_cmdbuf cb;
     cb.id = cb_id;
     return cb;
@@ -539,9 +547,9 @@ static scb_context _scb_make_cmdbuf_id(uint32_t cb_id) {
 
 static scb_cmdbuf _scb_alloc_cmdbuf(void) {
     scb_cmdbuf cb_id;
-    int slot_index = _scb_pool_alloc_index(&_scb.cmdbuf_pool.pool);
+    int slot_index = _scb_pool_alloc_index(&_scb.pools.cmdbuf_pool);
     if (_SCB_INVALID_SLOT_INDEX != slot_index) {
-        cb_id = _scb_make_cmdbuf_id(_scb_slot_alloc(&_scb.cmdbuf_pool.pool, &_scb.cmdbuf_pool.cmdbufs[slot_index].slot, slot_index));
+        cb_id = _scb_make_cmdbuf_id(_scb_slot_alloc(&_scb.pools.cmdbuf_pool, &_scb.pools.cmdbufs[slot_index].slot, slot_index));
     } else {
         // pool is exhausted
         cb_id = _scb_make_cmdbuf_id(SCB_INVALID_ID);
@@ -555,20 +563,10 @@ static void _scb_dealloc_cmdbuf(_scb_cmdbuf_t* cb) {
     _scb_clear(cb, sizeof(_scb_cmdbuf_t));
 }
 
-static scb_cmdbuf_desc _scb_cmdbuf_desc_defaults(const scb_cmdbuf_desc* desc) {
-    scb_cmdbuf_desc res = *desc;
-    res.size = _scb_def(res.size, _SCB_DEFAULT_CMDBUF_SIZE);
-    return res;
-}
-
 static void _scb_init_cmdbuf(_scb_cmdbuf_t* cb, const scb_cmdbuf_desc* desc) {
     SOKOL_ASSERT(cb && (cb->slot.state == SCB_RESOURCESTATE_ALLOC));
     SOKOL_ASSERT(desc);
-    if (desc->size == 0) {
-        _SCB_ERROR(INVALID_CMDBUF_SIZE);
-        cb->slot.state = SCB_RESOURCESTATE_FAILED;
-        return;
-    }
+    SOKOL_ASSERT(desc->size > 0);
     cb->buf = _scb_malloc(desc->size);
     if (0 == cb->buf) {
         // NOTE: allocation failure already logged _scb_malloc
@@ -582,7 +580,7 @@ static void _scb_init_cmdbuf(_scb_cmdbuf_t* cb, const scb_cmdbuf_desc* desc) {
 }
 
 static void _scb_uninit_cmdbuf(_scb_cmdbuf_t* cb) {
-    SOKOL_ASSERT(cb && ((cb->slot.state == SCB_RESOURCESTATE_VALID) || (cb->slot.state == SCB_RESOURCESTATE_FAILED));
+    SOKOL_ASSERT(cb && ((cb->slot.state == SCB_RESOURCESTATE_VALID) || (cb->slot.state == SCB_RESOURCESTATE_FAILED)));
     if (cb->buf) {
         _scb_free(cb->buf);
         cb->buf = 0;
@@ -592,9 +590,22 @@ static void _scb_uninit_cmdbuf(_scb_cmdbuf_t* cb) {
     cb->slot.state = SCB_RESOURCESTATE_ALLOC;
 }
 
+static scb_desc _scb_desc_defaults(const scb_desc* desc) {
+    SOKOL_ASSERT(desc);
+    scb_desc res = *desc;
+    res.cmdbuf_pool_size = _scb_def(res.cmdbuf_pool_size, _SCB_DEFAULT_CMDBUF_POOL_SIZE);
+    return res;
+}
+
+static scb_cmdbuf_desc _scb_cmdbuf_desc_defaults(const scb_cmdbuf_desc* desc) {
+    scb_cmdbuf_desc res = *desc;
+    res.size = _scb_def(res.size, _SCB_DEFAULT_CMDBUF_SIZE);
+    return res;
+}
+
 static void _scb_discard_all_resources(void) {
     for (int i = 1; i < _scb.pools.cmdbuf_pool.size; i++) {
-        const scb_resource_state state = _scb.pools.cmdbufs[i].slot.statel;
+        const scb_resource_state state = _scb.pools.cmdbufs[i].slot.state;
         if ((state == SCB_RESOURCESTATE_VALID) || (state == SCB_RESOURCESTATE_FAILED)) {
             _scb_uninit_cmdbuf(&_scb.pools.cmdbufs[i]);
         }
@@ -621,11 +632,12 @@ SOKOL_API_IMPL void scb_shutdown(void) {
 SOKOL_API_IMPL scb_cmdbuf scb_make_cmdbuf(const scb_cmdbuf_desc* desc) {
     SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
     SOKOL_ASSERT(desc);
+    scb_cmdbuf_desc desc_def = _scb_cmdbuf_desc_defaults(desc);
     scb_cmdbuf cb_id = _scb_alloc_cmdbuf();
     if (cb_id.id != SCB_INVALID_ID) {
         _scb_cmdbuf_t* cb = _scb_cmdbuf_at(cb_id.id);
         SOKOL_ASSERT(cb && (cb->slot.state == SCB_RESOURCESTATE_ALLOC));
-        _scb_init_cmdbuf(cb, desc);
+        _scb_init_cmdbuf(cb, &desc_def);
         SOKOL_ASSERT((cb->slot.state == SCB_RESOURCESTATE_VALID) || (cb->slot.state == SCB_RESOURCESTATE_FAILED));
     }
     return cb_id;
@@ -646,7 +658,7 @@ SOKOL_API_IMPL void scb_destroy_cmdbuf(scb_cmdbuf cb_id) {
     }
 }
 
-SOKOL_API_IMPL void scb_query_cmdbuf_state(scb_cmdbuf cb_id) {
+SOKOL_API_IMPL scb_resource_state scb_query_cmdbuf_state(scb_cmdbuf cb_id) {
     SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
     _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
     return cb ? cb->slot.state : SCB_RESOURCESTATE_INVALID;

--- a/util/sokol_cmdbuf.h
+++ b/util/sokol_cmdbuf.h
@@ -135,22 +135,22 @@ typedef struct scb_cmdbuf_desc {
 */
 typedef struct scb_cmdbuf_info {
     size_t size;        // overall command buffer size in bytes
-    size_t cur_offset;  // current recording byte offset
     size_t remaining;   // number of remaining bytes in command buffer
-    bool overflown;     // true if command buffer is in overflown state
+    bool overflown;     // set to true if the cmdbuf is in overflown state
 } scb_cmdbuf_info;
 
 /*
     scb_log_item
 
     Log items are defined via X-Macro, expanded into an enum scb_log_item
-    and (in debug-mode only also to human readable strings.
+    and (in debug-mode only also to human readable strings).
 
     Used as parameter to the logging callback.
 */
 #define _SCB_LOG_ITEMS \
     _SCB_LOGITEM_XMACRO(OK, "Ok") \
     _SCB_LOGITEM_XMACRO(MALLOC_FAILED, "memory allocation failed") \
+    _SCB_LOGITEM_XMACRO(CMDBUF_OVERFLOW, "command buffer has overflown") \
 
 #define _SCB_LOGITEM_XMACRO(item,msg) SCB_LOGITEM_##item,
 typedef enum scb_log_item {
@@ -170,7 +170,7 @@ typedef struct scb_logger {
         uint32_t log_level,             // 0=panic, 1=error, 2=warning, 3=info
         uint32_t log_item_id,           // SCB_LOGITEM_*
         const char* message_or_null,    // a message string, may be nullptr in release mode
-        uint32_t line_nr,               // line number in sokol_debugtext.h
+        uint32_t line_nr,               // line number in sokol_cmdbuf.h
         const char* filename_or_null,   // source filename, may be nullptr in release mode
         void* user_data);
     void* user_data;
@@ -235,11 +235,9 @@ SOKOL_CMDBUF_API_DECL void scb_draw_ex(scb_cmdbuf cb, int base_element, int num_
 SOKOL_CMDBUF_API_DECL void scb_dispatch(scb_cmdbuf cb, int num_groups_x, int num_groups_y, int num_groups_z);
 
 // query command buffer resource state (valid or failed)
-SOKOL_CMDBUF_API_DECL scb_resource_state scb_query_cmdbuf_resource_state(scb_cmdbuf cb);
+SOKOL_CMDBUF_API_DECL scb_resource_state scb_query_cmdbuf_state(scb_cmdbuf cb);
 // query current command buffer properties
 SOKOL_CMDBUF_API_DECL scb_cmdbuf_info scb_query_cmdbuf_info(scb_cmdbuf cb);
-// query command buffer desc with default values patched in
-SOKOL_CMDBUF_API_DECL scb_cmdbuf_desc scb_query_cmdbuf_desc(scb_cmdbuf cb);
 
 #ifdef __cplusplus
 } // extern "C"
@@ -291,6 +289,18 @@ inline void scb_apply_uniforms(scb_cmdbuf cb, int ub_slot, const sg_range& data)
 #define _SCB_SLOT_MASK (_SCB_MAX_POOL_SIZE-1)
 
 // >>structs
+typedef enum {
+    _SCB_CMD_NONE = 0,
+    _SCB_CMD_APPLY_VIEWPORT,
+    _SCB_CMD_APPLY_SCISSOR_RECT,
+    _SCB_CMD_APPLY_PIPELINE,
+    _SCB_CMD_APPLY_BINDINGS,
+    _SCB_CMD_APPLY_UNIFORMS,
+    _SCB_CMD_DRAW,
+    _SCB_CMD_DRAW_EX,
+    _SCB_CMD_DISPATCH,
+} _scb_cmd_t;
+
 typedef struct {
     uint32_t id;
     scb_resource_state state;
@@ -312,11 +322,10 @@ typedef struct {
     uint8_t* buf;
     uint8_t* cur;
     const uint8_t* end;
+    const uint8_t* cmd_end;
+    bool overflown; // tried to encode cmd past end
     _scb_str_t label;
 } _scb_cmdbuf_t;
-
-typedef struct {
-} _scb_cmdbuf_pool_t;
 
 typedef struct {
     _scb_pool_t cmdbuf_pool;
@@ -409,12 +418,6 @@ static void _scb_strcpy(_scb_str_t* dst, const char* src) {
         _scb_clear(dst->buf, _SCB_STRING_SIZE);
     }
 }
-
-/* FIXME
-static const char* _scb_strptr(const _scb_str_t* str) {
-    return &str->buf[0];
-}
-*/
 
 // >>pool
 static void _scb_pool_init(_scb_pool_t* pool, int num) {
@@ -612,6 +615,123 @@ static void _scb_discard_all_resources(void) {
     }
 }
 
+static bool _scb_cmdbuf_valid(_scb_cmdbuf_t* cb) {
+    return cb && (cb->slot.state == SCB_RESOURCESTATE_VALID);
+}
+
+static void _scb_enc_u8(_scb_cmdbuf_t* cb, uint8_t val) {
+    SOKOL_ASSERT((cb->cur + 1) <= cb->end);
+    *cb->cur++ = val;
+}
+
+static void _scb_enc_bool(_scb_cmdbuf_t* cb, bool val) {
+    SOKOL_ASSERT((cb->cur + 1) <= cb->end);
+    *cb->cur++ = (uint8_t)val;
+}
+
+static void _scb_enc_int(_scb_cmdbuf_t* cb, int val) {
+    SOKOL_ASSERT((cb->cur + 4) <= cb->end);
+    cb->cur[0] = (uint8_t)val;
+    cb->cur[1] = (uint8_t)(val >> 8);
+    cb->cur[2] = (uint8_t)(val >> 16);
+    cb->cur[3] = (uint8_t)(val >> 24);
+    cb->cur += 4;
+}
+
+static void _scb_enc_u32(_scb_cmdbuf_t* cb, uint32_t val) {
+    SOKOL_ASSERT((cb->cur + 4) <= cb->end);
+    cb->cur[0] = (uint8_t)val;
+    cb->cur[1] = (uint8_t)(val >> 8);
+    cb->cur[2] = (uint8_t)(val >> 16);
+    cb->cur[3] = (uint8_t)(val >> 24);
+    cb->cur += 4;
+}
+
+static bool _scb_enc_cmd(_scb_cmdbuf_t* cb, _scb_cmd_t cmd, size_t payload_size) {
+    SOKOL_ASSERT(cb->cmd_end == 0);
+    if (cb->overflown) {
+        return false;
+    }
+    const size_t cmd_payload_size = payload_size + 1;
+    if ((cb->cur + cmd_payload_size) > cb->end) {
+        cb->overflown = true;
+        _SCB_ERROR(CMDBUF_OVERFLOW);
+        return false;
+    }
+    cb->cmd_end = cb->cur + cmd_payload_size;
+    _scb_enc_u8(cb, (uint8_t)cmd);
+    return true;
+}
+
+static void _scb_enc_end(_scb_cmdbuf_t* cb) {
+    SOKOL_ASSERT(cb->cmd_end && (cb->cur == cb->cmd_end));
+    cb->cmd_end = 0;
+}
+
+static void _scb_enc_apply_viewport(_scb_cmdbuf_t* cb, int x, int y, int width, int height, bool origin_top_left) {
+    const size_t payload_size = 4 * sizeof(int) + sizeof(uint8_t);
+    if (_scb_enc_cmd(cb, _SCB_CMD_APPLY_VIEWPORT, payload_size)) {
+        _scb_enc_int(cb, x);
+        _scb_enc_int(cb, y);
+        _scb_enc_int(cb, width);
+        _scb_enc_int(cb, height);
+        _scb_enc_bool(cb, origin_top_left);
+        _scb_enc_end(cb);
+    }
+}
+
+static void _scb_enc_apply_scissor_rect(_scb_cmdbuf_t* cb, int x, int y, int width, int height, bool origin_top_left) {
+    const size_t payload_size = 4 * sizeof(int) + sizeof(uint8_t);
+    if (_scb_enc_cmd(cb, _SCB_CMD_APPLY_SCISSOR_RECT, payload_size)) {
+        _scb_enc_int(cb, x);
+        _scb_enc_int(cb, y);
+        _scb_enc_int(cb, width);
+        _scb_enc_int(cb, height);
+        _scb_enc_bool(cb, origin_top_left);
+        _scb_enc_end(cb);
+    }
+}
+
+static void _scb_enc_apply_pipeline(_scb_cmdbuf_t* cb, uint32_t pip_id) {
+    const size_t payload_size = sizeof(uint32_t);
+    if (_scb_enc_cmd(cb, _SCB_CMD_APPLY_PIPELINE, payload_size)) {
+        _scb_enc_u32(cb, pip_id);
+        _scb_enc_end(cb);
+    }
+}
+
+static void _scb_enc_draw(_scb_cmdbuf_t* cb, int base_element, int num_elements, int num_instances) {
+    const size_t payload_size = 3 * sizeof(int);
+    if (_scb_enc_cmd(cb, _SCB_CMD_DRAW, payload_size)) {
+        _scb_enc_int(cb, base_element);
+        _scb_enc_int(cb, num_elements);
+        _scb_enc_int(cb, num_instances);
+        _scb_enc_end(cb);
+    }
+}
+
+static void _scb_enc_draw_ex(_scb_cmdbuf_t* cb, int base_element, int num_elements, int num_instances, int base_vertex, int base_instance) {
+    const size_t payload_size = 5 * sizeof(int);
+    if (_scb_enc_cmd(cb, _SCB_CMD_DRAW_EX, payload_size)) {
+        _scb_enc_int(cb, base_element);
+        _scb_enc_int(cb, num_elements);
+        _scb_enc_int(cb, num_instances);
+        _scb_enc_int(cb, base_vertex);
+        _scb_enc_int(cb, base_instance);
+        _scb_enc_end(cb);
+    }
+}
+
+static void _scb_enc_dispatch(_scb_cmdbuf_t* cb, int num_groups_x, int num_groups_y, int num_groups_z) {
+    const size_t payload_size = 3 * sizeof(int);
+    if (_scb_enc_cmd(cb, _SCB_CMD_DISPATCH, payload_size)) {
+        _scb_enc_int(cb, num_groups_x);
+        _scb_enc_int(cb, num_groups_y);
+        _scb_enc_int(cb, num_groups_z);
+        _scb_enc_end(cb);
+    }
+}
+
 // >>public
 SOKOL_API_IMPL void scb_setup(const scb_desc* desc) {
     SOKOL_ASSERT(desc);
@@ -662,6 +782,86 @@ SOKOL_API_IMPL scb_resource_state scb_query_cmdbuf_state(scb_cmdbuf cb_id) {
     SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
     _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
     return cb ? cb->slot.state : SCB_RESOURCESTATE_INVALID;
+}
+
+SOKOL_API_IMPL scb_cmdbuf_info scb_query_cmdbuf_info(scb_cmdbuf cb_id) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
+    scb_cmdbuf_info info;
+    _scb_clear(&info, sizeof(info));
+    if (_scb_cmdbuf_valid(cb)) {
+        SOKOL_ASSERT(cb->buf && cb->cur && cb->end);
+        SOKOL_ASSERT((cb->cur >= cb->buf) && (cb->cur <= cb->end));
+        SOKOL_ASSERT(cb->end > cb->buf);
+        info.size = (size_t)(cb->end - cb->buf);
+        info.remaining = (size_t)(cb->end - cb->cur);
+        info.overflown = cb->overflown;
+    }
+    return info;
+}
+
+SOKOL_API_IMPL void scb_apply_viewport(scb_cmdbuf cb_id, int x, int y, int width, int height, bool origin_top_left) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
+    if (_scb_cmdbuf_valid(cb)) {
+        _scb_enc_apply_viewport(cb, x, y, width, height, origin_top_left);
+    }
+}
+
+SOKOL_API_IMPL void scb_apply_viewportf(scb_cmdbuf cb_id, float x, float y, float width, float height, bool origin_top_left) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
+    if (_scb_cmdbuf_valid(cb)) {
+        _scb_enc_apply_viewport(cb, (int)x, (int)y, (int)width, (int)height, origin_top_left);
+    }
+}
+
+SOKOL_API_IMPL void scb_apply_scissor_rect(scb_cmdbuf cb_id, int x, int y, int width, int height, bool origin_top_left) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
+    if (_scb_cmdbuf_valid(cb)) {
+        _scb_enc_apply_scissor_rect(cb, x, y, width, height, origin_top_left);
+    }
+}
+
+SOKOL_API_IMPL void scb_apply_scissor_rectf(scb_cmdbuf cb_id, float x, float y, float width, float height, bool origin_top_left) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
+    if (_scb_cmdbuf_valid(cb)) {
+        _scb_enc_apply_scissor_rect(cb, (int)x, (int)y, (int)width, (int)height, origin_top_left);
+    }
+}
+
+SOKOL_API_IMPL void scb_apply_pipeline(scb_cmdbuf cb_id, sg_pipeline pip) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
+    if (_scb_cmdbuf_valid(cb)) {
+        _scb_enc_apply_pipeline(cb, pip.id);
+    }
+}
+
+SOKOL_API_IMPL void scb_draw(scb_cmdbuf cb_id, int base_element, int num_elements, int num_instances) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
+    if (_scb_cmdbuf_valid(cb)) {
+        _scb_enc_draw(cb, base_element, num_elements, num_instances);
+    }
+}
+
+SOKOL_API_IMPL void scb_draw_ex(scb_cmdbuf cb_id, int base_element, int num_elements, int num_instances, int base_vertex, int base_instance) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
+    if (_scb_cmdbuf_valid(cb)) {
+        _scb_enc_draw_ex(cb, base_element, num_elements, num_instances, base_vertex, base_instance);
+    }
+}
+
+SOKOL_API_IMPL void scb_dispatch(scb_cmdbuf cb_id, int num_groups_x, int num_groups_y, int num_groups_z) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
+    if (_scb_cmdbuf_valid(cb)) {
+        _scb_enc_dispatch(cb, num_groups_x, num_groups_y, num_groups_z);
+    }
 }
 
 #endif // SOKOL_CMDBUF_IMPL

--- a/util/sokol_cmdbuf.h
+++ b/util/sokol_cmdbuf.h
@@ -97,7 +97,23 @@ enum {
 
     A command buffer handle created with scb_make_cmdbuf().
 */
-typedef struct scb_cmdbuf_s { uint32_t id; } scb_cmdbuf;
+typedef struct scb_cmdbuf { uint32_t id; } scb_cmdbuf;
+
+/*
+    scb_resource_state
+
+    The state of a command buffer object, obtainable via scb_query_cmdbuf_state().
+    Publicly visible values are only SCB_RESOURCESTATE_VALID
+    and SCB_RESOURCESTATE_FAILED.
+*/
+typedef enum scb_resource_state {
+    SCB_RESOURCESTATE_INITIAL,
+    SCB_RESOURCESTATE_ALLOC,
+    SCB_RESOURCESTATE_VALID,
+    SCB_RESOURCESTATE_FAILED,
+    SCB_RESOURCESTATE_INVALID,
+    _SCB_RESOURCESTATE_FORCE_U32 = 0x7FFFFFFF
+} scb_resource_state;
 
 /*
     scb_cmdbuf_desc
@@ -107,7 +123,7 @@ typedef struct scb_cmdbuf_s { uint32_t id; } scb_cmdbuf;
 
     TODO: information on how to estimate required size
 */
-typedef struct scb_cmdbuf_desc_s {
+typedef struct scb_cmdbuf_desc {
     size_t size;            // command buffer size in bytes (default: 256 * 1024 (256 KBytes))
     const char* label;
 } scb_cmdbuf_desc;
@@ -117,7 +133,7 @@ typedef struct scb_cmdbuf_desc_s {
 
     Result of scb_query_cmdbuf_info.
 */
-typedef struct scb_cmdbuf_info_s {
+typedef struct scb_cmdbuf_info {
     size_t size;        // overall command buffer size in bytes
     size_t cur_offset;  // current recording byte offset
     size_t remaining;   // number of remaining bytes in command buffer
@@ -137,7 +153,7 @@ typedef struct scb_cmdbuf_info_s {
     _SCB_LOGITEM_XMACRO(MALLOC_FAILED, "memory allocation failed") \
 
 #define _SCB_LOGITEM_XMACRO(item,msg) SCB_LOGITEM_##item,
-typedef enum scb_log_item_e {
+typedef enum scb_log_item {
     _SCB_LOG_ITEMS
 } scb_log_item;
 #undef _SCB_LOGITEM_XMACRO
@@ -148,7 +164,7 @@ typedef enum scb_log_item_e {
     Used in scb_desc to provide a custom logging and error reporting
     callback to sokol_cmdbuf.h
 */
-typedef struct scb_logger_s {
+typedef struct scb_logger {
     void (*func)(
         const char* tag,                // always "scb"
         uint32_t log_level,             // 0=panic, 1=error, 2=warning, 3=info
@@ -168,7 +184,7 @@ typedef struct scb_logger_s {
     alloc_fn and free_fn function must be provided (e.g. it's not valid to
     override one function but not the other).
 */
-typedef struct scb_allocator_s {
+typedef struct scb_allocator {
     void* (*alloc_fn)(size_t size, void* user_data);
     void (*free_fn)(void* ptr, void* user_data);
     void* user_data;
@@ -179,39 +195,51 @@ typedef struct scb_allocator_s {
 
     FIXME: docs
 */
-typedef struct scb_desc_s {
-    int buffer_pool_size;       // max number of command buffers that can be alive simultanously (default: 16)
+typedef struct scb_desc {
+    int cmdbuf_pool_size;       // max number of command buffers that can be alive simultanously (default: 16)
     scb_allocator allocator;    // optional memory allocation overrides (default: malloc/free)
     scb_logger logger;          // optional log override functions (default: NO LOGGING)
 } scb_desc;
 
-// initialization and shutdown
+// setup sokol-cmdbuf
 SOKOL_CMDBUF_API_DECL void scb_setup(const scb_desc* desc);
+// shutdown sokol-cmdbuf
 SOKOL_CMDBUF_API_DECL void scb_shutdown(void);
 
-// create and destroy command buffer objects
+// create a cmdbuf object
 SOKOL_CMDBUF_API_DECL scb_cmdbuf scb_make_cmdbuf(const scb_cmdbuf_desc* desc);
+// destroy cmdbuf object
 SOKOL_CMDBUF_API_DECL void scb_destroy_cmdbuf(scb_cmdbuf cb);
-
 // submit command buffer to sokol-gfx (call inside a sokol-gfx pass)
-SOKOL_CMDBUF_API_DECL void scb_submit(scb_cmdbuf cb, bool rewind);
+SOKOL_CMDBUF_API_DECL void scb_submit(scb_cmdbuf cb);
 
-// record sokol-gfx commands into command buffer
+// record apply-viewport command (integer variant)
 SOKOL_CMDBUF_API_DECL void scb_apply_viewport(scb_cmdbuf cb, int x, int y, int width, int height, bool origin_top_left);
+// record apply-viewport command (float variant)
 SOKOL_CMDBUF_API_DECL void scb_apply_viewportf(scb_cmdbuf cb, float x, float y, float width, float height, bool origin_top_left);
+// record apply-scissor-rect command (integer variant)
 SOKOL_CMDBUF_API_DECL void scb_apply_scissor_rect(scb_cmdbuf cb, int x, int y, int width, int height, bool origin_top_left);
+// record apply-scissor-rect command (float variant)
 SOKOL_CMDBUF_API_DECL void scb_apply_scissor_rectf(scb_cmdbuf cb, float x, float y, float width, float height, bool origin_top_left);
+// record apply pipeline command
 SOKOL_CMDBUF_API_DECL void scb_apply_pipeline(scb_cmdbuf cb, sg_pipeline pip);
+// record apply bindings command
 SOKOL_CMDBUF_API_DECL void scb_apply_bindings(scb_cmdbuf cb, const sg_bindings* bindings);
+// record apply uniforms command
 SOKOL_CMDBUF_API_DECL void scb_apply_uniforms(scb_cmdbuf cb, int ub_slot, const sg_range* data);
+// record draw command
 SOKOL_CMDBUF_API_DECL void scb_draw(scb_cmdbuf cb, int base_element, int num_elements, int num_instances);
+// record draw-ex command
 SOKOL_CMDBUF_API_DECL void scb_draw_ex(scb_cmdbuf cb, int base_element, int num_elements, int num_instances, int base_vertex, int base_instance);
+// record dispatch command
 SOKOL_CMDBUF_API_DECL void scb_dispatch(scb_cmdbuf cb, int num_groups_x, int num_groups_y, int num_groups_z);
 
-// getting info
-SOKOL_CMDBUF_API_DECL scb_desc scb_query_desc(void);
-SOKOL_CMDBUF_API_DECL scb_cmdbuf_desc scb_query_cmdbuf_desc(scb_cmdbuf cb);
+// query command buffer resource state (valid or failed)
+SOKOL_CMDBUF_API_DECL scb_resource_state scb_query_cmdbuf_resource_state(scb_cmdbuf cb);
+// query current command buffer properties
 SOKOL_CMDBUF_API_DECL scb_cmdbuf_info scb_query_cmdbuf_info(scb_cmdbuf cb);
+// query command buffer desc with default values patched in
+SOKOL_CMDBUF_API_DECL scb_cmdbuf_desc scb_query_cmdbuf_desc(scb_cmdbuf cb);
 
 #ifdef __cplusplus
 } // extern "C"
@@ -246,7 +274,7 @@ FIXME
 #endif
 
 #define _scb_def(val, def) (((val) == 0) ? (def) : (val))
-#define _SCB_INIT_COOKIE (0xACBAABCA)
+#define _SCB_INIT_TAG (0xACBAABCA)
 
 #define _SCB_STRING_SIZE (32)
 #define _SCB_DEFAULT_CMDBUF_POOL_SIZE (16)
@@ -259,6 +287,7 @@ FIXME
 // >>structs
 typedef struct {
     uint32_t id;
+    scb_resource_state state;
 } _scb_slot_t;
 
 typedef struct {
@@ -274,22 +303,24 @@ typedef struct {
 
 typedef struct {
     _scb_slot_t slot;
-    uint8_t* buffer;
-    size_t offset;
-    bool overflown;
-    scb_cmdbuf_desc desc;
-    scb_str_t label;
+    uint8_t* buf;
+    uint8_t* cur;
+    const uint8_t* end;
+    _scb_str_t label;
 } _scb_cmdbuf_t;
 
 typedef struct {
-    _scb_pool_t;
-    _scb_cmdbuf_t* cmdbufs;
 } _scb_cmdbuf_pool_t;
 
 typedef struct {
-    uint32_t init_cookie;
+    _scb_pool_t cmdbuf_pool;
+    _scb_cmdbuf_t* cmdbufs;
+} _scb_pools_t;
+
+typedef struct {
+    uint32_t init_tag;
     scb_desc desc;
-    _scb_cmdbuf_pool_t cmdbuf_pool;
+    _scb_pools_t pools;
 } _scb_t;
 static _scb_t _scb;
 
@@ -307,7 +338,7 @@ static const char* _scb_log_messages[] = {
 #define _SCB_WARN(code) _scb_log(SCB_LOGITEM_ ##code, 2, __LINE__)
 #define _SCB_INFO(code) _scb_log(SCB_LOGITEM_ ##code, 3, __LINE__)
 
-static void _scb_log(scb_log_item_t log_item, uint32_t log_level, uint32_t line_nr) {
+static void _scb_log(scb_log_item log_item, uint32_t log_level, uint32_t line_nr) {
     if (_scb.desc.logger.func) {
         #if defined(SOKOL_DEBUG)
             const char* filename = __FILE__;
@@ -340,7 +371,7 @@ static void* _scb_malloc(size_t size) {
         ptr = malloc(size);
     }
     if (0 == ptr) {
-        _SCB_PANIC(MALLOC_FAILED);
+        _SCB_ERROR(MALLOC_FAILED);
     }
     return ptr;
 }
@@ -359,8 +390,26 @@ static void _scb_free(void* ptr) {
     }
 }
 
+static void _scb_strcpy(_scb_str_t* dst, const char* src) {
+    SOKOL_ASSERT(dst);
+    if (src) {
+        #if defined(_MSC_VER)
+        strncpy_s(dst->buf, _SCB_STRING_SIZE, src, (_SCB_STRING_SIZE-1));
+        #else
+        strncpy(dst->buf, src, _SCB_STRING_SIZE);
+        #endif
+        dst->buf[_SCB_STRING_SIZE-1] = 0;
+    } else {
+        _scb_clear(dst->buf, _SCB_STRING_SIZE);
+    }
+}
+
+static const char* _scb_strptr(const _scb_str_t* str) {
+    return &str->buf[0];
+}
+
 // >>pool
-static void _scb(_scb_pool_t* pool, int num) {
+static void _scb_pool_init(_scb_pool_t* pool, int num) {
     SOKOL_ASSERT(pool && (num >= 1));
     // slot 0 is reserved for the 'invalid id', so bump the pool size by 1
     pool->size = num + 1;
@@ -376,7 +425,7 @@ static void _scb(_scb_pool_t* pool, int num) {
     }
 }
 
-static void _scb_discard_pool(_scb_pool_t* pool) {
+static void _scb_pool_discard(_scb_pool_t* pool) {
     SOKOL_ASSERT(pool);
     SOKOL_ASSERT(pool->free_queue);
     _scb_free(pool->free_queue);
@@ -416,20 +465,21 @@ static void _scb_pool_free_index(_scb_pool_t* pool, int slot_index) {
     SOKOL_ASSERT(pool->queue_top <= (pool->size-1));
 }
 
-static void _scb_setup_cmdbuf_pool(const scb_desc_t* desc) {
+static void _scb_setup_pools(_scb_pools_t* p, const scb_desc* desc) {
+    SOKOL_ASSERT(p);
     SOKOL_ASSERT(desc);
-    // note: the pool will have an additional item, since slot 0 is reserved
-    SOKOL_ASSERT((desc->context_pool_size > 0) && (desc->context_pool_size < _SCB_MAX_POOL_SIZE));
-    _scb_init_pool(&_scb.context_pool.pool, desc->context_pool_size);
-    size_t pool_byte_size = sizeof(_scb_context_t) * (size_t)_scb.context_pool.pool.size;
-    _scb.context_pool.contexts = (_scb_context_t*) _scb_malloc_clear(pool_byte_size);
+    // note: the pools will have an additional item, since slot 0 is reserved
+    SOKOL_ASSERT((desc->cmdbuf_pool_size > 0) && (desc->cmdbuf_pool_size < _SCB_MAX_POOL_SIZE));
+    _scb_pool_init(&p->cmdbuf_pool, desc->cmdbuf_pool_size);
+    size_t cb_pool_byte_size = sizeof(_scb_cmdbuf_t) * (size_t)p->cmdbuf_pool.size;
+    p->cmdbufs = (_scb_cmdbuf_t*)_scb_malloc_clear(cb_pool_byte_size);
 }
 
-static void _scb_discard_cmdbuf_pool(void) {
-    SOKOL_ASSERT(_scb.context_pool.contexts);
-    _scb_free(_scb.context_pool.contexts);
-    _scb.context_pool.contexts = 0;
-    _scb_discard_pool(&_scb.context_pool.pool);
+static void _scb_discard_pools(_scb_pools_t* p) {
+    SOKOL_ASSERT(p);
+    SOKOL_ASSERT(p->cmdbufs);
+    _scb_free(p->cmdbufs); p->cmdbufs = 0;
+    _scb_pool_discard(&p->cmdbuf_pool);
 }
 
 /* allocate the slot at slot_index:
@@ -446,9 +496,11 @@ static uint32_t _scb_slot_alloc(_scb_pool_t* pool, _scb_slot_t* slot, int slot_i
     */
     SOKOL_ASSERT(pool && pool->gen_ctrs);
     SOKOL_ASSERT((slot_index > _SCB_INVALID_SLOT_INDEX) && (slot_index < pool->size));
-    SOKOL_ASSERT(slot->id == SG_INVALID_ID);
+    SOKOL_ASSERT(slot->id == SCB_INVALID_ID);
+    SOKOL_ASSERT(slot->state == SCB_RESOURCESTATE_INITIAL);
     uint32_t ctr = ++pool->gen_ctrs[slot_index];
     slot->id = (ctr<<_SCB_SLOT_SHIFT)|(slot_index & _SCB_SLOT_MASK);
+    slot->state = SCB_RESOURCESTATE_ALLOC;
     return slot->id;
 }
 
@@ -461,7 +513,7 @@ static int _scb_slot_index(uint32_t id) {
 
 // get cmdbuf pointer without id-check
 static _scb_cmdbuf_t* _scb_cmdbuf_at(uint32_t cb_id) {
-    SOKOL_ASSERT(SG_INVALID_ID != cb_id);
+    SOKOL_ASSERT(SCB_INVALID_ID != cb_id);
     int slot_index = _scb_slot_index(cb_id);
     SOKOL_ASSERT((slot_index > _SCB_INVALID_SLOT_INDEX) && (slot_index < _scb.cmdbuf_pool.pool.size));
     return &_scb.cmdbuf_pool.cmdbufs[slot_index];
@@ -469,7 +521,7 @@ static _scb_cmdbuf_t* _scb_cmdbuf_at(uint32_t cb_id) {
 
 // get cmdbuf pointer with id-check, returns 0 if no match
 static _scb_cmdbuf_t* _scb_lookup_cmdbuf(uint32_t cb_id) {
-    if (SG_INVALID_ID != cb_id) {
+    if (SCB_INVALID_ID != cb_id) {
         _scb_cmdbuf_t* cb = _scb_cmdbuf_at(cb_id);
         if (cb->slot.id == cb_id) {
             return cb;
@@ -497,13 +549,107 @@ static scb_cmdbuf _scb_alloc_cmdbuf(void) {
     return cb_id;
 }
 
+static void _scb_dealloc_cmdbuf(_scb_cmdbuf_t* cb) {
+    SOKOL_ASSERT(cb && (cb->slot.state == SCB_RESOURCESTATE_ALLOC) && (cb->slot.id != SCB_INVALID_ID));
+    _scb_pool_free_index(&_scb.pools.cmdbuf_pool, _scb_slot_index(cb->slot.id));
+    _scb_clear(cb, sizeof(_scb_cmdbuf_t));
+}
+
 static scb_cmdbuf_desc _scb_cmdbuf_desc_defaults(const scb_cmdbuf_desc* desc) {
     scb_cmdbuf_desc res = *desc;
     res.size = _scb_def(res.size, _SCB_DEFAULT_CMDBUF_SIZE);
     return res;
 }
 
+static void _scb_init_cmdbuf(_scb_cmdbuf_t* cb, const scb_cmdbuf_desc* desc) {
+    SOKOL_ASSERT(cb && (cb->slot.state == SCB_RESOURCESTATE_ALLOC));
+    SOKOL_ASSERT(desc);
+    if (desc->size == 0) {
+        _SCB_ERROR(INVALID_CMDBUF_SIZE);
+        cb->slot.state = SCB_RESOURCESTATE_FAILED;
+        return;
+    }
+    cb->buf = _scb_malloc(desc->size);
+    if (0 == cb->buf) {
+        // NOTE: allocation failure already logged _scb_malloc
+        cb->slot.state = SCB_RESOURCESTATE_FAILED;
+        return;
+    }
+    cb->cur = cb->buf;
+    cb->end = cb->buf + desc->size;
+    _scb_strcpy(&cb->label, desc->label);
+    cb->slot.state = SCB_RESOURCESTATE_VALID;
+}
 
+static void _scb_uninit_cmdbuf(_scb_cmdbuf_t* cb) {
+    SOKOL_ASSERT(cb && ((cb->slot.state == SCB_RESOURCESTATE_VALID) || (cb->slot.state == SCB_RESOURCESTATE_FAILED));
+    if (cb->buf) {
+        _scb_free(cb->buf);
+        cb->buf = 0;
+        cb->cur = 0;
+        cb->end = 0;
+    }
+    cb->slot.state = SCB_RESOURCESTATE_ALLOC;
+}
 
+static void _scb_discard_all_resources(void) {
+    for (int i = 1; i < _scb.pools.cmdbuf_pool.size; i++) {
+        const scb_resource_state state = _scb.pools.cmdbufs[i].slot.statel;
+        if ((state == SCB_RESOURCESTATE_VALID) || (state == SCB_RESOURCESTATE_FAILED)) {
+            _scb_uninit_cmdbuf(&_scb.pools.cmdbufs[i]);
+        }
+    }
+}
+
+// >>public
+SOKOL_API_IMPL void scb_setup(const scb_desc* desc) {
+    SOKOL_ASSERT(desc);
+    SOKOL_ASSERT((desc->allocator.alloc_fn && desc->allocator.free_fn) || (!desc->allocator.alloc_fn && !desc->allocator.free_fn));
+    _scb_clear(&_scb, sizeof(_scb));
+    _scb.init_tag = _SCB_INIT_TAG;
+    _scb.desc = _scb_desc_defaults(desc);
+    _scb_setup_pools(&_scb.pools, &_scb.desc);
+}
+
+SOKOL_API_IMPL void scb_shutdown(void) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    _scb_discard_all_resources();
+    _scb_discard_pools(&_scb.pools);
+    _scb_clear(&_scb, sizeof(_scb));
+}
+
+SOKOL_API_IMPL scb_cmdbuf scb_make_cmdbuf(const scb_cmdbuf_desc* desc) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    SOKOL_ASSERT(desc);
+    scb_cmdbuf cb_id = _scb_alloc_cmdbuf();
+    if (cb_id.id != SCB_INVALID_ID) {
+        _scb_cmdbuf_t* cb = _scb_cmdbuf_at(cb_id.id);
+        SOKOL_ASSERT(cb && (cb->slot.state == SCB_RESOURCESTATE_ALLOC));
+        _scb_init_cmdbuf(cb, desc);
+        SOKOL_ASSERT((cb->slot.state == SCB_RESOURCESTATE_VALID) || (cb->slot.state == SCB_RESOURCESTATE_FAILED));
+    }
+    return cb_id;
+}
+
+SOKOL_API_IMPL void scb_destroy_cmdbuf(scb_cmdbuf cb_id) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
+    if (cb) {
+        if ((cb->slot.state == SCB_RESOURCESTATE_VALID) || (cb->slot.state == SCB_RESOURCESTATE_FAILED)) {
+            _scb_uninit_cmdbuf(cb);
+            SOKOL_ASSERT(cb->slot.state == SCB_RESOURCESTATE_ALLOC);
+        }
+        if (cb->slot.state == SCB_RESOURCESTATE_ALLOC) {
+            _scb_dealloc_cmdbuf(cb);
+            SOKOL_ASSERT(cb->slot.state == SCB_RESOURCESTATE_INITIAL);
+        }
+    }
+}
+
+SOKOL_API_IMPL void scb_query_cmdbuf_state(scb_cmdbuf cb_id) {
+    SOKOL_ASSERT(_SCB_INIT_TAG == _scb.init_tag);
+    _scb_cmdbuf_t* cb = _scb_lookup_cmdbuf(cb_id.id);
+    return cb ? cb->slot.state : SCB_RESOURCESTATE_INVALID;
+}
 
 #endif // SOKOL_CMDBUF_IMPL

--- a/util/sokol_framebuffer.h
+++ b/util/sokol_framebuffer.h
@@ -5605,8 +5605,8 @@ SOKOL_API_IMPL bool sfb_resize(sfb_framebuffer fb_id, const sfb_resize_desc* des
             retval = true;
             _sfb_destroy_offscreen_images_and_views(fb);
             fb->prescale = prescale;
-            fb->cliprect.width = desc->cliprect.width;
-            fb->cliprect.height = desc->cliprect.height;
+            fb->cliprect.width = cw;
+            fb->cliprect.height = ch;
             bool res = _sfb_create_offscreen_images_and_views(fb);
             if (!res) {
                 fb->slot.state = SFB_RESOURCESTATE_FAILED;

--- a/util/sokol_framebuffer.h
+++ b/util/sokol_framebuffer.h
@@ -4868,6 +4868,7 @@ static void _sfb_setup_pools(_sfb_pools_t* p, const sfb_desc* desc) {
 
 static void _sfb_discard_pools(_sfb_pools_t* p) {
     SOKOL_ASSERT(p);
+    SOKOL_ASSERT(p->framebuffers);
     _sfb_free(p->framebuffers); p->framebuffers = 0;
     _sfb_pool_discard(&p->framebuffer_pool);
 }


### PR DESCRIPTION
Implements https://github.com/floooh/sokol/issues/1557

- [x] deploy sample webpages
- [x] changelog
- [x] merge:
    - [x] sample: https://github.com/floooh/sokol-samples/pull/211
    - [x] zig: https://github.com/floooh/sokol-zig/pull/168
    - [x] odin: https://github.com/floooh/sokol-odin/pull/44
    - [x] nim: https://github.com/floooh/sokol-nim/pull/44
    - [x] rust: https://github.com/floooh/sokol-rust/pull/46
    - [x] c3: https://github.com/floooh/sokol-c3/pull/16
    - [x] d: https://github.com/floooh/sokol-d/pull/110
    - [x] jai: https://github.com/colinbellino/sokol-jai/pull/12
- [x] try to reduce uniform alignment (check the Emscripten WebGL2 shim what max alignment is actually requried) => reduced from 16 to 4 bytes
- [x] inline docs
- [x] new sample
    - [x] add sample to webpage
    - [x] modify to look different then offscreen-sapp, also do a proper step-debug session
    - [x] add to samples page
- [x] hrmpf, webgl2 needs aligned uniform buffer data
- [x] use `sg_push_debug_group()` and `sg_pop_debug_group()`
- [x] feature complete
- [x] add compile and functional test
- [x] sokol_framebuffer.h drive-by fixes:
    - [x] functional test added
    - [x] fix wrong default cliprect being applied in `sfb_resize()`

