### PR TITLE
Defer "write-transient call missing" validation from apply-bindings to draw/dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Updates
 
+### 11-Sep-2026
+
+- sokol_gfx.h: the validation layer checks which make sure that
+  `sg_write_*_transient()` has been called at least once for a write-transient
+  resource in the same frame have been moved from `sg_apply_bindings()` into
+  `sg_draw/draw_ex/dispatch()`. This fixes a catch-22 when a per-frame update into a
+  write-transient buffer would drop down to zero bytes. Additionally some minor
+  cleanup code in the Vulkan backend around resource access flags.
+
+  See ticket https://github.com/floooh/sokol/issues/1598 for details.
+
+  PR: https://github.com/floooh/sokol/pull/1599
+
 ### 07-Sep-2026
 
 Language bindings:
@@ -25,7 +38,7 @@ mechanism for sokol_gfx.h functions that need to be issued inside a
 render or compute pass and that way allows to move those calls outside
 of passes.
 
-For more imformation see the header documentation in [util/sokol_cmdbuf.h](https://github.com/floooh/sokol/blob/master/util/sokol_cmdbuf.h),
+For more information see the header documentation in [util/sokol_cmdbuf.h](https://github.com/floooh/sokol/blob/master/util/sokol_cmdbuf.h),
 and for a usage example the new sample [cmdbuf-sapp](https://floooh.github.io/sokol-html5/cmdbuf-sapp.html).
 
 Planning ticket: https://github.com/floooh/sokol/issues/1557

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -5132,13 +5132,11 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_VBUF_ALIVE, "sg_apply_bindings: vertex buffer no longer alive") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_VBUF_USAGE, "sg_apply_bindings: buffer in vertex buffer bind slot must have usage.vertex_buffer") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_VBUF_OVERFLOW, "sg_apply_bindings: buffer in vertex buffer bind slot is overflown") \
-    _SG_LOGITEM_XMACRO(VALIDATE_ABND_VBUF_WRITE_TRANSIENT, "sg_apply_bindings: sg_write_buffer_transient() hasn't been called this frame for usage.write_transient buffer in vertex buffer slot") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECTED_NO_IBUF, "sg_apply_bindings: pipeline object defines non-indexed rendering, but index buffer binding provided") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECTED_IBUF, "sg_apply_bindings: pipeline object defines indexed rendering, but no index buffer binding provided") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_IBUF_ALIVE, "sg_apply_bindings: index buffer no longer alive") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_IBUF_USAGE, "sg_apply_bindings: buffer in index buffer bind slot must have usage.index_buffer") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_IBUF_OVERFLOW, "sg_apply_bindings: buffer in index buffer slot is overflown") \
-    _SG_LOGITEM_XMACRO(VALIDATE_ABND_IBUF_WRITE_TRANSIENT, "sg_apply_bindings: sg_write_buffer_transient() hasn't been called this frame for usage.write_transient buffer in index buffer slot") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECTED_VIEW_BINDING, "sg_apply_bindings: view binding is missing or the view handle is invalid") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_VIEW_ALIVE, "sg_apply_bindings: view no longer alive") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECT_TEXVIEW, "sg_apply_bindings: view type mismatch in bindslot (shader expects a texture view)") \
@@ -5149,13 +5147,10 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_TEXVIEW_EXPECTED_NON_MULTISAMPLED_IMAGE, "sg_apply_bindings: texture bindings expects image with sample_count == 1") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_TEXVIEW_EXPECTED_FILTERABLE_IMAGE, "sg_apply_bindings: filterable image expected") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_TEXVIEW_EXPECTED_DEPTH_IMAGE, "sg_apply_bindings: depth image expected") \
-    _SG_LOGITEM_XMACRO(VALIDATE_ABND_TEXVIEW_IMAGE_WRITE_TRANSIENT, "sg_apply_bindings: sg_write_image_transient() hasn't been called this frame for usage.write_transient texture image in view slot") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_SBVIEW_READWRITE_IMMUTABLE, "sg_apply_bindings: storage buffers bound as read/write must have usage immutable") \
-    _SG_LOGITEM_XMACRO(VALIDATE_ABND_SBVIEW_BUFFER_WRITE_TRANSIENT, "sg_apply_bindings: sg_write_buffer_transient() hasn't been called this frame for usage.write_transient storage buffer in view slot") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_SIMGVIEW_COMPUTE_PASS_EXPECTED, "sg_apply_bindings: storage image bindings can only appear on compute passes") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_SIMGVIEW_IMAGETYPE_MISMATCH, "sg_apply_bindings: image type of bound storage image doesn't match shader desc") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_SIMGVIEW_ACCESSFORMAT, "sg_apply_bindings: pixel format of storage image view doesn't match access format in shader desc") \
-    _SG_LOGITEM_XMACRO(VALIDATE_ABND_SIMGVIEW_IMAGE_WRITE_TRANSIENT, "sg_apply_bindings: sg_write_image_transient() hasn't been called this frame for usage.write_transient storage image in view slot") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECTED_SAMPLER_BINDING, "sg_apply_bindings: sampler binding is missing or the sampler handle is invalid") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_UNEXPECTED_SAMPLER_COMPARE_NEVER, "sg_apply_bindings: shader expects SG_SAMPLERTYPE_COMPARISON but sampler has SG_COMPAREFUNC_NEVER") \
     _SG_LOGITEM_XMACRO(VALIDATE_ABND_EXPECTED_SAMPLER_COMPARE_NEVER, "sg_apply_bindings: shader expects SG_SAMPLERTYPE_FILTERING or SG_SAMPLERTYPE_NONFILTERING but sampler doesn't have SG_COMPAREFUNC_NEVER") \
@@ -5188,11 +5183,15 @@ typedef struct sg_stats {
     _SG_LOGITEM_XMACRO(VALIDATE_DRAW_EX_BASEVERTEX_NOT_SUPPORTED, "sg_draw_ex(): base_vertex != 0 not supported on this backend (sg_features.draw_base_vertex)") \
     _SG_LOGITEM_XMACRO(VALIDATE_DRAW_EX_BASEINSTANCE_NOT_SUPPORTED, "sg_draw_ex(): base_instance > 0 not supported on this backend (sg_features.draw_base_instance)") \
     _SG_LOGITEM_XMACRO(VALIDATE_DRAW_REQUIRED_BINDINGS_OR_UNIFORMS_MISSING, "sg_draw: call to sg_apply_bindings() and/or sg_apply_uniforms() missing after sg_apply_pipeline()") \
+    _SG_LOGITEM_XMACRO(VALIDATE_DRAW_WRITE_BUFFER_TRANSIENT_MISSING, "sg_draw: a bound usage.write_transient buffer hasn't been written this frame (missing sg_write_buffer_transient call)") \
+    _SG_LOGITEM_XMACRO(VALIDATE_DRAW_WRITE_IMAGE_TRANSIENT_MISSING, "sg_draw: a bound usage.write_transient image hasn't been written this frame (missing sg_write_image_transient call)") \
     _SG_LOGITEM_XMACRO(VALIDATE_DISPATCH_COMPUTEPASS_EXPECTED, "sg_dispatch: must be called in a compute pass") \
     _SG_LOGITEM_XMACRO(VALIDATE_DISPATCH_NUMGROUPSX, "sg_dispatch: num_groups_x must be >=0 and <65536") \
     _SG_LOGITEM_XMACRO(VALIDATE_DISPATCH_NUMGROUPSY, "sg_dispatch: num_groups_y must be >=0 and <65536") \
     _SG_LOGITEM_XMACRO(VALIDATE_DISPATCH_NUMGROUPSZ, "sg_dispatch: num_groups_z must be >=0 and <65536") \
     _SG_LOGITEM_XMACRO(VALIDATE_DISPATCH_REQUIRED_BINDINGS_OR_UNIFORMS_MISSING, "sg_dispatch: call to sg_apply_bindings() and/or sg_apply_uniforms() missing after sg_apply_pipeline()") \
+    _SG_LOGITEM_XMACRO(VALIDATE_DISPATCH_WRITE_BUFFER_TRANSIENT_MISSING, "sg_dispatch: a bound usage.write_transient buffer hasn't been written this frame (missing sg_write_buffer_transient call)") \
+    _SG_LOGITEM_XMACRO(VALIDATE_DISPATCH_WRITE_IMAGE_TRANSIENT_MISSING, "sg_dispatch: a bound usage.write_transient image hasn't been written this frame (missing sg_write_image_transient call)") \
     _SG_LOGITEM_XMACRO(VALIDATE_UPDATEBUF_USAGE, "sg_update_buffer: cannot update immutable buffer") \
     _SG_LOGITEM_XMACRO(VALIDATE_UPDATEBUF_SIZE, "sg_update_buffer: update size is bigger than buffer size") \
     _SG_LOGITEM_XMACRO(VALIDATE_UPDATEBUF_ONCE, "sg_update_buffer: only one update allowed per buffer and frame") \
@@ -7717,8 +7716,12 @@ typedef struct {
     bool next_draw_valid;
     bool use_indexed_draw;
     bool use_instanced_draw;
-    uint32_t required_bindings_and_uniforms;    // used to check that bindings and uniforms are applied after applying pipeline
-    uint32_t applied_bindings_and_uniforms;     // bits 0..7: uniform blocks, bit 8: bindings
+    struct {
+        uint32_t required_bindings_and_uniforms;    // used to check that bindings and uniforms are applied after applying pipeline
+        uint32_t applied_bindings_and_uniforms;     // bits 0..7: uniform blocks, bit 8: bindings
+        bool write_buffer_transient_missing;        // used for 'deferred validation' in draw/dispatch when sg_write_buffer_transient() hasn't been called in current frame
+        bool write_image_transient_missing;         // ditto for transient images
+    } validate;
     #if defined(SOKOL_DEBUG)
     sg_log_item validate_error;
     #endif
@@ -24939,6 +24942,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_pipeline(sg_pipeline pip_id) {
         if (_sg.desc.disable_validation) {
             return true;
         }
+
         _sg_validate_begin();
         // the pipeline object must be alive and valid
         _SG_VALIDATE(pip_id.id != SG_INVALID_ID, VALIDATE_APIP_PIPELINE_VALID_ID);
@@ -24947,6 +24951,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_pipeline(sg_pipeline pip_id) {
         if (!pip) {
             return _sg_validate_end();
         }
+
         _SG_VALIDATE(pip->slot.state == SG_RESOURCESTATE_VALID, VALIDATE_APIP_PIPELINE_VALID);
 
         // the pipeline's shader must be alive and valid
@@ -24959,6 +24964,13 @@ _SOKOL_PRIVATE bool _sg_validate_apply_pipeline(sg_pipeline pip_id) {
         } else {
             return _sg_validate_end();
         }
+
+        // set the expected bindings and uniform block flags for deferred validation in draw/dispatch
+        _sg.validate.required_bindings_and_uniforms = pip->cmn.required_bindings_and_uniforms | shd->cmn.required_bindings_and_uniforms;
+        _sg.validate.applied_bindings_and_uniforms = 0;
+        // resetting the write-transient flags here prevents potential validation misfires when sg_apply_bindings() isn't called
+        _sg.validate.write_buffer_transient_missing = false;
+        _sg.validate.write_image_transient_missing = false;
 
         if (pip->cmn.is_compute) {
             _SG_VALIDATE(_sg.cur_pass.is_compute, VALIDATE_APIP_COMPUTEPASS_EXPECTED);
@@ -25015,6 +25027,10 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bindings) {
         }
         _sg_validate_begin();
 
+        _sg.validate.applied_bindings_and_uniforms |= (1 << SG_MAX_UNIFORMBLOCK_BINDSLOTS);
+        _sg.validate.write_buffer_transient_missing = false;
+        _sg.validate.write_image_transient_missing = false;
+
         // must be called in a pass
         _SG_VALIDATE(_sg.cur_pass.in_pass, VALIDATE_ABND_PASS_EXPECTED);
 
@@ -25066,7 +25082,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bindings) {
                             _SG_VALIDATE(buf->cmn.usage.vertex_buffer, VALIDATE_ABND_VBUF_USAGE);
                             _SG_VALIDATE(!buf->cmn.append_overflow, VALIDATE_ABND_VBUF_OVERFLOW);
                             if (buf->cmn.usage.write_transient) {
-                                _SG_VALIDATE(buf->cmn.write_transient_frame_index == _sg.frame_index, VALIDATE_ABND_VBUF_WRITE_TRANSIENT);
+                                _sg.validate.write_buffer_transient_missing |= buf->cmn.write_transient_frame_index != _sg.frame_index;
                             }
                         }
                     }
@@ -25094,7 +25110,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bindings) {
                     _SG_VALIDATE(buf->cmn.usage.index_buffer, VALIDATE_ABND_IBUF_USAGE);
                     _SG_VALIDATE(!buf->cmn.append_overflow, VALIDATE_ABND_IBUF_OVERFLOW);
                     if (buf->cmn.usage.write_transient) {
-                        _SG_VALIDATE(buf->cmn.write_transient_frame_index == _sg.frame_index, VALIDATE_ABND_IBUF_WRITE_TRANSIENT);
+                        _sg.validate.write_buffer_transient_missing |= buf->cmn.write_transient_frame_index != _sg.frame_index;
                     }
                 }
             }
@@ -25135,7 +25151,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bindings) {
                                             break;
                                     }
                                     if (img->cmn.usage.write_transient) {
-                                        _SG_VALIDATE(img->cmn.write_transient_frame_index == _sg.frame_index, VALIDATE_ABND_TEXVIEW_IMAGE_WRITE_TRANSIENT);
+                                        _sg.validate.write_image_transient_missing |= img->cmn.write_transient_frame_index != _sg.frame_index;
                                     }
                                 }
                             } else if (shd->cmn.views[i].view_type == SG_VIEWTYPE_STORAGEBUFFER) {
@@ -25148,7 +25164,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bindings) {
                                         _SG_VALIDATE(buf->cmn.usage.immutable, VALIDATE_ABND_SBVIEW_READWRITE_IMMUTABLE);
                                     }
                                     if (buf->cmn.usage.write_transient) {
-                                        _SG_VALIDATE(buf->cmn.write_transient_frame_index == _sg.frame_index, VALIDATE_ABND_SBVIEW_BUFFER_WRITE_TRANSIENT);
+                                        _sg.validate.write_buffer_transient_missing |= buf->cmn.write_transient_frame_index != _sg.frame_index;
                                     }
                                 }
                             } else if (shd->cmn.views[i].view_type == SG_VIEWTYPE_STORAGEIMAGE) {
@@ -25162,7 +25178,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_bindings(const sg_bindings* bindings) {
                                     _SG_VALIDATE(img->cmn.type == shd->cmn.views[i].image_type, VALIDATE_ABND_SIMGVIEW_IMAGETYPE_MISMATCH);
                                     _SG_VALIDATE(img->cmn.pixel_format == shd->cmn.views[i].access_format, VALIDATE_ABND_SIMGVIEW_ACCESSFORMAT);
                                     if (img->cmn.usage.write_transient) {
-                                        _SG_VALIDATE(img->cmn.write_transient_frame_index == _sg.frame_index, VALIDATE_ABND_SIMGVIEW_IMAGE_WRITE_TRANSIENT);
+                                        _sg.validate.write_image_transient_missing |= img->cmn.write_transient_frame_index != _sg.frame_index;
                                     }
                                 }
                             }
@@ -25252,6 +25268,7 @@ _SOKOL_PRIVATE bool _sg_validate_apply_uniforms(int ub_slot, const sg_range* dat
         }
         SOKOL_ASSERT((ub_slot >= 0) && (ub_slot < SG_MAX_UNIFORMBLOCK_BINDSLOTS));
         _sg_validate_begin();
+        _sg.validate.applied_bindings_and_uniforms |= 1 << ub_slot;
         _SG_VALIDATE(_sg.cur_pass.in_pass, VALIDATE_AU_PASS_EXPECTED);
         const _sg_pipeline_ref_t* pip_ref = &_sg.cur_pip;
         const bool pip_null = _sg_pipeline_ref_null(pip_ref);
@@ -25290,7 +25307,9 @@ _SOKOL_PRIVATE bool _sg_validate_draw(int base_element, int num_elements, int nu
         _SG_VALIDATE(base_element >= 0, VALIDATE_DRAW_BASEELEMENT_GE_ZERO);
         _SG_VALIDATE(num_elements >= 0, VALIDATE_DRAW_NUMELEMENTS_GE_ZERO);
         _SG_VALIDATE(num_instances >= 0, VALIDATE_DRAW_NUMINSTANCES_GE_ZERO);
-        _SG_VALIDATE(_sg.required_bindings_and_uniforms == _sg.applied_bindings_and_uniforms, VALIDATE_DRAW_REQUIRED_BINDINGS_OR_UNIFORMS_MISSING);
+        _SG_VALIDATE(_sg.validate.required_bindings_and_uniforms == _sg.validate.applied_bindings_and_uniforms, VALIDATE_DRAW_REQUIRED_BINDINGS_OR_UNIFORMS_MISSING);
+        _SG_VALIDATE(!_sg.validate.write_buffer_transient_missing, VALIDATE_DRAW_WRITE_BUFFER_TRANSIENT_MISSING);
+        _SG_VALIDATE(!_sg.validate.write_image_transient_missing, VALIDATE_DRAW_WRITE_IMAGE_TRANSIENT_MISSING);
         return _sg_validate_end();
     #endif
 }
@@ -25327,7 +25346,9 @@ _SOKOL_PRIVATE bool _sg_validate_draw_ex(int base_element, int num_elements, int
         if (!use_instanced_draw) {
             _SG_VALIDATE(base_instance == 0, VALIDATE_DRAW_EX_BASEINSTANCE_VS_INSTANCED);
         }
-        _SG_VALIDATE(_sg.required_bindings_and_uniforms == _sg.applied_bindings_and_uniforms, VALIDATE_DRAW_REQUIRED_BINDINGS_OR_UNIFORMS_MISSING);
+        _SG_VALIDATE(_sg.validate.required_bindings_and_uniforms == _sg.validate.applied_bindings_and_uniforms, VALIDATE_DRAW_REQUIRED_BINDINGS_OR_UNIFORMS_MISSING);
+        _SG_VALIDATE(!_sg.validate.write_buffer_transient_missing, VALIDATE_DRAW_WRITE_BUFFER_TRANSIENT_MISSING);
+        _SG_VALIDATE(!_sg.validate.write_image_transient_missing, VALIDATE_DRAW_WRITE_IMAGE_TRANSIENT_MISSING);
         return _sg_validate_end();
     #endif
 }
@@ -25347,7 +25368,9 @@ _SOKOL_PRIVATE bool _sg_validate_dispatch(int num_groups_x, int num_groups_y, in
         _SG_VALIDATE((num_groups_x >= 0) && (num_groups_x < (1<<16)), VALIDATE_DISPATCH_NUMGROUPSX);
         _SG_VALIDATE((num_groups_y >= 0) && (num_groups_y < (1<<16)), VALIDATE_DISPATCH_NUMGROUPSY);
         _SG_VALIDATE((num_groups_z >= 0) && (num_groups_z < (1<<16)), VALIDATE_DISPATCH_NUMGROUPSZ);
-        _SG_VALIDATE(_sg.required_bindings_and_uniforms == _sg.applied_bindings_and_uniforms, VALIDATE_DRAW_REQUIRED_BINDINGS_OR_UNIFORMS_MISSING);
+        _SG_VALIDATE(_sg.validate.required_bindings_and_uniforms == _sg.validate.applied_bindings_and_uniforms, VALIDATE_DRAW_REQUIRED_BINDINGS_OR_UNIFORMS_MISSING);
+        _SG_VALIDATE(!_sg.validate.write_buffer_transient_missing, VALIDATE_DISPATCH_WRITE_BUFFER_TRANSIENT_MISSING);
+        _SG_VALIDATE(!_sg.validate.write_image_transient_missing, VALIDATE_DISPATCH_WRITE_IMAGE_TRANSIENT_MISSING);
         return _sg_validate_end();
     #endif
 }
@@ -25469,7 +25492,7 @@ _SOKOL_PRIVATE void _sg_validate_write_image_common(const _sg_image_t* img, cons
     const int mip_depth_or_slices = (SG_IMAGETYPE_3D == img->cmn.type) ? _sg_miplevel_dim(img->cmn.num_slices, desc->dst.mip_level) : img->cmn.num_slices;
     const int bsize = _sg_block_bytesize(img->cmn.pixel_format);
     _SG_VALIDATE(desc->src.data.ptr, VALIDATE_WRITEIMAGE_SRC_DATA_POINTER);
-    _SG_VALIDATE(desc->src.data.size, VALIDATE_WRITEIMAGE_SRC_DATA_SIZE);
+    _SG_VALIDATE(desc->src.data.size > 0, VALIDATE_WRITEIMAGE_SRC_DATA_SIZE);
     _SG_VALIDATE((desc->src.bytes_per_row > 0) && _sg_multiple(desc->src.bytes_per_row, bsize), VALIDATE_WRITEIMAGE_BYTESPERROW);
     _SG_VALIDATE((desc->src.bytes_per_slice > 0) && _sg_multiple(desc->src.bytes_per_slice, desc->src.bytes_per_row), VALIDATE_WRITEIMAGE_BYTESPERSLICE);
     _SG_VALIDATE((desc->dst.mip_level >= 0) && (desc->dst.mip_level < img->cmn.num_mipmaps), VALIDATE_WRITEIMAGE_MIPLEVEL);
@@ -27214,11 +27237,6 @@ SOKOL_API_IMPL void sg_apply_pipeline(sg_pipeline pip_id) {
     _sg.use_instanced_draw = pip->cmn.use_instanced_draw;
 
     _sg_apply_pipeline(pip);
-
-    // set the expected bindings and uniform block flags
-    const _sg_shader_t* shd = _sg_shader_ref_ptr(&pip->cmn.shader);
-    _sg.required_bindings_and_uniforms = pip->cmn.required_bindings_and_uniforms | shd->cmn.required_bindings_and_uniforms;
-    _sg.applied_bindings_and_uniforms = 0;
 }
 
 SOKOL_API_IMPL void sg_apply_bindings(const sg_bindings* bindings) {
@@ -27229,7 +27247,6 @@ SOKOL_API_IMPL void sg_apply_bindings(const sg_bindings* bindings) {
     if (!_sg.cur_pass.valid) {
         return;
     }
-    _sg.applied_bindings_and_uniforms |= (1 << SG_MAX_UNIFORMBLOCK_BINDSLOTS);
     if (!_sg_validate_apply_bindings(bindings)) {
         _sg.next_draw_valid = false;
     }
@@ -27318,7 +27335,6 @@ SOKOL_API_IMPL void sg_apply_uniforms(int ub_slot, const sg_range* data) {
     if (!_sg.cur_pass.valid) {
         return;
     }
-    _sg.applied_bindings_and_uniforms |= 1 << ub_slot;
     if (!_sg_validate_apply_uniforms(ub_slot, data)) {
         _sg.next_draw_valid = false;
         return;

--- a/sokol_gfx.h
+++ b/sokol_gfx.h
@@ -19964,6 +19964,25 @@ _SOKOL_PRIVATE void _sg_wgpu_write_image_unsealed(_sg_image_t* img, const sg_wri
 // >>vk
 #elif defined(SOKOL_VULKAN)
 
+_SOKOL_PRIVATE _sg_vk_access_t _sg_vk_default_buffer_access_mask(const _sg_buffer_t* buf) {
+    _sg_vk_access_t res = 0;
+    if (buf->cmn.usage.vertex_buffer) {
+        res |= _SG_VK_ACCESS_VERTEXBUFFER;
+    }
+    if (buf->cmn.usage.index_buffer) {
+        res |= _SG_VK_ACCESS_INDEXBUFFER;
+    }
+    if (buf->cmn.usage.storage_buffer) {
+        res |= _SG_VK_ACCESS_STORAGEBUFFER_RO;
+    }
+    return res;
+}
+
+_SOKOL_PRIVATE _sg_vk_access_t _sg_vk_default_image_access_mask(const _sg_image_t* img) {
+    (void)img;
+    return _SG_VK_ACCESS_TEXTURE;
+}
+
 _SOKOL_PRIVATE void _sg_vk_set_object_label(VkObjectType obj_type, uint64_t obj_handle, const char* label) {
     #if defined(SOKOL_DEBUG)
         SOKOL_ASSERT(_sg.vk.dev);
@@ -20356,12 +20375,16 @@ _SOKOL_PRIVATE void _sg_vk_barrier_on_apply_bindings(VkCommandBuffer cmd_buf, co
     } else {
         // no transitions allowed in render passes, but check if resources are in
         // correct access state
+        // NOTE: the write-transient check is necessary because of
+        //  https://github.com/floooh/sokol/issues/1598
+        //
+        // Technically this check should go into the validation layer!
         for (size_t i = 0; i < SG_MAX_VERTEXBUFFER_BINDSLOTS; i++) {
-            if (bnd->vbs[i]) {
+            if (bnd->vbs[i] && !bnd->vbs[i]->cmn.usage.write_transient) {
                 SOKOL_ASSERT(0 != (bnd->vbs[i]->vk.cur_access & _SG_VK_ACCESS_VERTEXBUFFER));
             }
         }
-        if (bnd->ib) {
+        if (bnd->ib && !bnd->ib->cmn.usage.write_transient) {
             SOKOL_ASSERT(0 != (bnd->ib->vk.cur_access & _SG_VK_ACCESS_INDEXBUFFER));
         }
         for (size_t i = 0; i < SG_MAX_VIEW_BINDSLOTS; i++) {
@@ -20371,12 +20394,14 @@ _SOKOL_PRIVATE void _sg_vk_barrier_on_apply_bindings(VkCommandBuffer cmd_buf, co
             }
             else if (view->cmn.type == SG_VIEWTYPE_STORAGEBUFFER) {
                 const _sg_buffer_t* buf = _sg_buffer_ref_ptr(&view->cmn.buf.ref);
-                _SOKOL_UNUSED(buf);
-                SOKOL_ASSERT(0 != (buf->vk.cur_access & _SG_VK_ACCESS_STORAGEBUFFER_RO));
+                if (!buf->cmn.usage.write_transient) {
+                    SOKOL_ASSERT(0 != (buf->vk.cur_access & _SG_VK_ACCESS_STORAGEBUFFER_RO));
+                }
             } else if (view->cmn.type == SG_VIEWTYPE_TEXTURE) {
                 const _sg_image_t* img = _sg_image_ref_ptr(&view->cmn.img.ref);
-                _SOKOL_UNUSED(img);
-                SOKOL_ASSERT(0 != (img->vk.cur_access & _SG_VK_ACCESS_TEXTURE));
+                if (!img->cmn.usage.write_transient) {
+                    SOKOL_ASSERT(0 != (img->vk.cur_access & _SG_VK_ACCESS_TEXTURE));
+                }
             } else {
                 SOKOL_UNREACHABLE;
             }
@@ -20388,23 +20413,21 @@ _SOKOL_PRIVATE void _sg_vk_barrier_on_end_pass(VkCommandBuffer cmd_buf, const _s
     SOKOL_ASSERT(cmd_buf);
     if (is_compute_pass) {
         // transition all tracked buffers into vertex+index+sbuf-ro access
-        const _sg_vk_access_t new_buf_access = _SG_VK_ACCESS_VERTEXBUFFER|_SG_VK_ACCESS_INDEXBUFFER|_SG_VK_ACCESS_STORAGEBUFFER_RO;
         for (int i = 0; i < _sg.vk.track.buffers.cur_slot; i++) {
             const uint32_t buf_id = _sg.vk.track.buffers.slots[i];
             _sg_buffer_t* buf = _sg_lookup_buffer(buf_id);
             if (buf) {
-                _sg_vk_buffer_barrier(cmd_buf, buf, new_buf_access);
+                _sg_vk_buffer_barrier(cmd_buf, buf, _sg_vk_default_buffer_access_mask(buf));
             }
         }
         _sg_track_reset(&_sg.vk.track.buffers);
 
         // transition all tracked images into texture access
-        const _sg_vk_access_t new_img_access = _SG_VK_ACCESS_TEXTURE;
         for (int i = 0; i < _sg.vk.track.images.cur_slot; i++) {
             const uint32_t img_id = _sg.vk.track.images.slots[i];
             _sg_image_t* img = _sg_lookup_image(img_id);
             if (img) {
-                _sg_vk_image_barrier(cmd_buf, img, new_img_access);
+                _sg_vk_image_barrier(cmd_buf, img, _sg_vk_default_image_access_mask(img));
             }
         }
         _sg_track_reset(&_sg.vk.track.images);
@@ -20421,17 +20444,17 @@ _SOKOL_PRIVATE void _sg_vk_barrier_on_end_pass(VkCommandBuffer cmd_buf, const _s
                 if (_sg.cur_pass.action.colors[i].store_action == SG_STOREACTION_STORE) {
                     SOKOL_ASSERT(atts->color_views[i]);
                     _sg_image_t* img = _sg_image_ref_ptr(&atts->color_views[i]->cmn.img.ref);
-                    _sg_vk_image_barrier(cmd_buf, img, _SG_VK_ACCESS_TEXTURE);
+                    _sg_vk_image_barrier(cmd_buf, img, _sg_vk_default_image_access_mask(img));
                 }
                 if (atts->resolve_views[i]) {
                     _sg_image_t* img = _sg_image_ref_ptr(&atts->resolve_views[i]->cmn.img.ref);
-                    _sg_vk_image_barrier(cmd_buf, img, _SG_VK_ACCESS_TEXTURE);
+                    _sg_vk_image_barrier(cmd_buf, img, _sg_vk_default_image_access_mask(img));
                 }
             }
             if (atts->ds_view) {
                 _sg_image_t* img = _sg_image_ref_ptr(&atts->ds_view->cmn.img.ref);
                 if (_sg.cur_pass.action.depth.store_action == SG_STOREACTION_STORE) {
-                    _sg_vk_image_barrier(cmd_buf, img, _SG_VK_ACCESS_TEXTURE);
+                    _sg_vk_image_barrier(cmd_buf, img, _sg_vk_default_image_access_mask(img));
                 }
             }
         }
@@ -20923,7 +20946,7 @@ _SOKOL_PRIVATE void _sg_vk_staging_copy_buffer_data(_sg_buffer_t* buf, const sg_
         src_ptr += bytes_to_copy;
         region.dstOffset += bytes_to_copy;
     }
-    buf->vk.cur_access = _SG_VK_ACCESS_VERTEXBUFFER | _SG_VK_ACCESS_INDEXBUFFER | _SG_VK_ACCESS_STORAGEBUFFER_RO;
+    buf->vk.cur_access = _sg_vk_default_buffer_access_mask(buf);
 }
 
 _SOKOL_PRIVATE void _sg_vk_init_vk_image_staging_structs(const _sg_image_t* img, VkBuffer vk_buf, VkBufferImageCopy2* region, VkCopyBufferToImageInfo2* copy_info) {
@@ -21042,7 +21065,7 @@ _SOKOL_PRIVATE void _sg_vk_staging_copy_miplevel_data(_sg_image_t* img,
             region.imageExtent.height = (uint32_t)_sg_min(height, rows_to_copy * block_dim);
             vkCmdCopyBufferToImage2(cmd_buf, &copy_info);
             _sg_stats_inc(vk.num_cmd_copy_buffer_to_image);
-            _sg_vk_image_barrier(cmd_buf, img, _SG_VK_ACCESS_TEXTURE);
+            _sg_vk_image_barrier(cmd_buf, img, _sg_vk_default_image_access_mask(img));
             _sg_vk_staging_copy_end(cmd_buf, _sg.vk.queue);
             cur_row += rows_to_copy;
         }
@@ -21127,7 +21150,7 @@ _SOKOL_PRIVATE void _sg_vk_staging_stream_buffer_data(_sg_buffer_t* buf, const s
     // FIXME: not great to issue a barrier right here,
     // rethink buffer barrier strategy? => a single memory barrier
     // at the end of the stream command buffer should be sufficient?
-    _sg_vk_buffer_barrier(cmd_buf, buf, _SG_VK_ACCESS_VERTEXBUFFER|_SG_VK_ACCESS_INDEXBUFFER|_SG_VK_ACCESS_STORAGEBUFFER_RO);
+    _sg_vk_buffer_barrier(cmd_buf, buf, _sg_vk_default_buffer_access_mask(buf));
 }
 
 _SOKOL_PRIVATE void _sg_vk_staging_stream_miplevel_data(_sg_image_t* img,
@@ -23202,7 +23225,7 @@ _SOKOL_PRIVATE void _sg_vk_write_image_transient(_sg_image_t* img, const sg_writ
         desc->size.width,
         desc->size.height,
         desc->size.num_slices);
-    _sg_vk_image_barrier(cmd_buf, img, _SG_VK_ACCESS_TEXTURE);
+    _sg_vk_image_barrier(cmd_buf, img, _sg_vk_default_image_access_mask(img));
 }
 
 _SOKOL_PRIVATE void _sg_vk_write_buffer_unsealed(_sg_buffer_t* buf, const sg_write_buffer_desc* desc) {

--- a/tests/functional/sokol_gfx_test.c
+++ b/tests/functional/sokol_gfx_test.c
@@ -1,5 +1,8 @@
 //------------------------------------------------------------------------------
 //  sokol-gfx-test.c
+//
+//  LLM maintained.
+//
 //  NOTE: this is not only testing the public API behaviour, but also
 //  accesses private functions and data. It may make sense to split
 //  these into two separate tests.
@@ -2731,6 +2734,195 @@ UTEST(sokol_gfx, max_pass_attachments) {
     sg_begin_pass(&pass);
     T(log_items[0] == SG_LOGITEM_BEGINPASS_TOO_MANY_COLOR_ATTACHMENTS);
     T(log_items[1] == SG_LOGITEM_BEGINPASS_TOO_MANY_RESOLVE_ATTACHMENTS);
+    sg_end_pass();
+    sg_commit();
+    sg_shutdown();
+}
+
+// write-transient deferred-validation tests
+
+static sg_pipeline create_write_transient_test_pipeline(void) {
+    return sg_make_pipeline(&(sg_pipeline_desc){
+        .shader = sg_make_shader(&(sg_shader_desc){0}),
+        .layout.attrs[0].format = SG_VERTEXFORMAT_FLOAT3,
+    });
+}
+
+static sg_buffer create_write_transient_test_buffer(void) {
+    return sg_make_buffer(&(sg_buffer_desc){
+        .usage = { .vertex_buffer = true, .write_transient = true },
+        .size = 128,
+    });
+}
+
+// pipeline + shader with one write_transient texture view for the image tests
+typedef struct {
+    sg_pipeline pip;
+    sg_buffer vbuf;
+    sg_image img;
+    sg_view view;
+    sg_sampler smp;
+} write_transient_image_setup_t;
+
+static write_transient_image_setup_t create_write_transient_image_setup(void) {
+    write_transient_image_setup_t s = {0};
+    // non-transient vertex buffer to keep the buffer-side check silent
+    const float verts[8] = {0};
+    s.vbuf = sg_make_buffer(&(sg_buffer_desc){
+        .usage.vertex_buffer = true,
+        .data = SG_RANGE(verts),
+    });
+    s.img = sg_make_image(&(sg_image_desc){
+        .usage.write_transient = true,
+        .width = 8,
+        .height = 8,
+        .pixel_format = SG_PIXELFORMAT_RGBA8,
+    });
+    s.view = sg_make_view(&(sg_view_desc){ .texture.image = s.img });
+    s.smp = sg_make_sampler(&(sg_sampler_desc){0});
+    sg_shader shd = sg_make_shader(&(sg_shader_desc){
+        .views[0].texture = {
+            .stage = SG_SHADERSTAGE_FRAGMENT,
+            .image_type = SG_IMAGETYPE_2D,
+            .sample_type = SG_IMAGESAMPLETYPE_FLOAT,
+        },
+        .samplers[0] = {
+            .stage = SG_SHADERSTAGE_FRAGMENT,
+            .sampler_type = SG_SAMPLERTYPE_FILTERING,
+        },
+        .texture_sampler_pairs[0] = {
+            .stage = SG_SHADERSTAGE_FRAGMENT,
+            .view_slot = 0,
+            .sampler_slot = 0,
+        },
+    });
+    s.pip = sg_make_pipeline(&(sg_pipeline_desc){
+        .shader = shd,
+        .layout.attrs[0].format = SG_VERTEXFORMAT_FLOAT3,
+    });
+    return s;
+}
+
+#define WRITE_TRANSIENT_TEST_PASS &(sg_pass){ \
+    .swapchain = { \
+        .width = 64, \
+        .height = 64, \
+        .sample_count = 1, \
+        .color_format = SG_PIXELFORMAT_RGBA8, \
+    } \
+}
+
+// missing sg_write_buffer_transient() must be reported at sg_draw() time,
+// not at sg_apply_bindings() time
+UTEST(sokol_gfx, draw_write_buffer_transient_missing) {
+    setup(&(sg_desc){0});
+    sg_buffer buf = create_write_transient_test_buffer();
+    sg_pipeline pip = create_write_transient_test_pipeline();
+    sg_begin_pass(WRITE_TRANSIENT_TEST_PASS);
+    sg_apply_pipeline(pip);
+    sg_apply_bindings(&(sg_bindings){ .vertex_buffers[0] = buf });
+    reset_log_items();
+    sg_draw(0, 3, 1);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_DRAW_WRITE_BUFFER_TRANSIENT_MISSING);
+    T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
+    T(num_log_called == 2);
+    sg_end_pass();
+    sg_commit();
+    sg_shutdown();
+}
+
+// write -> bind -> draw is the correct sequence and must not error
+UTEST(sokol_gfx, draw_write_buffer_transient_ok) {
+    setup(&(sg_desc){0});
+    sg_buffer buf = create_write_transient_test_buffer();
+    sg_pipeline pip = create_write_transient_test_pipeline();
+    sg_begin_pass(WRITE_TRANSIENT_TEST_PASS);
+    const float data[8] = {0};
+    sg_write_buffer_transient(&(sg_write_buffer_desc){
+        .src.data = SG_RANGE(data),
+        .dst.buffer = buf,
+        .size = sizeof(data),
+    });
+    sg_apply_pipeline(pip);
+    sg_apply_bindings(&(sg_bindings){ .vertex_buffers[0] = buf });
+    reset_log_items();
+    sg_draw(0, 3, 1);
+    T(num_log_called == 0);
+    sg_end_pass();
+    sg_commit();
+    sg_shutdown();
+}
+
+// regression test: sg_apply_pipeline() must reset the write_transient_missing
+// flags so an apply_pipeline -> draw sequence (bindings skipped) only reports
+// the real REQUIRED_BINDINGS_OR_UNIFORMS_MISSING error and doesn't leak a
+// stale flag from an earlier sg_apply_bindings()
+UTEST(sokol_gfx, apply_pipeline_resets_write_transient_flag) {
+    setup(&(sg_desc){0});
+    sg_buffer buf = create_write_transient_test_buffer();
+    sg_pipeline pip = create_write_transient_test_pipeline();
+    sg_begin_pass(WRITE_TRANSIENT_TEST_PASS);
+    // set the stale flag by binding an unwritten write_transient buffer
+    sg_apply_pipeline(pip);
+    sg_apply_bindings(&(sg_bindings){ .vertex_buffers[0] = buf });
+    // fresh apply_pipeline must clear the flag
+    sg_apply_pipeline(pip);
+    reset_log_items();
+    sg_draw(0, 3, 1);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_DRAW_REQUIRED_BINDINGS_OR_UNIFORMS_MISSING);
+    T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
+    T(num_log_called == 2);
+    sg_end_pass();
+    sg_commit();
+    sg_shutdown();
+}
+
+// missing sg_write_image_transient() must be reported at sg_draw() time,
+// not at sg_apply_bindings() time
+UTEST(sokol_gfx, draw_write_image_transient_missing) {
+    setup(&(sg_desc){0});
+    write_transient_image_setup_t s = create_write_transient_image_setup();
+    sg_begin_pass(WRITE_TRANSIENT_TEST_PASS);
+    sg_apply_pipeline(s.pip);
+    sg_apply_bindings(&(sg_bindings){
+        .vertex_buffers[0] = s.vbuf,
+        .views[0] = s.view,
+        .samplers[0] = s.smp,
+    });
+    reset_log_items();
+    sg_draw(0, 3, 1);
+    T(log_items[0] == SG_LOGITEM_VALIDATE_DRAW_WRITE_IMAGE_TRANSIENT_MISSING);
+    T(log_items[1] == SG_LOGITEM_VALIDATION_FAILED);
+    T(num_log_called == 2);
+    sg_end_pass();
+    sg_commit();
+    sg_shutdown();
+}
+
+// write -> bind -> draw for a write_transient image must not error
+UTEST(sokol_gfx, draw_write_image_transient_ok) {
+    setup(&(sg_desc){0});
+    write_transient_image_setup_t s = create_write_transient_image_setup();
+    sg_begin_pass(WRITE_TRANSIENT_TEST_PASS);
+    const uint32_t pixels[8*8] = {0};
+    sg_write_image_transient(&(sg_write_image_desc){
+        .src = {
+            .data = SG_RANGE(pixels),
+            .bytes_per_row = 8 * 4,
+            .bytes_per_slice = 8 * 8 * 4,
+        },
+        .dst.image = s.img,
+        .size = { .width = 8, .height = 8, .num_slices = 1 },
+    });
+    sg_apply_pipeline(s.pip);
+    sg_apply_bindings(&(sg_bindings){
+        .vertex_buffers[0] = s.vbuf,
+        .views[0] = s.view,
+        .samplers[0] = s.smp,
+    });
+    reset_log_items();
+    sg_draw(0, 3, 1);
+    T(num_log_called == 0);
     sg_end_pass();
     sg_commit();
     sg_shutdown();


### PR DESCRIPTION
See: https://github.com/floooh/sokol/issues/1598

Test "write-transient call missing" behavior (buffer and image!) on:

- [x] metal
- [x] d3d11
- [x] vulkan (assertion kicks in when a write-transient buffer wasn't populated... investigating... and cleaned up)
- [x] gl
- [x] webgl2
- [x] webgpu
